### PR TITLE
[sstinfo] Should not return when a file within a directory cannot be …

### DIFF
--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -184,7 +184,7 @@ void processSSTElementFiles(std::string searchPath)
                 } else {
                     // Failed to open the directory for some reason
                     fprintf(stderr, "ERROR: %s - Unable to get stat info on Directory Entry %s\n", strerror(errno), dirEntryPath.c_str());
-                    return;
+                    continue;
                 }
                 
                 for (x = 0; x < g_configuration.getElementsToProcessArray()->size(); x++) {


### PR DESCRIPTION
sstinfo was returning (and thus, stopping processing of directories) as soon as any file or directory failed on a 'stat' call.  This can occur if there is a dead symlink.

Change from 'return' to 'continue', to allow additional processing.