### PR TITLE
Remove redundant "--output-directory" in config.cc

### DIFF
--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -148,18 +148,16 @@ Config::Config(RankInfo rankInfo)
          "Controls where SST will place output files including debug output and simulation statistics, default is for SST to create a unique directory.")
         ("output-dot", po::value <string >(&output_dot),
          "Dump the SST component and link graph to this file in DOT-format, empty string (default) is not to dump anything.")
-        ("output-directory", po::value <string >(&output_directory),
-         "Controls where SST will place output files including debug output and simulation statistics, default is for SST to create a unique directory.")
-    ("num_threads,n", po::value <uint32_t>(&world_size.thread),
-     "Number of parallel threads to use per rank.")
+        ("num_threads,n", po::value <uint32_t>(&world_size.thread),
+         "Number of parallel threads to use per rank.")
 #ifdef SST_CONFIG_HAVE_PYTHON
         ("model-options", po::value< string >(&model_options),
          "Provide options to the SST Python scripting engine (default is to provide no script options)")
 #endif
         ("output-partition", po::value< string >(&dump_component_graph_file),
          "Dump the component partition to this file (default is not to dump information)")
-	("output-prefix-core", po::value< string >(&output_core_prefix),
-	 "Sets the SST::Output prefix for the core during execution")
+        ("output-prefix-core", po::value< string >(&output_core_prefix),
+         "Sets the SST::Output prefix for the core during execution")
 #ifdef USE_MEMPOOL
         ("output-undeleted-events", po::value<string>(&event_dump_file),
          "Outputs information about all undeleted events to the specified file at end of simulation (STDOUT and STDERR can be used to output to console on stdout and stderr")


### PR DESCRIPTION
There are 2 "output-directory" options in *config.cc* file (line 147 and line 151), which would result an error when running something like *sst foo.py --output-directory bar/*

> Error: option '--output-directory' is ambiguous and matches different versions of '--output-directory'

Removing one of them would eliminate this error.

Also fixed some indentation along the way...