### PR TITLE
Call component destructors when owning simulation is destroyed

### DIFF
--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -20,6 +20,7 @@ namespace SST {
 
 ComponentInfo::~ComponentInfo() {
     delete link_map;
+    delete component;
 }
 
 } // namespace SST

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -145,6 +145,14 @@ public:
     bool empty() {
         return dataByName.empty();
     }
+
+    void clear() {
+        for ( auto i : dataByName ) {
+            delete i; 
+        }
+        dataByName.clear();
+        dataByID.clear();
+    }
 };
     
 } //namespace SST

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -92,6 +92,9 @@ Simulation::~Simulation()
     
     // OneShots already got deleted by timeVortex, simply clear the onsShotMap
     oneShotMap.clear();
+
+    // Clear out Components
+    compInfoMap.clear();
     
     // // Delete any remaining links.  This should never happen now, but
     // // when we add an API to have components build subcomponents, user


### PR DESCRIPTION
Attempt to fix #126.  Delete components when Simulation is destroyed.  (Thus, calling destructors of components.)

