### PR TITLE
fix compilation on gcc 5.2.1

### DIFF
--- a/configGraph.h
+++ b/configGraph.h
@@ -145,6 +145,7 @@ public:
     ConfigComponent cloneWithoutLinks() const;
     ConfigComponent cloneWithoutLinksOrParams() const;
     
+    ConfigComponent() {}
     ~ConfigComponent() {}
 private:
 
@@ -158,8 +159,6 @@ private:
         rank(rank),
         isIntrospector(isIntrospector)
     { }
-
-    ConfigComponent() {}
 
     friend class boost::serialization::access;
     template<class Archive>


### PR DESCRIPTION
The ConfigComponent constructor is listed under the wrong access specifier:
    ../../sst/core/configGraph.h:162:5: error: ‘SST::ConfigComponent::ConfigComponent()’ is private