### PR TITLE
Adds an option to SST to print timing even when verbose is not enabled

### DIFF
--- a/config.cc
+++ b/config.cc
@@ -66,6 +66,7 @@ Config::Config(RankInfo rankInfo)
     no_env_config = false;
     enable_sig_handling = true;
     output_core_prefix = "@x SST Core: ";
+    print_timing = false;
 
 #ifdef __SST_DEBUG_EVENT_TRACKING__
     event_dump_file = "";
@@ -82,6 +83,7 @@ Config::Config(RankInfo rankInfo)
         ("verbose,v", "print information about core runtimes")
         ("disable-signal-handlers", "disable SST automatic dynamic library environment configuration")
         ("no-env-config", "disable SST environment configuration")
+        ("print-timing-info", "print SST timing information")
         ("version,V", "print SST Release Version")
     ;
 
@@ -170,6 +172,10 @@ Config::Config(RankInfo rankInfo)
         ;
 
     	var_map = new po::variables_map();
+}
+
+bool Config::printTimingInfo() {
+	return print_timing;
 }
 
 uint32_t Config::getVerboseLevel() {

--- a/config.cc
+++ b/config.cc
@@ -234,6 +234,7 @@ Config::parseCmdLine(int argc, char* argv[]) {
 
     verbose = var_map->count( "verbose" );
     enable_sig_handling = (var_map->count("disable-signal-handlers") > 0) ? false : true;
+    print_timing = (var_map->count("print-timing-info") > 0);
 
     if ( var_map->count( "version" ) ) {
         cout << "SST Release Version (" PACKAGE_VERSION << ", " SST_SVN_REVISION ")" << endl;

--- a/config.h
+++ b/config.h
@@ -50,6 +50,9 @@ public:
     /** Return the current Verbosity level */
     uint32_t getVerboseLevel();
 
+    /** Print the SST core timing information */
+    bool printTimingInfo();
+
     /** Set the cycle at which to stop the simulation */
     void setStopAt(std::string stopAtStr);
     /** Sets the default timebase of the simulation */
@@ -79,6 +82,7 @@ public:
     uint32_t        verbose;            /*!< Verbosity */
     bool	    no_env_config;      /*!< Bypass compile-time environmental configuration */
     bool            enable_sig_handling; /*!< Enable signal handling */
+    bool            print_timing;       /*!< Print SST timing information */
 
 #ifdef USE_MEMPOOL
     std::string     event_dump_file;    /*!< File to dump undeleted events to */
@@ -116,9 +120,10 @@ public:
 		std::cout << "output_directory = " << output_directory << std::endl;
 		std::cout << "output_json = " << output_json << std::endl;
 		std::cout << "model_options = " << model_options << std::endl;
-        std::cout << "num_threads = " << world_size.thread << std::endl;
+        	std::cout << "num_threads = " << world_size.thread << std::endl;
 		std::cout << "enable_sig_handling = " << enable_sig_handling << std::endl;
 		std::cout << "output_core_prefix = " << output_core_prefix << std::endl;
+      		std::cout << "print_timing=" << print_timing << std::endl;
 	}
 
     /** Return the library search path */

--- a/config.h
+++ b/config.h
@@ -174,8 +174,9 @@ private:
         ar & BOOST_SERIALIZATION_NVP(no_env_config);
         ar & BOOST_SERIALIZATION_NVP(model_options);
         ar & BOOST_SERIALIZATION_NVP(world_size);
-	    ar & BOOST_SERIALIZATION_NVP(enable_sig_handling);
+	ar & BOOST_SERIALIZATION_NVP(enable_sig_handling);
         ar & BOOST_SERIALIZATION_NVP(output_core_prefix);
+        ar & BOOST_SERIALIZATION_NVP(print_timing);
     }
     
     int rank;

--- a/main.cc
+++ b/main.cc
@@ -768,7 +768,7 @@ main(int argc, char *argv[])
     const uint64_t global_max_io_in  = maxInputOperations();
     const uint64_t global_max_io_out = maxOutputOperations();
 
-    if ( myRank.rank == 0 && cfg.verbose ) {
+    if ( myRank.rank == 0 && ( cfg.verbose || cfg.printTimingInfo() ) ) {
         char ua_buffer[256];
         sprintf(ua_buffer, "%" PRIu64 "KB", local_max_rss);
         UnitAlgebra max_rss_ua(ua_buffer);

--- a/main.cc
+++ b/main.cc
@@ -788,45 +788,45 @@ main(int argc, char *argv[])
         sprintf(ua_buffer, "%" PRIu64 "B", global_mempool_size);
         UnitAlgebra global_mempool_size_ua(ua_buffer);
         
-        g_output.verbose(CALL_INFO, 1, 0, "\n");
-        g_output.verbose(CALL_INFO, 1, 0, "\n");
-        g_output.verbose(CALL_INFO, 1, 0, "------------------------------------------------------------\n");
-        g_output.verbose(CALL_INFO, 1, 0, "Simulation Timing Information:\n");
-        g_output.verbose(CALL_INFO, 1, 0, "Build time:                      %f seconds\n", max_build_time);
-        g_output.verbose(CALL_INFO, 1, 0, "Simulation time:                 %f seconds\n", max_run_time);
-        g_output.verbose(CALL_INFO, 1, 0, "Total time:                      %f seconds\n", max_total_time);
-        g_output.verbose(CALL_INFO, 1, 0, "Simulated time:                  %s\n", threadInfo[0].simulated_time.toStringBestSI().c_str());
-        g_output.verbose(CALL_INFO, 1, 0, "\n");
-        g_output.verbose(CALL_INFO, 1, 0, "Simulation Resource Information:\n");
-        g_output.verbose(CALL_INFO, 1, 0, "Max Resident Set Size:           %s\n",
-                max_rss_ua.toStringBestSI().c_str());
-        g_output.verbose(CALL_INFO, 1, 0, "Approx. Global Max RSS Size:     %s\n",
-                global_rss_ua.toStringBestSI().c_str());
-        g_output.verbose(CALL_INFO, 1, 0, "Max Local Page Faults:           %" PRIu64 " faults\n",
-                local_max_pf);
-        g_output.verbose(CALL_INFO, 1, 0, "Global Page Faults:              %" PRIu64 " faults\n",
-                global_pf);
-        g_output.verbose(CALL_INFO, 1, 0, "Max Output Blocks:               %" PRIu64 " blocks\n",
-                global_max_io_in);
-        g_output.verbose(CALL_INFO, 1, 0, "Max Input Blocks:                %" PRIu64 " blocks\n",
-                global_max_io_out);
-        g_output.verbose(CALL_INFO, 1, 0, "Max mempool usage:               %s\n",
-                max_mempool_size_ua.toStringBestSI().c_str());
-        g_output.verbose(CALL_INFO, 1, 0, "Global mempool usage:            %s\n",
-                global_mempool_size_ua.toStringBestSI().c_str());
-        g_output.verbose(CALL_INFO, 1, 0, "Global active activities:        %" PRIu64 " activities\n",
-                global_active_activities);
-        g_output.verbose(CALL_INFO, 1, 0, "Current global TimeVortex depth: %" PRIu64 " entries\n",
-                global_current_tv_depth);
-        g_output.verbose(CALL_INFO, 1, 0, "Max TimeVortex depth:            %" PRIu64 " entries\n",
-                global_max_tv_depth);
-        g_output.verbose(CALL_INFO, 1, 0, "Max Sync data size:              %s\n",
-                global_max_sync_data_size_ua.toStringBestSI().c_str());
-        g_output.verbose(CALL_INFO, 1, 0, "Global Sync data size:           %s\n",
-                global_sync_data_size_ua.toStringBestSI().c_str());
-        g_output.verbose(CALL_INFO, 1, 0, "------------------------------------------------------------\n");
-        g_output.verbose(CALL_INFO, 1, 0, "\n");
+        g_output.output( "\n");
         g_output.output("\n");
+        g_output.output( "------------------------------------------------------------\n");
+        g_output.output( "Simulation Timing Information:\n");
+        g_output.output( "Build time:                      %f seconds\n", max_build_time);
+        g_output.output( "Simulation time:                 %f seconds\n", max_run_time);
+        g_output.output( "Total time:                      %f seconds\n", max_total_time);
+        g_output.output( "Simulated time:                  %s\n", threadInfo[0].simulated_time.toStringBestSI().c_str());
+        g_output.output( "\n");
+        g_output.output( "Simulation Resource Information:\n");
+        g_output.output( "Max Resident Set Size:           %s\n",
+                max_rss_ua.toStringBestSI().c_str());
+        g_output.output( "Approx. Global Max RSS Size:     %s\n",
+                global_rss_ua.toStringBestSI().c_str());
+        g_output.output( "Max Local Page Faults:           %" PRIu64 " faults\n",
+                local_max_pf);
+        g_output.output( "Global Page Faults:              %" PRIu64 " faults\n",
+                global_pf);
+        g_output.output( "Max Output Blocks:               %" PRIu64 " blocks\n",
+                global_max_io_in);
+        g_output.output( "Max Input Blocks:                %" PRIu64 " blocks\n",
+                global_max_io_out);
+        g_output.output( "Max mempool usage:               %s\n",
+                max_mempool_size_ua.toStringBestSI().c_str());
+        g_output.output( "Global mempool usage:            %s\n",
+                global_mempool_size_ua.toStringBestSI().c_str());
+        g_output.output( "Global active activities:        %" PRIu64 " activities\n",
+                global_active_activities);
+        g_output.output( "Current global TimeVortex depth: %" PRIu64 " entries\n",
+                global_current_tv_depth);
+        g_output.output( "Max TimeVortex depth:            %" PRIu64 " entries\n",
+                global_max_tv_depth);
+        g_output.output( "Max Sync data size:              %s\n",
+                global_max_sync_data_size_ua.toStringBestSI().c_str());
+        g_output.output( "Global Sync data size:           %s\n",
+                global_sync_data_size_ua.toStringBestSI().c_str());
+        g_output.output( "------------------------------------------------------------\n");
+        g_output.output( "\n" );
+        g_output.output( "\n" );
 
     }
 


### PR DESCRIPTION
Need to support better timing when verbose is not enabled. Currently with verbose large simulations dump a lot of extra info to stdout. This option prints only timing. 