### PR TITLE
Fix a warning about mismatched delete calls

### DIFF
--- a/objectComms.h
+++ b/objectComms.h
@@ -211,7 +211,7 @@ void all_gather(const dataType& data, std::vector<dataType> &out_data) {
         Comms::deserialize(&bigBuff[displ[i]], allSizes[i], out_data[i]);
     }
 
-    delete bigBuff;
+    delete [] bigBuff;
 
 }
 


### PR DESCRIPTION
Fixes a compiler warning with regards to mismatched `delete` and `delete []`