### PR TITLE
Fix printing incorrect directory when a directory cannot be opened

### DIFF
--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -234,7 +234,7 @@ void processSSTElementFiles(std::string searchPath)
             closedir(pDir);
         } else {
             // Failed to open the directory for some reason
-            fprintf(stderr, "ERROR: %s - When trying to open Directory %s\n", strerror(errno), targetDir.c_str());
+            fprintf(stderr, "ERROR: %s - When trying to open Directory %s\n", strerror(errno), searchDir.c_str());
         }
     
     } while (foundIndex != std::string::npos);


### PR DESCRIPTION
sst-info was printing out the previous directory tested, rather than the current directory tested, when such directory could not be found.