### PR TITLE
Added ability to specify multiple addresses in the simpleMem interface

### DIFF
--- a/src/sst/core/interfaces/simpleMem.h
+++ b/src/sst/core/interfaces/simpleMem.h
@@ -76,38 +76,36 @@ public:
         typedef std::vector<uint8_t> dataVec;
 
         Command cmd;        /*!< Command to issue */
-        Addr addr;          /*!< Target address */
+        std::vector<Addr> addrs; /*!< Target address(es) */
+        Addr addr;          /*!< Target address - DEPRECATED but included for backward compatibility, defaults to addrs[0] */
         size_t size;        /*!< Size of this request or response */
         dataVec data;       /*!< Payload data (for Write, or ReadResp) */
         flags_t flags;      /*!< Flags associated with this request or response */
         flags_t memFlags;   /*!< Memory flags - ignored by caches except to be passed through with request to main memory */
         id_t id;            /*!< Unique ID to identify responses with requests */
-        uint32_t groupId;   /* Group Id.  Used to maintain group-based stats in MH */
 	Addr instrPtr;      /*!< Instruction pointer associated with the operation */
         Addr virtualAddr;   /*!< Virtual address associated with the operation */
 
         /** Constructor */
         Request(Command cmd, Addr addr, size_t size, dataVec &data, flags_t flags = 0, flags_t memFlags = 0) :
-            cmd(cmd), addr(addr), size(size), data(data), flags(flags), memFlags(memFlags), groupId(0),
+            cmd(cmd), addr(addr), size(size), data(data), flags(flags), memFlags(memFlags),
 		instrPtr(0), virtualAddr(0)
         {
+            addrs.push_back(addr);
             id = main_id++;
         }
 
         /** Constructor */
         Request(Command cmd, Addr addr, size_t size, flags_t flags = 0, flags_t memFlags = 0) :
-            cmd(cmd), addr(addr), size(size), flags(flags), memFlags(memFlags), groupId(0),
+            cmd(cmd), addr(addr), size(size), flags(flags), memFlags(memFlags),
 		instrPtr(0), virtualAddr(0)
         {
+            addrs.push_back(addr);
             id = main_id++;
         }
 
-        /**
-         * Set Stats Group Id
-         */
-        void setGroupId(uint32_t _groupId)
-        {
-            groupId = _groupId;
+        void addAddress(Addr addr) {
+            addrs.push_back(addr);
         }
 
         /**


### PR DESCRIPTION
For memory accesses that have a src and dst or multiple src/dst
Also removed the unused groupId which was used for statistics