### PR TITLE
Graph Output tweaks

### DIFF
--- a/src/sst/core/cfgoutput/dotConfigOutput.cc
+++ b/src/sst/core/cfgoutput/dotConfigOutput.cc
@@ -24,41 +24,40 @@ DotConfigGraphOutput::DotConfigGraphOutput(const char* path) :
 void DotConfigGraphOutput::generate(const Config* cfg,
                 ConfigGraph* graph) throw(ConfigGraphOutputException) {
 
-	if(NULL == outputFile) {
+	if ( NULL == outputFile ) {
 		throw ConfigGraphOutputException("Output file is not open for writing");
 	}
 
 	fprintf(outputFile, "graph \"sst_simulation\" {\n");
-	fprintf(outputFile, "\tnode [shape=record] ;\n");
+	fprintf(outputFile, "\tnewrank = true;\n");
+	fprintf(outputFile, "\tnode [shape=record];\n");
 
-	uint32_t maxRank = 0;
 	const auto compMap = graph->getComponentMap();
 	const auto linkMap = graph->getLinkMap();
 
 	// Find the maximum rank which is marked for the graph partitioning
-	for(auto compItr = compMap.begin(); compItr != compMap.end(); compItr++) {
-		maxRank = (compItr->rank.rank > maxRank) ? compItr->rank.rank : maxRank;
-	}
 
-	if( maxRank > 0 ) {
-		for( uint32_t r = 0; r <= maxRank; r++ ) {
-			fprintf(outputFile, "subgraph cluster %u {\n", r);
+    for ( uint32_t r = 0; r < cfg->world_size.rank ; r++ ) {
+        fprintf(outputFile, "\tsubgraph cluster_%u {\n", r);
+        fprintf(outputFile, "\t\tlabel=\"Rank %u\";\n", r);
 
-			for(auto compItr = compMap.begin(); compItr != compMap.end(); compItr++) {
-				if( compItr->rank.rank == r ) {
-					fprintf(outputFile, "\t\t");
-					generateDot( *compItr, linkMap );
-				}
-			}
-		}
-	} else {
-		for(auto compItr = compMap.begin(); compItr != compMap.end(); compItr++) {
-			fprintf(outputFile, "\t");
-			generateDot( *compItr, linkMap );
-		}
-	}
+        for ( uint32_t t = 0 ; t < cfg->world_size.thread ; t++ ) {
+            fprintf(outputFile, "\t\tsubgraph cluster_%u_%u {\n", r, t);
+            fprintf(outputFile, "\t\t\tlabel=\"Thread %u\";\n", t);
 
-	for(auto linkItr = linkMap.begin(); linkItr != linkMap.end(); linkItr++) {
+            for ( auto compItr : compMap ) {
+                if ( compItr.rank.rank == r && compItr.rank.thread == t ) {
+                    fprintf(outputFile, "\t\t\t\t");
+                    generateDot( compItr, linkMap );
+                }
+            }
+            fprintf(outputFile, "\t\t};\n");
+        }
+        fprintf(outputFile, "\t};\n");
+    }
+
+    fprintf(outputFile, "\n");
+	for ( auto linkItr = linkMap.begin(); linkItr != linkMap.end(); linkItr++ ) {
 		fprintf(outputFile, "\t");
 		generateDot( *linkItr );
 	}
@@ -69,29 +68,24 @@ void DotConfigGraphOutput::generate(const Config* cfg,
 void DotConfigGraphOutput::generateDot(const ConfigComponent& comp,
 	const ConfigLinkMap_t& linkMap) const {
 
-	fprintf(outputFile, "%" PRIu64 " [label=\"{%s\\n%s | {",
+	fprintf(outputFile, "%" PRIu64 " [label=\"{%s\\n%s",
 		(uint64_t) comp.id, comp.name.c_str(), comp.type.c_str());
 
-	for(auto linkItr = linkMap.begin(); linkItr != linkMap.end(); linkItr++) {
-		const ConfigLink& link = *linkItr;
+    for(LinkId_t i : comp.links) {
+        const ConfigLink &link = linkMap[i];
+        const int port = (link.component[0] == comp.id) ? 0 : 1;
 
-		const int port = (link.component[0] == comp.id) ? 0 : 1;
-		fprintf(outputFile, " < %s > %s", link.port[port].c_str(),
-			link.port[port].c_str());
-
-		if( (linkItr + 1) != linkMap.end() ) {
-			fprintf(outputFile, " |");
-		}
-	}
-
-	fprintf(outputFile, " } }\"];\n");
+        fprintf(outputFile, " | < %s > Port: %s", link.port[port].c_str(), link.port[port].c_str());
+    }
+    fprintf(outputFile, " }\"];\n");
 }
 
 void DotConfigGraphOutput::generateDot(const ConfigLink& link) const {
 
-	fprintf(outputFile, "%" PRIu64 ":\"%s\" -- %" PRIu64
-		":%s [label=\"%s\"]; \n",
+    int minLatIdx = (link.latency[0] <= link.latency[1]) ? 0 : 1;
+	fprintf(outputFile, "%" PRIu64 ":\"%s\" -- %" PRIu64 ":\"%s\" [label=\"%s\\n%s\"]; \n",
 		(uint64_t) link.component[0], link.port[0].c_str(),
 		(uint64_t) link.component[1], link.port[1].c_str(),
-		link.name.c_str());
+		link.name.c_str(),
+        link.latency_str[minLatIdx].c_str());
 }

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -152,6 +152,12 @@ static void do_graph_wireup(ConfigGraph* graph,
                 myRank.rank, myRank.thread);
     }
 
+    sim->performWireUp( *graph, myRank, min_part );
+
+}
+
+
+static void doGraphOutput(SST::Config *cfg, ConfigGraph *graph) {
     std::vector<ConfigGraphOutput*> graphOutputs;
 
     // User asked us to dump the config graph to a file in Python
@@ -178,11 +184,7 @@ static void do_graph_wireup(ConfigGraph* graph,
         graphOutputs[i]->generate(cfg, graph);
         delete graphOutputs[i];
     }
-
-    sim->performWireUp( *graph, myRank, min_part );
-
 }
-
 
 
 typedef struct {
@@ -510,6 +512,7 @@ main(int argc, char *argv[])
 
         // Output the partition information is user requests it
         dump_partition(cfg, graph, world_size);
+        doGraphOutput(&cfg, graph);
     }
 
     ////// End Partitioning //////


### PR DESCRIPTION
Tweak `main()` to only do the Graph Config outputs (for example json, dot, etc) only on a single MPI rank, to avoid overwrites.

Tweak the Dot graph config output to designate Threads as subgraphs (in addition to Ranks), and to add latency to edge labels.