### PR TITLE
Restores Core Configuration Options Removed during External-Core-ization

### DIFF
--- a/config/sst_enable_core_profile.m4
+++ b/config/sst_enable_core_profile.m4
@@ -1,0 +1,11 @@
+
+AC_DEFUN([SST_ENABLE_CORE_PROFILE], [
+
+  AC_ARG_ENABLE([profile],
+    [AS_HELP_STRING([--enable-profile],
+      [Enables performance profiling of core features.  Slight performance penalties incurred.])])
+
+  AS_IF([test "x$enable_profile" = "xyes" ],
+	[AC_DEFINE([__SST_ENABLE_PROFILE__], [1], [Defines if core should have profiling enabled.])])
+
+])

--- a/config/sst_enable_debug_output.m4
+++ b/config/sst_enable_debug_output.m4
@@ -1,0 +1,11 @@
+
+AC_DEFUN([SST_ENABLE_DEBUG_OUTPUT], [
+
+  AC_ARG_ENABLE([debug],
+    [AS_HELP_STRING([--enable-debug],
+      [Enables additional debug output to be compiled by components and the SST core.])])
+
+  AS_IF([test "x$enable_debug" = "xyes" ],
+	[AC_DEFINE([__SST_DEBUG_OUTPUT__], [1], [Defines additional debug output is to be printed])])
+
+])

--- a/config/sst_enable_event_tracking.m4
+++ b/config/sst_enable_event_tracking.m4
@@ -1,0 +1,12 @@
+
+AC_DEFUN([SST_ENABLE_DEBUG_EVENT_TRACKING], [
+  enable_debug_event_tracking="no"
+
+  AC_ARG_ENABLE([event-tracking], [AS_HELP_STRING([--enable-event-tracking],
+      [Enables additional tracking information for events and activities to help find memory leaks in event processing.  This adds information about first and last component to access the event.  This is a debug mode and will add significant memory usage to runs.])])
+
+  AS_IF([test "x$enable_event_tracking" = "xyes" ], [enable_debug_event_tracking="yes"])
+
+  AS_IF([test "$enable_debug_event_tracking" = "yes"], [AC_DEFINE([__SST_DEBUG_EVENT_TRACKING__], [1],
+              [Tracks extra information about events and activities.])])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,10 @@ SST_CHECK_PYTHON([], [AC_MSG_ERROR([Could not find Python, this is required for 
 SST_CHECK_LIBZ()
 SST_CHECK_MEM_POOL()
 
+SST_ENABLE_DEBUG_OUTPUT()
+SST_ENABLE_DEBUG_EVENT_TRACKING()
+SST_ENABLE_CORE_PROFILE()
+
 SST_CHECK_ZOLTAN([have_zoltan=1],[have_zoltan=0],[AC_MSG_ERROR([Zoltan requested but not found])])
 AS_IF([test "x$have_zoltan" = "x1"], [AC_DEFINE_UNQUOTED([HAVE_ZOLTAN], [1],
 	[Define if you have the Zoltan library.])])
@@ -116,7 +120,6 @@ AC_DEFINE_UNQUOTED([SST_BOOST_LIBDIR], ["$BOOST_LIBDIR"],
 	[Defines the LIBDIR needed to load dynamic libraries for Boost])
 
 AC_DEFINE([__STDC_FORMAT_MACROS], [1], [Defines that standard PRI macros should be enabled])
-
 
 AC_CACHE_SAVE
 


### PR DESCRIPTION
Restores:

- Core Debug Preprocessor Options (for `Output` class)
- Core Profiling
- Core Event Tracking
