### PR TITLE
Ports on Subcomponents

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -23,6 +23,7 @@ nobase_dist_sst_HEADERS = \
 	action.h \
 	activity.h \
 	clock.h \
+	baseComponent.h \
 	component.h \
 	componentInfo.h \
 	config.h \
@@ -140,6 +141,7 @@ nobase_nodist_sst_HEADERS = \
 sst_core_sources = \
 	action.cc \
 	clock.cc \
+	baseComponent.cc \
 	component.cc \
 	componentInfo.cc \
 	config.cc \

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -276,6 +276,7 @@ BaseComponent::loadModuleWithComponent(std::string type, Component* comp, Params
 SubComponent*
 BaseComponent::loadSubComponent(std::string type, Component* comp, Params& params)
 {
+    /* Old Style SubComponents end up with their parent's Id, name, etc. */
     ComponentInfo *sub_info = new ComponentInfo(type, &params, comp->my_info);
     ComponentInfo *oldLoadingSubCopmonent = getTrueComponent()->currentlyLoadingSubComponent;
     /* By "magic", the new component will steal ownership of this pointer */

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -276,12 +276,12 @@ BaseComponent::loadModuleWithComponent(std::string type, Component* comp, Params
 SubComponent*
 BaseComponent::loadSubComponent(std::string type, Component* comp, Params& params)
 {
-    ComponentInfo *oldLoadingSubCopmonent = currentlyLoadingSubComponent;
+    ComponentInfo *oldLoadingSubCopmonent = getTrueComponent()->currentlyLoadingSubComponent;
     /* By "magic", the new component will steal ownership of this pointer */
-    currentlyLoadingSubComponent = new ComponentInfo(comp->my_info->getID(), comp->getName(), type, &params, comp->my_info->getLinkMap());
-    currentlyLoadingSubComponent->setStatEnablement(comp->my_info->getStatEnableList(), comp->my_info->getStatParams());
+    currentlyLoadingSubComponent = new ComponentInfo(type, &params, comp->my_info);
+
     SubComponent* ret = Factory::getFactory()->CreateSubComponent(type,comp,params);
-    currentlyLoadingSubComponent = oldLoadingSubCopmonent;
+    getTrueComponent()->currentlyLoadingSubComponent = oldLoadingSubCopmonent;
     return ret;
 }
 
@@ -298,11 +298,8 @@ BaseComponent::loadNamedSubComponent(std::string name, Params& params)
     auto infoItr = my_info->getSubComponents().find(name);
     if ( infoItr == my_info->getSubComponents().end() ) return NULL;
 
-    ComponentInfo *oldLoadingSubCopmonent = currentlyLoadingSubComponent;
+    ComponentInfo *oldLoadingSubCopmonent = getTrueComponent()->currentlyLoadingSubComponent;
     currentlyLoadingSubComponent = &(infoItr->second);
-
-    /* TODO:  Get subcomponent stat enablement */
-    currentlyLoadingSubComponent->setStatEnablement(my_info->getStatEnableList(), my_info->getStatParams());
 
     Params myParams;
     if ( currentlyLoadingSubComponent->getParams() != NULL )
@@ -311,8 +308,7 @@ BaseComponent::loadNamedSubComponent(std::string name, Params& params)
 
     SubComponent* ret = Factory::getFactory()->CreateSubComponent(currentlyLoadingSubComponent->getType(), getTrueComponent(), myParams);
 
-    // currentlyLoadingSubComponent->clearStatEnablement(); Don't clear - assumptions are different for subcomponents
-    currentlyLoadingSubComponent = oldLoadingSubCopmonent;
+    getTrueComponent()->currentlyLoadingSubComponent = oldLoadingSubCopmonent;
     return ret;
 }
 

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -10,21 +10,21 @@
 // distribution.
 
 #include <sst_config.h>
-#include "sst/core/component.h"
-#include "sst/core/unitAlgebra.h"
 
 #include <string>
 
-//#include "sst/core/event.h"
-#include "sst/core/exit.h"
-#include "sst/core/factory.h"
-#include "sst/core/link.h"
-#include "sst/core/linkMap.h"
-#include "sst/core/simulation.h"
-#include "sst/core/timeConverter.h"
-#include "sst/core/timeLord.h"
-#include "sst/core/unitAlgebra.h"
-#include "sst/core/sharedRegion.h"
+#include <sst/core/basecomponent.h>
+#include <sst/core/component.h>
+#include <sst/core/subcomponent.h>
+#include <sst/core/unitAlgebra.h>
+#include <sst/core/factory.h>
+#include <sst/core/link.h>
+#include <sst/core/linkMap.h>
+#include <sst/core/simulation.h>
+#include <sst/core/timeConverter.h>
+#include <sst/core/timeLord.h>
+#include <sst/core/unitAlgebra.h>
+#include <sst/core/sharedRegion.h>
 
 using namespace SST::Statistics;
 
@@ -281,6 +281,7 @@ BaseComponent::loadSubComponent(std::string type, Component* comp, Params& param
     currentlyLoadingSubComponent = new ComponentInfo(type, &params, comp->my_info);
 
     SubComponent* ret = Factory::getFactory()->CreateSubComponent(type,comp,params);
+    currentlyLoadingSubComponent->setComponent(ret);
     getTrueComponent()->currentlyLoadingSubComponent = oldLoadingSubCopmonent;
     return ret;
 }
@@ -307,6 +308,7 @@ BaseComponent::loadNamedSubComponent(std::string name, Params& params)
     myParams.insert(params);
 
     SubComponent* ret = Factory::getFactory()->CreateSubComponent(currentlyLoadingSubComponent->getType(), getTrueComponent(), myParams);
+    currentlyLoadingSubComponent->setComponent(ret);
 
     getTrueComponent()->currentlyLoadingSubComponent = oldLoadingSubCopmonent;
     return ret;

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -276,12 +276,13 @@ BaseComponent::loadModuleWithComponent(std::string type, Component* comp, Params
 SubComponent*
 BaseComponent::loadSubComponent(std::string type, Component* comp, Params& params)
 {
+    ComponentInfo *sub_info = new ComponentInfo(type, &params, comp->my_info);
     ComponentInfo *oldLoadingSubCopmonent = getTrueComponent()->currentlyLoadingSubComponent;
     /* By "magic", the new component will steal ownership of this pointer */
-    currentlyLoadingSubComponent = new ComponentInfo(type, &params, comp->my_info);
+    getTrueComponent()->currentlyLoadingSubComponent = sub_info;
 
     SubComponent* ret = Factory::getFactory()->CreateSubComponent(type,comp,params);
-    currentlyLoadingSubComponent->setComponent(ret);
+    sub_info->setComponent(ret);
     getTrueComponent()->currentlyLoadingSubComponent = oldLoadingSubCopmonent;
     return ret;
 }
@@ -300,15 +301,16 @@ BaseComponent::loadNamedSubComponent(std::string name, Params& params)
     if ( infoItr == my_info->getSubComponents().end() ) return NULL;
 
     ComponentInfo *oldLoadingSubCopmonent = getTrueComponent()->currentlyLoadingSubComponent;
-    currentlyLoadingSubComponent = &(infoItr->second);
+    ComponentInfo *sub_info = &(infoItr->second);
+    getTrueComponent()->currentlyLoadingSubComponent = sub_info;
 
     Params myParams;
-    if ( currentlyLoadingSubComponent->getParams() != NULL )
-        myParams.insert(*currentlyLoadingSubComponent->getParams());
+    if ( sub_info->getParams() != NULL )
+        myParams.insert(*sub_info->getParams());
     myParams.insert(params);
 
-    SubComponent* ret = Factory::getFactory()->CreateSubComponent(currentlyLoadingSubComponent->getType(), getTrueComponent(), myParams);
-    currentlyLoadingSubComponent->setComponent(ret);
+    SubComponent* ret = Factory::getFactory()->CreateSubComponent(sub_info->getType(), getTrueComponent(), myParams);
+    sub_info->setComponent(ret);
 
     getTrueComponent()->currentlyLoadingSubComponent = oldLoadingSubCopmonent;
     return ret;

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -1,0 +1,321 @@
+// Copyright 2009-2016 Sandia Corporation. Under the terms
+// of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2016, Sandia Corporation
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include <sst_config.h>
+#include "sst/core/component.h"
+#include "sst/core/unitAlgebra.h"
+
+#include <string>
+
+//#include "sst/core/event.h"
+#include "sst/core/exit.h"
+#include "sst/core/factory.h"
+#include "sst/core/link.h"
+#include "sst/core/linkMap.h"
+#include "sst/core/simulation.h"
+#include "sst/core/timeConverter.h"
+#include "sst/core/timeLord.h"
+#include "sst/core/unitAlgebra.h"
+#include "sst/core/sharedRegion.h"
+
+using namespace SST::Statistics;
+
+namespace SST {
+
+BaseComponent::BaseComponent() :
+    defaultTimeBase(NULL), my_info(NULL),
+    sim(Simulation::getSimulation()),
+    currentlyLoadingSubComponent(NULL)
+{
+}
+
+
+BaseComponent::~BaseComponent()
+{
+}
+
+
+
+TimeConverter* BaseComponent::registerClock( std::string freq, Clock::HandlerBase* handler, bool regAll) {
+    TimeConverter* tc = getSimulation()->registerClock(freq,handler);
+
+    // if regAll is true set tc as the default for the component and
+    // for all the links
+    if ( regAll ) {
+        LinkMap* myLinks = my_info->getLinkMap();
+        if (NULL != myLinks) {
+            for ( std::pair<std::string,Link*> p : myLinks->getLinkMap() ) {
+                if ( NULL == p.second->getDefaultTimeBase() ) {
+                    p.second->setDefaultTimeBase(tc);
+                }
+            }
+        }
+	defaultTimeBase = tc;
+    }
+    return tc;
+}
+
+TimeConverter* BaseComponent::registerClock( const UnitAlgebra& freq, Clock::HandlerBase* handler, bool regAll) {
+    TimeConverter* tc = getSimulation()->registerClock(freq,handler);
+
+    // if regAll is true set tc as the default for the component and
+    // for all the links
+    if ( regAll ) {
+        LinkMap* myLinks = my_info->getLinkMap();
+        if (NULL != myLinks) {
+            for ( std::pair<std::string,Link*> p : myLinks->getLinkMap() ) {
+                if ( NULL == p.second->getDefaultTimeBase() ) {
+                    p.second->setDefaultTimeBase(tc);
+                }
+            }
+        }
+	defaultTimeBase = tc;
+    }
+    return tc;
+}
+
+Cycle_t BaseComponent::reregisterClock( TimeConverter* freq, Clock::HandlerBase* handler) {
+    return getSimulation()->reregisterClock(freq,handler);
+}
+
+Cycle_t BaseComponent::getNextClockCycle( TimeConverter* freq ) {
+    return getSimulation()->getNextClockCycle(freq);
+}
+
+void BaseComponent::unregisterClock(TimeConverter *tc, Clock::HandlerBase* handler) {
+    getSimulation()->unregisterClock(tc,handler);
+}
+
+TimeConverter* BaseComponent::registerOneShot( std::string timeDelay, OneShot::HandlerBase* handler) {
+    return getSimulation()->registerOneShot(timeDelay, handler);
+}
+
+TimeConverter* BaseComponent::registerOneShot( const UnitAlgebra& timeDelay, OneShot::HandlerBase* handler) {
+    return getSimulation()->registerOneShot(timeDelay, handler);
+}
+
+TimeConverter* BaseComponent::registerTimeBase( std::string base, bool regAll) {
+    TimeConverter* tc = getSimulation()->getTimeLord()->getTimeConverter(base);
+
+    // if regAll is true set tc as the default for the component and
+    // for all the links
+    if ( regAll ) {
+        LinkMap* myLinks = my_info->getLinkMap();
+        if (NULL != myLinks) {
+            for ( std::pair<std::string,Link*> p : myLinks->getLinkMap() ) {
+                if ( NULL == p.second->getDefaultTimeBase() ) {
+                    p.second->setDefaultTimeBase(tc);
+                }
+            }
+        }
+	defaultTimeBase = tc;
+    }
+    return tc;
+}
+
+TimeConverter*
+BaseComponent::getTimeConverter( const std::string& base )
+{
+    return getSimulation()->getTimeLord()->getTimeConverter(base);
+}
+
+TimeConverter*
+BaseComponent::getTimeConverter( const UnitAlgebra& base )
+{
+    return getSimulation()->getTimeLord()->getTimeConverter(base);
+}
+
+
+bool
+BaseComponent::isPortConnected(const std::string &name) const
+{
+    return (my_info->getLinkMap()->getLink(name) != NULL);
+}
+
+Link*
+BaseComponent::configureLink(std::string name, TimeConverter* time_base, Event::HandlerBase* handler)
+{
+    LinkMap* myLinks = my_info->getLinkMap();
+    const std::string& type = my_info->getType();
+    Link* tmp = myLinks->getLink(name);
+    if ( tmp == NULL ) return NULL;
+
+    // If no functor, this is a polling link
+    if ( handler == NULL ) {
+        tmp->setPolling();
+    }
+    tmp->setFunctor(handler);
+    tmp->setDefaultTimeBase(time_base);
+#ifdef __SST_DEBUG_EVENT_TRACKING__
+    tmp->setSendingComponentInfo(my_info->getName(), my_info->getType(), name);
+#endif
+    return tmp;
+}
+
+Link*
+BaseComponent::configureLink(std::string name, std::string time_base, Event::HandlerBase* handler)
+{
+    return configureLink(name,getSimulation()->getTimeLord()->getTimeConverter(time_base),handler);
+}
+
+Link*
+BaseComponent::configureLink(std::string name, Event::HandlerBase* handler)
+{
+    LinkMap* myLinks = my_info->getLinkMap();
+    const std::string& type = my_info->getType();
+    Link* tmp = myLinks->getLink(name);
+    if ( tmp == NULL ) return NULL;
+
+    // If no functor, this is a polling link
+    if ( handler == NULL ) {
+        tmp->setPolling();
+    }
+    tmp->setFunctor(handler);
+#ifdef __SST_DEBUG_EVENT_TRACKING__
+    tmp->setSendingComponentInfo(my_info->getName(), my_info->getType(), name);
+#endif
+    return tmp;
+}
+
+void
+BaseComponent::addSelfLink(std::string name)
+{
+    LinkMap* myLinks = my_info->getLinkMap();
+    myLinks->addSelfPort(name);
+    if ( myLinks->getLink(name) != NULL ) {
+        printf("Attempting to add self link with duplicate name: %s\n",name.c_str());
+	abort();
+    }
+
+    Link* link = new SelfLink();
+    // Set default time base to the component time base
+    link->setDefaultTimeBase(defaultTimeBase);
+    myLinks->insertLink(name,link);
+
+}
+
+Link*
+BaseComponent::configureSelfLink( std::string name, TimeConverter* time_base, Event::HandlerBase* handler)
+{
+    addSelfLink(name);
+    return configureLink(name,time_base,handler);
+}
+
+Link*
+BaseComponent::configureSelfLink( std::string name, std::string time_base, Event::HandlerBase* handler)
+{
+    addSelfLink(name);
+    return configureLink(name,time_base,handler);
+}
+
+Link*
+BaseComponent::configureSelfLink( std::string name, Event::HandlerBase* handler)
+{
+    addSelfLink(name);
+    return configureLink(name,handler);
+}
+
+Link* BaseComponent::selfLink( std::string name, Event::HandlerBase* handler )
+{
+//     Link* link = new Link(handler);
+//     link->Connect(link,0);
+//     return link;
+    Link* link = new SelfLink();
+    link->setLatency(0);
+    link->setFunctor(handler);
+    if ( handler == NULL ) {
+	link->setPolling();
+    }
+    return link;
+}
+
+SimTime_t BaseComponent::getCurrentSimTime(TimeConverter *tc) const {
+    return tc->convertFromCoreTime(getSimulation()->getCurrentSimCycle());
+}
+
+SimTime_t BaseComponent::getCurrentSimTime(std::string base) {
+    return getCurrentSimTime(getSimulation()->getTimeLord()->getTimeConverter(base));
+
+}
+
+SimTime_t BaseComponent::getCurrentSimTimeNano() const {
+    return getCurrentSimTime(getSimulation()->getTimeLord()->getNano());
+}
+
+SimTime_t BaseComponent::getCurrentSimTimeMicro() const {
+    return getCurrentSimTime(getSimulation()->getTimeLord()->getMicro());
+}
+
+SimTime_t BaseComponent::getCurrentSimTimeMilli() const {
+    return getCurrentSimTime(getSimulation()->getTimeLord()->getMilli());
+}
+
+
+
+Module*
+BaseComponent::loadModule(std::string type, Params& params)
+{
+    return Factory::getFactory()->CreateModule(type,params);
+}
+
+Module*
+BaseComponent::loadModuleWithComponent(std::string type, Component* comp, Params& params)
+{
+    return Factory::getFactory()->CreateModuleWithComponent(type,comp,params);
+}
+
+/* Old ELI style */
+SubComponent*
+BaseComponent::loadSubComponent(std::string type, Component* comp, Params& params)
+{
+    ComponentInfo *oldLoadingSubCopmonent = currentlyLoadingSubComponent;
+    /* By "magic", the new component will steal ownership of this pointer */
+    currentlyLoadingSubComponent = new ComponentInfo(comp->my_info->getID(), comp->getName(), type, comp->my_info->getLinkMap());
+    currentlyLoadingSubComponent->setStatEnablement(comp->my_info->getStatEnableList(), comp->my_info->getStatParams());
+    SubComponent* ret = Factory::getFactory()->CreateSubComponent(type,comp,params);
+    currentlyLoadingSubComponent = oldLoadingSubCopmonent;
+    return ret;
+}
+
+/* New ELI style */
+SubComponent*
+BaseComponent::loadNamedSubComponent(std::string name, Params& params)
+{
+    ComponentInfo *oldLoadingSubCopmonent = currentlyLoadingSubComponent;
+    currentlyLoadingSubComponent = &(my_info->getSubComponents().at(name));
+    /* TODO:  Get subcomponent stat enablement */
+    currentlyLoadingSubComponent->setStatEnablement(my_info->getStatEnableList(), my_info->getStatParams());
+    SubComponent* ret = Factory::getFactory()->CreateSubComponent(currentlyLoadingSubComponent->getType(), getTrueComponent(), params); /* TODO:  Mix params */
+    // currentlyLoadingSubComponent->clearStatEnablement(); Don't clear - assumptions are different for subcomponents
+    currentlyLoadingSubComponent = oldLoadingSubCopmonent;
+    return ret;
+}
+
+
+
+
+SharedRegion* BaseComponent::getLocalSharedRegion(const std::string &key, size_t size)
+{
+    SharedRegionManager *mgr = Simulation::getSharedRegionManager();
+    return mgr->getLocalSharedRegion(key, size);
+}
+
+
+SharedRegion* BaseComponent::getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger)
+{
+    SharedRegionManager *mgr = Simulation::getSharedRegionManager();
+    return mgr->getGlobalSharedRegion(key, size, merger);
+}
+
+
+} // namespace SST
+
+

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -13,7 +13,7 @@
 
 #include <string>
 
-#include <sst/core/basecomponent.h>
+#include <sst/core/baseComponent.h>
 #include <sst/core/component.h>
 #include <sst/core/subcomponent.h>
 #include <sst/core/unitAlgebra.h>

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -299,6 +299,12 @@ protected:
     virtual std::string getComponentInfoStatisticUnits(const std::string &statisticName) = 0;
 
     virtual Component* getTrueComponent() = 0;
+    /**
+     * Returns self if Component
+     * If sub-component, returns self if a "modern" subcomponent
+     *    otherwise, return base component.
+     */
+    virtual BaseComponent* getStatisticOwner() = 0;
 
 protected:
     ComponentInfo* my_info;

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -56,6 +56,9 @@ public:
     BaseComponent();
     virtual ~BaseComponent();
 
+    /** Returns unique component ID */
+    inline ComponentId_t getId() const { return my_info->id; }
+
     /** Called when SIGINT or SIGTERM has been seen.
      * Allows components opportunity to clean up external state.
      */

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -1,0 +1,350 @@
+// Copyright 2009-2016 Sandia Corporation. Under the terms
+// of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2016, Sandia Corporation
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_BASECOMPONENT_H
+#define SST_CORE_BASECOMPONENT_H
+
+#include <sst/core/sst_types.h>
+
+#include <map>
+#include <string>
+
+#include <sst/core/statapi/statoutput.h>
+#include <sst/core/statapi/statengine.h>
+#include <sst/core/statapi/statnull.h>
+#include <sst/core/statapi/stataccumulator.h>
+#include <sst/core/statapi/stathistogram.h>
+#include <sst/core/statapi/statuniquecount.h>
+#include <sst/core/statapi/statbase.h>
+#include <sst/core/event.h>
+#include <sst/core/clock.h>
+#include <sst/core/oneshot.h>
+#include <sst/core/unitAlgebra.h>
+#include <sst/core/componentInfo.h>
+#include <sst/core/simulation.h>
+
+using namespace SST::Statistics;
+
+namespace SST {
+
+class Clock;
+class Link;
+class LinkMap;
+class Module;
+class Params;
+class SubComponent;
+class TimeConverter;
+class UnitAlgebra;
+class SharedRegion;
+class SharedRegionMerger;
+class Component;
+class SubComponent;
+
+/**
+ * Main component object for the simulation.
+ */
+class BaseComponent {
+public:
+
+    BaseComponent();
+    virtual ~BaseComponent();
+
+    /** Called when SIGINT or SIGTERM has been seen.
+     * Allows components opportunity to clean up external state.
+     */
+    virtual void emergencyShutdown(void) {}
+
+
+	/** Returns component Name */
+	/* inline const std::string& getName() const { return name; } */
+	inline const std::string& getName() const { return my_info->getName(); }
+
+
+    /** Used during the init phase.  The method will be called each phase of initialization.
+     Initialization ends when no components have sent any data. */
+    virtual void init(unsigned int phase) {}
+    /** Called after all components have been constructed and inialization has
+	completed, but before simulation time has begun. */
+    virtual void setup( ) { }
+    /** Called after simulation completes, but before objects are
+        destroyed. A good place to print out statistics. */
+    virtual void finish( ) { }
+
+    /** Currently unused function */
+    virtual bool Status( ) { return 0; }
+
+    /**
+     * Called by the Simulation to request that the component
+     * print it's current status.  Useful for debugging.
+     * @param out The Output class which should be used to print component status.
+     */
+    virtual void printStatus(Output &out) { return; }
+
+    /** Determine if a port name is connected to any links */
+    bool isPortConnected(const std::string &name) const;
+
+    /** Configure a Link
+     * @param name - Port Name on which the link to configure is attached.
+     * @param time_base - Time Base of the link
+     * @param handler - Optional Handler to be called when an Event is received
+     * @return A pointer to the configured link, or NULL if an error occured.
+     */
+    Link* configureLink( std::string name, TimeConverter* time_base, Event::HandlerBase* handler = NULL);
+    /** Configure a Link
+     * @param name - Port Name on which the link to configure is attached.
+     * @param time_base - Time Base of the link
+     * @param handler - Optional Handler to be called when an Event is received
+     * @return A pointer to the configured link, or NULL if an error occured.
+     */
+    Link* configureLink( std::string name, std::string time_base, Event::HandlerBase* handler = NULL);
+    /** Configure a Link
+     * @param name - Port Name on which the link to configure is attached.
+     * @param handler - Optional Handler to be called when an Event is received
+     * @return A pointer to the configured link, or NULL if an error occured.
+     */
+    Link* configureLink( std::string name, Event::HandlerBase* handler = NULL);
+
+    /** Configure a SelfLink  (Loopback link)
+     * @param name - Name of the self-link port
+     * @param time_base - Time Base of the link
+     * @param handler - Optional Handler to be called when an Event is received
+     * @return A pointer to the configured link, or NULL if an error occured.
+     */
+    Link* configureSelfLink( std::string name, TimeConverter* time_base, Event::HandlerBase* handler = NULL);
+    /** Configure a SelfLink  (Loopback link)
+     * @param name - Name of the self-link port
+     * @param time_base - Time Base of the link
+     * @param handler - Optional Handler to be called when an Event is received
+     * @return A pointer to the configured link, or NULL if an error occured.
+     */
+    Link* configureSelfLink( std::string name, std::string time_base, Event::HandlerBase* handler = NULL);
+    /** Configure a SelfLink  (Loopback link)
+     * @param name - Name of the self-link port
+     * @param handler - Optional Handler to be called when an Event is received
+     * @return A pointer to the configured link, or NULL if an error occured.
+     */
+    Link* configureSelfLink( std::string name, Event::HandlerBase* handler = NULL);
+
+    /** Registers a clock for this component.
+        @param freq Frequency for the clock in SI units
+        @param handler Pointer to Clock::HandlerBase which is to be invoked
+        at the specified interval
+        @param regAll Should this clock perioud be used as the default
+        time base for all of the links connected to this component
+    */
+    TimeConverter* registerClock( std::string freq, Clock::HandlerBase* handler,
+                                  bool regAll = true);
+    TimeConverter* registerClock( const UnitAlgebra& freq, Clock::HandlerBase* handler,
+                                  bool regAll = true);
+    /** Removes a clock handler from the component */
+    void unregisterClock(TimeConverter *tc, Clock::HandlerBase* handler);
+
+    /** Reactivates an existing Clock and Handler
+     * @return time of next time clock handler will fire
+     */
+    Cycle_t reregisterClock(TimeConverter *freq, Clock::HandlerBase* handler);
+    /** Returns the next Cycle that the TimeConverter would fire */
+    Cycle_t getNextClockCycle(TimeConverter *freq);
+
+    /** Registers a OneShot event for this component.
+        Note: OneShot cannot be canceled, and will always callback after
+          the timedelay.
+        @param timeDelay Time delay for the OneShot in SI units
+        @param handler Pointer to OneShot::HandlerBase which is to be invoked
+        at the specified interval
+    */
+    TimeConverter* registerOneShot( std::string timeDelay, OneShot::HandlerBase* handler);
+    TimeConverter* registerOneShot( const UnitAlgebra& timeDelay, OneShot::HandlerBase* handler);
+
+    /** Registers a default time base for the component and optionally
+        sets the the component's links to that timebase. Useful for
+        components which do not have a clock, but would like a default
+        timebase.
+        @param base Frequency for the clock in SI units
+        @param regAll Should this clock perioud be used as the default
+        time base for all of the links connected to this component
+    */
+    TimeConverter* registerTimeBase( std::string base, bool regAll = true);
+
+    TimeConverter* getTimeConverter( const std::string& base );
+    TimeConverter* getTimeConverter( const UnitAlgebra& base );
+
+    /** return the time since the simulation began in units specified by
+        the parameter.
+        @param tc TimeConverter specificing the units */
+    SimTime_t getCurrentSimTime(TimeConverter *tc) const;
+    /** return the time since the simulation began in the default timebase */
+    inline SimTime_t getCurrentSimTime()  const{
+        return getCurrentSimTime(defaultTimeBase);
+    }
+    /** return the time since the simulation began in timebase specified
+        @param base Timebase frequency in SI Units */
+    SimTime_t getCurrentSimTime(std::string base);
+
+    /** Utility function to return the time since the simulation began in nanoseconds */
+    SimTime_t getCurrentSimTimeNano() const;
+    /** Utility function to return the time since the simulation began in microseconds */
+    SimTime_t getCurrentSimTimeMicro() const;
+    /** Utility function to return the time since the simulation began in milliseconds */
+    SimTime_t getCurrentSimTimeMilli() const;
+
+    /** Registers a statistic.
+        If Statistic is allowed to run (controlled by Python runtime parameters),
+        then a statistic will be created and returned. If not allowed to run,
+        then a NullStatistic will be returned.  In either case, the returned
+        value should be used for all future Statistic calls.  The type of
+        Statistic and the Collection Rate is set by Python runtime parameters.
+        If no type is defined, then an Accumulator Statistic will be provided
+        by default.  If rate set to 0 or not provided, then the statistic will
+        output results only at end of sim (if output is enabled).
+        @param statName Primary name of the statistic.  This name must match the
+               defined ElementInfoStatistic in the component, and must also
+               be enabled in the Python input file.
+        @param statSubId An additional sub name for the statistic
+        @return Either a created statistic of desired type or a NullStatistic
+                depending upon runtime settings.
+    */
+    template <typename T>
+    Statistic<T>* registerStatisticCore(std::string statName, std::string statSubId = "")
+    {
+        // NOTE: Templated Code for implementation of Statistic Registration
+        // is in the componentregisterstat_impl.h file.  This was done
+        // to avoid code bloat in the .h file.
+        #include "sst/core/statapi/componentregisterstat_impl.h"
+    }
+
+    template <typename T>
+    Statistic<T>* registerStatistic(std::string statName, std::string statSubId = "")
+    {
+        // Verify here that name of the stat is one of the registered
+        // names of the component's ElementInfoStatistic.
+        if (false == doesComponentInfoStatisticExist(statName)) {
+            printf("Error: Statistic %s name %s is not found in ElementInfoStatistic, exiting...\n",
+                   StatisticBase::buildStatisticFullName(getName().c_str(), statName, statSubId).c_str(),
+                   statName.c_str());
+            exit(1);
+        }
+        return registerStatisticCore<T>(statName, statSubId);
+    }
+
+    template <typename T>
+    Statistic<T>* registerStatistic(const char* statName, const char* statSubId = "")
+    {
+        return registerStatistic<T>(std::string(statName), std::string(statSubId));
+    }
+
+
+    /** Loads a module from an element Library
+     * @param type Fully Qualified library.moduleName
+     * @param params Parameters the module should use for configuration
+     * @return handle to new instance of module, or NULL on failure.
+     */
+    Module* loadModule(std::string type, Params& params);
+
+    /** Loads a module from an element Library
+     * @param type Fully Qualified library.moduleName
+     * @param comp Pointer to component to pass to Module's constructor
+     * @param params Parameters the module should use for configuration
+     * @return handle to new instance of module, or NULL on failure.
+     */
+    Module* loadModuleWithComponent(std::string type, Component* comp, Params& params);
+
+    /** Loads a SubComponent from an element Library
+     * @param type Fully Qualified library.moduleName
+     * @param comp Pointer to component to pass to SuBaseComponent's constructor
+     * @param params Parameters the module should use for configuration
+     * @return handle to new instance of SubComponent, or NULL on failure.
+     */
+    SubComponent* loadSubComponent(std::string type, Component* comp, Params& params);
+    /* New ELI style */
+    SubComponent* loadNamedSubComponent(std::string name, Params& params);
+
+protected:
+
+    /** Manually set the default detaulTimeBase */
+    void setDefaultTimeBase(TimeConverter *tc) {
+        defaultTimeBase = tc;
+    }
+
+    /** Timebase used if no other timebase is specified for calls like
+        BaseComponent::getCurrentSimTime(). Often set by BaseComponent::registerClock()
+        function */
+    TimeConverter* defaultTimeBase;
+
+    /** Creates a new selfLink */
+    Link* selfLink( std::string name, Event::HandlerBase* handler = NULL );
+
+
+    /** Find a lookup table */
+    SharedRegion* getLocalSharedRegion(const std::string &key, size_t size);
+    SharedRegion* getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger = NULL);
+
+    /* Get the Simulation */
+    Simulation* getSimulation() const { return sim; }
+
+    // Does the statisticName exist in the ElementInfoStatistic
+    virtual bool doesComponentInfoStatisticExist(const std::string &statisticName) = 0;
+    virtual uint8_t getComponentInfoStatisticEnableLevel(const std::string &statisticName) = 0;
+    virtual std::string getComponentInfoStatisticUnits(const std::string &statisticName) = 0;
+
+    virtual Component* getTrueComponent() = 0;
+
+protected:
+    ComponentInfo* my_info;
+    Simulation *sim;
+    ComponentInfo* currentlyLoadingSubComponent;
+
+
+private:
+    void addSelfLink(std::string name);
+
+    template <typename T>
+    Statistic<T>* CreateStatistic(BaseComponent* comp, std::string& type, std::string& statName, std::string& statSubId, Params& params)
+    {
+        // Load one of the SST Core provided Statistics
+        // NOTE: This happens here (in simulation) instead of the factory because
+        //       it is a templated method.  The BaseComponent::registerStatistic<T>()
+        //       must be defined in the component.h however the the Factory is
+        //       not available from the Simulation::::getSimulation() because
+        //       Factory is only defined via a forwarded definition.  Basically
+        //       we have to go through some twists and jumps to make this work.
+
+        // Names of sst.xxx Statistics
+        if (0 == ::strcasecmp("sst.nullstatistic", type.c_str())) {
+            return new NullStatistic<T>(comp, statName, statSubId, params);
+        }
+
+        if (0 == ::strcasecmp("sst.accumulatorstatistic", type.c_str())) {
+            return new AccumulatorStatistic<T>(comp, statName, statSubId, params);
+        }
+
+        if (0 == ::strcasecmp("sst.histogramstatistic", type.c_str())) {
+            return new HistogramStatistic<T>(comp, statName, statSubId, params);
+        }
+
+	if(0 == ::strcasecmp("sst.uniquecountstatistic", type.c_str())) {
+	    return new UniqueCountStatistic<T>(comp, statName, statSubId, params);
+	}
+
+        // We did not find this statistic
+        printf("ERROR: Statistic %s is not supported by the SST Core...\n", type.c_str());
+
+        return NULL;
+    }
+
+
+
+
+};
+
+} //namespace SST
+
+#endif // SST_CORE_BASECOMPONENT_H

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -265,6 +265,7 @@ public:
      */
     SubComponent* loadSubComponent(std::string type, Component* comp, Params& params);
     /* New ELI style */
+    SubComponent* loadNamedSubComponent(std::string name);
     SubComponent* loadNamedSubComponent(std::string name, Params& params);
 
 protected:

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -27,7 +27,6 @@
 #include <sst/core/event.h>
 #include <sst/core/clock.h>
 #include <sst/core/oneshot.h>
-#include <sst/core/unitAlgebra.h>
 #include <sst/core/componentInfo.h>
 #include <sst/core/simulation.h>
 

--- a/src/sst/core/component.cc
+++ b/src/sst/core/component.cc
@@ -1,338 +1,49 @@
 // Copyright 2009-2016 Sandia Corporation. Under the terms
 // of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S.
 // Government retains certain rights in this software.
-// 
+//
 // Copyright (c) 2009-2016, Sandia Corporation
 // All rights reserved.
-// 
+//
 // This file is part of the SST software package. For license
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
 #include <sst_config.h>
-#include "sst/core/component.h"
-#include "sst/core/unitAlgebra.h"
-
 #include <string>
 
-//#include "sst/core/event.h"
-#include "sst/core/exit.h"
-#include "sst/core/factory.h"
-#include "sst/core/link.h"
-#include "sst/core/linkMap.h"
-#include "sst/core/simulation.h"
-#include "sst/core/timeConverter.h"
-#include "sst/core/timeLord.h"
-#include "sst/core/unitAlgebra.h"
-#include "sst/core/sharedRegion.h"
+#include <sst/core/component.h>
+#include <sst/core/exit.h>
+#include <sst/core/simulation.h>
+#include <sst/core/factory.h>
 
 using namespace SST::Statistics;
 
 namespace SST {
 
-Component::Component(ComponentId_t id) :
-    defaultTimeBase(NULL), id(id)//, my_info(Simulation::getSimulation()->getComponentInfoMap()[id])
+Component::Component(ComponentId_t id) : BaseComponent(),
+    id(id)
 {
-    sim = Simulation::getSimulation();
     my_info = sim->getComponentInfo(id);
-    currentlyLoadingSubComponent = "";
 }
 
-Component::Component()
+
+Component::~Component()
 {
 }
 
-Component::~Component() 
-{
-}
 
-bool checkPort(const char *def, const char *offered)
-{
-    const char * x = def;
-    const char * y = offered;
-    
-    /* Special case.  Name of '*' matches everything */
-    if ( *x == '*' && *(x+1) == '\0' ) return true;
-    
-    do {
-        if ( *x == '%' && (*(x+1) == '(' || *(x+1) == 'd') ) {
-            // We have a %d or %(var)d to eat
-            x++;
-            if ( *x == '(' ) {
-                while ( *x && (*x != ')') ) x++;
-                x++;  /* *x should now == 'd' */
-            }
-            if ( *x != 'd') /* Malformed string.  Fail all the things */
-                return false;
-            x++; /* Finish eating the variable */
-            /* Now, eat the corresponding digits of y */
-            while ( *y && isdigit(*y) ) y++;
-        }
-        if ( *x != *y ) return false;
-        if ( *x == '\0' ) return true;
-        x++;
-        y++;
-    } while ( *x && *y );
-    if ( *x != *y ) return false; // aka, both NULL
-    return true;
-}
-    
-    
-bool
-Component::isPortValidForComponent(const std::string& comp_name, const std::string& port_name) {
-    const std::vector<std::string>* allowedPorts = Factory::getFactory()->GetComponentAllowedPorts(comp_name);
-
-    const char *x = port_name.c_str();
-    bool found = false;
-    if ( NULL != allowedPorts ) {
-        for ( std::vector<std::string>::const_iterator i = allowedPorts->begin() ; i != allowedPorts->end() ; ++i ) {
-            /* Compare name with stored name, which may have wildcards */
-            if ( checkPort(i->c_str(), x) ) {
-                found = true;
-                break;
-            }
-        }
-    }
-        
-    return found;
-    
-}
-
-
-TimeConverter* Component::registerClock( std::string freq, Clock::HandlerBase* handler, bool regAll) {
-    TimeConverter* tc = getSimulation()->registerClock(freq,handler);
-    
-    // if regAll is true set tc as the default for the component and
-    // for all the links
-    if ( regAll ) {
-        LinkMap* myLinks = my_info->getLinkMap();
-        if (NULL != myLinks) {
-            for ( std::pair<std::string,Link*> p : myLinks->getLinkMap() ) {
-                if ( NULL == p.second->getDefaultTimeBase() ) {
-                    p.second->setDefaultTimeBase(tc);
-                }
-            }
-        }
-	defaultTimeBase = tc;
-    }
-    return tc;
-}
-
-TimeConverter* Component::registerClock( const UnitAlgebra& freq, Clock::HandlerBase* handler, bool regAll) {
-    TimeConverter* tc = getSimulation()->registerClock(freq,handler);
-    
-    // if regAll is true set tc as the default for the component and
-    // for all the links
-    if ( regAll ) {
-        LinkMap* myLinks = my_info->getLinkMap();
-        if (NULL != myLinks) {
-            for ( std::pair<std::string,Link*> p : myLinks->getLinkMap() ) {
-                if ( NULL == p.second->getDefaultTimeBase() ) {
-                    p.second->setDefaultTimeBase(tc);
-                }
-            }
-        }
-	defaultTimeBase = tc;
-    }
-    return tc;
-}
-
-Cycle_t Component::reregisterClock( TimeConverter* freq, Clock::HandlerBase* handler) {
-    return getSimulation()->reregisterClock(freq,handler);
-}
-
-Cycle_t Component::getNextClockCycle( TimeConverter* freq ) {
-    return getSimulation()->getNextClockCycle(freq);
-}
-
-void Component::unregisterClock(TimeConverter *tc, Clock::HandlerBase* handler) {
-    getSimulation()->unregisterClock(tc,handler);
-}
-
-TimeConverter* Component::registerOneShot( std::string timeDelay, OneShot::HandlerBase* handler) {
-    return getSimulation()->registerOneShot(timeDelay, handler);
-}
-
-TimeConverter* Component::registerOneShot( const UnitAlgebra& timeDelay, OneShot::HandlerBase* handler) {
-    return getSimulation()->registerOneShot(timeDelay, handler);
-}
-
-TimeConverter* Component::registerTimeBase( std::string base, bool regAll) {
-    TimeConverter* tc = getSimulation()->getTimeLord()->getTimeConverter(base);
-    
-    // if regAll is true set tc as the default for the component and
-    // for all the links
-    if ( regAll ) {
-        LinkMap* myLinks = my_info->getLinkMap();
-        if (NULL != myLinks) {
-            for ( std::pair<std::string,Link*> p : myLinks->getLinkMap() ) {
-                if ( NULL == p.second->getDefaultTimeBase() ) {
-                    p.second->setDefaultTimeBase(tc);
-                }
-            }
-        }
-	defaultTimeBase = tc;
-    }
-    return tc;
-}
-
-TimeConverter*
-Component::getTimeConverter( const std::string& base )
-{
-    return getSimulation()->getTimeLord()->getTimeConverter(base);
-}
-    
-TimeConverter*
-Component::getTimeConverter( const UnitAlgebra& base )
-{
-    return getSimulation()->getTimeLord()->getTimeConverter(base);
-}
-
-    
-bool
-Component::isPortConnected(const std::string &name) const
-{
-    return (my_info->getLinkMap()->getLink(name) != NULL);
-}
-
-Link*
-Component::configureLink(std::string name, TimeConverter* time_base, Event::HandlerBase* handler)
-{
-    LinkMap* myLinks = my_info->getLinkMap();
-    const std::string& type = my_info->getType();
-    if ( !isPortValidForComponent(type,name) && !myLinks->isSelfPort(name) ) {
-#ifdef USE_PARAM_WARNINGS
-            std::cerr << "Warning:  Using undocumented port '" << name << "'." << std::endl;
-#endif
-    }
-    Link* tmp = myLinks->getLink(name);
-    if ( tmp == NULL ) return NULL;
-    
-    // If no functor, this is a polling link
-    if ( handler == NULL ) {
-        tmp->setPolling();
-    }
-    tmp->setFunctor(handler);
-    tmp->setDefaultTimeBase(time_base);
-#ifdef __SST_DEBUG_EVENT_TRACKING__
-    tmp->setSendingComponentInfo(my_info->getName(), my_info->getType(), name);
-#endif
-    return tmp;    
-}
-
-Link*
-Component::configureLink(std::string name, std::string time_base, Event::HandlerBase* handler)
-{
-    return configureLink(name,getSimulation()->getTimeLord()->getTimeConverter(time_base),handler);
-}
-
-Link*
-Component::configureLink(std::string name, Event::HandlerBase* handler)
-{
-    LinkMap* myLinks = my_info->getLinkMap();
-    const std::string& type = my_info->getType();
-    if ( !isPortValidForComponent(type,name) && !myLinks->isSelfPort(name) ) {
-#ifdef USE_PARAM_WARNINGS
-            std::cerr << "Warning:  Using undocumented port '" << name << "'." << std::endl;
-#endif
-    }
-    Link* tmp = myLinks->getLink(name);
-    if ( tmp == NULL ) return NULL;
-    
-    // If no functor, this is a polling link
-    if ( handler == NULL ) {
-        tmp->setPolling();
-    }
-    tmp->setFunctor(handler);
-#ifdef __SST_DEBUG_EVENT_TRACKING__
-    tmp->setSendingComponentInfo(my_info->getName(), my_info->getType(), name);
-#endif
-    return tmp;    
-}
-
-void
-Component::addSelfLink(std::string name)
-{
-    LinkMap* myLinks = my_info->getLinkMap();
-    myLinks->addSelfPort(name);
-    if ( myLinks->getLink(name) != NULL ) {
-        printf("Attempting to add self link with duplicate name: %s\n",name.c_str());
-	abort();
-    }
-
-    Link* link = new SelfLink();
-    // Set default time base to the component time base
-    link->setDefaultTimeBase(defaultTimeBase);
-    myLinks->insertLink(name,link);
-    
-}
-
-Link*
-Component::configureSelfLink( std::string name, TimeConverter* time_base, Event::HandlerBase* handler)
-{
-    addSelfLink(name);
-    return configureLink(name,time_base,handler);
-}
-
-Link*
-Component::configureSelfLink( std::string name, std::string time_base, Event::HandlerBase* handler)
-{
-    addSelfLink(name);
-    return configureLink(name,time_base,handler);
-}
-
-Link*
-Component::configureSelfLink( std::string name, Event::HandlerBase* handler)
-{
-    addSelfLink(name);
-    return configureLink(name,handler);
-}
-
-Link* Component::selfLink( std::string name, Event::HandlerBase* handler )
-{
-//     Link* link = new Link(handler);
-//     link->Connect(link,0);
-//     return link;
-    Link* link = new SelfLink();
-    link->setLatency(0);
-    link->setFunctor(handler);
-    if ( handler == NULL ) {
-	link->setPolling();
-    }
-    return link;
-}
-    
-SimTime_t Component::getCurrentSimTime(TimeConverter *tc) const {
-    return tc->convertFromCoreTime(getSimulation()->getCurrentSimCycle());
-}
-
-SimTime_t Component::getCurrentSimTime(std::string base) {
-    return getCurrentSimTime(getSimulation()->getTimeLord()->getTimeConverter(base));
-
-}
-    
-SimTime_t Component::getCurrentSimTimeNano() const {
-    return getCurrentSimTime(getSimulation()->getTimeLord()->getNano());
-}
-
-SimTime_t Component::getCurrentSimTimeMicro() const {
-    return getCurrentSimTime(getSimulation()->getTimeLord()->getMicro());
-}
-
-SimTime_t Component::getCurrentSimTimeMilli() const {
-    return getCurrentSimTime(getSimulation()->getTimeLord()->getMilli());
-}
 
 bool Component::registerExit()
 {
     int thread = getSimulation()->getRank().thread;
-    return getSimulation()->getExit()->refInc( getId(), thread ); 
+    return getSimulation()->getExit()->refInc( getId(), thread );
 }
 
 bool Component::unregisterExit()
 {
     int thread = getSimulation()->getRank().thread;
-    return getSimulation()->getExit()->refDec( getId(), thread ); 
+    return getSimulation()->getExit()->refDec( getId(), thread );
 }
 
 void
@@ -347,70 +58,35 @@ Component::primaryComponentDoNotEndSim()
     int thread = getSimulation()->getRank().thread;
     getSimulation()->getExit()->refInc( getId(), thread );
 }
-    
+
 void
 Component::primaryComponentOKToEndSim()
 {
     int thread = getSimulation()->getRank().thread;
-    getSimulation()->getExit()->refDec( getId(), thread ); 
+    getSimulation()->getExit()->refDec( getId(), thread );
 }
 
-Module*
-Component::loadModule(std::string type, Params& params)
-{
-    return Factory::getFactory()->CreateModule(type,params);
-}
 
-Module*
-Component::loadModuleWithComponent(std::string type, Component* comp, Params& params)
-{
-    return Factory::getFactory()->CreateModuleWithComponent(type,comp,params);
-}
 
-SubComponent*
-Component::loadSubComponent(std::string type, Component* comp, Params& params)
-{
-    std::string oldLoadingSubCopmonent = currentlyLoadingSubComponent;
-    currentlyLoadingSubComponent = type;
-    SubComponent* ret = Factory::getFactory()->CreateSubComponent(type,comp,params);
-    currentlyLoadingSubComponent = oldLoadingSubCopmonent;
-    return ret;
-}
-    
-bool Component::doesComponentInfoStatisticExist(std::string statisticName)
+bool Component::doesComponentInfoStatisticExist(const std::string &statisticName)
 {
     const std::string& type = my_info->getType();
     return Factory::getFactory()->DoesComponentInfoStatisticNameExist(type, statisticName);
 }
 
-uint8_t Component::getComponentInfoStatisticEnableLevel(std::string statisticName)
+
+uint8_t Component::getComponentInfoStatisticEnableLevel(const std::string &statisticName)
 {
     const std::string& type = my_info->getType();
     return Factory::getFactory()->GetComponentInfoStatisticEnableLevel(type, statisticName);
 }
 
-std::string Component::getComponentInfoStatisticUnits(std::string statisticName)
+std::string Component::getComponentInfoStatisticUnits(const std::string &statisticName)
 {
     const std::string& type = my_info->getType();
     return Factory::getFactory()->GetComponentInfoStatisticUnits(type, statisticName);
 }
 
-
-
-SharedRegion* Component::getLocalSharedRegion(const std::string &key, size_t size)
-{
-    SharedRegionManager *mgr = Simulation::getSharedRegionManager();
-    return mgr->getLocalSharedRegion(key, size);
-}
-
-
-SharedRegion* Component::getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger)
-{
-    SharedRegionManager *mgr = Simulation::getSharedRegionManager();
-    return mgr->getGlobalSharedRegion(key, size, merger);
-}
-
-    
 } // namespace SST
 
 

