### PR TITLE
Add SST Configuration File Locking when Reading/Registering

### DIFF
--- a/src/sst/core/env/envconfig.cc
+++ b/src/sst/core/env/envconfig.cc
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <cstdlib>
 #include <cstdio>
+#include <sys/file.h>
 
 //SST::Core::Environment::EnvironmentConfigGroup(std::string gName) {
 //	groupName(gName);
@@ -124,10 +125,22 @@ void SST::Core::Environment::EnvironmentConfiguration::print() {
 void SST::Core::Environment::EnvironmentConfiguration::writeTo(std::string filePath) {
 	FILE* output = fopen(filePath.c_str(), "w+");
 
+	if(NULL == output) {
+		fprintf(stderr, "Unable to open file: %s\n", filePath.c_str());
+		exit(-1);
+	}
+
+	const int outputFD = fileno(output);
+
+	// Lock the file because we are going to write it out (this should be
+	// exclusive since no one else should muck with it)
+	flock(outputFD, LOCK_EX);
+
 	for(auto groupItr = groups.begin(); groupItr != groups.end(); groupItr++) {
 		groupItr->second->writeTo(output);
 	}
 
+	flock(outputFD, LOCK_UN);
 	fclose(output);
 }
 

--- a/src/sst/core/env/envquery.cc
+++ b/src/sst/core/env/envquery.cc
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <cstring>
 #include <string>
+#include <sys/file.h>
 
 #include "envquery.h"
 #include "envconfig.h"
@@ -37,6 +38,11 @@ void SST::Core::Environment::configReadLine(FILE* theFile, char* lineBuffer) {
 }
 
 void SST::Core::Environment::populateEnvironmentConfig(FILE* configFile, EnvironmentConfiguration* cfg, bool errorOnNotOpen) {
+
+	// Get the file descriptor and lock the file using a shared lock so
+	// people don't come and change it from under us
+	int configFileFD = fileno(configFile);
+	flock(configFileFD, LOCK_SH);
 
 	constexpr size_t maxBufferLength = 4096;
 	char* lineBuffer = (char*) malloc(sizeof(char) * maxBufferLength);
@@ -86,6 +92,8 @@ void SST::Core::Environment::populateEnvironmentConfig(FILE* configFile, Environ
 		}
 	}
 
+	// Unlock since we are done processing it
+	flock(configFileFD, LOCK_UN);
 	free(lineBuffer);
 }
 


### PR DESCRIPTION
Add SST Configuration File Locking when Reading/Registering (`sst-register` and `sst` now use exclusive and shared file locks respectively to prevent simultaneous updating while other operations are in flight). These are blocking lock calls to ensure operations are queued up on the configuration files to execute cleanly.
