### PR TITLE
Change Statistics shutdown per issue #61

### DIFF
--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -243,11 +243,6 @@ public:
     template <typename T>
     Statistic<T>* registerStatistic(std::string statName, std::string statSubId = "")
     {
-        // // NOTE: Templated Code for implementation of Statistic Registration
-        // // is in the componentregisterstat_impl.h file.  This was done
-        // // to avoid code bloat in the .h file.  
-        // #include "sst/core/statapi/componentregisterstat_impl.h"
-
         // Verify here that name of the stat is one of the registered
         // names of the component's ElementInfoStatistic.  
         if (false == doesComponentInfoStatisticExist(statName)) {

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -316,17 +316,14 @@ static void start_simulation(uint32_t tid, SimThreadInfo_t &info, Core::ThreadSa
         barrier.wait();
     // fprintf(stderr, "thread %u release from run finish barrier\n", tid);
 
+        sim->finish();
+    // fprintf(stderr, "thread %u waiting on finish() finish barrier\n", tid);
+        barrier.wait();
+    // fprintf(stderr, "thread %u release from finish() finish barrier\n", tid);
 
         // Tell the Statistics Output that the simulation is finished
         if ( 0 == info.myRank.thread )
             Simulation::signalStatisticsEnd();
-
-    // fprintf(stderr, "thread %u waiting on statEnd finish barrier\n", tid);
-        barrier.wait();
-    // fprintf(stderr, "thread %u release from statEnd finish barrier\n", tid);
-
-        sim->finish();
-
     }
 
     barrier.wait();

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -757,10 +757,6 @@ void Simulation::run() {
     barrier.wait();  // TODO<- Is this needed?
     // fprintf(stderr, "thread %u released from runLoop finish barrier\n", my_rank.thread);
     if (num_ranks.rank != 1 && num_ranks.thread == 0) delete m_exit;
-
-
-    // Tell the Statistics Engine that the simulation is ending
-    statisticsEngine->endOfSimulation();
 }
 
 
@@ -825,6 +821,8 @@ void Simulation::finish() {
                 my_rank.rank, my_rank.thread);
     }
 
+    // Tell the Statistics Engine that the simulation is ending
+    statisticsEngine->endOfSimulation();
 }
 
 const SimTime_t&


### PR DESCRIPTION
Move the shutdown at end of simulation::finish() instead of at end of
simulation::run().  Also cleaned up statistic’s debris code in
component.h