--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -106,6 +106,7 @@ protected:
     Component() {} // Unused, but previously available
 
     Component* getTrueComponent() final { return this; }
+    BaseComponent* getStatisticOwner() final { return this; }
 
 
     // Does the statisticName exist in the ElementInfoStatistic

--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -1,10 +1,10 @@
 // Copyright 2009-2016 Sandia Corporation. Under the terms
 // of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S.
 // Government retains certain rights in this software.
-// 
+//
 // Copyright (c) 2009-2016, Sandia Corporation
 // All rights reserved.
-// 
+//
 // This file is part of the SST software package. For license
 // information, see the LICENSE file in the top level directory of the
 // distribution.
@@ -17,248 +17,31 @@
 #include <map>
 #include <string>
 
-#include <sst/core/clock.h>
-#include <sst/core/oneshot.h>
-#include <sst/core/event.h>
-//#include <sst/core/params.h>
-//#include <sst/core/link.h>
-//#include <sst/core/timeConverter.h>
-#include <sst/core/statapi/statoutput.h>
-#include <sst/core/statapi/statengine.h>
-#include <sst/core/statapi/statnull.h>
-#include <sst/core/statapi/stataccumulator.h>
-#include <sst/core/statapi/stathistogram.h>
-#include <sst/core/statapi/statuniquecount.h>
-#include "sst/core/simulation.h"
-#include "sst/core/unitAlgebra.h"
-#include "sst/core/statapi/statbase.h"
+#include <sst/core/baseComponent.h>
+
 
 using namespace SST::Statistics;
 
 namespace SST {
-
-class Link;
-class LinkMap;
-class Module;
-class Params;
 class SubComponent;
-class TimeConverter;
-class UnitAlgebra;
-class SharedRegion;
-class SharedRegionMerger;
-
-#define _COMP_DBG( fmt, args...) __DBG( DBG_COMP, Component, fmt, ## args )
 
 /**
- * Main component object for the simulation. 
- *  All models inherit from this. 
+ * Main component object for the simulation.
+ *  All models inherit from this.
  */
-class Component {
+class Component: public BaseComponent {
 public:
 
-    static bool isPortValidForComponent(const std::string& comp_name, const std::string& port_name);
-    
-    /* Deprecated typedef */
-//    typedef Params Params_t;
-
-    /** Constructor. Generally only called by the factory class. 
+    /** Constructor. Generally only called by the factory class.
         @param id Unique component ID
     */
     Component( ComponentId_t id );
     virtual ~Component();
 
-    /** Called when SIGINT or SIGTERM has been seen.
-     * Allows components opportunity to clean up external state.
-     */
-    virtual void emergencyShutdown(void) {}
-
     /** Returns unique component ID */
     inline ComponentId_t getId() const { return id; }
 
-	/** Returns component Name */
-	/* inline const std::string& getName() const { return name; } */
-	inline const std::string& getName() const { return my_info->getName(); }
-    
-    
-    /** Component's type, set by the factory when the object is created.
-        It is identical to the configuration string used to create the
-        component. I.e. the XML "<component id="aFoo"><foo>..." would
-        set component::type to "foo" */
-    /* std::string type; */
 
-    /** Used during the init phase.  The method will be called each phase of initialization.
-     Initialization ends when no components have sent any data. */
-    virtual void init(unsigned int phase) {}
-    /** Called after all components have been constructed and inialization has
-	completed, but before simulation time has begun. */
-    virtual void setup( ) { }
-    /** Called after simulation completes, but before objects are
-        destroyed. A good place to print out statistics. */
-    virtual void finish( ) { }
-
-    /** Currently unused function */
-    virtual bool Status( ) { return 0; }
-
-    /**
-     * Called by the Simulation to request that the component
-     * print it's current status.  Useful for debugging.
-     * @param out The Output class which should be used to print component status.
-     */
-    virtual void printStatus(Output &out) { return; }
-
-    /** Determine if a port name is connected to any links */
-    bool isPortConnected(const std::string &name) const;
-
-    /** Configure a Link
-     * @param name - Port Name on which the link to configure is attached.
-     * @param time_base - Time Base of the link
-     * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
-     */
-    Link* configureLink( std::string name, TimeConverter* time_base, Event::HandlerBase* handler = NULL);
-    /** Configure a Link
-     * @param name - Port Name on which the link to configure is attached.
-     * @param time_base - Time Base of the link
-     * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
-     */
-    Link* configureLink( std::string name, std::string time_base, Event::HandlerBase* handler = NULL);
-    /** Configure a Link
-     * @param name - Port Name on which the link to configure is attached.
-     * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
-     */
-    Link* configureLink( std::string name, Event::HandlerBase* handler = NULL);
-
-    /** Configure a SelfLink  (Loopback link)
-     * @param name - Name of the self-link port
-     * @param time_base - Time Base of the link
-     * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
-     */
-    Link* configureSelfLink( std::string name, TimeConverter* time_base, Event::HandlerBase* handler = NULL);
-    /** Configure a SelfLink  (Loopback link)
-     * @param name - Name of the self-link port
-     * @param time_base - Time Base of the link
-     * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
-     */
-    Link* configureSelfLink( std::string name, std::string time_base, Event::HandlerBase* handler = NULL);
-    /** Configure a SelfLink  (Loopback link)
-     * @param name - Name of the self-link port
-     * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
-     */
-    Link* configureSelfLink( std::string name, Event::HandlerBase* handler = NULL);
-
-    /** Registers a clock for this component.
-        @param freq Frequency for the clock in SI units
-        @param handler Pointer to Clock::HandlerBase which is to be invoked
-        at the specified interval
-        @param regAll Should this clock perioud be used as the default
-        time base for all of the links connected to this component
-    */
-    TimeConverter* registerClock( std::string freq, Clock::HandlerBase* handler,
-                                  bool regAll = true);
-    TimeConverter* registerClock( const UnitAlgebra& freq, Clock::HandlerBase* handler, 
-                                  bool regAll = true);
-    /** Removes a clock handler from the component */
-    void unregisterClock(TimeConverter *tc, Clock::HandlerBase* handler);
-
-    /** Reactivates an existing Clock and Handler
-     * @return time of next time clock handler will fire
-     */
-    Cycle_t reregisterClock(TimeConverter *freq, Clock::HandlerBase* handler);
-    /** Returns the next Cycle that the TimeConverter would fire */
-    Cycle_t getNextClockCycle(TimeConverter *freq);
-
-    /** Registers a OneShot event for this component.
-        Note: OneShot cannot be canceled, and will always callback after
-          the timedelay.  
-        @param timeDelay Time delay for the OneShot in SI units
-        @param handler Pointer to OneShot::HandlerBase which is to be invoked
-        at the specified interval
-    */
-    TimeConverter* registerOneShot( std::string timeDelay, OneShot::HandlerBase* handler);
-    TimeConverter* registerOneShot( const UnitAlgebra& timeDelay, OneShot::HandlerBase* handler);
-
-    /** Registers a default time base for the component and optionally
-        sets the the component's links to that timebase. Useful for
-        components which do not have a clock, but would like a default
-        timebase.
-        @param base Frequency for the clock in SI units
-        @param regAll Should this clock perioud be used as the default
-        time base for all of the links connected to this component
-    */
-    TimeConverter* registerTimeBase( std::string base, bool regAll = true);
-
-    TimeConverter* getTimeConverter( const std::string& base );
-    TimeConverter* getTimeConverter( const UnitAlgebra& base );
-    
-    /** return the time since the simulation began in units specified by
-        the parameter.
-        @param tc TimeConverter specificing the units */
-    SimTime_t getCurrentSimTime(TimeConverter *tc) const;
-    /** return the time since the simulation began in the default timebase */
-    inline SimTime_t getCurrentSimTime()  const{
-        return getCurrentSimTime(defaultTimeBase);
-    }
-    /** return the time since the simulation began in timebase specified
-        @param base Timebase frequency in SI Units */
-    SimTime_t getCurrentSimTime(std::string base);
-
-    /** Utility function to return the time since the simulation began in nanoseconds */ 
-    SimTime_t getCurrentSimTimeNano() const;
-    /** Utility function to return the time since the simulation began in microseconds */ 
-    SimTime_t getCurrentSimTimeMicro() const;
-    /** Utility function to return the time since the simulation began in milliseconds */ 
-    SimTime_t getCurrentSimTimeMilli() const;
-
-    /** Registers a statistic.  
-        If Statistic is allowed to run (controlled by Python runtime parameters), 
-        then a statistic will be created and returned. If not allowed to run,
-        then a NullStatistic will be returned.  In either case, the returned 
-        value should be used for all future Statistic calls.  The type of 
-        Statistic and the Collection Rate is set by Python runtime parameters.
-        If no type is defined, then an Accumulator Statistic will be provided 
-        by default.  If rate set to 0 or not provided, then the statistic will 
-        output results only at end of sim (if output is enabled).  
-        @param statName Primary name of the statistic.  This name must match the 
-               defined ElementInfoStatistic in the component, and must also 
-               be enabled in the Python input file.
-        @param statSubId An additional sub name for the statistic 
-        @return Either a created statistic of desired type or a NullStatistic 
-                depending upon runtime settings.
-    */
-    template <typename T>
-    Statistic<T>* registerStatisticCore(std::string statName, std::string statSubId = "")
-    {
-        // NOTE: Templated Code for implementation of Statistic Registration
-        // is in the componentregisterstat_impl.h file.  This was done
-        // to avoid code bloat in the .h file.  
-        #include "sst/core/statapi/componentregisterstat_impl.h"
-    }
-    
-    template <typename T>
-    Statistic<T>* registerStatistic(std::string statName, std::string statSubId = "")
-    {
-        // Verify here that name of the stat is one of the registered
-        // names of the component's ElementInfoStatistic.  
-        if (false == doesComponentInfoStatisticExist(statName)) {
-            printf("Error: Statistic %s name %s is not found in ElementInfoStatistic, exiting...\n",
-                   StatisticBase::buildStatisticFullName(getName().c_str(), statName, statSubId).c_str(),
-                   statName.c_str());
-            exit(1);
-        }
-        return registerStatisticCore<T>(statName, statSubId);
-    }
-
-    template <typename T>
-    Statistic<T>* registerStatistic(const char* statName, const char* statSubId = "")
-    {   
-        return registerStatistic<T>(std::string(statName), std::string(statSubId));
-    }
-    
     /** Register that the simulation should not end until this
         component says it is OK to. Calling this function (generally
         done in Component::setup() or in component constructor)
@@ -310,124 +93,36 @@ public:
         @sa Component::primaryComponentOKToEndSim()
     */
     void primaryComponentDoNotEndSim();
-    
+
     /** Tells the simulation that it is now OK to end simulation.
 	Simulation will not end until all primary components have
 	called this function.
-	
+
         @sa Component::registerAsPrimaryComponent()
         @sa Component::primaryComponentDoNotEndSim()
     */
     void primaryComponentOKToEndSim();
 
-    /** Loads a module from an element Library
-     * @param type Fully Qualified library.moduleName
-     * @param params Parameters the module should use for configuration
-     * @return handle to new instance of module, or NULL on failure.
-     */
-    Module* loadModule(std::string type, Params& params);
 
-    /** Loads a module from an element Library
-     * @param type Fully Qualified library.moduleName
-     * @param comp Pointer to component to pass to Module's constructor
-     * @param params Parameters the module should use for configuration
-     * @return handle to new instance of module, or NULL on failure.
-     */
-    Module* loadModuleWithComponent(std::string type, Component* comp, Params& params);
-    
-    /** Loads a SubComponent from an element Library
-     * @param type Fully Qualified library.moduleName
-     * @param comp Pointer to component to pass to SuComponent's constructor
-     * @param params Parameters the module should use for configuration
-     * @return handle to new instance of SubComponent, or NULL on failure.
-     */
-    SubComponent* loadSubComponent(std::string type, Component* comp, Params& params);
-    
 protected:
-    Component(); // For serialization only
+    friend class SubComponent;
+    Component() {} // Unused, but previously available
 
-    /** Manually set the default detaulTimeBase */ 
-    void setDefaultTimeBase(TimeConverter *tc) {
-        defaultTimeBase = tc;
-    }
-
-    /** Timebase used if no other timebase is specified for calls like
-        Component::getCurrentSimTime(). Often set by Component::registerClock()
-        function */
-    TimeConverter* defaultTimeBase;
-
-    /** Creates a new selfLink */
-    Link* selfLink( std::string name, Event::HandlerBase* handler = NULL );
+    Component* getTrueComponent() final { return this; }
 
 
-    /** Find a lookup table */
-    SharedRegion* getLocalSharedRegion(const std::string &key, size_t size);
-    SharedRegion* getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger = NULL);
-
-    /* Get the Simulation */
-    Simulation* getSimulation() const { return sim; }
+    // Does the statisticName exist in the ElementInfoStatistic
+    virtual bool doesComponentInfoStatisticExist(const std::string &statisticName) final;
+    // Return the EnableLevel for the statisticName from the ElementInfoStatistic
+    virtual uint8_t getComponentInfoStatisticEnableLevel(const std::string &statisticName) final;
+    // Return the Units for the statisticName from the ElementInfoStatistic
+    virtual std::string getComponentInfoStatisticUnits(const std::string &statisticName) final;
 
 private:
 
-    friend class SubComponent;
-
-    void addSelfLink(std::string name);
-
-    // Does the statisticName exist in the ElementInfoStatistic 
-    bool doesComponentInfoStatisticExist(std::string statisticName);
-    // Return the EnableLevel for the statisticName from the ElementInfoStatistic 
-    uint8_t getComponentInfoStatisticEnableLevel(std::string statisticName);
-    // Return the Units for the statisticName from the ElementInfoStatistic 
-    std::string getComponentInfoStatisticUnits(std::string statisticName);
-
     /** Unique ID */
     ComponentId_t   id;
-	/* std::string name; */
-    ComponentInfo* my_info;
-    Simulation *sim;
 
-    // LinkMap* myLinks;
-    std::string currentlyLoadingSubComponent;
-
-
-
-    template <typename T>
-    Statistic<T>* CreateStatistic(Component* comp, std::string& type, std::string& statName, std::string& statSubId, Params& params)
-    {
-        // Load one of the SST Core provided Statistics
-        // NOTE: This happens here (in simulation) instead of the factory because 
-        //       it is a templated method.  The Component::registerStatistic<T>() 
-        //       must be defined in the component.h however the the Factory is 
-        //       not available from the Simulation::::getSimulation() because
-        //       Factory is only defined via a forwarded definition.  Basically
-        //       we have to go through some twists and jumps to make this work.        
-
-        // Names of sst.xxx Statistics
-        if (0 == ::strcasecmp("sst.nullstatistic", type.c_str())) {
-            return new NullStatistic<T>(comp, statName, statSubId, params);
-        }
-
-        if (0 == ::strcasecmp("sst.accumulatorstatistic", type.c_str())) {
-            return new AccumulatorStatistic<T>(comp, statName, statSubId, params);
-        }
-
-        if (0 == ::strcasecmp("sst.histogramstatistic", type.c_str())) {
-            return new HistogramStatistic<T>(comp, statName, statSubId, params);
-        }
-
-	if(0 == ::strcasecmp("sst.uniquecountstatistic", type.c_str())) {
-	    return new UniqueCountStatistic<T>(comp, statName, statSubId, params);
-	}
-
-        // We did not find this statistic
-        printf("ERROR: Statistic %s is not supported by the SST Core...\n", type.c_str());
-
-        return NULL;
-    }
-
-
-
-    
 };
 
 } //namespace SST

