### PR TITLE
Added more serialization functionality.

### DIFF
--- a/src/sst/core/serialization/serializable.h
+++ b/src/sst/core/serialization/serializable.h
@@ -286,14 +286,20 @@ template<class T> const uint32_t serializable_builder_impl<T>::cls_id_
   = serializable_factory::add_builder(new serializable_builder_impl<T>,
        typeid(T).name());
 
+// Hold off on trivailly_serializable for now, as it's not really safe
+// in the case of inheritance
+//
+// class trivially_serializable {
+// };
+
 }  // namespace Serialization
 }  // namespace Core
 }  // namespace SST
 
 #define SerializableName(obj) #obj
 
-
 #define DeclareSerializable(obj)
+
 
 #include <sst/core/serialization/serialize_serializable.h>
 

--- a/src/sst/core/serialization/serialize_array.h
+++ b/src/sst/core/serialization/serialize_array.h
@@ -43,10 +43,20 @@ class ser_buffer_wrapper
 }
 
 template <class T, int N>
-class serialize<T[N]> {
+class serialize<T[N], typename std::enable_if<std::is_fundamental<T>::value || std::is_enum<T>::value>::type> {
  public:
   void operator()(T arr[N], serializer& ser){
     ser.array<T,N>(arr);
+  }
+};
+
+template <class T, int N>
+class serialize<T[N], typename std::enable_if<!std::is_fundamental<T>::value && !std::is_enum<T>::value>::type> {
+ public:
+  void operator()(T arr[N], serializer& ser){
+      for ( int i = 0; i < N; i++ ) {
+          serialize<T>()(arr[i],ser);
+      }
   }
 };
 

--- a/src/sst/core/serialization/serialize_serializable.h
+++ b/src/sst/core/serialization/serialize_serializable.h
@@ -59,7 +59,7 @@ operator()(serializable*& s, serializer& ser)
 
 
 template <class T>
-class serialize<T*> {
+class serialize<T*, typename std::enable_if<std::is_base_of<SST::Core::Serialization::serializable,T>::value>::type> {
  
 public:
 void
@@ -110,6 +110,18 @@ public:
         t.serialize_order(ser);
     }
 };
+
+// Hold off on trivailly_serializable for now, as it's not really safe
+// in the case of inheritance
+//
+// template <class T>
+// class serialize <T, typename std::enable_if<std::is_base_of<SST::Core::Serialization::trivially_serializable,T>::value>::type> {
+// public:
+//     inline void operator()(T& t, serializer& ser){
+//         ser.primitive(t);
+//     }
+// };
+
 
 } 
 }


### PR DESCRIPTION
The following changes were made:
- serializing a std::pair will now serialize each part
  independently.
- Can now serialize pointers to values satisfying
  is_fundamental || is_enum.  Could already serialize
  pointers to serializable, but this is now a
  separate expansion.
- Serialization of statically sized arrays will now work
  for anything that is serializable (used to only work
  for base types).