### PR TITLE
[fix] do not crash when bad options are passed

### DIFF
--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -205,10 +205,11 @@ bool Config::usage() {
 int
 Config::parseCmdLine(int argc, char* argv[]) {
     static const char* sst_short_options = "hvVn:";
-    struct option sst_long_options[nLongOpts];
+    struct option sst_long_options[nLongOpts + 1];
     for ( size_t i = 0 ; i < nLongOpts ; i++ ) {
         sst_long_options[i] = sstOptions[i].opt;
     }
+    sst_long_options[nLongOpts] = {NULL, 0 ,0, 0};
 
     run_name = argv[0];
 


### PR DESCRIPTION
SST was crashing when bad options were passed on the commandline.   Was missing a 'null-row' in the LongOpts.