--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -38,9 +38,6 @@ public:
     Component( ComponentId_t id );
     virtual ~Component();
 
-    /** Returns unique component ID */
-    inline ComponentId_t getId() const { return id; }
-
 
     /** Register that the simulation should not end until this
         component says it is OK to. Calling this function (generally

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -18,6 +18,32 @@
 
 namespace SST {
 
+ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name, const std::string &type, LinkMap* link_map) :
+    id(id),
+    name(name),
+    type(type),
+    link_map(link_map),
+    component(NULL),
+    enabledStats(NULL),
+    statParams(NULL)
+{ }
+
+
+ComponentInfo::ComponentInfo(const ConfigComponent *ccomp, LinkMap* link_map) :
+    id(ccomp->id),
+    name(ccomp->name),
+    type(ccomp->type),
+    link_map(link_map),
+    component(NULL),
+    enabledStats(NULL),
+    statParams(NULL)
+{
+    for ( auto sc : ccomp->subComponents ) {
+        subComponents.emplace(std::make_pair(sc.first, ComponentInfo(&sc.second, new LinkMap())));
+    }
+}
+
+
 ComponentInfo::~ComponentInfo() {
     delete link_map;
     delete component;

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -18,27 +18,39 @@
 
 namespace SST {
 
-ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name, const std::string &type, const Params *params, LinkMap* link_map) :
+ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name) :
     id(id),
     name(name),
-    type(type),
-    link_map(link_map),
-    params(params),
+    type(""),
+    link_map(NULL),
+    params(NULL),
     component(NULL),
     enabledStats(NULL),
     statParams(NULL)
 { }
 
 
-ComponentInfo::ComponentInfo(const ConfigComponent *ccomp, LinkMap* link_map) :
+ComponentInfo::ComponentInfo(const std::string &type, const Params *params, const ComponentInfo *parent) :
+    id(parent->id),
+    name(parent->name),
+    type(type),
+    link_map(parent->link_map),
+    params(params),
+    component(NULL),
+    enabledStats(parent->enabledStats),
+    statParams(parent->statParams)
+{ }
+
+
+ComponentInfo::ComponentInfo(ConfigComponent *ccomp, LinkMap* link_map) :
     id(ccomp->id),
     name(ccomp->name),
     type(ccomp->type),
     link_map(link_map),
     component(NULL),
     params(&ccomp->params),
-    enabledStats(NULL),
-    statParams(NULL)
+    enabledStats(&ccomp->enabledStatistics),
+    statParams(&ccomp->enabledStatParams)
 {
     for ( auto &sc : ccomp->subComponents ) {
         subComponents.emplace(sc.first, ComponentInfo(&sc.second, new LinkMap()));
@@ -52,8 +64,8 @@ ComponentInfo::ComponentInfo(ComponentInfo &&o) :
     link_map(o.link_map),
     component(o.component),
     params(o.params),
-    enabledStats(std::move(o.enabledStats)),
-    statParams(std::move(o.statParams))
+    enabledStats(o.enabledStats),
+    statParams(o.statParams)
 {
     o.link_map = NULL;
     o.component = NULL;

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -104,6 +104,20 @@ ComponentInfo* ComponentInfo::findSubComponent(ComponentId_t id)
     return NULL;
 }
 
+
+std::vector<LinkId_t> ComponentInfo::getAllLinkIds() const
+{
+    std::vector<LinkId_t> res;
+    for ( auto & l : link_map->getLinkMap() ) {
+        res.push_back(l.second->id);
+    }
+    for ( auto& sc : subComponents ) {
+        std::vector<LinkId_t> s = sc.second.getAllLinkIds();
+        res.insert(res.end(), s.begin(), s.end());
+    }
+    return res;
+}
+
 } // namespace SST
 
 // BOOST_CLASS_EXPORT_IMPLEMENT(SST::InitQueue)

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -18,11 +18,12 @@
 
 namespace SST {
 
-ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name, const std::string &type, LinkMap* link_map) :
+ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name, const std::string &type, const Params *params, LinkMap* link_map) :
     id(id),
     name(name),
     type(type),
     link_map(link_map),
+    params(params),
     component(NULL),
     enabledStats(NULL),
     statParams(NULL)
@@ -35,18 +36,33 @@ ComponentInfo::ComponentInfo(const ConfigComponent *ccomp, LinkMap* link_map) :
     type(ccomp->type),
     link_map(link_map),
     component(NULL),
+    params(&ccomp->params),
     enabledStats(NULL),
     statParams(NULL)
 {
-    for ( auto sc : ccomp->subComponents ) {
-        subComponents.emplace(std::make_pair(sc.first, ComponentInfo(&sc.second, new LinkMap())));
+    for ( auto &sc : ccomp->subComponents ) {
+        subComponents.emplace(sc.first, ComponentInfo(&sc.second, new LinkMap()));
     }
+}
+
+ComponentInfo::ComponentInfo(ComponentInfo &&o) :
+    id(o.id),
+    name(std::move(o.name)),
+    type(std::move(o.type)),
+    link_map(o.link_map),
+    component(o.component),
+    params(o.params),
+    enabledStats(std::move(o.enabledStats)),
+    statParams(std::move(o.statParams))
+{
+    o.link_map = NULL;
+    o.component = NULL;
 }
 
 
 ComponentInfo::~ComponentInfo() {
-    delete link_map;
-    delete component;
+    if ( link_map ) delete link_map;
+    if ( component ) delete component;
 }
 
 } // namespace SST

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -77,6 +77,14 @@ ComponentInfo::~ComponentInfo() {
     if ( component ) delete component;
 }
 
+void ComponentInfo::finalizeLinkConfiguration() {
+    for ( auto & i : link_map->getLinkMap() ) {
+        i.second->finalizeConfiguration();
+    }
+    for ( auto &s : subComponents ) {
+        s.second.finalizeLinkConfiguration();
+    }
+}
 
 ComponentInfo* ComponentInfo::findSubComponent(ComponentId_t id)
 {

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -77,6 +77,25 @@ ComponentInfo::~ComponentInfo() {
     if ( component ) delete component;
 }
 
+
+ComponentInfo* ComponentInfo::findSubComponent(ComponentId_t id)
+{
+    /* See if it is us */
+    if ( id == this->id )
+        return this;
+
+    /* Check to make sure we're part of the same component */
+    if ( COMPONENT_ID_MASK(id) != COMPONENT_ID_MASK(this->id) )
+        return NULL;
+
+    for ( auto &s : subComponents ) {
+        ComponentInfo* found = s.second.findSubComponent(id);
+        if ( found != NULL )
+            return found;
+    }
+    return NULL;
+}
+
 } // namespace SST
 
 // BOOST_CLASS_EXPORT_IMPLEMENT(SST::InitQueue)

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -84,6 +84,7 @@ public:
     }
 
     ComponentInfo* findSubComponent(ComponentId_t id);
+    std::vector<LinkId_t> getAllLinkIds() const;
 
     statEnableList_t* getStatEnableList() { return enabledStats; }
     statParamsList_t* getStatParams() { return statParams; }
@@ -113,7 +114,6 @@ public:
             return lhs->id == rhs->id;
         }
     };
