### PR TITLE
[threading] Don't use cout - not thread-intelligent

### DIFF
--- a/stopAction.h
+++ b/stopAction.h
@@ -17,6 +17,7 @@
 #include <iostream>
 
 #include <sst/core/action.h>
+#include <sst/core/output.h>
 
 namespace SST {
 
@@ -46,7 +47,7 @@ public:
 
     void execute() {
         if ( print_message ) {
-            std::cout << message << std::endl;
+            Output::getDefaultObject().output("%s\n", message.c_str());
         }
         endSimulation();
     }


### PR DESCRIPTION
StopAction should not use cout (in fact, nothing should), as threading with cout is insane at best.

Should help address sst-elements/issue78