### PR TITLE
Added new functionality to Params.

### DIFF
--- a/cfgoutput/jsonConfigOutput.cc
+++ b/cfgoutput/jsonConfigOutput.cc
@@ -54,20 +54,28 @@ void JSONConfigGraphOutput::generateJSON(const std::string indent, const ConfigC
 	fprintf(outputFile, "%s    \"name\" : \"%s\",\n", indent.c_str(), comp.name.c_str());
 	fprintf(outputFile, "%s    \"type\" : \"%s\",\n", indent.c_str(), comp.type.c_str());
 
-	auto paramsItr = comp.params.begin();
+	// auto paramsItr = comp.params.begin();
+    auto keys = comp.params.getKeys();
+    auto paramsItr = keys.begin();
 
-	if(paramsItr != comp.params.end()) {
+	// if(paramsItr != comp.params.end()) {
+	if(paramsItr != keys.end()) {
 		fprintf(outputFile, "%s    \"params\" : [\n", indent.c_str());
 
 		fprintf(outputFile, "%s      { \"name\" : \"%s\", \"value\" : \"%s\" }",
-			indent.c_str(), Params::getParamName(paramsItr->first).c_str(),
-			paramsItr->second.c_str());
+			// indent.c_str(), Params::getParamName(paramsItr->first).c_str(),
+			// paramsItr->second.c_str());
+			indent.c_str(), paramsItr->c_str(),
+                comp.params.find_string(*paramsItr).c_str());
 
 		paramsItr++;
 
-		for(; paramsItr != comp.params.end(); paramsItr++) {
-			std::string paramName  = Params::getParamName(paramsItr->first);
-			std::string paramValue = paramsItr->second;
+		// for(; paramsItr != comp.params.end(); paramsItr++) {
+		for(; paramsItr != keys.end(); paramsItr++) {
+			// std::string paramName  = Params::getParamName(paramsItr->first);
+			// std::string paramValue = paramsItr->second;
+			std::string paramName  = *paramsItr;
+			std::string paramValue = comp.params.find_string(*paramsItr);
 
 			fprintf(outputFile, ",\n%s      { \"name\" : \"%s\", \"value\" : \"%s\" }",
 				indent.c_str(), paramName.c_str(), paramValue.c_str());

--- a/cfgoutput/pythonConfigOutput.cc
+++ b/cfgoutput/pythonConfigOutput.cc
@@ -37,11 +37,17 @@ void PythonConfigGraphOutput::generate(const Config* cfg,
 		fprintf(outputFile, "%s = sst.Component(\"%s\", \"%s\")\n",
 			pyCompName, esCompName, comp_itr->type.c_str());
 
-		auto params_itr = comp_itr->params.begin();
+        Params& params = comp_itr->params;
+        auto keys = params.getKeys();
+		// auto params_itr = comp_itr->params.begin();
+		auto params_itr = keys.begin();
 
-		if(params_itr != comp_itr->params.end()) {
-			char* esParamName = makeEscapeSafe(Params::getParamName(params_itr->first).c_str());
-			char* esValue     = makeEscapeSafe(params_itr->second.c_str());
+		// if(params_itr != comp_itr->params.end()) {
+		if(params_itr != keys.end()) {
+			// char* esParamName = makeEscapeSafe(Params::getParamName(params_itr->first).c_str());
+			// char* esValue     = makeEscapeSafe(params_itr->second.c_str());
+			char* esParamName = makeEscapeSafe(params_itr->c_str());
+			char* esValue     = makeEscapeSafe(params.find_string(*params_itr).c_str());
 
 			fprintf(outputFile, "%s.addParams({\n", pyCompName);
 
@@ -56,9 +62,10 @@ void PythonConfigGraphOutput::generate(const Config* cfg,
 
 			params_itr++;
 
-			for(; params_itr != comp_itr->params.end(); params_itr++) {
-				char* esParamName = makeEscapeSafe(Params::getParamName(params_itr->first).c_str());
-				char* esValue     = makeEscapeSafe(params_itr->second.c_str());
+			// for(; params_itr != comp_itr->params.end(); params_itr++) {
+			for(; params_itr != keys.end(); params_itr++) {
+				char* esParamName = makeEscapeSafe(params_itr->c_str());
+				char* esValue     = makeEscapeSafe(params.find_string(*params_itr).c_str());
 
 				if(isMultiLine(esValue)) {
 					fprintf(outputFile, ",\n     \"%s\" : \"\"\"%s\"\"\"",
@@ -99,16 +106,23 @@ void PythonConfigGraphOutput::generate(const Config* cfg,
 			if( 0 != comp_itr->enabledStatParams[statIndex].size() ) {
 				fprintf(outputFile, ", {\n");
 
-				auto param_itr = comp_itr->enabledStatParams[statIndex].begin();
+                Params& params = comp_itr->enabledStatParams[statIndex];
+                auto keys = params.getKeys();
+                auto param_itr = keys.begin();
+				// auto param_itr = comp_itr->enabledStatParams[statIndex].begin();
 
-				for(; param_itr != comp_itr->enabledStatParams[statIndex].end(); param_itr++) {
-					if(param_itr != comp_itr->enabledStatParams[statIndex].begin()) {
+				// for(; param_itr != comp_itr->enabledStatParams[statIndex].end(); param_itr++) {
+				for(; param_itr != keys.end(); param_itr++) {
+					// if(param_itr != comp_itr->enabledStatParams[statIndex].begin()) {
+					if(param_itr != keys.begin()) {
 						fprintf(outputFile, ",\n");
 					}
 
-					char* esParamName = makeEscapeSafe(Params::getParamName(
-						param_itr->first));
-					char* esValue     = makeEscapeSafe(param_itr->second);
+					// char* esParamName = makeEscapeSafe(Params::getParamName(
+					// 	param_itr->first));
+					// char* esValue     = makeEscapeSafe(param_itr->second);
+					char* esParamName = makeEscapeSafe(*param_itr);
+					char* esValue     = makeEscapeSafe(comp_itr->enabledStatParams[statIndex].find_string(*param_itr));
 
 					fprintf(outputFile, "     \"%s\" : \"%s\"", esParamName,
 						esValue);

--- a/cfgoutput/xmlConfigOutput.cc
+++ b/cfgoutput/xmlConfigOutput.cc
@@ -42,9 +42,11 @@ void XMLConfigGraphOutput::generateXML(const std::string indent, const ConfigCom
 	fprintf(outputFile, "%s<component id=\"system.%s\" name=\"%s\" type=\"%s\">\n",
 		indent.c_str(), comp.name.c_str(), comp.name.c_str(), comp.type.c_str());
 
-	for(auto paramsItr = comp.params.begin(); paramsItr != comp.params.end(); paramsItr++) {
-		std::string paramName  = Params::getParamName(paramsItr->first);
-		std::string paramValue = paramsItr->second;
+	// for(auto paramsItr = comp.params.begin(); paramsItr != comp.params.end(); paramsItr++) {
+    auto keys = comp.params.getKeys();
+	for(auto paramsItr = keys.begin(); paramsItr != keys.end(); paramsItr++) {
+		std::string paramName  = *paramsItr;
+		std::string paramValue = comp.params.find_string(*paramsItr);
 
 		fprintf(outputFile, "%s%s<param name=\"%s\" value=\"%s\"/>\n",
 			indent.c_str(), "   ",

--- a/configGraph.cc
+++ b/configGraph.cc
@@ -272,7 +272,8 @@ void
 ConfigGraph::addParams(ComponentId_t comp_id, Params& p)
 {
     bool bk = comps[comp_id].params.enableVerify(false);
-    comps[comp_id].params.insert(p.begin(),p.end());
+    // comps[comp_id].params.insert(p.begin(),p.end());
+    comps[comp_id].params.insert(p);
     comps[comp_id].params.enableVerify(bk);
 }
 
@@ -280,12 +281,13 @@ void
 ConfigGraph::addParameter(ComponentId_t comp_id, const string key, const string value, bool overwrite)
 {
     bool bk = comps[comp_id].params.enableVerify(false);
-	if ( overwrite ) {
-		comps[comp_id].params[key] = value;
-	}
-	else {
-		comps[comp_id].params.insert(pair<string,string>(key,value));
-	}
+	// if ( overwrite ) {
+	// 	comps[comp_id].params[key] = value;
+	// }
+	// else {
+	// 	comps[comp_id].params.insert(pair<string,string>(key,value));
+	// }
+    comps[comp_id].params.insert(key,value,overwrite);
     comps[comp_id].params.enableVerify(bk);
 }
 
@@ -304,7 +306,8 @@ ConfigGraph::setStatisticOutputParams(const Params& p)
 void 
 ConfigGraph::addStatisticOutputParameter(const char* param, const char* value)
 {
-    statOutputParams[param] = value;
+    // statOutputParams[param] = value;
+    statOutputParams.insert(std::string(param), std::string(value));
 }
 
 void 
@@ -395,7 +398,8 @@ ConfigGraph::addComponentStatisticParameter(ComponentId_t comp_id, string statis
         // Check to see if the names match.  NOTE this also works for the STATALLFLAG
         if (statisticName == comps[comp_id].enabledStatistics.at(x)) {
             // Add/set the parameter
-            comps[comp_id].enabledStatParams.at(x)[param] = value;
+            // comps[comp_id].enabledStatParams.at(x)[param] = value;
+            comps[comp_id].enabledStatParams.at(x).insert(std::string(param),std::string(value));
         }
     }
 }

--- a/main.cc
+++ b/main.cc
@@ -655,8 +655,12 @@ main(int argc, char *argv[])
         g_output.output("\n");
 
         g_output.output("Statistic Output Parameters Provided:\n");
-        for (Params::const_iterator it = graph->getStatOutputParams().begin(); it != graph->getStatOutputParams().end(); ++it ) {
-            g_output.output("  %s = %s\n", Params::getParamName(it->first).c_str(), it->second.c_str());
+        // for (Params::const_iterator it = graph->getStatOutputParams().begin(); it != graph->getStatOutputParams().end(); ++it ) {
+        //     g_output.output("  %s = %s\n", Params::getParamName(it->first).c_str(), it->second.c_str());
+        // }
+        std::set<std::string> keys = graph->getStatOutputParams().getKeys();
+        for (auto it = keys.begin(); it != keys.end(); ++it ) {
+            g_output.output("  %s = %s\n", it->c_str(), graph->getStatOutputParams().find_string(*it).c_str());
         }
         g_output.fatal(CALL_INFO, -1, " - Required Statistic Output Parameters not set\n");
     }

--- a/params.h
+++ b/params.h
@@ -121,46 +121,46 @@ public:
      *  Params.
      *  Iteration is done in ascending order according to the keys.
      */
-    iterator begin() { return data.begin(); }
+    iterator begin() __attribute__ ((deprecated)) { return data.begin(); }
     /**  Returns a read/write iterator that points one past the last
      *  pair in the Params.  Iteration is done in ascending order
      *  according to the keys.
      */
-    iterator end() { return data.end(); }
+    iterator end() __attribute__ ((deprecated)) { return data.end(); }
     /** Returns a read-only (constant) iterator that points to the first pair
      *  in the Params.  Iteration is done in ascending order according to the
      *  keys.
      */
-    const_iterator begin() const { return data.begin(); }
+    const_iterator begin() const __attribute__ ((deprecated)) { return data.begin(); }
     /** Returns a read-only (constant) iterator that points one past the last
      *  pair in the Params.  Iteration is done in ascending order according to
      *  the keys.
      */
-    const_iterator end() const { return data.end(); }
+    const_iterator end() const __attribute__ ((deprecated)) { return data.end(); }
     /** Returns a read/write reverse iterator that points to the last pair in
      *  the Params.  Iteration is done in descending order according to the
      *  keys.
      */
-    reverse_iterator rbegin() { return data.rbegin(); }
+    reverse_iterator rbegin() __attribute__ ((deprecated)) { return data.rbegin(); }
     /** Returns a read/write reverse iterator that points to one before the
      *  first pair in the Params.  Iteration is done in descending order
      *  according to the keys.
      */
-    reverse_iterator rend() { return data.rend(); }
+    reverse_iterator rend() __attribute__ ((deprecated)) { return data.rend(); }
     /** Returns a read-only (constant) reverse iterator that points to the
      *  last pair in the Params.  Iteration is done in descending order
      *  according to the keys.
      */
-    const_reverse_iterator rbegin() const { return data.rbegin(); }
+    const_reverse_iterator rbegin() const __attribute__ ((deprecated)) { return data.rbegin(); }
     /** Returns a read-only (constant) reverse iterator that points to one
      *  before the first pair in the Params.  Iteration is done in descending
      *  order according to the keys.
      */
-    const_reverse_iterator rend() const { return data.rend(); }
+    const_reverse_iterator rend() const __attribute__ ((deprecated)) { return data.rend(); }
     /** Returns the size of the Params.  */
     size_type size() const { return data.size(); }
     /** Returns the maximum size of the Params.  */
-    size_type max_size() const { return data.max_size(); }
+    size_type max_size() const __attribute__ ((deprecated)) { return data.max_size(); }
     /** Returns true if the Params is empty.  (Thus begin() would equal end().) */
     bool empty() const { return data.empty(); }
 
@@ -207,7 +207,7 @@ public:
      *
      *  Insertion requires logarithmic time.
      */
-    std::pair<iterator, bool> insert(const value_type& x) {
+    std::pair<iterator, bool> insert(const value_type& x) __attribute__ ((deprecated)) {
         uint32_t id = getKey(x.first);
         return data.insert(std::make_pair(id, x.second));
     }
@@ -231,7 +231,7 @@ public:
      *
      *  Insertion requires logarithmic time (if the hint is not taken).
      */
-    iterator insert(iterator pos, const value_type& x) {
+    iterator insert(iterator pos, const value_type& x) __attribute__ ((deprecated)) {
         uint32_t id = getKey(x.first);
         return data.insert(pos, std::make_pair(id, x.second));
     }
@@ -244,7 +244,7 @@ public:
      *  Complexity similar to that of the range constructor.
      */
     template <class InputIterator>
-    void insert(InputIterator f, InputIterator l) {
+    void insert(InputIterator f, InputIterator l) __attribute__ ((deprecated)) {
         data.insert(f, l);
     }
 
@@ -258,7 +258,7 @@ public:
      *  the pointed-to memory is not touched in any way.  Managing
      *  the pointer is the user's responsibilty.
      */
-    void erase(iterator pos) {  data.erase(pos); }
+    void erase(iterator pos) __attribute__ ((deprecated)) {  data.erase(pos); }
     /**
      *  @brief Erases elements according to the provided key.
      *  @param  k  Key of element to be erased.
@@ -270,7 +270,7 @@ public:
      *  the element is itself a pointer, the pointed-to memory is not touched
      *  in any way.  Managing the pointer is the user's responsibilty.
      */
-    size_type erase(const key_type& k) { return data.erase(getKey(k)); }
+    size_type erase(const key_type& k) __attribute__ ((deprecated)) { return data.erase(getKey(k)); }
     /**
      *  Erases all elements in a %map.  Note that this function only
      *  erases the elements, and that if the elements themselves are
@@ -291,7 +291,7 @@ public:
      *  pointing to the sought after %pair.  If unsuccessful it returns the
      *  past-the-end ( @c end() ) iterator.
      */
-    iterator find(const key_type& k) { verifyParam(k); return data.find(getKey(k)); }
+    iterator find(const key_type& k) __attribute__ ((deprecated)) { verifyParam(k); return data.find(getKey(k)); }
     /**
      *  @brief Tries to locate an element in a %map.
      *  @param  k  Key of (key, value) %pair to be located.
@@ -303,7 +303,7 @@ public:
      *  iterator pointing to the sought after %pair. If unsuccessful it
      *  returns the past-the-end ( @c end() ) iterator.
      */
-    const_iterator find(const key_type& k) const { verifyParam(k); return data.find(getKey(k)); }
+    const_iterator find(const key_type& k) const __attribute__ ((deprecated)) { verifyParam(k); return data.find(getKey(k)); }
     /**
      *  @brief  Finds the number of elements with given key.
      *  @param  k  Key of (key, value) pairs to be located.
@@ -325,7 +325,7 @@ public:
      *
      *  Lookup requires logarithmic time.
      */
-    mapped_type& operator[](const key_type& k) { verifyParam(k); return data[getKey(k)]; }
+    mapped_type& operator[](const key_type& k) __attribute__ ((deprecated)) { verifyParam(k); return data[getKey(k)]; }
 
     /** Find a Parameter value in the set, and return its value as an integer
      * @param k - Parameter name
@@ -505,7 +505,33 @@ public:
         }
     }
 
-    /** Returns a new parameter object with parameters that match
+
+
+    /** Add a key value pair into the param object.
+     */
+    void insert(std::string key, std::string value, bool overwrite = true) {
+        if ( overwrite ) {
+            data[getKey(key)] = value;
+        }
+        else {
+            uint32_t id = getKey(key);
+            data.insert(std::make_pair(id, value));
+        }
+    }
+
+    void insert(const Params& params) {
+        data.insert(params.data.begin(), params.data.end());
+    }
+
+    std::set<std::string> getKeys() const {
+        std::set<std::string> ret;
+        for (const_iterator i = data.begin() ; i != data.end() ; ++i) {
+            ret.insert(keyMapReverse[i->first]);
+        }
+        return ret;
+    }
+    
+     /** Returns a new parameter object with parameters that match
      * the specified prefix.
      */
     Params find_prefix_params(std::string prefix) const {
@@ -514,7 +540,8 @@ public:
         for (const_iterator i = data.begin() ; i != data.end() ; ++i) {
             std::string key = keyMapReverse[i->first].substr(0, prefix.length());
             if (key == prefix) {
-                ret[keyMapReverse[i->first].substr(prefix.length())] = i->second;
+                // ret[keyMapReverse[i->first].substr(prefix.length())] = i->second;
+                ret.insert(keyMapReverse[i->first].substr(prefix.length()), i->second);
             }
         }
         ret.allowedKeys = allowedKeys;


### PR DESCRIPTION
Added new insertion functions to Params, as well as the
getKeys call.  These are intended to replace all the calls
the were designed to mimic std::map.  Additionally, marked
all the calls mimicking std:map as deprecated.