-    
 };
 
 

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -24,7 +24,7 @@
 namespace SST {
 
 class LinkMap;
-class Component;
+class BaseComponent;
 
 class ComponentInfoMap;
 
@@ -36,23 +36,23 @@ public:
 
 private:
     friend class Simulation;
+    friend class BaseComponent;
+    friend class ComponentInfoMap;
     const ComponentId_t id;
     const std::string name;
     const std::string type;
     LinkMap* link_map;
-    Component* component;
+    BaseComponent* component;
     std::map<std::string, ComponentInfo> subComponents;
     const Params *params;
 
     statEnableList_t * enabledStats;
     statParamsList_t * statParams;
 
-    inline void setComponent(Component* comp) { component = comp; }
+    inline void setComponent(BaseComponent* comp) { component = comp; }
 
-    friend class ComponentInfoMap;
     /* Lookup Key style constructor */
     ComponentInfo(ComponentId_t id, const std::string &name);
-    friend class Simulation;
     void finalizeLinkConfiguration();
 
 public:
@@ -70,7 +70,7 @@ public:
 
     inline const std::string& getType() const { return type; }
 
-    inline Component* getComponent() const { return component; }
+    inline BaseComponent* getComponent() const { return component; }
 
     inline LinkMap* getLinkMap() const { return link_map; }
 

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -18,63 +18,68 @@
 #include <string>
 #include <functional>
 
-/* #include <sst/core/clock.h> */
-/* #include <sst/core/oneshot.h> */
-/* #include <sst/core/event.h> */
-/* //#include <sst/core/params.h> */
-/* //#include <sst/core/link.h> */
-/* //#include <sst/core/timeConverter.h> */
-/* #include "sst/core/simulation.h" */
-/* #include "sst/core/unitAlgebra.h" */
-/* #include "sst/core/statapi/statbase.h" */
+#include <sst/core/configGraph.h>
+
 
 namespace SST {
 
 class LinkMap;
 class Component;
-    
+
 struct ComponentInfo {
 
-    friend class Simulation;
-    
+public:
+    typedef std::vector<std::string>      statEnableList_t;        /*!< List of Enabled Statistics */
+    typedef std::vector<Params>           statParamsList_t;        /*!< List of Enabled Statistics Parameters */
+
 private:
+    friend class Simulation;
     const ComponentId_t id;
     const std::string name;
     const std::string type;
     LinkMap* link_map;
     Component* component;
+    std::map<std::string, ComponentInfo> subComponents;
+
+
+    statEnableList_t *enabledStats;
+    statParamsList_t *statParams;
 
     inline void setComponent(Component* comp) { component = comp; }
 
-    
-public:
-    ComponentInfo(ComponentId_t id, std::string name, std::string type, LinkMap* link_map) :
-        id(id),
-        name(name),
-        type(type),
-        link_map(link_map),
-        component(NULL)
-    {}
 
+public:
+    /* Old ELI Style */
+    ComponentInfo(ComponentId_t id, const std::string &name, const std::string &type, LinkMap* link_map);
+
+    /* New ELI Style */
+    ComponentInfo(const ConfigComponent *ccomp, LinkMap* link_map);
     ~ComponentInfo();
 
-    // ComponentInfo() :
-    //     id(0),
-    //     name(""),
-    //     type(""),
-    //     link_map(NULL)
-    // {}
-
     inline ComponentId_t getID() const { return id; }
-    
+
     inline const std::string& getName() const { return name; }
 
     inline const std::string& getType() const { return type; }
 
     inline Component* getComponent() const { return component; }
-    
+
     inline LinkMap* getLinkMap() const { return link_map; }
 
+    inline std::map<std::string, ComponentInfo> getSubComponents() const { return subComponents; }
+
+    void setStatEnablement(statEnableList_t *enabled, statParamsList_t *params) {
+        enabledStats = enabled;
+        statParams = params;
+    }
+
+    statEnableList_t* getStatEnableList() const { return enabledStats; }
+    statParamsList_t* getStatParams() const { return statParams; }
+
+    void clearStatEnablement() {
+        enabledStats = NULL;
+        statParams = NULL;
+    }
 
     struct HashName {
         size_t operator() (const ComponentInfo* info) const {

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -26,6 +26,8 @@ namespace SST {
 class LinkMap;
 class Component;
 
+class ComponentInfoMap;
+
 struct ComponentInfo {
 
 public:
@@ -42,18 +44,21 @@ private:
     std::map<std::string, ComponentInfo> subComponents;
     const Params *params;
 
-    statEnableList_t *enabledStats;
-    statParamsList_t *statParams;
+    statEnableList_t * enabledStats;
+    statParamsList_t * statParams;
 
     inline void setComponent(Component* comp) { component = comp; }
 
+    friend class ComponentInfoMap;
+    /* Lookup Key style constructor */
+    ComponentInfo(ComponentId_t id, const std::string &name);
 
 public:
-    /* Old ELI Style */
-    ComponentInfo(ComponentId_t id, const std::string &name, const std::string &type, const Params *params, LinkMap* link_map);
+    /* Old ELI Style subcomponent constructor */
+    ComponentInfo(const std::string &type, const Params *params, const ComponentInfo *parent);
 
     /* New ELI Style */
-    ComponentInfo(const ConfigComponent *ccomp, LinkMap* link_map);
+    ComponentInfo(ConfigComponent *ccomp, LinkMap* link_map);
     ComponentInfo(ComponentInfo &&o);
     ~ComponentInfo();
 
@@ -71,18 +76,13 @@ public:
 
     inline std::map<std::string, ComponentInfo>& getSubComponents() { return subComponents; }
 
-    void setStatEnablement(statEnableList_t *enabled, statParamsList_t *params) {
+    void setStatEnablement(statEnableList_t * enabled, statParamsList_t * params) {
         enabledStats = enabled;
         statParams = params;
     }
 
-    statEnableList_t* getStatEnableList() const { return enabledStats; }
-    statParamsList_t* getStatParams() const { return statParams; }
-
-    void clearStatEnablement() {
-        enabledStats = NULL;
-        statParams = NULL;
-    }
+    statEnableList_t* getStatEnableList() { return enabledStats; }
+    statParamsList_t* getStatParams() { return statParams; }
 
     struct HashName {
         size_t operator() (const ComponentInfo* info) const {
@@ -137,14 +137,14 @@ public:
     }
 
     ComponentInfo* getByName(const std::string& key) const {
-        ComponentInfo infoKey(0, key, "", NULL, NULL);
+        ComponentInfo infoKey(0, key);
         auto value = dataByName.find(&infoKey);
         if ( value == dataByName.end() ) return NULL;
         return *value;
     }
 
     ComponentInfo* getByID(const ComponentId_t key) const {
-        ComponentInfo infoKey(key, "", "", NULL, NULL);
+        ComponentInfo infoKey(key, "");
         auto value = dataByID.find(&infoKey);
         if ( value == dataByID.end() ) return NULL;
         return *value;

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -52,6 +52,8 @@ private:
     friend class ComponentInfoMap;
     /* Lookup Key style constructor */
     ComponentInfo(ComponentId_t id, const std::string &name);
+    friend class Simulation;
+    void finalizeLinkConfiguration();
 
 public:
     /* Old ELI Style subcomponent constructor */
@@ -120,7 +122,7 @@ private:
     std::unordered_set<ComponentInfo*, ComponentInfo::HashID, ComponentInfo::EqualsID> dataByID;
 
 public:
-    typedef std::unordered_set<ComponentInfo*, ComponentInfo::HashName, ComponentInfo::EqualsName>::const_iterator const_iterator;
+    typedef std::unordered_set<ComponentInfo*, ComponentInfo::HashID, ComponentInfo::EqualsID>::const_iterator const_iterator;
 
     const_iterator begin() const {
         return dataByID.begin();

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -40,7 +40,7 @@ private:
     LinkMap* link_map;
     Component* component;
     std::map<std::string, ComponentInfo> subComponents;
-
+    const Params *params;
 
     statEnableList_t *enabledStats;
     statParamsList_t *statParams;
@@ -50,10 +50,11 @@ private:
 
 public:
     /* Old ELI Style */
-    ComponentInfo(ComponentId_t id, const std::string &name, const std::string &type, LinkMap* link_map);
+    ComponentInfo(ComponentId_t id, const std::string &name, const std::string &type, const Params *params, LinkMap* link_map);
 
     /* New ELI Style */
     ComponentInfo(const ConfigComponent *ccomp, LinkMap* link_map);
+    ComponentInfo(ComponentInfo &&o);
     ~ComponentInfo();
 
     inline ComponentId_t getID() const { return id; }
@@ -66,7 +67,9 @@ public:
 
     inline LinkMap* getLinkMap() const { return link_map; }
 
-    inline std::map<std::string, ComponentInfo> getSubComponents() const { return subComponents; }
+    inline const Params* getParams() const { return params; }
+
+    inline std::map<std::string, ComponentInfo>& getSubComponents() { return subComponents; }
 
     void setStatEnablement(statEnableList_t *enabled, statParamsList_t *params) {
         enabledStats = enabled;
@@ -134,14 +137,14 @@ public:
     }
 
     ComponentInfo* getByName(const std::string& key) const {
-        ComponentInfo infoKey(0, key, "", NULL);
+        ComponentInfo infoKey(0, key, "", NULL, NULL);
         auto value = dataByName.find(&infoKey);
         if ( value == dataByName.end() ) return NULL;
         return *value;
     }
 
     ComponentInfo* getByID(const ComponentId_t key) const {
-        ComponentInfo infoKey(key, "", "", NULL);
+        ComponentInfo infoKey(key, "", "", NULL, NULL);
         auto value = dataByID.find(&infoKey);
         if ( value == dataByID.end() ) return NULL;
         return *value;

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -19,6 +19,7 @@
 #include <sst/core/config.h>
 #include <sst/core/timeLord.h>
 #include <sst/core/simulation.h>
+#include <sst/core/factory.h>
 
 #include <string.h>
 
@@ -289,7 +290,7 @@ ConfigGraph::checkForStructuralErrors()
                 const ConfigLink& link = links[ccomp->links[i]];
                 if ( link.component[j] == ccomp->id ) {
                     // If port is not found, print a warning
-                    if (!Component::isPortValidForComponent(ccomp->type, link.port[j]) ) {
+                    if (!Factory::getFactory()->isPortNameValid(ccomp->type, link.port[j]) ) {
                         // For now this is not a fatal error
                         // found_error = true;
                         output.output("WARNING:  Attempling to connect to undocumented port: %s, "

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -72,6 +72,9 @@ ConfigComponent::cloneWithoutLinks() const
     ret.params = params;
     ret.enabledStatistics = enabledStatistics;
     ret.enabledStatParams = enabledStatParams;
+    for ( auto &i : subComponents ) {
+        ret.subComponents.emplace_back(i.first, i.second.cloneWithoutLinks());
+    }
     return ret;
 }
 
@@ -87,6 +90,9 @@ ConfigComponent::cloneWithoutLinksOrParams() const
     ret.rank = rank;
     ret.enabledStatistics = enabledStatistics;
     ret.enabledStatParams = enabledStatParams;
+    for ( auto &i : subComponents ) {
+        ret.subComponents.emplace_back(i.first, i.second.cloneWithoutLinksOrParams());
+    }
     return ret;
 }
 
@@ -173,7 +179,7 @@ void ConfigComponent::addStatisticParameter(const std::string &statisticName, co
     }
 }
 
-ConfigComponent* ConfigComponent::addSubComponent(const std::string &name, const std::string &type)
+ConfigComponent* ConfigComponent::addSubComponent(ComponentId_t id, const std::string &name, const std::string &type)
 {
     /* Check for existing subComponent with this name */
     for ( auto &i : subComponents ) {
@@ -184,11 +190,7 @@ ConfigComponent* ConfigComponent::addSubComponent(const std::string &name, const
     subComponents.emplace_back(
             std::make_pair(
                 name,
-                ConfigComponent((ComponentId_t)-1, /* TODO: Do we need IDs? */
-                                name,
-                                type,
-                                this->weight,
-                                this->rank)));
+                ConfigComponent(id, name, type, this->weight, this->rank)));
 
     return &(subComponents.back().second);
 }
@@ -338,23 +340,23 @@ ConfigGraph::checkForStructuralErrors()
         // }
     }
 #endif
-    
+
     return found_error;
 }
 
 
 ComponentId_t
-ConfigGraph::addComponent(std::string name, std::string type, float weight, RankInfo rank)
+ConfigGraph::addComponent(ComponentId_t id, std::string name, std::string type, float weight, RankInfo rank)
 {
-	comps.push_back(ConfigComponent(nextCompID, name, type, weight, rank));
-    return nextCompID++;
+	comps.push_back(ConfigComponent(id, name, type, weight, rank));
+    return id;
 }
 
 ComponentId_t
-ConfigGraph::addComponent(std::string name, std::string type)
+ConfigGraph::addComponent(ComponentId_t id, std::string name, std::string type)
 {
-	comps.push_back(ConfigComponent(nextCompID, name, type, 1.0f, RankInfo()));
-    return nextCompID++;
+	comps.push_back(ConfigComponent(id, name, type, 1.0f, RankInfo()));
+    return id;
 }
 
 

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -158,6 +158,7 @@ public:
     ConfigComponent* findSubComponent(ComponentId_t);
     void enableStatistic(const std::string &statisticName);
     void addStatisticParameter(const std::string &statisticName, const std::string &param, const std::string &value);
+    std::vector<LinkId_t> allLinks() const;
 
     void serialize_order(SST::Core::Serialization::serializer &ser) {
         ser & id;

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -154,7 +154,7 @@ public:
     void setRank(RankInfo r);
     void setWeight(double w);
     void addParameter(const std::string &key, const std::string &value, bool overwrite);
-    ConfigComponent* addSubComponent(const std::string &name, const std::string &type);
+    ConfigComponent* addSubComponent(ComponentId_t, const std::string &name, const std::string &type);
     void enableStatistic(const std::string &statisticName);
     void addStatisticParameter(const std::string &statisticName, const std::string &param, const std::string &value);
 
@@ -218,7 +218,6 @@ public:
     ConfigGraph() {
         links.clear();
         comps.clear();
-        nextCompID = 0;
         // Init the statistic output settings
         statOutputName = STATISTICSDEFAULTOUTPUTNAME;
         statLoadLevel = STATISTICSDEFAULTLOADLEVEL;
@@ -236,9 +235,9 @@ public:
 
     // API for programatic initialization
     /** Create a new component with weight and rank */
-    ComponentId_t addComponent(std::string name, std::string type, float weight, RankInfo rank);
+    ComponentId_t addComponent(ComponentId_t id, std::string name, std::string type, float weight, RankInfo rank);
     /** Create a new component */
-    ComponentId_t addComponent(std::string name, std::string type);
+    ComponentId_t addComponent(ComponentId_t id, std::string name, std::string type);
 
 
     /** Set the statistic ouput module */
@@ -300,7 +299,7 @@ public:
 		ser & statOutputParams;
 		ser & statLoadLevel;
 	}
-    
+
 private:
     friend class Simulation;
     friend class SSTSDLModelDefinition;
@@ -310,9 +309,7 @@ private:
 
     // temporary as a test
     std::map<std::string,LinkId_t> link_names;
-    
-    ComponentId_t  nextCompID;
-    
+
     std::string statOutputName;
     Params      statOutputParams;
     uint8_t     statLoadLevel;
@@ -321,7 +318,7 @@ private:
 
 };
 
-    
+
 class PartitionComponent {
 public:
     ComponentId_t             id;

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -139,17 +139,24 @@ public:
     bool                          isIntrospector;    /*!< Is this an Introspector? */
     std::vector<std::string>      enabledStatistics; /*!< List of statistics to be enabled */
     std::vector<Params>           enabledStatParams; /*!< List of parameters for enabled statistics */
+    std::vector<std::pair<std::string, ConfigComponent> > subComponents; /*!< List of subcomponents */
 
     inline const ComponentId_t& key()const { return id; }
-    
+
     /** Print Component information */
     void print(std::ostream &os) const;
 
     ConfigComponent cloneWithoutLinks() const;
     ConfigComponent cloneWithoutLinksOrParams() const;
-    
+
     ~ConfigComponent() {}
     ConfigComponent() {} // for serialization
+
+    void setRank(RankInfo r);
+    void setWeight(double w);
+    void addParameter(const std::string &key, const std::string &value, bool overwrite);
+    void enableStatistic(const std::string &statisticName);
+    void addStatisticParameter(const std::string &statisticName, const std::string &param, const std::string &value);
 
     void serialize_order(SST::Core::Serialization::serializer &ser) {
         ser & id;
@@ -163,6 +170,7 @@ public:
         ser & isIntrospector;
         ser & enabledStatistics;
         ser & enabledStatParams;
+        ser & subComponents;
     }
 
     ImplementSerializable(SST::ConfigComponent)
@@ -234,21 +242,12 @@ public:
     /** Create a new component */
     ComponentId_t addComponent(std::string name, std::string type);
 
-    /** Set on which rank a Component will exist (partitioning) */
-    void setComponentRank(ComponentId_t comp_id, RankInfo rank);
-    /** Set the weight of a Component (partitioning) */
-    void setComponentWeight(ComponentId_t comp_id, float weight);
-
-    /** Add a set of Parameters to a component */
-    void addParams(ComponentId_t comp_id, Params& p);
-    /** Add a single parameter to a component */
-    void addParameter(ComponentId_t comp_id, std::string key, std::string value, bool overwrite = false);
 
     /** Set the statistic ouput module */
-    void setStatisticOutput(const char* name);
-    
+    void setStatisticOutput(const std::string &name);
+
     /** Add parameter to the statistic output module */
-    void addStatisticOutputParameter(const char* param, const char* value);
+    void addStatisticOutputParameter(const std::string &param, const std::string &value);
 
     /** Set a set of parameter to the statistic output module */
     void setStatisticOutputParams(const Params& p);
@@ -257,19 +256,17 @@ public:
     void setStatisticLoadLevel(uint8_t loadLevel);
 
     /** Enable a Statistics assigned to a component */
-    void enableComponentStatistic(ComponentId_t comp_id, std::string statisticName);
     void enableStatisticForComponentName(std::string ComponentName, std::string statisticName);
     void enableStatisticForComponentType(std::string ComponentType, std::string statisticName);
 
     /** Add Parameters for a Statistic */
-    void addComponentStatisticParameter(ComponentId_t comp_id, std::string statisticName, const char* param, const char* value);
-    void addStatisticParameterForComponentName(std::string ComponentName, std::string statisticName, const char* param, const char* value);
-    void addStatisticParameterForComponentType(std::string ComponentType, std::string statisticName, const char* param, const char* value);
-    
+    void addStatisticParameterForComponentName(const std::string &ComponentName, const std::string &statisticName, const std::string &param, const std::string &value);
+    void addStatisticParameterForComponentType(const std::string &ComponentType, const std::string &statisticName, const std::string &param, const std::string &value);
+
     const std::string& getStatOutput() const {return statOutputName;}
     const Params&      getStatOutputParams() const {return statOutputParams;}
     long               getStatLoadLevel() const {return statLoadLevel;}
-    
+
     /** Add a Link to a Component on a given Port */
     void addLink(ComponentId_t comp_id, std::string link_name, std::string port, std::string latency_str, bool no_cut = false);
 

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -136,7 +136,6 @@ public:
     RankInfo                      rank;              /*!< Parallel Rank for this component */
     std::vector<LinkId_t>         links;             /*!< List of links connected */
     Params                        params;            /*!< Set of Parameters */
-    bool                          isIntrospector;    /*!< Is this an Introspector? */
     std::vector<std::string>      enabledStatistics; /*!< List of statistics to be enabled */
     std::vector<Params>           enabledStatParams; /*!< List of parameters for enabled statistics */
     std::vector<std::pair<std::string, ConfigComponent> > subComponents; /*!< List of subcomponents */
@@ -155,6 +154,7 @@ public:
     void setRank(RankInfo r);
     void setWeight(double w);
     void addParameter(const std::string &key, const std::string &value, bool overwrite);
+    ConfigComponent* addSubComponent(const std::string &name, const std::string &type);
     void enableStatistic(const std::string &statisticName);
     void addStatisticParameter(const std::string &statisticName, const std::string &param, const std::string &value);
 
@@ -167,7 +167,6 @@ public:
         ser & rank.thread;
         ser & links;
         ser & params;
-        ser & isIntrospector;
         ser & enabledStatistics;
         ser & enabledStatParams;
         ser & subComponents;
@@ -179,13 +178,12 @@ private:
 
     friend class ConfigGraph;
     /** Create a new Component */
-    ConfigComponent(ComponentId_t id, std::string name, std::string type, float weight, RankInfo rank, bool isIntrospector) :
+    ConfigComponent(ComponentId_t id, std::string name, std::string type, float weight, RankInfo rank) :
         id(id),
         name(name),
         type(type),
         weight(weight),
-        rank(rank),
-        isIntrospector(isIntrospector)
+        rank(rank)
     { }
 
 
@@ -269,9 +267,6 @@ public:
 
     /** Add a Link to a Component on a given Port */
     void addLink(ComponentId_t comp_id, std::string link_name, std::string port, std::string latency_str, bool no_cut = false);
-
-    /** Create a new Introspector */
-    ComponentId_t addIntrospector(std::string name, std::string type);
 
     /** Perform any post-creation cleanup processes */
     void postCreationCleanup();

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -155,6 +155,7 @@ public:
     void setWeight(double w);
     void addParameter(const std::string &key, const std::string &value, bool overwrite);
     ConfigComponent* addSubComponent(ComponentId_t, const std::string &name, const std::string &type);
+    ConfigComponent* findSubComponent(ComponentId_t);
     void enableStatistic(const std::string &statisticName);
     void addStatisticParameter(const std::string &statisticName, const std::string &param, const std::string &value);
 
@@ -278,6 +279,9 @@ public:
     ConfigComponentMap_t& getComponentMap() {
         return comps;
     }
+
+    ConfigComponent* findComponent(ComponentId_t);
+
     /** Return the map of links */
     ConfigLinkMap_t& getLinkMap() {
         return links;

--- a/src/sst/core/element.h
+++ b/src/sst/core/element.h
@@ -77,6 +77,7 @@ struct ElementInfoPort {
 
 struct ElementInfoSubComponentHook {
     const char * name;
+    const char * description;
     const char * superclass;
 };
 

--- a/src/sst/core/element.h
+++ b/src/sst/core/element.h
@@ -75,6 +75,11 @@ struct ElementInfoPort {
     const char **validEvents;	/*!< List of fully-qualified event types that this Port expects to send or receive */
 };
 
+struct ElementInfoSubComponentHook {
+    const char * name;
+    const char * superclass;
+};
+
 /** Describes a Component and its associated information
  */
 struct ElementInfoComponent {
@@ -86,6 +91,7 @@ struct ElementInfoComponent {
     const ElementInfoPort *ports;		/*!< List of ports that this component uses. */
     uint32_t category;	   		        /*!< Bit-mask of categories in which this component fits. */
     const ElementInfoStatistic *stats;	/*!< List of statistic Names that this component wants enabled. */
+    const ElementInfoSubComponentHook *subComponents;
 };
 
 /** Describes an Introspector
@@ -127,6 +133,7 @@ struct ElementInfoSubComponent {
     const ElementInfoParam *params;					/*!< List of parameters which are used by this subcomponent. */
     const ElementInfoStatistic *stats;              /*!< List of statistics supplied by this subcomponent. */
     const char *provides;                           /*!< Name of SuperClass which for this subcomponent can be used. */
+    const ElementInfoPort *ports;		            /*!< List of ports that this subcomponent uses. */
 };
 
 /** Describes a Partitioner

--- a/src/sst/core/element.h
+++ b/src/sst/core/element.h
@@ -134,6 +134,7 @@ struct ElementInfoSubComponent {
     const ElementInfoStatistic *stats;              /*!< List of statistics supplied by this subcomponent. */
     const char *provides;                           /*!< Name of SuperClass which for this subcomponent can be used. */
     const ElementInfoPort *ports;		            /*!< List of ports that this subcomponent uses. */
+    const ElementInfoSubComponentHook *subComponents;
 };
 
 /** Describes a Partitioner

--- a/src/sst/core/factory.h
+++ b/src/sst/core/factory.h
@@ -42,9 +42,9 @@ public:
 
     /** Get a list of allowed ports for a given component type.
      * @param type - Name of component in lib.name format
-     * @return Vector of allowed port names 
+     * @return True if this is a valid portname
      */
-    const std::vector<std::string>* GetComponentAllowedPorts(std::string type);
+    bool isPortNameValid(const std::string &type, const std::string port_name);
 
 
     /** Attempt to create a new Component instantiation
@@ -261,6 +261,7 @@ private:
         std::vector<std::string>  statNames;
         std::vector<std::string>  statUnits;
         std::vector<uint8_t>      statEnableLevels;
+        std::vector<std::string>  ports;
 
         SubComponentInfo() {}
 
@@ -274,6 +275,13 @@ private:
                 statEnableLevels.push_back(s->enableLevel);
                 s++;
             }
+
+            const ElementInfoPort *p = subcomponent->ports;
+            while ( NULL != p && NULL != p->name ) {
+                ports.push_back(p->name);
+                p++;
+            }
+
         }
 
     SubComponentInfo(const SubComponentInfo& old) : subcomponent(old.subcomponent), params(old.params), statNames(old.statNames), statUnits(old.statUnits), statEnableLevels(old.statEnableLevels)

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -41,6 +41,7 @@ public:
     friend class SyncBase;
     friend class ThreadSync;
     friend class SyncManager;
+    friend class ComponentInfo;
     
     /** Create a new link with a given ID */
     Link(LinkId_t id);

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -543,8 +543,8 @@ main(int argc, char *argv[])
                     iter != links.end(); ++iter ) {
                 ConfigLink &clink = *iter;
                 RankInfo rank[2];
-                rank[0] = comps[clink.component[0]].rank;
-                rank[1] = comps[clink.component[1]].rank;
+                rank[0] = comps[COMPONENT_ID_MASK(clink.component[0])].rank;
+                rank[1] = comps[COMPONENT_ID_MASK(clink.component[1])].rank;
                 if ( rank[0].rank == rank[1].rank ) continue;
                 if ( clink.getMinLatency() < min_part ) {
                     min_part = clink.getMinLatency();

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -45,7 +45,6 @@
 #include <sst/core/iouse.h>
 
 #include <sys/resource.h>
-#include <sst/core/interfaces/simpleNetwork.h>
 
 #include <sst/core/objectComms.h>
 

--- a/src/sst/core/model/Makefile.inc
+++ b/src/sst/core/model/Makefile.inc
@@ -8,7 +8,11 @@ sst_core_sources += \
 	model/sstmodel.h \
 	model/sstmodel.cc \
 	model/pymodel.h \
-	model/pymodel.cc
+	model/pymodel.cc \
+	model/pymodel_link.h \
+	model/pymodel_link.cc \
+	model/pymodel_comp.h \
+	model/pymodel_comp.cc
 
 libexec_SCRIPTS = model/xmlToPython.py
 EXTRA_DIST += model/xmlToPython.py

--- a/src/sst/core/model/pymodel.cc
+++ b/src/sst/core/model/pymodel.cc
@@ -181,6 +181,7 @@ static PyObject* findComponentByName(PyObject* self, PyObject* args)
     if ( id != UNSET_COMPONENT_ID ) {
         PyObject *argList = Py_BuildValue("ssk", name, "irrelephant", id);
         PyObject *res = PyObject_CallObject((PyObject *) &PyModel_ComponentType, argList);
+        Py_DECREF(argList);
         return res;
     }
     Py_INCREF(Py_None);
@@ -607,9 +608,11 @@ void SSTPythonModelDefinition::initModel(const std::string script_file, int verb
 
     // Initialize our types
     PyModel_ComponentType.tp_new = PyType_GenericNew;
+    PyModel_SubComponentType.tp_new = PyType_GenericNew;
     PyModel_LinkType.tp_new = PyType_GenericNew;
     ModuleLoaderType.tp_new = PyType_GenericNew;
     if ( ( PyType_Ready(&PyModel_ComponentType) < 0 ) ||
+         ( PyType_Ready(&PyModel_SubComponentType) < 0 ) ||
          ( PyType_Ready(&PyModel_LinkType) < 0 ) ||
          ( PyType_Ready(&ModuleLoaderType) < 0 ) ) {
         output->fatal(CALL_INFO, -1, "Error loading Python types.\n");
@@ -623,6 +626,7 @@ void SSTPythonModelDefinition::initModel(const std::string script_file, int verb
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
     Py_INCREF(&PyModel_ComponentType);
+    Py_INCREF(&PyModel_SubComponentType);
     Py_INCREF(&PyModel_LinkType);
     Py_INCREF(&ModuleLoaderType);
 #if ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
@@ -631,6 +635,7 @@ void SSTPythonModelDefinition::initModel(const std::string script_file, int verb
     
     PyModule_AddObject(module, "Link", (PyObject*)&PyModel_LinkType);
     PyModule_AddObject(module, "Component", (PyObject*)&PyModel_ComponentType);
+    PyModule_AddObject(module, "SubComponent", (PyObject*)&PyModel_SubComponentType);
 
 
     // Add our custom loader

--- a/src/sst/core/model/pymodel.cc
+++ b/src/sst/core/model/pymodel.cc
@@ -12,7 +12,6 @@
 // distribution.
 
 #include "sst_config.h"
-#ifdef SST_CONFIG_HAVE_PYTHON
 #include <Python.h>
 
 #ifdef SST_CONFIG_HAVE_MPI
@@ -24,54 +23,27 @@
 
 #include <sst/core/sst_types.h>
 #include <sst/core/model/pymodel.h>
+#include <sst/core/model/pymodel_comp.h>
+#include <sst/core/model/pymodel_link.h>
+
 #include <sst/core/simulation.h>
 #include <sst/core/element.h>
 #include <sst/core/factory.h>
 #include <sst/core/component.h>
 #include <sst/core/configGraph.h>
 
-static SSTPythonModelDefinition *gModel = NULL;
 
-using namespace SST;
+using namespace SST::Core;
+
+SST::Core::SSTPythonModelDefinition *gModel = NULL;
 
 extern "C" {
 
 
-typedef struct {
+struct ModuleLoaderPy_t {
     PyObject_HEAD
-    ComponentId_t id;
-	char *name;
+};
 
-    ConfigComponent& getComp() {
-        return gModel->getGraph()->getComponentMap()[id];
-    }
-} ComponentPy_t;
-
-
-typedef struct {
-    PyObject_HEAD
-    char *name;
-    bool no_cut;
-    char *latency;
-} LinkPy_t;
-
-
-typedef struct {
-    PyObject_HEAD
-} ModuleLoaderPy_t;
-
-static int compInit(ComponentPy_t *self, PyObject *args, PyObject *kwds);
-static void compDealloc(ComponentPy_t *self);
-static PyObject* compAddParam(PyObject *self, PyObject *args);
-static PyObject* compAddParams(PyObject *self, PyObject *args);
-static PyObject* compSetRank(PyObject *self, PyObject *arg);
-static PyObject* compSetWeight(PyObject *self, PyObject *arg);
-static PyObject* compAddLink(PyObject *self, PyObject *args);
-static PyObject* compGetFullName(PyObject *self, PyObject *args);
-static int compCompare(PyObject *obj0, PyObject *obj1);
-
-static PyObject* compEnableAllStatistics(PyObject *self, PyObject *args);
-static PyObject* compEnableStatistics(PyObject *self, PyObject *args);
 
 static PyObject* setStatisticOutput(PyObject *self, PyObject *args);
 static PyObject* setStatisticLoadLevel(PyObject *self, PyObject *args);
@@ -82,137 +54,11 @@ static PyObject* enableAllStatisticsForComponentType(PyObject *self, PyObject *a
 static PyObject* enableStatisticForComponentName(PyObject *self, PyObject *args);
 static PyObject* enableStatisticForComponentType(PyObject *self, PyObject *args);
 
-static int linkInit(LinkPy_t *self, PyObject *args, PyObject *kwds);
-static void linkDealloc(LinkPy_t *self);
-static PyObject* linkConnect(PyObject* self, PyObject *args);
-static PyObject* linkSetNoCut(PyObject* self, PyObject *args);
 
 static PyObject* mlFindModule(PyObject *self, PyObject *args);
 static PyObject* mlLoadModule(PyObject *self, PyObject *args);
 
-static PyMethodDef componentMethods[] = {
-    {   "addParam",
-        compAddParam, METH_VARARGS,
-        "Adds a parameter(name, value)"},
-    {   "addParams",
-        compAddParams, METH_O,
-        "Adds Multiple Parameters from a dict"},
-    {   "setRank",
-        compSetRank, METH_VARARGS,
-        "Sets which rank on which this component should sit"},
-    {   "setWeight",
-        compSetWeight, METH_O,
-        "Sets the weight of the component"},
-    {   "addLink",
-        compAddLink, METH_VARARGS,
-        "Connects this component to a Link"},
-	{	"getFullName",
-		compGetFullName, METH_NOARGS,
-		"Returns the full name, after any prefix, of the component."},
-    {   "enableAllStatistics",
-        compEnableAllStatistics, METH_VARARGS,
-        "Enable all Statistics in the component with optional parameters"},
-    {   "enableStatistics",
-        compEnableStatistics, METH_VARARGS,
-        "Enables Multiple Statistics in the component with optional parameters"},
-    {   NULL, NULL, 0, NULL }
-};
 
-
-static PyTypeObject ComponentType = {
-    PyObject_HEAD_INIT(NULL)
-    0,                         /* ob_size */
-    "sst.Component",           /* tp_name */
-    sizeof(ComponentPy_t),     /* tp_basicsize */
-    0,                         /* tp_itemsize */
-    (destructor)compDealloc,   /* tp_dealloc */
-    0,                         /* tp_print */
-    0,                         /* tp_getattr */
-    0,                         /* tp_setattr */
-    compCompare,               /* tp_compare */
-    0,                         /* tp_repr */
-    0,                         /* tp_as_number */
-    0,                         /* tp_as_sequence */
-    0,                         /* tp_as_mapping */
-    0,                         /* tp_hash */
-    0,                         /* tp_call */
-    0,                         /* tp_str */
-    0,                         /* tp_getattro */
-    0,                         /* tp_setattro */
-    0,                         /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,        /* tp_flags */
-    "SST Component",           /* tp_doc */
-    0,                         /* tp_traverse */
-    0,                         /* tp_clear */
-    0,                         /* tp_richcompare */
-    0,                         /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
-    componentMethods,          /* tp_methods */
-    0,                         /* tp_members */
-    0,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
-    0,                         /* tp_dictoffset */
-    (initproc)compInit,        /* tp_init */
-    0,                         /* tp_alloc */
-    0,                         /* tp_new */
-};
-
-static PyMethodDef linkMethods[] = {
-    {   "connect",
-        linkConnect, METH_VARARGS,
-        "Connects two components to a Link"},
-    {   "setNoCut",
-        linkSetNoCut, METH_NOARGS,
-        "Specifies that this link should not be partitioned across"},
-    {   NULL, NULL, 0, NULL }
-};
-
-
-static PyTypeObject LinkType = {
-    PyObject_HEAD_INIT(NULL)
-    0,                         /* ob_size */
-    "sst.Link",                /* tp_name */
-    sizeof(LinkPy_t),          /* tp_basicsize */
-    0,                         /* tp_itemsize */
-    (destructor)linkDealloc,   /* tp_dealloc */
-    0,                         /* tp_print */
-    0,                         /* tp_getattr */
-    0,                         /* tp_setattr */
-    0,                         /* tp_compare */
-    0,                         /* tp_repr */
-    0,                         /* tp_as_number */
-    0,                         /* tp_as_sequence */
-    0,                         /* tp_as_mapping */
-    0,                         /* tp_hash */
-    0,                         /* tp_call */
-    0,                         /* tp_str */
-    0,                         /* tp_getattro */
-    0,                         /* tp_setattro */
-    0,                         /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,        /* tp_flags */
-    "SST Link",                /* tp_doc */
-    0,                         /* tp_traverse */
-    0,                         /* tp_clear */
-    0,                         /* tp_richcompare */
-    0,                         /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
-    linkMethods,               /* tp_methods */
-    0,                         /* tp_members */
-    0,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
-    0,                         /* tp_dictoffset */
-    (initproc)linkInit,        /* tp_init */
-    0,                         /* tp_alloc */
-    0,                         /* tp_new */
-};
 
 
 static PyMethodDef mlMethods[] = {
@@ -266,318 +112,6 @@ static PyTypeObject ModuleLoaderType = {
 
 
 
-static int compInit(ComponentPy_t *self, PyObject *args, PyObject *kwds)
-{
-    char *name, *type;
-    ComponentId_t useID = UNSET_COMPONENT_ID;
-    if ( !PyArg_ParseTuple(args, "ss|k", &name, &type, &useID) )
-        return -1;
-
-    if ( useID == UNSET_COMPONENT_ID ) {
-        self->name = gModel->addNamePrefix(name);
-        self->id = gModel->addComponent(self->name, type);
-        gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Creating component [%s] of type [%s]: id [%lu]\n", name, type, self->id);
-    } else {
-        self->name = name;
-        self->id = useID;
-    }
-
-    return 0;
-}
-
-
-static void compDealloc(ComponentPy_t *self)
-{
-    if ( self->name ) free(self->name);
-    self->ob_type->tp_free((PyObject*)self);
-}
-
-
-
-static PyObject* compAddParam(PyObject *self, PyObject *args)
-{
-    char *param = NULL;
-    PyObject *value = NULL;
-    if ( !PyArg_ParseTuple(args, "sO", &param, &value) )
-        return NULL;
-
-    ConfigComponent &c = ((ComponentPy_t*)self)->getComp();
-
-    PyObject *vstr = PyObject_CallMethod(value, (char*)"__str__", NULL);
-    c.addParameter(param, PyString_AsString(vstr), true);
-    Py_XDECREF(vstr);
-
-    return PyInt_FromLong(0);
-}
-
-
-static PyObject* compAddParams(PyObject *self, PyObject *args)
-{
-    ConfigComponent &c = ((ComponentPy_t*)self)->getComp();
-
-    if ( !PyDict_Check(args) ) {
-        return NULL;
-    }
-
-    Py_ssize_t pos = 0;
-    PyObject *key, *val;
-    long count = 0;
-
-    while ( PyDict_Next(args, &pos, &key, &val) ) {
-        PyObject *kstr = PyObject_CallMethod(key, (char*)"__str__", NULL);
-        PyObject *vstr = PyObject_CallMethod(val, (char*)"__str__", NULL);
-        c.addParameter(PyString_AsString(kstr), PyString_AsString(vstr), true);
-        Py_XDECREF(kstr);
-        Py_XDECREF(vstr);
-        count++;
-    }
-    return PyInt_FromLong(count);
-}
-
-
-static PyObject* compSetRank(PyObject *self, PyObject *args)
-{
-    ConfigComponent &c = ((ComponentPy_t*)self)->getComp();
-
-    PyErr_Clear();
-
-    unsigned long rank = (unsigned long)-1;
-    unsigned long thread = (unsigned long)0;
-
-    if ( !PyArg_ParseTuple(args, "k|k", &rank, &thread) ) {
-        return NULL;
-    }
-
-    c.setRank(RankInfo(rank, thread));
-
-    return PyInt_FromLong(0);
-}
-
-
-static PyObject* compSetWeight(PyObject *self, PyObject *arg)
-{
-    ConfigComponent &c = ((ComponentPy_t*)self)->getComp();
-
-    PyErr_Clear();
-    double weight = PyFloat_AsDouble(arg);
-    if ( PyErr_Occurred() ) {
-        PyErr_Print();
-        exit(-1);
-    }
-
-    c.setWeight(weight);
-
-    return PyInt_FromLong(0);
-}
-
-
-static PyObject* compAddLink(PyObject *self, PyObject *args)
-{
-    ComponentId_t id = ((ComponentPy_t*)self)->id;
-
-    PyObject *plink = NULL;
-    char *port = NULL, *lat = NULL;
-
-
-    if ( !PyArg_ParseTuple(args, "O!s|s", &LinkType, &plink, &port, &lat) ) {
-        return NULL;
-    }
-    LinkPy_t* link = (LinkPy_t*)plink;
-    if ( NULL == lat ) lat = link->latency;
-    if ( NULL == lat ) return NULL;
-
-
-	gModel->getOutput()->verbose(CALL_INFO, 4, 0, "Connecting component %lu to Link %s\n", id, link->name);
-    gModel->addLink(id, link->name, port, lat, link->no_cut);
-
-    return PyInt_FromLong(0);
-}
-
-
-static PyObject* compGetFullName(PyObject *self, PyObject *args)
-{
-    return PyString_FromString(((ComponentPy_t*)self)->name);
-}
-
-static int compCompare(PyObject *obj0, PyObject *obj1) {
-    ComponentId_t id0 = ((ComponentPy_t*)obj0)->id;
-    ComponentId_t id1 = ((ComponentPy_t*)obj1)->id;
-    return (id0 < id1) ? -1 : (id0 > id1) ? 1 : 0;
-}
-
-static std::map<std::string,std::string> generateStatisticParameters(PyObject* statParamDict)
-{
-    PyObject*     pykey = NULL;
-    PyObject*     pyval = NULL;
-    Py_ssize_t    pos = 0;
-
-    std::map<std::string,std::string> p;
-
-    // If the user did not include a dict for the parameters
-    // the variable statParamDict will be NULL.
-    if (NULL != statParamDict) {
-        // Make sure it really is a Dict
-        if (true == PyDict_Check(statParamDict)) {
-
-            // Extract the Key and Value for each parameter and put them into the vectors 
-            while ( PyDict_Next(statParamDict, &pos, &pykey, &pyval) ) {
-                PyObject* pyparam = PyObject_CallMethod(pykey, (char*)"__str__", NULL);
-                PyObject* pyvalue = PyObject_CallMethod(pyval, (char*)"__str__", NULL);
-
-                p[PyString_AsString(pyparam)] = PyString_AsString(pyvalue);
-
-                Py_XDECREF(pyparam);
-                Py_XDECREF(pyvalue);
-            }
-        }
-    }
-    return p;
-}
-
-static PyObject* compEnableAllStatistics(PyObject *self, PyObject *args)
-{
-    int           argOK = 0;
-    PyObject*     statParamDict = NULL;
-    ConfigComponent &c = ((ComponentPy_t*)self)->getComp();
-
-    PyErr_Clear();
-
-    // Parse the Python Args and get optional Stat Params (as a Dictionary)
-    argOK = PyArg_ParseTuple(args, "|O!", &PyDict_Type, &statParamDict);
-
-    if (argOK) {
-        c.enableStatistic(STATALLFLAG);
-
-        // Generate and Add the Statistic Parameters
-        for ( auto p : generateStatisticParameters(statParamDict) ) {
-            c.addStatisticParameter(STATALLFLAG, p.first, p.second);
-        }
-
-    } else {
-        // ParseTuple Failed, return NULL for error
-        return NULL;
-    }
-    return PyInt_FromLong(0);
-}
-
-
-static PyObject* compEnableStatistics(PyObject *self, PyObject *args)
-{
-    int           argOK = 0;
-    PyObject*     statList = NULL;
-    PyObject*     statParamDict = NULL;
-    Py_ssize_t    numStats = 0;
-    ConfigComponent &c = ((ComponentPy_t*)self)->getComp();
-
-    PyErr_Clear();
-
-    // Parse the Python Args and get A List Object and the optional Stat Params (as a Dictionary)
-    argOK = PyArg_ParseTuple(args, "O!|O!", &PyList_Type, &statList, &PyDict_Type, &statParamDict);
-
-    if (argOK) {
-        // Generate the Statistic Parameters
-        auto params = generateStatisticParameters(statParamDict);
-
-        // Make sure we have a list
-        if ( !PyList_Check(statList) ) {
-            return NULL;
-        }
-
-        // Get the Number of Stats in the list, and enable them separatly,
-        // also set their parameters
-        numStats = PyList_Size(statList);
-        for (uint32_t x = 0; x < numStats; x++) {
-            PyObject* pylistitem = PyList_GetItem(statList, x);
-            PyObject* pyname = PyObject_CallMethod(pylistitem, (char*)"__str__", NULL);
-
-            c.enableStatistic(PyString_AsString(pyname));
-
-            // Add the parameters
-            for ( auto p : params ) {
-                c.addStatisticParameter(PyString_AsString(pyname), p.first, p.second);
-            }
-
-            Py_XDECREF(pyname);
-        }
-    } else {
-        // ParseTuple Failed, return NULL for error
-        return NULL;
-    }
-    return PyInt_FromLong(0);
-}
-
-static int linkInit(LinkPy_t *self, PyObject *args, PyObject *kwds)
-{
-    char *name = NULL, *lat = NULL;
-    if ( !PyArg_ParseTuple(args, "s|s", &name, &lat) ) return -1;
-
-    self->name = gModel->addNamePrefix(name);
-    self->no_cut = false;
-    self->latency = lat ? strdup(lat) : NULL;
-	gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Creating Link %s\n", self->name);
-
-    return 0;
-}
-
-static void linkDealloc(LinkPy_t *self)
-{
-    if ( self->name ) free(self->name);
-    if ( self->latency ) free(self->latency);
-    self->ob_type->tp_free((PyObject*)self);
-}
-
-
-static PyObject* linkConnect(PyObject* self, PyObject *args)
-{
-    PyObject *t0, *t1;
-    if ( !PyArg_ParseTuple(args, "O!O!",
-                &PyTuple_Type, &t0,
-                &PyTuple_Type, &t1) ) {
-        return NULL;
-    }
-
-    PyObject *c0, *c1;
-    char *port0, *port1;
-    char *lat0 = NULL, *lat1 = NULL;
-
-    LinkPy_t *link = (LinkPy_t*)self;
-
-    if ( !PyArg_ParseTuple(t0, "O!s|s",
-                &ComponentType, &c0, &port0, &lat0) )
-        return NULL;
-    if ( NULL == lat0 )
-        lat0 = link->latency;
-
-    if ( !PyArg_ParseTuple(t1, "O!s|s",
-                &ComponentType, &c1, &port1, &lat1) )
-        return NULL;
-    if ( NULL == lat1 )
-        lat1 = link->latency;
-
-    if ( NULL == lat0 || NULL == lat1 ) {
-        gModel->getOutput()->fatal(CALL_INFO, 1, "No Latency specified for link %s\n", link->name);
-        return NULL;
-    }
-
-	gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Connecting components %lu and %lu to Link %s (lat: %p %p)\n",
-			((ComponentPy_t*)c0)->id, ((ComponentPy_t*)c1)->id, ((LinkPy_t*)self)->name, lat0, lat1);
-    gModel->addLink(((ComponentPy_t*)c0)->id,
-            link->name, port0, lat0, link->no_cut);
-    gModel->addLink(((ComponentPy_t*)c1)->id,
-            link->name, port1, lat1, link->no_cut);
-
-
-    return PyInt_FromLong(0);
-}
-
-
-static PyObject* linkSetNoCut(PyObject* self, PyObject *args)
-{
-    LinkPy_t *link = (LinkPy_t*)self;
-    bool prev = link->no_cut;
-    link->no_cut = true;
-    return PyBool_FromLong(prev ? 1 : 0);
-}
 
 
 static PyObject* mlFindModule(PyObject *self, PyObject *args)
@@ -646,7 +180,7 @@ static PyObject* findComponentByName(PyObject* self, PyObject* args)
     ComponentId_t id = gModel->findComponentByName(name);
     if ( id != UNSET_COMPONENT_ID ) {
         PyObject *argList = Py_BuildValue("ssk", name, "irrelephant", id);
-        PyObject *res = PyObject_CallObject((PyObject *) &ComponentType, argList);
+        PyObject *res = PyObject_CallObject((PyObject *) &PyModel_ComponentType, argList);
         return res;
     }
     Py_INCREF(Py_None);
@@ -1072,11 +606,11 @@ void SSTPythonModelDefinition::initModel(const std::string script_file, int verb
     PySys_SetArgv(argc, argv);
 
     // Initialize our types
-    ComponentType.tp_new = PyType_GenericNew;
-    LinkType.tp_new = PyType_GenericNew;
+    PyModel_ComponentType.tp_new = PyType_GenericNew;
+    PyModel_LinkType.tp_new = PyType_GenericNew;
     ModuleLoaderType.tp_new = PyType_GenericNew;
-    if ( ( PyType_Ready(&ComponentType) < 0 ) ||
-         ( PyType_Ready(&LinkType) < 0 ) ||
+    if ( ( PyType_Ready(&PyModel_ComponentType) < 0 ) ||
+         ( PyType_Ready(&PyModel_LinkType) < 0 ) ||
          ( PyType_Ready(&ModuleLoaderType) < 0 ) ) {
         output->fatal(CALL_INFO, -1, "Error loading Python types.\n");
     }
@@ -1088,15 +622,15 @@ void SSTPythonModelDefinition::initModel(const std::string script_file, int verb
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
-    Py_INCREF(&ComponentType);
-    Py_INCREF(&LinkType);
+    Py_INCREF(&PyModel_ComponentType);
+    Py_INCREF(&PyModel_LinkType);
     Py_INCREF(&ModuleLoaderType);
 #if ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
 #pragma GCC diagnostic pop
 #endif
     
-    PyModule_AddObject(module, "Link", (PyObject*)&LinkType);
-    PyModule_AddObject(module, "Component", (PyObject*)&ComponentType);
+    PyModule_AddObject(module, "Link", (PyObject*)&PyModel_LinkType);
+    PyModule_AddObject(module, "Component", (PyObject*)&PyModel_ComponentType);
 
 
     // Add our custom loader
@@ -1276,4 +810,33 @@ char* SSTPythonModelDefinition::addNamePrefix(const char *name) const
     return buf;
 }
 
-#endif
+/* Utilties */
+std::map<std::string,std::string> SST::Core::generateStatisticParameters(PyObject* statParamDict)
+{
+    PyObject*     pykey = NULL;
+    PyObject*     pyval = NULL;
+    Py_ssize_t    pos = 0;
+
+    std::map<std::string,std::string> p;
+
+    // If the user did not include a dict for the parameters
+    // the variable statParamDict will be NULL.
+    if (NULL != statParamDict) {
+        // Make sure it really is a Dict
+        if (true == PyDict_Check(statParamDict)) {
+
+            // Extract the Key and Value for each parameter and put them into the vectors 
+            while ( PyDict_Next(statParamDict, &pos, &pykey, &pyval) ) {
+                PyObject* pyparam = PyObject_CallMethod(pykey, (char*)"__str__", NULL);
+                PyObject* pyvalue = PyObject_CallMethod(pyval, (char*)"__str__", NULL);
+
+                p[PyString_AsString(pyparam)] = PyString_AsString(pyvalue);
+
+                Py_XDECREF(pyparam);
+                Py_XDECREF(pyvalue);
+            }
+        }
+    }
+    return p;
+}
+

--- a/src/sst/core/model/pymodel.cc
+++ b/src/sst/core/model/pymodel.cc
@@ -584,6 +584,7 @@ void SSTPythonModelDefinition::initModel(const std::string script_file, int verb
     gModel = this;
 
     graph = new ConfigGraph();
+    nextComponentId = 0;
 
     std::string local_script_name;
     int substr_index = 0;

--- a/src/sst/core/model/pymodel.cc
+++ b/src/sst/core/model/pymodel.cc
@@ -405,7 +405,7 @@ static int compCompare(PyObject *obj0, PyObject *obj1) {
     return (id0 < id1) ? -1 : (id0 > id1) ? 1 : 0;
 }
 
-std::map<std::string,std::string> generateStatisticParameters(PyObject* statParamDict)
+static std::map<std::string,std::string> generateStatisticParameters(PyObject* statParamDict)
 {
     PyObject*     pykey = NULL;
     PyObject*     pyval = NULL;

--- a/src/sst/core/model/pymodel.cc
+++ b/src/sst/core/model/pymodel.cc
@@ -348,7 +348,7 @@ static PyObject* compSetRank(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    c.rank = RankInfo(rank, thread);
+    c.setRank(RankInfo(rank, thread));
 
     return PyInt_FromLong(0);
 }
@@ -365,7 +365,7 @@ static PyObject* compSetWeight(PyObject *self, PyObject *arg)
         exit(-1);
     }
 
-    c.weight = weight;
+    c.setWeight(weight);
 
     return PyInt_FromLong(0);
 }

--- a/src/sst/core/model/pymodel.h
+++ b/src/sst/core/model/pymodel.h
@@ -53,13 +53,10 @@ class SSTPythonModelDefinition : public SSTModelDescription {
         std::vector<size_t> nameStack;
         std::map<std::string, ComponentId_t> compNameMap;
 
-    public:
-        std::vector<std::string> statParamKeyArray;
-        std::vector<std::string> statParamValueArray;
 
 	public:  /* Public, but private.  Called only from Python functions */
 		Config* getConfig(void) const { return config; }
-		//ConfigGraph* getConfigGraph(void) const { return graph; }
+		ConfigGraph* getGraph(void) const { return graph; }
 		Output* getOutput() const { return output; }
         ComponentId_t addComponent(const char *name, const char *type) {
             ComponentId_t id = graph->addComponent(name, type);
@@ -70,10 +67,7 @@ class SSTPythonModelDefinition : public SSTModelDescription {
             auto itr = compNameMap.find(name);
             return ( itr != compNameMap.end() ) ? itr->second : UNSET_COMPONENT_ID;
         }
-        void addParameter(ComponentId_t id, const char *name, const char *value) const { graph->addParameter(id, name, value, true); }
 
-        void setComponentRank(ComponentId_t id, uint32_t rank, uint32_t thread) const { graph->setComponentRank(id, RankInfo(rank, thread)); }
-        void setComponentWeight(ComponentId_t id, float weight) const { graph->setComponentWeight(id, weight); }
         void addLink(ComponentId_t id, const char *name, const char *port, const char *latency, bool no_cut) const {graph->addLink(id, name, port, latency, no_cut); }
 
         void pushNamePrefix(const char *name);
@@ -81,16 +75,14 @@ class SSTPythonModelDefinition : public SSTModelDescription {
         char* addNamePrefix(const char *name) const;
 
         void setStatisticOutput(const char* Name) { graph->setStatisticOutput(Name); }
-        void addStatisticOutputParameter(const char* param, const char* value) { graph->addStatisticOutputParameter(param, value); }
+        void addStatisticOutputParameter(const std::string &param, const std::string &value) { graph->addStatisticOutputParameter(param, value); }
         void setStatisticLoadLevel(uint8_t loadLevel) { graph->setStatisticLoadLevel(loadLevel); }
 
-        void enableComponentStatistic(ComponentId_t compid, const char* statname) const { graph->enableComponentStatistic(compid, statname); }
-        void enableStatisticForComponentName(const char*  compname, const char*  statname) const { graph->enableStatisticForComponentName(compname, statname); }
-        void enableStatisticForComponentType(const char*  comptype, const char*  statname) const  { graph->enableStatisticForComponentType(comptype, statname); }
+        void enableStatisticForComponentName(const std::string &compname, const std::string &statname) const { graph->enableStatisticForComponentName(compname, statname); }
+        void enableStatisticForComponentType(const std::string &comptype, const std::string &statname) const  { graph->enableStatisticForComponentType(comptype, statname); }
 
-        void addComponentStatisticParameter(ComponentId_t compid, const char* statname, const char* param, const char* value) { graph->addComponentStatisticParameter(compid, statname, param, value); }
-        void addStatisticParameterForComponentName(const char*  compname, const char* statname, const char* param, const char* value) { graph->addStatisticParameterForComponentName(compname, statname, param, value); }
-        void addStatisticParameterForComponentType(const char*  comptype, const char* statname, const char* param, const char* value) { graph->addStatisticParameterForComponentType(comptype, statname, param, value); }
+        void addStatisticParameterForComponentName(const std::string &compname, const std::string &statname, const std::string &param, const std::string &value) { graph->addStatisticParameterForComponentName(compname, statname, param, value); }
+        void addStatisticParameterForComponentType(const std::string &comptype, const std::string &statname, const std::string &param, const std::string &value) { graph->addStatisticParameterForComponentType(comptype, statname, param, value); }
 };
 
 }

--- a/src/sst/core/model/pymodel.h
+++ b/src/sst/core/model/pymodel.h
@@ -32,6 +32,7 @@
 using namespace SST;
 
 namespace SST {
+namespace Core {
 
 class SSTPythonModelDefinition : public SSTModelDescription {
 
@@ -85,6 +86,9 @@ class SSTPythonModelDefinition : public SSTModelDescription {
         void addStatisticParameterForComponentType(const std::string &comptype, const std::string &statname, const std::string &param, const std::string &value) { graph->addStatisticParameterForComponentType(comptype, statname, param, value); }
 };
 
+std::map<std::string,std::string> generateStatisticParameters(PyObject* statParamDict);
+
+}
 }
 
 #endif

--- a/src/sst/core/model/pymodel.h
+++ b/src/sst/core/model/pymodel.h
@@ -53,14 +53,17 @@ class SSTPythonModelDefinition : public SSTModelDescription {
         size_t namePrefixLen;
         std::vector<size_t> nameStack;
         std::map<std::string, ComponentId_t> compNameMap;
+        ComponentId_t nextComponentId;
 
 
 	public:  /* Public, but private.  Called only from Python functions */
 		Config* getConfig(void) const { return config; }
 		ConfigGraph* getGraph(void) const { return graph; }
 		Output* getOutput() const { return output; }
+        ComponentId_t getNextComponentId() { return nextComponentId++; }
         ComponentId_t addComponent(const char *name, const char *type) {
-            ComponentId_t id = graph->addComponent(name, type);
+            ComponentId_t id = getNextComponentId();
+            graph->addComponent(id, name, type);
             compNameMap[std::string(name)] = id;
             return id;
         }

--- a/src/sst/core/model/pymodel_comp.cc
+++ b/src/sst/core/model/pymodel_comp.cc
@@ -1,0 +1,531 @@
+// -*- c++ -*-
+
+// Copyright 2009-2016 Sandia Corporation. Under the terms
+// of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2016, Sandia Corporation
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+#include <Python.h>
+
+
+#include <string.h>
+#include <sstream>
+
+#include <sst/core/model/pymodel.h>
+#include <sst/core/model/pymodel_comp.h>
+#include <sst/core/model/pymodel_link.h>
+
+#include <sst/core/sst_types.h>
+#include <sst/core/simulation.h>
+#include <sst/core/element.h>
+#include <sst/core/component.h>
+#include <sst/core/configGraph.h>
+
+using namespace SST::Core;
+extern SST::Core::SSTPythonModelDefinition *gModel;
+
+
+extern "C" {
+
+
+ConfigComponent* ComponentHolder::getSubComp(const std::string &name)
+{
+    for ( auto &sc : getComp().subComponents ) {
+        if ( sc.first == name )
+            return &(sc.second);
+    }
+    return NULL;
+}
+
+
+
+const char* PyComponent::getName() const {
+    return name;
+}
+
+
+ConfigComponent& PyComponent::getComp() {
+    return gModel->getGraph()->getComponentMap()[id];
+}
+
+
+PyComponent* PyComponent::getBaseObj() {
+    return this;
+}
+
+int PyComponent::compare(ComponentHolder *other) {
+    PyComponent *o = dynamic_cast<PyComponent*>(other);
+    if ( o ) {
+        return (id < o->id) ? -1 : (id > o->id) ? 1 : 0;
+    }
+    return 1;
+}
+
+
+const char* PySubComponent::getName() const {
+    return name;
+}
+
+
+ConfigComponent& PySubComponent::getComp() {
+    return *(parent->getSubComp(name));
+}
+
+
+PyComponent* PySubComponent::getBaseObj() {
+    return parent->getBaseObj();
+}
+
+
+int PySubComponent::compare(ComponentHolder *other) {
+    PySubComponent *o = dynamic_cast<PySubComponent*>(other);
+    if ( o ) {
+        int pCmp = parent->compare(o->parent);
+        if ( pCmp == 0 ) /* Parents are equal */
+            pCmp = strcmp(name, o->name);
+        return pCmp;
+    }
+    return -11;
+}
+
+
+static inline ConfigComponent& getComp(PyObject *pobj) {
+    return ((ComponentPy_t*)pobj)->obj->getComp();
+}
+
+
+static int compInit(ComponentPy_t *self, PyObject *args, PyObject *kwds)
+{
+    char *name, *type;
+    ComponentId_t useID = UNSET_COMPONENT_ID;
+    if ( !PyArg_ParseTuple(args, "ss|k", &name, &type, &useID) )
+        return -1;
+
+    PyComponent *obj = new PyComponent(self);
+    self->obj = obj;
+    if ( useID == UNSET_COMPONENT_ID ) {
+        obj->name = gModel->addNamePrefix(name);
+        obj->id = gModel->addComponent(obj->name, type);
+        gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Creating component [%s] of type [%s]: id [%lu]\n", name, type, obj->id);
+    } else {
+        obj->name = name;
+        obj->id = useID;
+    }
+
+    return 0;
+}
+
+
+static void compDealloc(ComponentPy_t *self)
+{
+    if ( self->obj ) delete self->obj;
+    self->ob_type->tp_free((PyObject*)self);
+}
+
+
+
+static PyObject* compAddParam(PyObject *self, PyObject *args)
+{
+    char *param = NULL;
+    PyObject *value = NULL;
+    if ( !PyArg_ParseTuple(args, "sO", &param, &value) )
+        return NULL;
+
+    ConfigComponent &c = getComp(self);
+
+    PyObject *vstr = PyObject_CallMethod(value, (char*)"__str__", NULL);
+    c.addParameter(param, PyString_AsString(vstr), true);
+    Py_XDECREF(vstr);
+
+    return PyInt_FromLong(0);
+}
+
+
+static PyObject* compAddParams(PyObject *self, PyObject *args)
+{
+    ConfigComponent &c = getComp(self);
+
+    if ( !PyDict_Check(args) ) {
+        return NULL;
+    }
+
+    Py_ssize_t pos = 0;
+    PyObject *key, *val;
+    long count = 0;
+
+    while ( PyDict_Next(args, &pos, &key, &val) ) {
+        PyObject *kstr = PyObject_CallMethod(key, (char*)"__str__", NULL);
+        PyObject *vstr = PyObject_CallMethod(val, (char*)"__str__", NULL);
+        c.addParameter(PyString_AsString(kstr), PyString_AsString(vstr), true);
+        Py_XDECREF(kstr);
+        Py_XDECREF(vstr);
+        count++;
+    }
+    return PyInt_FromLong(count);
+}
+
+
+static PyObject* compSetRank(PyObject *self, PyObject *args)
+{
+    ConfigComponent &c = getComp(self);
+
+    PyErr_Clear();
+
+    unsigned long rank = (unsigned long)-1;
+    unsigned long thread = (unsigned long)0;
+
+    if ( !PyArg_ParseTuple(args, "k|k", &rank, &thread) ) {
+        return NULL;
+    }
+
+    c.setRank(RankInfo(rank, thread));
+
+    return PyInt_FromLong(0);
+}
+
+
+static PyObject* compSetWeight(PyObject *self, PyObject *arg)
+{
+    ConfigComponent &c = getComp(self);
+
+    PyErr_Clear();
+    double weight = PyFloat_AsDouble(arg);
+    if ( PyErr_Occurred() ) {
+        PyErr_Print();
+        exit(-1);
+    }
+
+    c.setWeight(weight);
+
+    return PyInt_FromLong(0);
+}
+
+
+static PyObject* compAddLink(PyObject *self, PyObject *args)
+{
+    ComponentId_t id = ((PyComponent*)(((ComponentPy_t*)self)->obj))->id;;
+
+    PyObject *plink = NULL;
+    char *port = NULL, *lat = NULL;
+
+
+    if ( !PyArg_ParseTuple(args, "O!s|s", &PyModel_LinkType, &plink, &port, &lat) ) {
+        return NULL;
+    }
+    LinkPy_t* link = (LinkPy_t*)plink;
+    if ( NULL == lat ) lat = link->latency;
+    if ( NULL == lat ) return NULL;
+
+
+	gModel->getOutput()->verbose(CALL_INFO, 4, 0, "Connecting component %lu to Link %s\n", id, link->name);
+    gModel->addLink(id, link->name, port, lat, link->no_cut);
+
+    return PyInt_FromLong(0);
+}
+
+
+static PyObject* compGetFullName(PyObject *self, PyObject *args)
+{
+    return PyString_FromString(getComp(self).name.c_str());
+}
+
+static int compCompare(PyObject *obj0, PyObject *obj1) {
+    return ((ComponentPy_t*)obj0)->obj->compare(((ComponentPy_t*)obj1)->obj);
+}
+
+
+static PyObject* compSetSubComponent(PyObject *self, PyObject *args)
+{
+    char *name = NULL, *type = NULL;
+
+    if ( !PyArg_ParseTuple(args, "ss", &name, &type) )
+        return NULL;
+
+    ConfigComponent &c = ((ComponentHolder*)self)->getComp();
+    if ( NULL != c.addSubComponent(name, type) ) {
+        PyObject *argList = Py_BuildValue("Oss", self, name, type);
+        ComponentPy_t *subObj = (ComponentPy_t*)PyObject_CallObject((PyObject*)&PyModel_SubComponentType, argList);
+        return (PyObject*)subObj;
+    }
+
+    char errMsg[1024] = {0};
+    snprintf(errMsg, sizeof(errMsg)-1, "Failed to create subcomponent %s on %s.  Name already exists?\n", name, c.name.c_str());
+    PyErr_SetString(PyExc_RuntimeError, errMsg);
+    return NULL;
+}
+
+
+static PyObject* compEnableAllStatistics(PyObject *self, PyObject *args)
+{
+    int           argOK = 0;
+    PyObject*     statParamDict = NULL;
+    ConfigComponent &c = getComp(self);
+
+    PyErr_Clear();
+
+    // Parse the Python Args and get optional Stat Params (as a Dictionary)
+    argOK = PyArg_ParseTuple(args, "|O!", &PyDict_Type, &statParamDict);
+
+    if (argOK) {
+        c.enableStatistic(STATALLFLAG);
+
+        // Generate and Add the Statistic Parameters
+        for ( auto p : generateStatisticParameters(statParamDict) ) {
+            c.addStatisticParameter(STATALLFLAG, p.first, p.second);
+        }
+
+    } else {
+        // ParseTuple Failed, return NULL for error
+        return NULL;
+    }
+    return PyInt_FromLong(0);
+}
+
+
+static PyObject* compEnableStatistics(PyObject *self, PyObject *args)
+{
+    int           argOK = 0;
+    PyObject*     statList = NULL;
+    PyObject*     statParamDict = NULL;
+    Py_ssize_t    numStats = 0;
+    ConfigComponent &c = getComp(self);
+
+    PyErr_Clear();
+
+    // Parse the Python Args and get A List Object and the optional Stat Params (as a Dictionary)
+    argOK = PyArg_ParseTuple(args, "O!|O!", &PyList_Type, &statList, &PyDict_Type, &statParamDict);
+
+    if (argOK) {
+        // Generate the Statistic Parameters
+        auto params = generateStatisticParameters(statParamDict);
+
+        // Make sure we have a list
+        if ( !PyList_Check(statList) ) {
+            return NULL;
+        }
+
+        // Get the Number of Stats in the list, and enable them separatly,
+        // also set their parameters
+        numStats = PyList_Size(statList);
+        for (uint32_t x = 0; x < numStats; x++) {
+            PyObject* pylistitem = PyList_GetItem(statList, x);
+            PyObject* pyname = PyObject_CallMethod(pylistitem, (char*)"__str__", NULL);
+
+            c.enableStatistic(PyString_AsString(pyname));
+
+            // Add the parameters
+            for ( auto p : params ) {
+                c.addStatisticParameter(PyString_AsString(pyname), p.first, p.second);
+            }
+
+            Py_XDECREF(pyname);
+        }
+    } else {
+        // ParseTuple Failed, return NULL for error
+        return NULL;
+    }
+    return PyInt_FromLong(0);
+}
+
+
+static PyMethodDef componentMethods[] = {
+    {   "addParam",
+        compAddParam, METH_VARARGS,
+        "Adds a parameter(name, value)"},
+    {   "addParams",
+        compAddParams, METH_O,
+        "Adds Multiple Parameters from a dict"},
+    {   "setRank",
+        compSetRank, METH_VARARGS,
+        "Sets which rank on which this component should sit"},
+    {   "setWeight",
+        compSetWeight, METH_O,
+        "Sets the weight of the component"},
+    {   "addLink",
+        compAddLink, METH_VARARGS,
+        "Connects this component to a Link"},
+	{	"getFullName",
+		compGetFullName, METH_NOARGS,
+		"Returns the full name, after any prefix, of the component."},
+    {   "enableAllStatistics",
+        compEnableAllStatistics, METH_VARARGS,
+        "Enable all Statistics in the component with optional parameters"},
+    {   "enableStatistics",
+        compEnableStatistics, METH_VARARGS,
+        "Enables Multiple Statistics in the component with optional parameters"},
+    {   "setSubComponent",
+        compSetSubComponent, METH_VARARGS,
+        "Bind a subcomponent to slot <name>, with type <type>"},
+    {   NULL, NULL, 0, NULL }
+};
+
+
+PyTypeObject PyModel_ComponentType = {
+    PyObject_HEAD_INIT(NULL)
+    0,                         /* ob_size */
+    "sst.Component",           /* tp_name */
+    sizeof(ComponentPy_t),     /* tp_basicsize */
+    0,                         /* tp_itemsize */
+    (destructor)compDealloc,   /* tp_dealloc */
+    0,                         /* tp_print */
+    0,                         /* tp_getattr */
+    0,                         /* tp_setattr */
+    compCompare,               /* tp_compare */
+    0,                         /* tp_repr */
+    0,                         /* tp_as_number */
+    0,                         /* tp_as_sequence */
+    0,                         /* tp_as_mapping */
+    0,                         /* tp_hash */
+    0,                         /* tp_call */
+    0,                         /* tp_str */
+    0,                         /* tp_getattro */
+    0,                         /* tp_setattro */
+    0,                         /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,        /* tp_flags */
+    "SST Component",           /* tp_doc */
+    0,                         /* tp_traverse */
+    0,                         /* tp_clear */
+    0,                         /* tp_richcompare */
+    0,                         /* tp_weaklistoffset */
+    0,                         /* tp_iter */
+    0,                         /* tp_iternext */
+    componentMethods,          /* tp_methods */
+    0,                         /* tp_members */
+    0,                         /* tp_getset */
+    0,                         /* tp_base */
+    0,                         /* tp_dict */
+    0,                         /* tp_descr_get */
+    0,                         /* tp_descr_set */
+    0,                         /* tp_dictoffset */
+    (initproc)compInit,        /* tp_init */
+    0,                         /* tp_alloc */
+    0,                         /* tp_new */
+};
+
+
+
+
+
+static int subCompInit(ComponentPy_t *self, PyObject *args, PyObject *kwds)
+{
+    char *name, *type;
+    PyObject *parent;
+    ComponentId_t useID = UNSET_COMPONENT_ID;
+    if ( !PyArg_ParseTuple(args, "Oss", &parent, &name, &type) )
+        return -1;
+
+    PySubComponent *obj = new PySubComponent(self);
+    obj->parent = (ComponentHolder*)parent;
+
+    obj->name = (char*)calloc(1, strlen(obj->parent->getName()) + 2 + strlen(name));
+    sprintf(obj->name, "%s.%s", obj->parent->getName(), name);
+
+    self->obj = obj;
+    Py_INCREF(obj->parent->pobj);
+
+    gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Creating subcomponent [%s] of type [%s]]\n", name, type);
+
+    return 0;
+}
+
+
+static void subCompDealloc(ComponentPy_t *self)
+{
+    if ( self->obj ) {
+        PySubComponent *obj = (PySubComponent*)self->obj;
+        Py_XDECREF(obj->parent->pobj);
+        delete self->obj;
+    }
+    self->ob_type->tp_free((PyObject*)self);
+}
+
+
+
+static PyObject* subCompAddLink(PyObject *self, PyObject *args)
+{
+    /* TODO */
+    gModel->getOutput()->fatal(CALL_INFO, 1, "SubComponent Links not yet implemented.\n");
+    return NULL;
+}
+
+
+
+static PyMethodDef subComponentMethods[] = {
+    {   "addParam",
+        compAddParam, METH_VARARGS,
+        "Adds a parameter(name, value)"},
+    {   "addParams",
+        compAddParams, METH_O,
+        "Adds Multiple Parameters from a dict"},
+    {   "addLink",
+        subCompAddLink, METH_VARARGS,
+        "Connects this component to a Link"},
+	{	"getFullName",
+		compGetFullName, METH_NOARGS,
+		"Returns the full name, after any prefix, of the component."},
+    {   "enableAllStatistics",
+        compEnableAllStatistics, METH_VARARGS,
+        "Enable all Statistics in the component with optional parameters"},
+    {   "enableStatistics",
+        compEnableStatistics, METH_VARARGS,
+        "Enables Multiple Statistics in the component with optional parameters"},
+    {   "setSubComponent",
+        compSetSubComponent, METH_VARARGS,
+        "Bind a subcomponent to slot <name>, with type <type>"},
+    {   NULL, NULL, 0, NULL }
+};
+
+
+PyTypeObject PyModel_SubComponentType = {
+    PyObject_HEAD_INIT(NULL)
+    0,                         /* ob_size */
+    "sst.SubComponent",        /* tp_name */
+    sizeof(ComponentPy_t),     /* tp_basicsize */
+    0,                         /* tp_itemsize */
+    (destructor)subCompDealloc,/* tp_dealloc */
+    0,                         /* tp_print */
+    0,                         /* tp_getattr */
+    0,                         /* tp_setattr */
+    compCompare,               /* tp_compare */
+    0,                         /* tp_repr */
+    0,                         /* tp_as_number */
+    0,                         /* tp_as_sequence */
+    0,                         /* tp_as_mapping */
+    0,                         /* tp_hash */
+    0,                         /* tp_call */
+    0,                         /* tp_str */
+    0,                         /* tp_getattro */
+    0,                         /* tp_setattro */
+    0,                         /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,        /* tp_flags */
+    "SST SubComponent",        /* tp_doc */
+    0,                         /* tp_traverse */
+    0,                         /* tp_clear */
+    0,                         /* tp_richcompare */
+    0,                         /* tp_weaklistoffset */
+    0,                         /* tp_iter */
+    0,                         /* tp_iternext */
+    subComponentMethods,       /* tp_methods */
+    0,                         /* tp_members */
+    0,                         /* tp_getset */
+    0,                         /* tp_base */
+    0,                         /* tp_dict */
+    0,                         /* tp_descr_get */
+    0,                         /* tp_descr_set */
+    0,                         /* tp_dictoffset */
+    (initproc)subCompInit,     /* tp_init */
+    0,                         /* tp_alloc */
+    0,                         /* tp_new */
+};
+
+
+}  /* extern C */
+
+

--- a/src/sst/core/model/pymodel_comp.cc
+++ b/src/sst/core/model/pymodel_comp.cc
@@ -259,7 +259,7 @@ static PyObject* compSetSubComponent(PyObject *self, PyObject *args)
     ConfigComponent *c = getComp(self);
     if ( NULL == c ) return NULL;
 
-    if ( NULL != c->addSubComponent(name, type) ) {
+    if ( NULL != c->addSubComponent(gModel->getNextComponentId(), name, type) ) {
         PyObject *argList = Py_BuildValue("Oss", self, name, type);
         PyObject *subObj = PyObject_CallObject((PyObject*)&PyModel_SubComponentType, argList);
         Py_DECREF(argList);

--- a/src/sst/core/model/pymodel_comp.cc
+++ b/src/sst/core/model/pymodel_comp.cc
@@ -117,7 +117,7 @@ static int compInit(ComponentPy_t *self, PyObject *args, PyObject *kwds)
     if ( useID == UNSET_COMPONENT_ID ) {
         obj->name = gModel->addNamePrefix(name);
         obj->id = gModel->addComponent(obj->name, type);
-        gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Creating component [%s] of type [%s]: id [%lu]\n", name, type, obj->id);
+        gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Creating component [%s] of type [%s]: id [%" PRIu64 "]\n", name, type, obj->id);
     } else {
         obj->name = name;
         obj->id = useID;
@@ -232,7 +232,7 @@ static PyObject* compAddLink(PyObject *self, PyObject *args)
     if ( NULL == lat ) return NULL;
 
 
-	gModel->getOutput()->verbose(CALL_INFO, 4, 0, "Connecting component %lu to Link %s\n", id, link->name);
+	gModel->getOutput()->verbose(CALL_INFO, 4, 0, "Connecting component %" PRIu64 " to Link %s\n", id, link->name);
     gModel->addLink(id, link->name, port, lat, link->no_cut);
 
     return PyInt_FromLong(0);
@@ -259,7 +259,9 @@ static PyObject* compSetSubComponent(PyObject *self, PyObject *args)
     ConfigComponent *c = getComp(self);
     if ( NULL == c ) return NULL;
 
-    if ( NULL != c->addSubComponent(gModel->getNextComponentId(), name, type) ) {
+    PyComponent *baseComp = ((ComponentPy_t*)self)->obj->getBaseObj();
+    ComponentId_t subC_id = SUBCOMPONENT_ID_CREATE(++(baseComp->subCompId), baseComp->id);
+    if ( NULL != c->addSubComponent(subC_id, name, type) ) {
         PyObject *argList = Py_BuildValue("Oss", self, name, type);
         PyObject *subObj = PyObject_CallObject((PyObject*)&PyModel_SubComponentType, argList);
         Py_DECREF(argList);

--- a/src/sst/core/model/pymodel_comp.cc
+++ b/src/sst/core/model/pymodel_comp.cc
@@ -44,7 +44,10 @@ ConfigComponent* ComponentHolder::getSubComp(const std::string &name)
     return NULL;
 }
 
-
+ComponentId_t ComponentHolder::getID()
+{
+    return getComp()->id;
+}
 
 const char* PyComponent::getName() const {
     return name;
@@ -95,14 +98,6 @@ int PySubComponent::compare(ComponentHolder *other) {
     return -11;
 }
 
-
-static inline ConfigComponent* getComp(PyObject *pobj) {
-    ConfigComponent *c = ((ComponentPy_t*)pobj)->obj->getComp();
-    if ( c == NULL ) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to find ConfigComponent");
-    }
-    return c;
-}
 
 
 static int compInit(ComponentPy_t *self, PyObject *args, PyObject *kwds)
@@ -260,7 +255,7 @@ static PyObject* compSetSubComponent(PyObject *self, PyObject *args)
     if ( NULL == c ) return NULL;
 
     PyComponent *baseComp = ((ComponentPy_t*)self)->obj->getBaseObj();
-    ComponentId_t subC_id = SUBCOMPONENT_ID_CREATE(++(baseComp->subCompId), baseComp->id);
+    ComponentId_t subC_id = SUBCOMPONENT_ID_CREATE(baseComp->id, ++(baseComp->subCompId));
     if ( NULL != c->addSubComponent(subC_id, name, type) ) {
         PyObject *argList = Py_BuildValue("Oss", self, name, type);
         PyObject *subObj = PyObject_CallObject((PyObject*)&PyModel_SubComponentType, argList);

--- a/src/sst/core/model/pymodel_comp.h
+++ b/src/sst/core/model/pymodel_comp.h
@@ -1,0 +1,72 @@
+// -*- c++ -*-
+
+// Copyright 2009-2016 Sandia Corporation. Under the terms
+// of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2016, Sandia Corporation
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_MODEL_PYMODEL_COMP_H
+#define SST_CORE_MODEL_PYMODEL_COMP_H
+
+#include <sst/core/sst_types.h>
+
+extern "C" {
+
+
+struct ComponentPy_t;
+struct PyComponent;
+
+struct ComponentHolder {
+    ComponentPy_t *pobj;
+	char *name;
+    ComponentHolder(ComponentPy_t *pobj) : pobj(pobj), name(NULL) { }
+    virtual ~ComponentHolder() { free(name); }
+    virtual ConfigComponent& getComp() = 0;
+    virtual PyComponent* getBaseObj() = 0;
+    virtual int compare(ComponentHolder *other) = 0;
+    virtual const char* getName() const = 0;
+    ConfigComponent* getSubComp(const std::string &name);
+};
+
+struct PyComponent : ComponentHolder {
+    ComponentId_t id;
+
+    PyComponent(ComponentPy_t *pobj) : ComponentHolder(pobj) { }
+    ~PyComponent() {}
+    const char* getName() const ;
+    ConfigComponent& getComp();
+    PyComponent* getBaseObj();
+    int compare(ComponentHolder *other);
+};
+
+struct PySubComponent : ComponentHolder {
+    ComponentHolder *parent;
+
+    PySubComponent(ComponentPy_t *pobj) : ComponentHolder(pobj) { }
+    ~PySubComponent() {}
+    const char* getName() const ;
+    ConfigComponent& getComp();
+    PyComponent* getBaseObj();
+    int compare(ComponentHolder *other);
+};
+
+
+struct ComponentPy_t {
+    PyObject_HEAD
+    ComponentHolder *obj;
+};
+
+extern PyTypeObject PyModel_ComponentType;
+extern PyTypeObject PyModel_SubComponentType;
+
+
+}  /* extern C */
+
+
+#endif

--- a/src/sst/core/model/pymodel_comp.h
+++ b/src/sst/core/model/pymodel_comp.h
@@ -36,8 +36,9 @@ struct ComponentHolder {
 
 struct PyComponent : ComponentHolder {
     ComponentId_t id;
+    uint16_t subCompId;
 
-    PyComponent(ComponentPy_t *pobj) : ComponentHolder(pobj) { }
+    PyComponent(ComponentPy_t *pobj) : ComponentHolder(pobj), subCompId(0) { }
     ~PyComponent() {}
     const char* getName() const ;
     ConfigComponent* getComp();

--- a/src/sst/core/model/pymodel_comp.h
+++ b/src/sst/core/model/pymodel_comp.h
@@ -31,6 +31,7 @@ struct ComponentHolder {
     virtual PyComponent* getBaseObj() = 0;
     virtual int compare(ComponentHolder *other) = 0;
     virtual const char* getName() const = 0;
+    ComponentId_t getID();
     ConfigComponent* getSubComp(const std::string &name);
 };
 
@@ -65,6 +66,14 @@ struct ComponentPy_t {
 
 extern PyTypeObject PyModel_ComponentType;
 extern PyTypeObject PyModel_SubComponentType;
+
+static inline ConfigComponent* getComp(PyObject *pobj) {
+    ConfigComponent *c = ((ComponentPy_t*)pobj)->obj->getComp();
+    if ( c == NULL ) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to find ConfigComponent");
+    }
+    return c;
+}
 
 
 }  /* extern C */

--- a/src/sst/core/model/pymodel_comp.h
+++ b/src/sst/core/model/pymodel_comp.h
@@ -27,7 +27,7 @@ struct ComponentHolder {
 	char *name;
     ComponentHolder(ComponentPy_t *pobj) : pobj(pobj), name(NULL) { }
     virtual ~ComponentHolder() { free(name); }
-    virtual ConfigComponent& getComp() = 0;
+    virtual ConfigComponent* getComp() = 0;
     virtual PyComponent* getBaseObj() = 0;
     virtual int compare(ComponentHolder *other) = 0;
     virtual const char* getName() const = 0;
@@ -40,7 +40,7 @@ struct PyComponent : ComponentHolder {
     PyComponent(ComponentPy_t *pobj) : ComponentHolder(pobj) { }
     ~PyComponent() {}
     const char* getName() const ;
-    ConfigComponent& getComp();
+    ConfigComponent* getComp();
     PyComponent* getBaseObj();
     int compare(ComponentHolder *other);
 };
@@ -51,7 +51,7 @@ struct PySubComponent : ComponentHolder {
     PySubComponent(ComponentPy_t *pobj) : ComponentHolder(pobj) { }
     ~PySubComponent() {}
     const char* getName() const ;
-    ConfigComponent& getComp();
+    ConfigComponent* getComp();
     PyComponent* getBaseObj();
     int compare(ComponentHolder *other);
 };

--- a/src/sst/core/model/pymodel_link.cc
+++ b/src/sst/core/model/pymodel_link.cc
@@ -1,0 +1,171 @@
+// -*- c++ -*-
+
+// Copyright 2009-2016 Sandia Corporation. Under the terms
+// of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2016, Sandia Corporation
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+#include <Python.h>
+
+#include <string.h>
+#include <sstream>
+
+#include <sst/core/model/pymodel.h>
+#include <sst/core/model/pymodel_comp.h>
+#include <sst/core/model/pymodel_link.h>
+
+#include <sst/core/sst_types.h>
+#include <sst/core/simulation.h>
+#include <sst/core/element.h>
+#include <sst/core/component.h>
+#include <sst/core/configGraph.h>
+
+using namespace SST::Core;
+extern SST::Core::SSTPythonModelDefinition *gModel;
+
+extern "C" {
+
+
+static int linkInit(LinkPy_t *self, PyObject *args, PyObject *kwds)
+{
+    char *name = NULL, *lat = NULL;
+    if ( !PyArg_ParseTuple(args, "s|s", &name, &lat) ) return -1;
+
+    self->name = gModel->addNamePrefix(name);
+    self->no_cut = false;
+    self->latency = lat ? strdup(lat) : NULL;
+	gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Creating Link %s\n", self->name);
+
+    return 0;
+}
+
+static void linkDealloc(LinkPy_t *self)
+{
+    if ( self->name ) free(self->name);
+    if ( self->latency ) free(self->latency);
+    self->ob_type->tp_free((PyObject*)self);
+}
+
+
+static PyObject* linkConnect(PyObject* self, PyObject *args)
+{
+    PyObject *t0, *t1;
+    if ( !PyArg_ParseTuple(args, "O!O!",
+                &PyTuple_Type, &t0,
+                &PyTuple_Type, &t1) ) {
+        return NULL;
+    }
+
+    PyObject *c0, *c1;
+    char *port0, *port1;
+    char *lat0 = NULL, *lat1 = NULL;
+
+    LinkPy_t *link = (LinkPy_t*)self;
+
+    if ( !PyArg_ParseTuple(t0, "O!s|s",
+                &PyModel_ComponentType, &c0, &port0, &lat0) )
+        return NULL;
+    if ( NULL == lat0 )
+        lat0 = link->latency;
+
+    if ( !PyArg_ParseTuple(t1, "O!s|s",
+                &PyModel_ComponentType, &c1, &port1, &lat1) )
+        return NULL;
+    if ( NULL == lat1 )
+        lat1 = link->latency;
+
+    if ( NULL == lat0 || NULL == lat1 ) {
+        gModel->getOutput()->fatal(CALL_INFO, 1, "No Latency specified for link %s\n", link->name);
+        return NULL;
+    }
+
+    ComponentId_t id0, id1;
+    id0 = ((PyComponent*)(((ComponentPy_t*)c0)->obj))->id;
+    id1 = ((PyComponent*)(((ComponentPy_t*)c1)->obj))->id;
+
+	gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Connecting components %lu and %lu to Link %s (lat: %p %p)\n",
+			id0, id1, ((LinkPy_t*)self)->name, lat0, lat1);
+    gModel->addLink(id0, link->name, port0, lat0, link->no_cut);
+    gModel->addLink(id1, link->name, port1, lat1, link->no_cut);
+
+
+    return PyInt_FromLong(0);
+}
+
+
+static PyObject* linkSetNoCut(PyObject* self, PyObject *args)
+{
+    LinkPy_t *link = (LinkPy_t*)self;
+    bool prev = link->no_cut;
+    link->no_cut = true;
+    return PyBool_FromLong(prev ? 1 : 0);
+}
+
+
+
+
+static PyMethodDef linkMethods[] = {
+    {   "connect",
+        linkConnect, METH_VARARGS,
+        "Connects two components to a Link"},
+    {   "setNoCut",
+        linkSetNoCut, METH_NOARGS,
+        "Specifies that this link should not be partitioned across"},
+    {   NULL, NULL, 0, NULL }
+};
+
+
+PyTypeObject PyModel_LinkType = {
+    PyObject_HEAD_INIT(NULL)
+    0,                         /* ob_size */
+    "sst.Link",                /* tp_name */
+    sizeof(LinkPy_t),          /* tp_basicsize */
+    0,                         /* tp_itemsize */
+    (destructor)linkDealloc,   /* tp_dealloc */
+    0,                         /* tp_print */
+    0,                         /* tp_getattr */
+    0,                         /* tp_setattr */
+    0,                         /* tp_compare */
+    0,                         /* tp_repr */
+    0,                         /* tp_as_number */
+    0,                         /* tp_as_sequence */
+    0,                         /* tp_as_mapping */
+    0,                         /* tp_hash */
+    0,                         /* tp_call */
+    0,                         /* tp_str */
+    0,                         /* tp_getattro */
+    0,                         /* tp_setattro */
+    0,                         /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,        /* tp_flags */
+    "SST Link",                /* tp_doc */
+    0,                         /* tp_traverse */
+    0,                         /* tp_clear */
+    0,                         /* tp_richcompare */
+    0,                         /* tp_weaklistoffset */
+    0,                         /* tp_iter */
+    0,                         /* tp_iternext */
+    linkMethods,               /* tp_methods */
+    0,                         /* tp_members */
+    0,                         /* tp_getset */
+    0,                         /* tp_base */
+    0,                         /* tp_dict */
+    0,                         /* tp_descr_get */
+    0,                         /* tp_descr_set */
+    0,                         /* tp_dictoffset */
+    (initproc)linkInit,        /* tp_init */
+    0,                         /* tp_alloc */
+    0,                         /* tp_new */
+};
+
+
+
+}  /* extern C */
+
+

--- a/src/sst/core/model/pymodel_link.cc
+++ b/src/sst/core/model/pymodel_link.cc
@@ -71,12 +71,16 @@ static PyObject* linkConnect(PyObject* self, PyObject *args)
 
     if ( !PyArg_ParseTuple(t0, "O!s|s",
                 &PyModel_ComponentType, &c0, &port0, &lat0) )
+        if ( !PyArg_ParseTuple(t0, "O!s|s",
+                    &PyModel_SubComponentType, &c0, &port0, &lat0) )
         return NULL;
     if ( NULL == lat0 )
         lat0 = link->latency;
 
     if ( !PyArg_ParseTuple(t1, "O!s|s",
                 &PyModel_ComponentType, &c1, &port1, &lat1) )
+        if ( !PyArg_ParseTuple(t1, "O!s|s",
+                    &PyModel_SubComponentType, &c1, &port1, &lat1) )
         return NULL;
     if ( NULL == lat1 )
         lat1 = link->latency;
@@ -87,8 +91,8 @@ static PyObject* linkConnect(PyObject* self, PyObject *args)
     }
 
     ComponentId_t id0, id1;
-    id0 = ((PyComponent*)(((ComponentPy_t*)c0)->obj))->id;
-    id1 = ((PyComponent*)(((ComponentPy_t*)c1)->obj))->id;
+    id0 = getComp(c0)->id;
+    id1 = getComp(c1)->id;
 
 	gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Connecting components %" PRIu64 " and %" PRIu64 " to Link %s (lat: %p %p)\n",
 			id0, id1, ((LinkPy_t*)self)->name, lat0, lat1);

--- a/src/sst/core/model/pymodel_link.cc
+++ b/src/sst/core/model/pymodel_link.cc
@@ -90,7 +90,7 @@ static PyObject* linkConnect(PyObject* self, PyObject *args)
     id0 = ((PyComponent*)(((ComponentPy_t*)c0)->obj))->id;
     id1 = ((PyComponent*)(((ComponentPy_t*)c1)->obj))->id;
 
-	gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Connecting components %lu and %lu to Link %s (lat: %p %p)\n",
+	gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Connecting components %" PRIu64 " and %" PRIu64 " to Link %s (lat: %p %p)\n",
 			id0, id1, ((LinkPy_t*)self)->name, lat0, lat1);
     gModel->addLink(id0, link->name, port0, lat0, link->no_cut);
     gModel->addLink(id1, link->name, port1, lat1, link->no_cut);

--- a/src/sst/core/model/pymodel_link.h
+++ b/src/sst/core/model/pymodel_link.h
@@ -1,0 +1,36 @@
+// -*- c++ -*-
+
+// Copyright 2009-2016 Sandia Corporation. Under the terms
+// of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2016, Sandia Corporation
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_MODEL_PYMODEL_LINK_H
+#define SST_CORE_MODEL_PYMODEL_LINK_H
+
+#include <sst/core/sst_types.h>
+
+extern "C" {
+
+
+struct LinkPy_t {
+    PyObject_HEAD
+    char *name;
+    bool no_cut;
+    char *latency;
+};
+
+
+extern PyTypeObject PyModel_LinkType;
+
+
+}  /* extern C */
+
+
+#endif

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -422,7 +422,7 @@ int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTi
             // Check to make sure there are any entries in the component's LinkMap
             // TODO:  IS this still a valid warning?  Subcomponents may be the link owners
             ComponentInfo *cinfo = compInfoMap.getByID(ccomp->id);
-            if ( cinfo->getLinkMap()->empty() ) {
+            if ( cinfo->getAllLinkIds().empty() ) {
                 printf("WARNING: Building component \"%s\" with no links assigned.\n",ccomp->name.c_str());
             }
 

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -248,8 +248,8 @@ Simulation::processGraphInfo( ConfigGraph& graph, const RankInfo& myRank, SimTim
         for ( auto iter = links.begin(); iter != links.end(); ++iter ) {
             ConfigLink &clink = *iter;
             RankInfo rank[2];
-            rank[0] = comps[clink.component[0]].rank;
-            rank[1] = comps[clink.component[1]].rank;
+            rank[0] = comps[COMPONENT_ID_MASK(clink.component[0])].rank;
+            rank[1] = comps[COMPONENT_ID_MASK(clink.component[1])].rank;
             // We only care about links that are on my rank, but
             // different threads
 
@@ -560,24 +560,17 @@ int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTi
 
         if ( ccomp->rank == myRank ) {
             Component* tmp;
-            //             _SIM_DBG("creating component: name=\"%s\" type=\"%s\" id=%d\n",
-            // 		     name.c_str(), sdl_c->type().c_str(), (int)id );
 
             // Check to make sure there are any entries in the component's LinkMap
+            // TODO:  IS this still a valid warning?  Subcomponents may be the link owners
             ComponentInfo *cinfo = compInfoMap.getByID(ccomp->id);
             if ( cinfo->getLinkMap()->empty() ) {
                 printf("WARNING: Building component \"%s\" with no links assigned.\n",ccomp->name.c_str());
             }
 
-            // Save off what statistics can be enabled before instantiating the component
-            // This allows the component to register its statistics in its constructor.
-            cinfo->setStatEnablement(&ccomp->enabledStatistics, &ccomp->enabledStatParams);
+            tmp = createComponent( ccomp->id, ccomp->type, ccomp->params );
 
-            // compIdMap[ccomp->id] = ccomp->name;
-            tmp = createComponent( ccomp->id, ccomp->type,
-                    ccomp->params );
-            // compMap[ccomp->name] = tmp;
-            compInfoMap.getByName(ccomp->name)->setComponent(tmp);
+            cinfo->setComponent(tmp);
         }
     } // end for all vertex
     // Done with verticies, delete them;

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -578,8 +578,6 @@ int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTi
                     ccomp->params );
             // compMap[ccomp->name] = tmp;
             compInfoMap.getByName(ccomp->name)->setComponent(tmp);
-
-            cinfo->clearStatEnablement();
         }
     } // end for all vertex
     // Done with verticies, delete them;

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -323,7 +323,6 @@ int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTi
     {
         ConfigComponent* ccomp = &(*iter);
         if ( ccomp->rank == myRank ) {
-            // compInfoMap[ccomp->id] = ComponentInfo(ccomp->name, ccomp->type, new LinkMap());
             compInfoMap.insert(new ComponentInfo(ccomp, new LinkMap()));
         }
     }
@@ -469,12 +468,18 @@ void Simulation::initialize() {
     } while ( !done);
 
     // Walk through all the links and call finalizeConfiguration
+
+    for ( auto &i : compInfoMap ) {
+        i->finalizeLinkConfiguration();
+    }
+#if 0
     for ( auto i = compInfoMap.begin(); i != compInfoMap.end(); ++i) {
         std::map<std::string,Link*>& map = (*i)->getLinkMap()->getLinkMap();
         for ( std::map<std::string,Link*>::iterator j = map.begin(); j != map.end(); ++j ) {
             (*j).second->finalizeConfiguration();
         }
     }
+#endif
 #if 0
     if ( num_ranks.rank > 1 && my_rank.thread == 0 ) {
         sync->finalizeLinkConfigurations();

--- a/src/sst/core/simulation.h
+++ b/src/sst/core/simulation.h
@@ -203,45 +203,21 @@ public:
     // // const CompIdMap_t& getComponentIdMap(void) const { return compIdMap; }
     const ComponentInfoMap& getComponentInfoMap(void) { return compInfoMap; }
 
-    
-    /** Returns the component with a given name */
-    Component* getComponent(const std::string &name) const
-    {
-        ComponentInfo* i = compInfoMap.getByName(name);
-        if (NULL != i) {
-            return i->getComponent();
-        } else {
-            printf("Simulation::getComponent() couldn't find component with name = %s\n",
-                   name.c_str()); 
-            exit(1); 
-        }
-    }
-    
+
     /** returns the component with the given ID */
     Component* getComponent(const ComponentId_t &id) const
-    {        
+    {
 		ComponentInfo* i = compInfoMap.getByID(id);
 		// CompInfoMap_t::const_iterator i = compInfoMap.find(id);
 		if ( NULL != i ) {
 			return i->getComponent();
 		} else {
-            printf("Simulation::getComponent() couldn't find component with id = %lu\n", id);
+            printf("Simulation::getComponent() couldn't find component with id = %" PRIu64 "\n", id);
             exit(1);
 		}
     }
 
-    ComponentInfo* getComponentInfo(const std::string& name) const
-    {
-        ComponentInfo* i = compInfoMap.getByName(name);
-        if (NULL != i) {
-            return i;
-        } else {
-            printf("Simulation::getComponentInfo() couldn't find component with name = %s\n",
-                   name.c_str()); 
-            exit(1); 
-        }
-    }
-    
+
     ComponentInfo* getComponentInfo(const ComponentId_t &id) const
     {        
 		ComponentInfo* i = compInfoMap.getByID(id);
@@ -249,7 +225,7 @@ public:
 		if ( NULL != i ) {
 			return i;
 		} else {
-            printf("Simulation::getComponentInfo() couldn't find component with id = %lu\n", id);
+            printf("Simulation::getComponentInfo() couldn't find component with id = %" PRIu64 "\n", id);
             exit(1);
 		}
     }

--- a/src/sst/core/simulation.h
+++ b/src/sst/core/simulation.h
@@ -205,7 +205,7 @@ public:
 
 
     /** returns the component with the given ID */
-    Component* getComponent(const ComponentId_t &id) const
+    BaseComponent* getComponent(const ComponentId_t &id) const
     {
 		ComponentInfo* i = compInfoMap.getByID(id);
 		// CompInfoMap_t::const_iterator i = compInfoMap.find(id);

--- a/src/sst/core/simulation.h
+++ b/src/sst/core/simulation.h
@@ -81,10 +81,6 @@ public:
 
     typedef std::map<SimTime_t, Clock*>   clockMap_t;              /*!< Map of times to clocks */
     typedef std::map<SimTime_t, OneShot*> oneShotMap_t;            /*!< Map of times to OneShots */
-    typedef std::vector<std::string>      statEnableList_t;        /*!< List of Enabled Statistics */
-    typedef std::vector<Params>           statParamsList_t;        /*!< List of Enabled Statistics Parameters */
-    typedef std::map<ComponentId_t, statEnableList_t*> statEnableMap_t;  /*!< Map of Statistics that are requested to be enabled for a component defined in configGraph */
-    typedef std::map<ComponentId_t, statParamsList_t*> statParamsMap_t;  /*!< Map of Statistic Params for a component defined in configGraph */
     // typedef std::map< unsigned int, Sync* > SyncMap_t; /*!< Map of times to Sync Objects */
 
     ~Simulation();
@@ -258,29 +254,6 @@ public:
 		}
     }
 
-    statEnableList_t* getComponentStatisticEnableList(const ComponentId_t &id) const
-    {
-		statEnableMap_t::const_iterator i = statisticEnableMap.find(id);
-		if (i != statisticEnableMap.end()) {
-			return i->second;
-		} else {
-            printf("Simulation::getComponentStatisticEnableList() couldn't find component with id = %lu\n", id);
-            exit(1);
-		}
-        return NULL; 
-    }
-    
-    statParamsList_t* getComponentStatisticParamsList(const ComponentId_t &id) const
-    {
-		statParamsMap_t::const_iterator i = statisticParamsMap.find(id);
-		if (i != statisticParamsMap.end()) {
-			return i->second;
-		} else {
-            printf("Simulation::getComponentStatisticParamsList() couldn't find component with id = %lu\n", id);
-            exit(1);
-		}
-        return NULL; 
-    }
 
 
     /**
@@ -395,8 +368,6 @@ private:
     ThreadSync*      threadSync;
     ComponentInfoMap compInfoMap;
     clockMap_t       clockMap;
-    statEnableMap_t  statisticEnableMap;
-    statParamsMap_t  statisticParamsMap;
     oneShotMap_t     oneShotMap;
     SimTime_t        currentSimCycle;
     SimTime_t        endSimCycle;

--- a/src/sst/core/sst_types.h
+++ b/src/sst/core/sst_types.h
@@ -18,15 +18,21 @@
 
 namespace SST {
 
-typedef unsigned long   ComponentId_t;
+typedef uint64_t  ComponentId_t;
 typedef int32_t   LinkId_t;
 typedef uint64_t  Cycle_t;
 typedef uint64_t  SimTime_t;
 typedef double          Time_t;
 
 #define MAX_SIMTIME_T 0xFFFFFFFFFFFFFFFFl
-#define UNSET_COMPONENT_ID 0xFFFFFFFF
- 
+/* Subcomponent IDs are in the high-12 bits of the Component ID */
+#define UNSET_COMPONENT_ID 0xFFFFFFFFFFFFFFFFULL
+#define COMPONENT_ID_BITS 48
+#define COMPONENT_ID_MASK(x) ((x) & 0x0000FFFFFFFFFFFFULL)
+#define SUBCOMPONENT_ID_BITS 16
+#define SUBCOMPONENT_ID_MASK(x) ((x) >> COMPONENT_ID_BITS)
+#define SUBCOMPONENT_ID_CREATE(compId, sCompId) ((((uint64_t)sCompId) << COMPONENT_ID_BITS) | compId)
+
 typedef double watts;
 typedef double joules;
 typedef double farads;

--- a/src/sst/core/statapi/componentregisterstat_impl.h
+++ b/src/sst/core/statapi/componentregisterstat_impl.h
@@ -53,6 +53,12 @@
         fprintf(stderr, "ERROR: Statistic %s - Cannot be registered after the Components have been wired up.  Statistics must be registered on Component creation.; exiting...\n", fullStatName.c_str());
         exit(1);
     }
+
+    /* Create the statistic in the "owning" component.  That should just be us, 
+     * in the case of 'modern' subcomponents.  For legacy subcomponents, that will
+     * be the owning component.  We've got the ID of that component in 'my_info->getID()'
+     */
+    BaseComponent *owner = this->getStatisticOwner();
     
     // // Verify here that name of the stat is one of the registered
     // // names of the component's ElementInfoStatistic.  
@@ -143,7 +149,7 @@
 
     if (true == statGood) {
         // Instantiate the Statistic here defined by the type here
-        statistic = CreateStatistic<T>(this, statTypeParam, statName, statSubId, statParams);
+        statistic = CreateStatistic<T>(owner, statTypeParam, statName, statSubId, statParams);
         if (NULL == statistic) {
             fprintf(stderr, "ERROR: Unable to instantiate Statistic %s; exiting...\n", fullStatName.c_str());
             exit(1);
@@ -216,7 +222,7 @@
         
         // Instantiate the Statistic here defined by the type here
         statTypeParam = "sst.NullStatistic";
-        statistic = CreateStatistic<T>(this, statTypeParam, statName, statSubId, statParams);
+        statistic = CreateStatistic<T>(owner, statTypeParam, statName, statSubId, statParams);
         if (NULL == statistic) {
             statGood = false;
             fprintf(stderr, "ERROR: Unable to instantiate Null Statistic %s; exiting...\n", fullStatName.c_str());

--- a/src/sst/core/statapi/componentregisterstat_impl.h
+++ b/src/sst/core/statapi/componentregisterstat_impl.h
@@ -24,8 +24,8 @@
     bool                            statGood = true;
     bool                            nameFound = false;
     StatisticBase::StatMode_t       statCollectionMode = StatisticBase::STAT_MODE_COUNT;
-    Simulation::statEnableList_t*   statEnableList;
-    Simulation::statParamsList_t*   statParamsList;
+    ComponentInfo::statEnableList_t*   statEnableList;
+    ComponentInfo::statParamsList_t*   statParamsList;
     Output                          out = Simulation::getSimulation()->getSimulationOutput();
     UnitAlgebra                     collectionRate;
     UnitAlgebra                     startAtTime;
@@ -38,7 +38,7 @@
     Statistic<T>*                   statistic = NULL;    
     
     // Check to see if the Statistic is previously registered with the Statistics Engine
-    StatisticBase* prevStat = Simulation::getSimulation()->getStatisticsProcessingEngine()->isStatisticRegisteredWithEngine<T>(getName(), getId(), statName, statSubId);
+    StatisticBase* prevStat = Simulation::getSimulation()->getStatisticsProcessingEngine()->isStatisticRegisteredWithEngine<T>(getName(), my_info->getID(), statName, statSubId);
     if (NULL != prevStat) {
         // Dynamic cast the base stat to the expected type
         return dynamic_cast<Statistic<T>*>(prevStat);
@@ -62,8 +62,8 @@
     // }
 
     // Get Component Statistic Information from the ConfigGraph data
-    statEnableList = Simulation::getSimulation()->getComponentStatisticEnableList(getId());
-    statParamsList = Simulation::getSimulation()->getComponentStatisticParamsList(getId());
+    statEnableList = my_info->getStatEnableList();
+    statParamsList = my_info->getStatParams();
     
     // Check each entry in the StatEnableList (from the ConfigGraph via the 
     // Python File) to see if this Statistic is enabled, then check any of 
@@ -225,7 +225,7 @@
     }
 
     // Register the new Statistic with the Statistic Engine
-    Simulation::getSimulation()->getStatisticsProcessingEngine()->registerStatisticWithEngine<T>(getId(), statistic);
+    Simulation::getSimulation()->getStatisticsProcessingEngine()->registerStatisticWithEngine<T>(my_info->getID(), statistic);
     return statistic;
 //}
 

--- a/src/sst/core/statapi/stataccumulator.h
+++ b/src/sst/core/statapi/stataccumulator.h
@@ -42,9 +42,9 @@ template <typename NumberBase>
 class AccumulatorStatistic : public Statistic<NumberBase> 
 {
 private:
-    friend class SST::Component;
+    friend class SST::BaseComponent;
 
-    AccumulatorStatistic(Component* comp, std::string& statName, std::string& statSubId, Params& statParams) 
+    AccumulatorStatistic(BaseComponent* comp, std::string& statName, std::string& statSubId, Params& statParams) 
 		: Statistic<NumberBase>(comp, statName, statSubId, statParams)
     {
         m_sum = 0;

--- a/src/sst/core/statapi/statbase.cc
+++ b/src/sst/core/statapi/statbase.cc
@@ -11,19 +11,19 @@
 
 #include <sst_config.h>
 
-#include <sst/core/component.h>
+#include <sst/core/baseComponent.h>
 #include <sst/core/statapi/statbase.h>
 
 namespace SST {
 namespace Statistics {
-    
-StatisticBase::StatisticBase(Component* comp, std::string& statName, std::string& statSubId, Params& statParams)
+
+StatisticBase::StatisticBase(BaseComponent* comp, std::string& statName, std::string& statSubId, Params& statParams)
 {
     m_statName   = statName;
     m_statSubId  = statSubId;
     m_component  = comp;
     m_statParams = statParams;
-    
+
     initializeProperties();
 }
 

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -18,10 +18,9 @@
 #include <sst/core/statapi/statfieldinfo.h>
 
 namespace SST {
-class Component; 
-class SubComponent; 
+class BaseComponent;
 namespace Statistics {
-class StatisticOutput; 
+class StatisticOutput;
 class StatisticProcessingEngine;
 
 /**
@@ -105,7 +104,7 @@ public:
     inline const char* getStatDataTypeFullName() const {return StatisticFieldInfo::getFieldTypeFullName(m_statDataType);} 
     
     /** Return a pointer to the parent Component */
-    Component*   getComponent() const {return m_component;}
+    BaseComponent*   getComponent() const {return m_component;}
     
     /** Return the enable status of the Statistic */
     bool         isEnabled() const {return m_statEnabled;}
@@ -150,8 +149,6 @@ public:
     virtual bool isNullStatistic() const {return false;} 
 
 protected:  
-    friend class SST::Component;
-    friend class SST::SubComponent;
     friend class SST::Statistics::StatisticProcessingEngine;
     
     /** Construct a StatisticBase
@@ -162,7 +159,7 @@ protected:
       * @param statParams - The parameters for this statistic
       */
     // Constructors:
-    StatisticBase(Component* comp, std::string& statName, std::string& statSubId, Params& statParams);
+    StatisticBase(BaseComponent* comp, std::string& statName, std::string& statSubId, Params& statParams);
 
     // Destructor
     virtual ~StatisticBase() {}
@@ -177,6 +174,8 @@ protected:
     void setStatisticTypeName(const char* typeName) {m_statTypeName = typeName;}
     
 private:
+    friend class SST::BaseComponent;
+
     /** Set the Registered Collection Mode */
     void setRegisteredCollectionMode(StatMode_t mode) {m_registeredCollectionMode = mode;} 
 
@@ -223,7 +222,7 @@ private:
     StatisticBase(); // For serialization only
     
 private:
-    Component*            m_component;
+    BaseComponent*        m_component;
     std::string           m_statName;
     std::string           m_statSubId;
     std::string           m_statFullName;
@@ -278,7 +277,7 @@ public:
     }
     
 protected:    
-    friend class SST::Component;
+    friend class SST::BaseComponent;
     /** Construct a Statistic
       * @param comp - Pointer to the parent constructor.
       * @param statName - Name of the statistic to be registered.  This name must
@@ -286,7 +285,7 @@ protected:
       * @param statSubId - Additional name of the statistic 
       * @param statParams - The parameters for this statistic
       */
-    Statistic(Component* comp, std::string& statName, std::string& statSubId, Params& statParams) :
+    Statistic(BaseComponent* comp, std::string& statName, std::string& statSubId, Params& statParams) :
         StatisticBase(comp, statName, statSubId, statParams)
     {
         setStatisticDataType(StatisticFieldInfo::getFieldTypeFromTemplate<T>());

--- a/src/sst/core/statapi/statengine.h
+++ b/src/sst/core/statapi/statengine.h
@@ -15,12 +15,15 @@
 #include <sst/core/sst_types.h>
 #include <sst/core/statapi/statfieldinfo.h>
 #include <sst/core/unitAlgebra.h>
+#include <sst/core/clock.h>
+#include <sst/core/oneshot.h>
 
 namespace SST {
-class Component;
+class BaseComponent;
 class Simulation;
+
 namespace Statistics {
-    
+
 class StatisticBase;
 
 /**
@@ -47,7 +50,7 @@ public:
     void performGlobalStatisticOutput(bool endOfSimFlag = false);
 
 private:
-    friend class SST::Component;
+    friend class SST::BaseComponent;
     friend class SST::Simulation;
 
     StatisticProcessingEngine();

--- a/src/sst/core/statapi/stathistogram.h
+++ b/src/sst/core/statapi/stathistogram.h
@@ -18,6 +18,7 @@
 #include <sst/core/statapi/statbase.h>
 
 namespace SST {
+class BaseComponent;
 namespace Statistics {
 
 // NOTE: When calling base class members in classes derived from 
@@ -41,9 +42,9 @@ template<class BinDataType>
 class HistogramStatistic : public Statistic<BinDataType> 
 {
 private:
-    friend class SST::Component;
+    friend class SST::BaseComponent;
     
-    HistogramStatistic(Component* comp, std::string& statName, std::string& statSubId, Params& statParams)
+    HistogramStatistic(BaseComponent* comp, std::string& statName, std::string& statSubId, Params& statParams)
 		: Statistic<BinDataType>(comp, statName, statSubId, statParams)
     {
         // Identify what keys are Allowed in the parameters

--- a/src/sst/core/statapi/statnull.h
+++ b/src/sst/core/statapi/statnull.h
@@ -15,10 +15,10 @@
 
 #include <sst/core/sst_types.h>
 
-#include <sst/core/component.h>
 #include <sst/core/statapi/statbase.h>
 
 namespace SST {
+class BaseComponent;
 namespace Statistics {
 
 // NOTE: When calling base class members of classes derived from 
@@ -42,9 +42,9 @@ template <typename T>
 class NullStatistic : public Statistic<T>
 {
 private:    
-    friend class SST::Component;
+    friend class SST::BaseComponent;
     
-    NullStatistic(Component* comp, std::string& statName, std::string& statSubId, Params& statParams) 
+    NullStatistic(BaseComponent* comp, std::string& statName, std::string& statSubId, Params& statParams) 
 		: Statistic<T>(comp, statName, statSubId, statParams)
     {
         // Set the Name of this Statistic

--- a/src/sst/core/statapi/statoutput.h
+++ b/src/sst/core/statapi/statoutput.h
@@ -28,7 +28,7 @@
 extern int main(int argc, char **argv);
 
 namespace SST {
-class Component;
+class BaseComponent;
 class Simulation;
 namespace Statistics {
 class StatisticProcessingEngine;
@@ -172,7 +172,7 @@ public:
     
 protected:    
     friend int ::main(int argc, char **argv);
-    friend class SST::Component;
+    friend class SST::BaseComponent;
     friend class SST::Simulation;
     friend class SST::Statistics::StatisticProcessingEngine;
 

--- a/src/sst/core/statapi/statuniquecount.h
+++ b/src/sst/core/statapi/statuniquecount.h
@@ -18,6 +18,7 @@
 #include <sst/core/statapi/statbase.h>
 
 namespace SST {
+class BaseComponent;
 namespace Statistics {
 
 /**
@@ -32,9 +33,9 @@ template <typename T>
 class UniqueCountStatistic : public Statistic<T>
 {
 private:
-    friend class SST::Component;
+    friend class SST::BaseComponent;
 
-    UniqueCountStatistic(Component* comp, std::string& statName, std::string& statSubId, Params& statParams)
+    UniqueCountStatistic(BaseComponent* comp, std::string& statName, std::string& statSubId, Params& statParams)
 		: Statistic<T>(comp, statName, statSubId, statParams)
     {
         // Set the Name of this Statistic

--- a/src/sst/core/subcomponent.cc
+++ b/src/sst/core/subcomponent.cc
@@ -10,186 +10,30 @@
 // distribution.
 
 #include <sst_config.h>
-#include "sst/core/component.h"
-#include "sst/core/subcomponent.h"
-#include "sst/core/unitAlgebra.h"
-
-#include <string>
-
-//#include "sst/core/event.h"
-#include "sst/core/factory.h"
-#include "sst/core/link.h"
-#include "sst/core/linkMap.h"
-#include "sst/core/simulation.h"
-#include "sst/core/timeConverter.h"
-#include "sst/core/timeLord.h"
-#include "sst/core/unitAlgebra.h"
-
-using namespace SST::Statistics;
+#include <sst/core/subcomponent.h>
+#include <sst/core/factory.h>
 
 namespace SST {
 
-SubComponent::SubComponent(Component* parent) :
-    parent(parent)
-{
-    type = parent->currentlyLoadingSubComponent;
-}
-
-SubComponent::SubComponent() : 
-    parent(NULL)
-{
-}
-
-SubComponent::~SubComponent() 
-{
-}
-
 bool
-SubComponent::isPortConnected(const std::string &name) const
+SubComponent::doesComponentInfoStatisticExist(const std::string &statisticName)
 {
-    return parent->isPortConnected(name);
+    return Factory::getFactory()->DoesSubComponentInfoStatisticNameExist(my_info->getType(), statisticName);
 }
 
-Link*
-SubComponent::configureLink(std::string name, TimeConverter* time_base, Event::HandlerBase* handler)
+uint8_t SubComponent::getComponentInfoStatisticEnableLevel(const std::string &statisticName)
 {
-    return parent->configureLink(name,time_base,handler);
+    const std::string& type = parent->my_info->getType();
+    /* TODO:  SubComponent, not component stat? */
+    return Factory::getFactory()->GetComponentInfoStatisticEnableLevel(type, statisticName);
 }
 
-Link*
-SubComponent::configureLink(std::string name, std::string time_base, Event::HandlerBase* handler)
+std::string SubComponent::getComponentInfoStatisticUnits(const std::string &statisticName)
 {
-    return configureLink(name,Simulation::getSimulation()->getTimeLord()->getTimeConverter(time_base),handler);
+    const std::string& type = parent->my_info->getType();
+    /* TODO:  SubComponent, not component stat? */
+    return Factory::getFactory()->GetComponentInfoStatisticUnits(type, statisticName);
 }
-
-Link*
-SubComponent::configureLink(std::string name, Event::HandlerBase* handler)
-{
-    return parent->configureLink(name,handler);
-}
-
-Link*
-SubComponent::configureSelfLink( std::string name, TimeConverter* time_base, Event::HandlerBase* handler)
-{
-    return parent->configureSelfLink(name,time_base,handler);
-}
-
-Link*
-SubComponent::configureSelfLink( std::string name, std::string time_base, Event::HandlerBase* handler)
-{
-    return parent->configureSelfLink(name,time_base,handler);
-}
-
-Link*
-SubComponent::configureSelfLink( std::string name, Event::HandlerBase* handler)
-{
-    return parent->configureSelfLink(name,handler);
-}
-
-bool
-SubComponent::doesSubComponentInfoStatisticExist(std::string statisticName)
-{
-    return Factory::getFactory()->DoesSubComponentInfoStatisticNameExist(type, statisticName);
-}
-
-
-TimeConverter* SubComponent::registerClock( std::string freq, Clock::HandlerBase* handler) {
-    return parent->registerClock(freq,handler,false);
-}
-
-TimeConverter* SubComponent::registerClock( const UnitAlgebra& freq, Clock::HandlerBase* handler) {
-    return parent->registerClock(freq,handler,false);
-}
-
-void SubComponent::unregisterClock(TimeConverter *tc, Clock::HandlerBase* handler) {
-    parent->unregisterClock(tc,handler);
-}
-
-Cycle_t SubComponent::reregisterClock( TimeConverter* freq, Clock::HandlerBase* handler) {
-    return parent->reregisterClock(freq,handler);
-}
-
-Cycle_t SubComponent::getNextClockCycle( TimeConverter* freq ) {
-    return Simulation::getSimulation()->getNextClockCycle(freq);
-}
-
-//For now, no OneShot support in SubSubComponent
-#if 0
-TimeConverter* SubComponent::registerOneShot( std::string timeDelay, OneShot::HandlerBase* handler) {
-    return Simulation::getSimulation()->registerOneShot(timeDelay, handler);
-}
-
-TimeConverter* SubComponent::registerOneShot( const UnitAlgebra& timeDelay, OneShot::HandlerBase* handler) {
-    return Simulation::getSimulation()->registerOneShot(timeDelay, handler);
-}
-#endif
-    
-
-TimeConverter*
-SubComponent::getTimeConverter( const std::string& base )
-{
-    return Simulation::getSimulation()->getTimeLord()->getTimeConverter(base);
-}
-    
-TimeConverter*
-SubComponent::getTimeConverter( const UnitAlgebra& base )
-{
-    return Simulation::getSimulation()->getTimeLord()->getTimeConverter(base);
-}
-
-    
-SimTime_t SubComponent::getCurrentSimTime(TimeConverter *tc) const {
-    return tc->convertFromCoreTime(Simulation::getSimulation()->getCurrentSimCycle());
-}
-
-SimTime_t SubComponent::getCurrentSimTime(std::string base) {
-    return getCurrentSimTime(Simulation::getSimulation()->getTimeLord()->getTimeConverter(base));
-
-}
-    
-SimTime_t SubComponent::getCurrentSimTimeNano() const {
-    return getCurrentSimTime(Simulation::getSimulation()->getTimeLord()->getNano());
-}
-
-SimTime_t SubComponent::getCurrentSimTimeMicro() const {
-    return getCurrentSimTime(Simulation::getSimulation()->getTimeLord()->getMicro());
-}
-
-SimTime_t SubComponent::getCurrentSimTimeMilli() const {
-    return getCurrentSimTime(Simulation::getSimulation()->getTimeLord()->getMilli());
-}
-
-Module*
-SubComponent::loadModule(std::string type, Params& params)
-{
-    return parent->loadModule(type,params);
-}
-
-Module*
-SubComponent::loadModuleWithComponent(std::string type, Params& params)
-{
-    return parent->loadModuleWithComponent(type,parent,params);
-
-}
-
-SubComponent*
-SubComponent::loadSubComponent(std::string type, Params& params)
-{
-    return parent->loadSubComponent(type,parent,params);
-}
-
-SharedRegion*
-SubComponent::getLocalSharedRegion(const std::string &key, size_t size)
-{
-    return parent->getLocalSharedRegion(key,size);
-}
-
-SharedRegion*
-SubComponent::getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger)
-{
-    return parent->getGlobalSharedRegion(key, size, merger);
-}
-
 
 
 } // namespace SST

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -13,6 +13,7 @@
 #ifndef SST_CORE_SUBCOMPONENT_H
 #define SST_CORE_SUBCOMPONENT_H
 
+#include <sst/core/baseComponent.h>
 #include <sst/core/component.h>
 
 namespace SST {
@@ -24,11 +25,13 @@ namespace SST {
    SubComponent API is nearly identical to the Component API and all
    the calls are proxied to the parent Compoent.
 */
-class SubComponent : public Module {
+class SubComponent : public Module, public BaseComponent {
 
 public:
-	SubComponent(Component* parent);
-	virtual ~SubComponent();
+	SubComponent(Component* parent) : BaseComponent(), parent(parent) {
+        my_info = parent->currentlyLoadingSubComponent;
+    };
+	virtual ~SubComponent() {};
 
     /** Used during the init phase.  The method will be called each phase of initialization.
      Initialization ends when no components have sent any data. */
@@ -42,142 +45,30 @@ public:
 
 protected:
     Component* const parent;
-    // Component* parent;
 
-    /** Determine if a port name is connected to any links */
-    bool isPortConnected(const std::string &name) const;
+    Component* getTrueComponent() final { return parent; }
 
-    /** Configure a Link
-     * @param name - Port Name on which the link to configure is attached.
-     * @param time_base - Time Base of the link
-     * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
-     */
-    Link* configureLink( std::string name, TimeConverter* time_base, Event::HandlerBase* handler = NULL);
-    /** Configure a Link
-     * @param name - Port Name on which the link to configure is attached.
-     * @param time_base - Time Base of the link
-     * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
-     */
-    Link* configureLink( std::string name, std::string time_base, Event::HandlerBase* handler = NULL);
-    /** Configure a Link
-     * @param name - Port Name on which the link to configure is attached.
-     * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
-     */
-    Link* configureLink( std::string name, Event::HandlerBase* handler = NULL);
-
-    /** Configure a SelfLink  (Loopback link)
-     * @param name - Name of the self-link port
-     * @param time_base - Time Base of the link
-     * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
-     */
-    Link* configureSelfLink( std::string name, TimeConverter* time_base, Event::HandlerBase* handler = NULL);
-    /** Configure a SelfLink  (Loopback link)
-     * @param name - Name of the self-link port
-     * @param time_base - Time Base of the link
-     * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
-     */
-    Link* configureSelfLink( std::string name, std::string time_base, Event::HandlerBase* handler = NULL);
-    /** Configure a SelfLink  (Loopback link)
-     * @param name - Name of the self-link port
-     * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
-     */
-    Link* configureSelfLink( std::string name, Event::HandlerBase* handler = NULL);
-
-    bool doesSubComponentInfoStatisticExist(std::string statisticName);
-
-    template <typename T>
-    Statistic<T>* registerStatistic(std::string statName, std::string statSubId = "")
-    {
-        // Verify here that name of the stat is one of the registered
-        // names of the component's ElementInfoStatistic.  
-        if (false == doesSubComponentInfoStatisticExist(statName)) {
-            printf("Error: Statistic %s name %s is not found in ElementInfoStatistic, exiting...\n",
-                   StatisticBase::buildStatisticFullName(parent->getName().c_str(), statName, statSubId).
-                   c_str(),
-                   statName.c_str());
-            exit(1);
-        }
-        return parent->registerStatisticCore<T>(statName, statSubId);
+    /* Deprecate?   Old ELI style*/
+    SubComponent* loadSubComponent(std::string type, Params& params) {
+        return parent->loadSubComponent(type, parent, params);
     }
 
-    /** Registers a clock for this component.
-        @param freq Frequency for the clock in SI units
-        @param handler Pointer to Clock::HandlerBase which is to be invoked
-        at the specified interval
-        NOTE:  Unlike Components, SubComponents do not have a default timebase
-    */
-    TimeConverter* registerClock( std::string freq, Clock::HandlerBase* handler);
-    TimeConverter* registerClock( const UnitAlgebra& freq, Clock::HandlerBase* handler);
+    // Does the statisticName exist in the ElementInfoStatistic
+    virtual bool doesComponentInfoStatisticExist(const std::string &statisticName) final;
+    // Return the EnableLevel for the statisticName from the ElementInfoStatistic
+    virtual uint8_t getComponentInfoStatisticEnableLevel(const std::string &statisticName) final;
+    // Return the Units for the statisticName from the ElementInfoStatistic
+    virtual std::string getComponentInfoStatisticUnits(const std::string &statisticName) final;
 
-    /** Removes a clock handler from the component */
-    void unregisterClock(TimeConverter *tc, Clock::HandlerBase* handler);
-
-    /** Reactivates an existing Clock and Handler
-     * @return time of next time clock handler will fire
-     */
-    Cycle_t reregisterClock(TimeConverter *freq, Clock::HandlerBase* handler);
-    /** Returns the next Cycle that the TimeConverter would fire */
-    Cycle_t getNextClockCycle(TimeConverter *freq);
-    
-    // For now, no OneShot support in SubComponent
-#if 0
-    /** Registers a OneShot event for this component.
-        Note: OneShot cannot be canceled, and will always callback after
-          the timedelay.  
-        @param timeDelay Time delay for the OneShot in SI units
-        @param handler Pointer to OneShot::HandlerBase which is to be invoked
-        at the specified interval
-    */
-    TimeConverter* registerOneShot( std::string timeDelay, OneShot::HandlerBase* handler);
-    TimeConverter* registerOneShot( const UnitAlgebra& timeDelay, OneShot::HandlerBase* handler);
-#endif
-
-    TimeConverter* getTimeConverter( const std::string& base );
-    TimeConverter* getTimeConverter( const UnitAlgebra& base );
-
-    /** return the time since the simulation began in units specified by
-        the parameter.
-        @param tc TimeConverter specificing the units */
-    SimTime_t getCurrentSimTime(TimeConverter *tc) const;
-
-    /** return the time since the simulation began in timebase specified
-        @param base Timebase frequency in SI Units */
-    SimTime_t getCurrentSimTime(std::string base);
-
-    /** Utility function to return the time since the simulation began in nanoseconds */ 
-    SimTime_t getCurrentSimTimeNano() const;
-    /** Utility function to return the time since the simulation began in microseconds */ 
-    SimTime_t getCurrentSimTimeMicro() const;
-    /** Utility function to return the time since the simulation began in milliseconds */ 
-    SimTime_t getCurrentSimTimeMilli() const;
-
-    Module* loadModule(std::string type, Params& params);
-    Module* loadModuleWithComponent(std::string type, Params& params);
-    SubComponent* loadSubComponent(std::string type, Params& params);
-
-
-    /** Find a lookup table */
-    SharedRegion* getLocalSharedRegion(const std::string &key, size_t size);
-    SharedRegion* getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger = NULL);
-
-    
 private:
     /** Component's type, set by the factory when the object is created.
         It is identical to the configuration string used to create the
         component. I.e. the XML "<component id="aFoo"><foo>..." would
         set component::type to "foo" */
     friend class Component;
-    std::string type;
-    SubComponent();
-    };
+
+};
 } //namespace SST
 
-// BOOST_CLASS_EXPORT_KEY(SST::SubComponent)
 
 #endif // SST_CORE_SUBCOMPONENT_H

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -47,6 +47,12 @@ protected:
     Component* const parent;
 
     Component* getTrueComponent() final { return parent; }
+    BaseComponent* getStatisticOwner() final {
+        /* If our ID == parent ID, then we're a legacy subcomponent that doesn't own stats. */
+        if ( this->getId() == parent->getId() )
+            return parent;
+        return this;
+    }
 
     /* Deprecate?   Old ELI style*/
     SubComponent* loadSubComponent(std::string type, Params& params) {


### PR DESCRIPTION
This PR represents a fair number of changes to enable Ports on Subgraphs.  It adds to the Python API to allow registering SubComponents, and then treating the subcomponents as "components" in their own right -> Registering Statistics, setting Parameters, connecting to other components/subcomponents via Links.