### PR TITLE
update version data in configure.ac and display of sst --version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 
 
-AC_INIT([SSTCore], [Under-Development], [sst@sandia.gov])
+AC_INIT([SSTCore], [-dev], [sst@sandia.gov])
 
 AC_PREREQ([2.59])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 
 
-AC_INIT([SSTCore], [6.0.0], [sst@sandia.gov])
+AC_INIT([SSTCore], [Under-Development], [sst@sandia.gov])
 
 AC_PREREQ([2.59])
 
@@ -120,18 +120,25 @@ AC_DEFINE_UNQUOTED([SST_BOOST_LIBDIR], ["$BOOST_LIBDIR"],
 
 AC_DEFINE([__STDC_FORMAT_MACROS], [1], [Defines that standard PRI macros should be enabled])
 
-AC_MSG_CHECKING([for SST-Core Git Head SHA and Commit Count])
+AC_MSG_CHECKING([for SST-Core Git Branch, Head SHA and Commit Count])
 if test -d ".git" ; then
+    SSTCORE_GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+    AC_MSG_RESULT([${SSTCORE_GIT_BRANCH}])
     SSTCORE_GIT_HEADSHA=`git rev-parse HEAD`
     AC_MSG_RESULT([${SSTCORE_GIT_HEADSHA}])
 	SSTCORE_GIT_COMMITCOUNT=`git rev-list HEAD | wc -l | sed -e 's/^ *//g'`
 	AC_MSG_RESULT([${SSTCORE_GIT_COMMITCOUNT}])
 else
+    SSTCORE_GIT_BRANCH="N/A"
+    AC_MSG_RESULT([${SSTCORE_GIT_BRANCH}])
     SSTCORE_GIT_HEADSHA="${PACKAGE_VERSION}"
     AC_MSG_RESULT([${SSTCORE_GIT_HEADSHA}])
 	SSTCORE_GIT_COMMITCOUNT="0"
 	AC_MSG_RESULT([${SSTCORE_GIT_COMMITCOUNT}])
 fi
+
+AC_SUBST(SSTCORE_GIT_BRANCH)
+AC_DEFINE_UNQUOTED([SSTCORE_GIT_BRANCH], ["$SSTCORE_GIT_BRANCH"], [SST-Core Git Branch])
 
 AC_SUBST(SSTCORE_GIT_HEADSHA)
 AC_DEFINE_UNQUOTED([SSTCORE_GIT_HEADSHA], ["$SSTCORE_GIT_HEADSHA"], [SST-Core Git Head SHA])
@@ -169,10 +176,11 @@ echo "Build Environment:"
 echo ""
 printf "%38s : %s\n" "SST-Core Version" "$PACKAGE_VERSION"
 if test "x$SSTCORE_GIT_HEADSHA" != "x$PACKAGE_VERSION"; then
+printf "%38s : %s\n" "Git Branch" "$SSTCORE_GIT_BRANCH"
 printf "%38s : %s\n" "Git HEAD SHA" "$SSTCORE_GIT_HEADSHA"
 printf "%38s : %s\n" "Branch Commit Count" "$SSTCORE_GIT_COMMITCOUNT"
 else 
-printf "%38s : %s\n" "Release Package" "For SST-Core $PACKAGE_VERSION"
+printf "%38s : %s\n" "Version" "SST-Core $PACKAGE_VERSION"
 fi
 printf "%38s : %s\n" "Prefix" "$prefix"
 printf "%38s : %s\n" "Preprocessor" "$CPP"

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -293,9 +293,11 @@ bool Config::setConfigEntryFromModel(const string &entryName, const string &valu
 
 
 bool Config::printVersion() {
-    printf("SST-Core Release Version (" PACKAGE_VERSION);
-    if (SSTCORE_GIT_HEADSHA != PACKAGE_VERSION)
-        printf(", Branch SHA: " SSTCORE_GIT_HEADSHA );
+    printf("SST-Core Version (" PACKAGE_VERSION);
+    if (SSTCORE_GIT_HEADSHA != PACKAGE_VERSION) { 
+        printf(", git branch : " SSTCORE_GIT_BRANCH);
+        printf(", SHA: " SSTCORE_GIT_HEADSHA);
+    }
     printf(")\n");
 
     return false; /* Should not continue */


### PR DESCRIPTION
Update version data in sst-elements to indicate that the version is coming from github not from a release.  This is related to sst-core issue#177.