### PR TITLE
StatAPI: Add performGlobalStatisticOutput function

### DIFF
--- a/statapi/statengine.cc
+++ b/statapi/statengine.cc
@@ -169,6 +169,28 @@ void StatisticProcessingEngine::performStatisticOutput(StatisticBase* stat, bool
     }
 }
 
+void StatisticProcessingEngine::performGlobalStatisticOutput(bool endOfSimFlag /*=false*/) 
+{
+    StatArray_t*    statArray;
+    StatisticBase*  stat;
+
+    // Output Event based statistics
+    for (StatArray_t::iterator it_v = m_EventStatisticArray.begin(); it_v != m_EventStatisticArray.end(); it_v++) {
+        stat = * it_v;
+        performStatisticOutput(stat, endOfSimFlag);
+    }
+
+    // Output Periodic based statistics 
+    for (StatMap_t::iterator it_m = m_PeriodicStatisticMap.begin(); it_m != m_PeriodicStatisticMap.end(); it_m++) {
+        statArray = it_m->second;
+
+        for (StatArray_t::iterator it_v = statArray->begin(); it_v != statArray->end(); it_v++) {
+            stat = *it_v;
+            performStatisticOutput(stat, endOfSimFlag);
+        }
+    }
+}
+
 void StatisticProcessingEngine::endOfSimulation()
 {
     StatArray_t*     statArray;

--- a/statapi/statengine.h
+++ b/statapi/statengine.h
@@ -39,6 +39,13 @@ public:
       * @param EndOfSimFlag - Indicates that the output is occuring at the end of simulation.
       */
     void performStatisticOutput(StatisticBase* stat, bool endOfSimFlag = false);
+    
+    /** Called by the Components and Subcomponent to perform a global statistic Output.
+     * This routine will force ALL Components and Subcomponents to output their statistic information.
+     * This may lead to unexpected results if the statistic counts or data is reset on output.
+     * @param endOfSimFlag - Indicates that the output is occurring at the end of simulation.
+     */
+    void performGlobalStatisticOutput(bool endOfSimFlag = false);
 
 private:
     friend class SST::Component;


### PR DESCRIPTION
Can be called by a component to output statistics for all components and subcomponents in the simulation