### PR TITLE
Re-enable the --add-lib-path support

### DIFF
--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -171,6 +171,11 @@ public:
 		fullLibPath.append(envpath);
 	}
 
+    if ( !addlLibPath.empty() ) {
+        fullLibPath.append(":");
+        fullLibPath.append(addlLibPath);
+    }
+
 	if(verbose) {
 		std::cout << "SST-Core: Configuration Library Path will read from: " << fullLibPath << std::endl;
 	}


### PR DESCRIPTION
`--add-lib-path` support was accidentally dropped recently.  This patch restores it.
