### PR TITLE
Serialization

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -95,6 +95,7 @@ nobase_dist_sst_HEADERS = \
 	serialization/serialize.h \
 	serialization/serialize_array.h \
 	serialization/serialize_buffer_accessor.h \
+	serialization/serialize_deque.h \
 	serialization/serialize_list.h \
 	serialization/serialize_map.h \
 	serialization/serialize_packer.h \

--- a/src/sst/core/params.h
+++ b/src/sst/core/params.h
@@ -26,6 +26,9 @@
 #include <utility>
 #include <sst/core/threadsafe.h>
 
+#include <sst/core/serialization/serializable.h>
+#include <sst/core/serialization/serializer.h>
+
 int main(int argc, char *argv[]);
 
 namespace SST {
@@ -41,7 +44,7 @@ class ConfigGraph;
  *  For a @c map<Key,T> the key_type is Key, the mapped_type is T, and the
  *  value_type is std::pair<const Key,T>.
  */
-class Params {
+class Params : public SST::Core::Serialization::serializable {
 private:
     struct KeyCompare : std::binary_function<std::string, std::string, bool>
     {
@@ -444,6 +447,13 @@ public:
     }
 
 
+    void serialize_order(SST::Core::Serialization::serializer &ser) {
+        std::cout << "Params: starting serialization of data" << std::endl;
+        ser & data;
+        std::cout << "Params: done with serialization of data" << std::endl;
+    }    
+    
+    ImplementSerializable(SST::Params)
 
 private:
     std::map<uint32_t, std::string> data;
@@ -481,7 +491,6 @@ private:
     {
         ar & BOOST_SERIALIZATION_NVP(data);
     }
-
 
     /* Friend main() because it broadcasts the maps */
     friend int ::main(int argc, char *argv[]);

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -25,37 +25,47 @@ namespace Serialization {
 
 template <class T, class Enable = void>
 class serialize {
- public:
-  inline void operator()(T& t, serializer& ser){
-      // If the default gets called, then it's actually invalid
-      // because we don't know how to serialize it.
-
-      // This is a bit strange, but if I just do a
-      // static_assert(false) it always triggers, but if I use
-      // std::is_* then it seems to only trigger if something expands
-      // to this version of the template.
-      // static_assert(false,"Trying to serialize an object that is not serializable.");
-      static_assert(std::is_fundamental<T>::value,"Trying to serialize an object that is not serializable.");
-      static_assert(!std::is_fundamental<T>::value,"Trying to serialize an object that is not serializable.");
-  }
+public:
+    inline void operator()(T& t, serializer& ser){
+        // If the default gets called, then it's actually invalid
+        // because we don't know how to serialize it.
+        
+        // This is a bit strange, but if I just do a
+        // static_assert(false) it always triggers, but if I use
+        // std::is_* then it seems to only trigger if something expands
+        // to this version of the template.
+        // static_assert(false,"Trying to serialize an object that is not serializable.");
+        static_assert(std::is_fundamental<T>::value,"Trying to serialize an object that is not serializable.");
+        static_assert(!std::is_fundamental<T>::value,"Trying to serialize an object that is not serializable.");
+    }
 };
 
 template <class T>
 class serialize <T, typename std::enable_if<std::is_fundamental<T>::value || std::is_enum<T>::value>::type> {
- public:
-  inline void operator()(T& t, serializer& ser){
-      ser.primitive(t); 
-  }
+public:
+    inline void operator()(T& t, serializer& ser){
+        ser.primitive(t); 
+    }
+};
+
+// Maintains backward compatibility for now.  In the future, probably
+// need to do some error checking
+template <class U, class V>
+class serialize<std::pair<U,V> > {
+public:
+    inline void operator()(std::pair<U,V>& t, serializer& ser){
+        ser.primitive(t); 
+    }
 };
 
 template <>
 class serialize<bool> {
- public:
-  void operator()(bool &t, serializer& ser){
-    int bval = t;
-    ser.primitive(bval);
-    t = bool(bval);
-  }
+public:
+    void operator()(bool &t, serializer& ser){
+        int bval = t;
+        ser.primitive(bval);
+        t = bool(bval);
+    }
 };
 
 
@@ -70,6 +80,7 @@ operator&(serializer& ser, T& t){
 }
 
 #include <sst/core/serialization/serialize_array.h>
+#include <sst/core/serialization/serialize_deque.h>
 #include <sst/core/serialization/serialize_list.h>
 #include <sst/core/serialization/serialize_map.h>
 #include <sst/core/serialization/serialize_set.h>

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -23,8 +23,25 @@ namespace SST {
 namespace Core {
 namespace Serialization {
 
-template <class T>
+template <class T, class Enable = void>
 class serialize {
+ public:
+  inline void operator()(T& t, serializer& ser){
+      // If the default gets called, then it's actually invalid
+      // because we don't know how to serialize it.
+
+      // This is a bit strange, but if I just do a
+      // static_assert(false) it always triggers, but if I use
+      // std::is_* then it seems to only trigger if something expands
+      // to this version of the template.
+      // static_assert(false,"Trying to serialize an object that is not serializable.");
+      static_assert(std::is_fundamental<T>::value,"Trying to serialize an object that is not serializable.");
+      static_assert(!std::is_fundamental<T>::value,"Trying to serialize an object that is not serializable.");
+  }
+};
+
+template <class T>
+class serialize <T, typename std::enable_if<std::is_fundamental<T>::value || std::is_enum<T>::value>::type> {
  public:
   inline void operator()(T& t, serializer& ser){
       ser.primitive(t); 

--- a/src/sst/core/serialization/serialize_deque.h
+++ b/src/sst/core/serialization/serialize_deque.h
@@ -1,0 +1,66 @@
+// Copyright 2009-2016 Sandia Corporation. Under the terms
+// of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+// 
+// Copyright (c) 2009-2016, Sandia Corporation
+// All rights reserved.
+// 
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SERIALIZE_DEQUE_H
+#define SERIALIZE_DEQUE_H
+
+#include <deque>
+#include <sst/core/serialization/serializer.h>
+
+namespace SST {
+namespace Core {
+namespace Serialization {
+
+template <class T>
+class serialize<std::deque<T> > {
+  typedef std::deque<T> Deque;
+ 
+public:
+  void
+  operator()(Deque& v, serializer& ser) {
+      typedef typename std::set<T>::iterator iterator;
+      switch(ser.mode()) {
+      case serializer::SIZER: {
+          size_t size = v.size();
+          ser.size(size);
+          for (auto it = v.begin(); it != v.end(); ++it){
+              T& t = const_cast<T&>(*it); 
+              serialize<T>()(t,ser);
+          }
+          break;
+      }
+      case serializer::PACK: {
+          size_t size = v.size();
+          ser.pack(size);
+          for (auto it = v.begin(); it != v.end(); ++it){
+              T& t = const_cast<T&>(*it); 
+              serialize<T>()(t,ser);
+          }
+          break;
+      }
+      case serializer::UNPACK: {
+          size_t size;
+          ser.unpack(size);
+          for (int i=0; i < size; ++i){
+              T t;
+              serialize<T>()(t,ser);
+              v.push_back(t);
+          }
+          break;
+      }
+      }
+  }
+};
+
+}
+}
+}
+#endif // SERIALIZE_DEQUE_H

--- a/src/sst/core/serialization/serialize_serializable.h
+++ b/src/sst/core/serialization/serialize_serializable.h
@@ -101,15 +101,15 @@ case serializer::UNPACK:
   }  
 }
 
-template <>
-class serialize<serializable> {
- public:
-  void operator()(serializable& o, serializer& ser){
-    serializable* tmp = &o;
-    serialize_intrusive_ptr(tmp, ser);
-  }
+template <class T>
+class serialize <T, typename std::enable_if<std::is_base_of<SST::Core::Serialization::serializable,T>::value>::type> {
+public:
+    inline void operator()(T& t, serializer& ser){
+        // T* tmp = &t;
+        // serialize_intrusive_ptr(tmp, ser);
+        t.serialize_order(ser);
+    }
 };
-
 
 } 
 }

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -317,14 +317,14 @@ namespace SST {
 namespace Core {
 namespace Serialization {
 
-template <>
-class serialize <SST::UnitAlgebra> {
-public:
-    void
-    operator()(UnitAlgebra& v, SST::Core::Serialization::serializer& ser) {
-        v.serialize_order(ser);
-    }
-};
+// template <>
+// class serialize <SST::UnitAlgebra> {
+// public:
+//     void
+//     operator()(UnitAlgebra& v, SST::Core::Serialization::serializer& ser) {
+//         v.serialize_order(ser);
+//     }
+// };
 }
 }
 }


### PR DESCRIPTION
Added some extra checking into the serialization.  Old code would attempt to just treat any unknown object as a primitive and do a copy of size sizeof(T).  New code will fail at compile time if it doesn't know about how to serialize an object.  Also add new serialization to Params and added serialization for std::deque.