### PR TITLE
Fix deadlock on exit

### DIFF
--- a/simulation.cc
+++ b/simulation.cc
@@ -735,6 +735,23 @@ void Simulation::emergencyShutdown()
 }
 
 
+void Simulation::endSimulation(SimTime_t end)
+{
+    // shutdown_mode = SHUTDOWN_CLEAN;
+
+    // This is a collective operation across threads.  All threads
+    // must enter and set flag before any will exit.
+    // exit_barrier.wait();
+
+    endSimCycle = end;
+    endSim = true;
+
+    exit_barrier.wait();
+
+
+}
+    
+
 void Simulation::finish() {
 
     for ( auto iter = compInfoMap.begin(); iter != compInfoMap.end(); ++iter )
@@ -1023,6 +1040,7 @@ TimeLord Simulation::timeLord;
 Statistics::StatisticOutput* Simulation::statisticsOutput;
 Output Simulation::sim_output;
 Core::ThreadSafe::Barrier Simulation::barrier;
+Core::ThreadSafe::Barrier Simulation::exit_barrier;
 std::mutex Simulation::simulationMutex;
 TimeConverter* Simulation::minPartTC = NULL;
 SyncBase* Simulation::sync = NULL;

--- a/simulation.h
+++ b/simulation.h
@@ -369,6 +369,7 @@ private:
     /** Output */
     static Output sim_output;
     static Core::ThreadSafe::Barrier barrier;
+    static Core::ThreadSafe::Barrier exit_barrier;
     static std::mutex simulationMutex;
 
 
@@ -387,16 +388,7 @@ private:
     /** Normal Shutdown
      */
     void endSimulation(void) { endSimulation(currentSimCycle); }
-    void endSimulation(SimTime_t end) {
-        shutdown_mode = SHUTDOWN_CLEAN;
-        // For now, only thread 0 will do anything
-        if ( my_rank.thread != 0 ) return;
-        // Need to notify all threads
-        for ( auto && instance : instanceVec ) {
-            instance->endSimCycle = end;
-            instance->endSim = true;
-        }
-    }
+    void endSimulation(SimTime_t end); 
 
     typedef enum {
         SHUTDOWN_CLEAN,     /* Normal shutdown */

--- a/syncManager.cc
+++ b/syncManager.cc
@@ -89,7 +89,7 @@ SyncManager::SyncManager(const RankInfo& rank, const RankInfo& num_ranks, Core::
     }
 
     if ( num_ranks.thread > 1 ) {
-        threadSync = new ThreadSyncSimpleSkip(num_ranks.thread, Simulation::getSimulation());
+        threadSync = new ThreadSyncSimpleSkip(num_ranks.thread, rank.thread, Simulation::getSimulation());
     }
     else {
         threadSync = new EmptyThreadSync();

--- a/threadSyncSimpleSkip.h
+++ b/threadSyncSimpleSkip.h
@@ -34,7 +34,7 @@ class ThreadSyncQueue;
 class ThreadSyncSimpleSkip : public NewThreadSync {
 public:
     /** Create a new ThreadSync object */
-    ThreadSyncSimpleSkip(int num_threads, Simulation* sim);
+    ThreadSyncSimpleSkip(int num_threads, int thread, Simulation* sim);
     ~ThreadSyncSimpleSkip();
 
     void setMaxPeriod(TimeConverter* period);
@@ -61,6 +61,8 @@ private:
     std::unordered_map<LinkId_t, Link*> link_map;
     SimTime_t max_period;
     int num_threads;
+    int thread;
+    static SimTime_t localMinimumNextActivityTime;
     Simulation* sim;
     // static bool disabled;
     static Core::ThreadSafe::Barrier barrier;


### PR DESCRIPTION
Made Simulation::endSimulation() a node level collective call to fix deadlock on exit.  Removed extraneous barriers in sync objects.