### PR TITLE
Remove extra (unguarded) #include of mpi.h

### DIFF
--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -55,8 +55,6 @@
 #include <sst/core/cfgoutput/xmlConfigOutput.h>
 #include <sst/core/cfgoutput/jsonConfigOutput.h>
 
-#include <mpi.h>
-
 using namespace SST::Core;
 using namespace SST::Partition;
 using namespace std;


### PR DESCRIPTION
Don't want/need extra #include of MPI, especially when MPI is disabled.