### PR TITLE
Thread syncronization fixes

### DIFF
--- a/src/sst/core/rankSyncParallelSkip.h
+++ b/src/sst/core/rankSyncParallelSkip.h
@@ -31,7 +31,7 @@ class RankSyncParallelSkip : public NewRankSync {
 public:
     /** Create a new Sync object which fires with a specified period */
     // Sync(TimeConverter* period);
-    RankSyncParallelSkip(RankInfo num_ranks, Core::ThreadSafe::Barrier& barrier, TimeConverter* minPartTC);
+    RankSyncParallelSkip(RankInfo num_ranks, TimeConverter* minPartTC);
     virtual ~RankSyncParallelSkip();
     
     /** Register a Link which this Sync Object is responsible for */
@@ -100,7 +100,9 @@ private:
     void deserializeMessage(comm_recv_pair* msg);
     
 
-    Core::ThreadSafe::Barrier& barrier;
+    Core::ThreadSafe::Barrier serializeReadyBarrier;
+    Core::ThreadSafe::Barrier slaveExchangeDoneBarrier;
+    Core::ThreadSafe::Barrier allDoneBarrier;
 };
 
 

--- a/src/sst/core/rankSyncSerialSkip.h
+++ b/src/sst/core/rankSyncSerialSkip.h
@@ -27,7 +27,7 @@ class RankSyncSerialSkip : public NewRankSync {
 public:
     /** Create a new Sync object which fires with a specified period */
     // Sync(TimeConverter* period);
-    RankSyncSerialSkip(Core::ThreadSafe::Barrier& barrier, TimeConverter* minPartTC);
+    RankSyncSerialSkip(TimeConverter* minPartTC);
     virtual ~RankSyncSerialSkip();
     
     /** Register a Link which this Sync Object is responsible for */
@@ -68,8 +68,6 @@ private:
 
     double mpiWaitTime;
     double deserializeTime;
-
-    Core::ThreadSafe::Barrier& barrier;
 
 };
 

--- a/src/sst/core/simulation.h
+++ b/src/sst/core/simulation.h
@@ -293,7 +293,6 @@ private:
      * @param cycles Frequency which is the base of the TimeConverter
      */
     TimeConverter* minPartToTC(SimTime_t cycles) const;
-    static Core::ThreadSafe::Barrier& getThreadBarrier() { return barrier; }
 
     /** Factory used to generate the simulation components */
     static Factory *factory;
@@ -303,8 +302,11 @@ private:
     static Statistics::StatisticOutput* statisticsOutput;
     /** Output */
     static Output sim_output;
-    static Core::ThreadSafe::Barrier barrier;
-    static Core::ThreadSafe::Barrier exit_barrier;
+    static void resizeBarriers(uint32_t nthr);
+    static Core::ThreadSafe::Barrier initBarrier;
+    static Core::ThreadSafe::Barrier setupBarrier;
+    static Core::ThreadSafe::Barrier runBarrier;
+    static Core::ThreadSafe::Barrier exitBarrier;
     static std::mutex simulationMutex;
 
 
@@ -380,13 +382,7 @@ private:
 // time.  ONLY FOR DEBUG USE.
 void wait_my_turn_start(Core::ThreadSafe::Barrier& barrier, int thread, int total_threads);
 
-// Uses Simulation's barrier
-void wait_my_turn_start();
-
 void wait_my_turn_end(Core::ThreadSafe::Barrier& barrier, int thread, int total_threads);
-
-// Uses Simulation's barrier
-void wait_my_turn_end();
 
 
 } // namespace SST

--- a/src/sst/core/syncManager.cc
+++ b/src/sst/core/syncManager.cc
@@ -28,7 +28,7 @@ namespace SST {
 
 // Static data members
 NewRankSync* SyncManager::rankSync = NULL;
-Core::ThreadSafe::Barrier SyncManager::RankExecBarrier[5];
+Core::ThreadSafe::Barrier SyncManager::RankExecBarrier[6];
 Core::ThreadSafe::Barrier SyncManager::LinkInitBarrier[3];
 SimTime_t SyncManager::next_rankSync = MAX_SIMTIME_T;
 
@@ -213,6 +213,7 @@ SyncManager::execute(void)
     }
     computeNextInsert();
     // trace.getOutput().output(CALL_INFO, "next_sync_type = %d\n", next_sync_type);
+    RankExecBarrier[5].wait();
 }
 
 /** Cause an exchange of Initialization Data to occur */

--- a/src/sst/core/syncManager.cc
+++ b/src/sst/core/syncManager.cc
@@ -27,8 +27,9 @@
 namespace SST {
 
 // Static data members
-std::mutex SyncManager::sync_mutex;
 NewRankSync* SyncManager::rankSync = NULL;
+Core::ThreadSafe::Barrier SyncManager::RankExecBarrier[5];
+Core::ThreadSafe::Barrier SyncManager::LinkInitBarrier[3];
 SimTime_t SyncManager::next_rankSync = MAX_SIMTIME_T;
 
 class EmptyRankSync : public NewRankSync {
@@ -71,33 +72,34 @@ public:
 };
 
 
-SyncManager::SyncManager(const RankInfo& rank, const RankInfo& num_ranks, Core::ThreadSafe::Barrier& barrier, TimeConverter* minPartTC, SimTime_t min_part, const std::vector<SimTime_t>& interThreadLatencies) :
+SyncManager::SyncManager(const RankInfo& rank, const RankInfo& num_ranks, TimeConverter* minPartTC, SimTime_t min_part, const std::vector<SimTime_t>& interThreadLatencies) :
     Action(),
     rank(rank),
     num_ranks(num_ranks),
-    barrier(barrier),
     threadSync(NULL),
     next_threadSync(0),
     min_part(min_part)
 {
     // TraceFunction trace(CALL_INFO_LONG);    
-    
+
     sim = Simulation::getSimulation();
-    
+
+
     if ( rank.thread == 0  ) {
         // if ( num_ranks.rank > 1 ) {
+        for ( auto &b : RankExecBarrier ) { b.resize(num_ranks.thread); }
+        for ( auto &b : LinkInitBarrier ) { b.resize(num_ranks.thread); }
         if ( min_part != MAX_SIMTIME_T ) {
             if ( num_ranks.thread == 1 ) {
-                rankSync = new RankSyncSerialSkip(/*num_ranks,*/ barrier, minPartTC);
+                rankSync = new RankSyncSerialSkip(/*num_ranks,*/ minPartTC);
             }
             else {
-                rankSync = new RankSyncParallelSkip(num_ranks, barrier, minPartTC);
+                rankSync = new RankSyncParallelSkip(num_ranks, minPartTC);
             }
         }
         else {
             rankSync = new EmptyRankSync();
         }
-        
     }
 
     // Need to check to see if there are any inter-thread
@@ -159,7 +161,7 @@ SyncManager::execute(void)
         // Need to make sure all threads have reached the sync to
         // guarantee that all events have been sent to the appropriate
         // queues.
-        barrier.wait();
+        RankExecBarrier[0].wait();
         
         // For a rank sync, we will force a thread sync first.  This
         // will ensure that all events sent between threads will be
@@ -170,24 +172,24 @@ SyncManager::execute(void)
 
         // Need to make sure everyone has made it through the mutex
         // and the min time computation is complete
-        barrier.wait();
+        RankExecBarrier[1].wait();
         
         // Now call the actual RankSync
         // trace.getOutput().output(CALL_INFO, "About to enter rankSync->execute()\n");
         rankSync->execute(rank.thread);
         // trace.getOutput().output(CALL_INFO, "Complete rankSync->execute()\n");
 
-        barrier.wait();
+        RankExecBarrier[2].wait();
 
         // Now call the threadSync after() call
         threadSync->after();
         // trace.getOutput().output(CALL_INFO, "Complete threadSync->after()\n");
 
-        barrier.wait();
+        RankExecBarrier[3].wait();
         
         if ( exit != NULL && rank.thread == 0 ) exit->check();
 
-        barrier.wait();
+        RankExecBarrier[4].wait();
 
         if ( exit->getGlobalCount() == 0 ) {
             endSimulation(exit->getEndTime());
@@ -218,11 +220,11 @@ void
 SyncManager::exchangeLinkInitData(std::atomic<int>& msg_count)
 {
     // TraceFunction trace(CALL_INFO_LONG);    
-    barrier.wait();
+    LinkInitBarrier[0].wait();
     threadSync->processLinkInitData();
-    barrier.wait();
+    LinkInitBarrier[1].wait();
     rankSync->exchangeLinkInitData(rank.thread, msg_count);
-    barrier.wait();
+    LinkInitBarrier[2].wait();
 }
 
 /** Finish link configuration */

--- a/src/sst/core/syncManager.h
+++ b/src/sst/core/syncManager.h
@@ -102,7 +102,7 @@ private:
 
 class SyncManager : public Action {
 public:
-    SyncManager(const RankInfo& rank, const RankInfo& num_ranks, Core::ThreadSafe::Barrier& barrier, TimeConverter* minPartTC, SimTime_t min_part, const std::vector<SimTime_t>& interThreadLatencies);
+    SyncManager(const RankInfo& rank, const RankInfo& num_ranks, TimeConverter* minPartTC, SimTime_t min_part, const std::vector<SimTime_t>& interThreadLatencies);
     virtual ~SyncManager();
 
     /** Register a Link which this Sync Object is responsible for */
@@ -117,12 +117,12 @@ public:
     void print(const std::string& header, Output &out) const;
 
 private:
-    enum sync_type_t { RANK, THREAD}; 
+    enum sync_type_t { RANK, THREAD};
 
     RankInfo rank;
     RankInfo num_ranks;
-    Core::ThreadSafe::Barrier& barrier;
-    static std::mutex sync_mutex;
+    static Core::ThreadSafe::Barrier RankExecBarrier[5];
+    static Core::ThreadSafe::Barrier LinkInitBarrier[3];
     // static SimTime_t min_next_time;
     // static int min_count;
     

--- a/src/sst/core/syncManager.h
+++ b/src/sst/core/syncManager.h
@@ -121,7 +121,7 @@ private:
 
     RankInfo rank;
     RankInfo num_ranks;
-    static Core::ThreadSafe::Barrier RankExecBarrier[5];
+    static Core::ThreadSafe::Barrier RankExecBarrier[6];
     static Core::ThreadSafe::Barrier LinkInitBarrier[3];
     // static SimTime_t min_next_time;
     // static int min_count;

--- a/src/sst/core/threadSyncSimpleSkip.cc
+++ b/src/sst/core/threadSyncSimpleSkip.cc
@@ -42,8 +42,8 @@ ThreadSyncSimpleSkip::ThreadSyncSimpleSkip(int num_threads, int thread, Simulati
     if ( sim->getNumRanks().rank > 1 ) single_rank = false;
     else single_rank = true;
 
-    max_period = sim->getInterThreadMinLatency();
-    nextSyncTime = max_period;
+    my_max_period = sim->getInterThreadMinLatency();
+    nextSyncTime = my_max_period;
 }
 
 ThreadSyncSimpleSkip::~ThreadSyncSimpleSkip()
@@ -116,7 +116,9 @@ ThreadSyncSimpleSkip::after()
 
     // if ( thread == 0 ) localMinimumNextActivityTime = sim->getLocalMinimumNextActivityTime();
     // nextSyncTime = localMinimumNextActivityTime + max_period;
-    nextSyncTime = sim->getLocalMinimumNextActivityTime() + max_period;
+    auto nextmin = sim->getLocalMinimumNextActivityTime();
+    auto nextminPlus = nextmin + my_max_period;
+    nextSyncTime = nextmin > nextminPlus ? nextmin : nextminPlus;
 }
 
 void

--- a/src/sst/core/threadSyncSimpleSkip.cc
+++ b/src/sst/core/threadSyncSimpleSkip.cc
@@ -85,13 +85,6 @@ ThreadSyncSimpleSkip::before()
 {
     // TraceFunction trace(CALL_INFO_LONG);
 
-    // No need to barrier.  SyncManger already barriers before calling
-    // this function
-
-    // totalWaitTime += barrier.wait();
-
-    // if ( disabled ) return;
-
     // Empty all the queues and send events on the links
     for ( int i = 0; i < queues.size(); i++ ) {
         ThreadSyncQueue* queue = queues[i];
@@ -109,12 +102,6 @@ ThreadSyncSimpleSkip::before()
         }
         queue->clear();
     }
-
-    // No need to barrier, SyncManger will barrier right after this
-    // call
-
-    // totalWaitTime += barrier.wait();
-
 }
 
 void
@@ -124,22 +111,12 @@ ThreadSyncSimpleSkip::after()
 
     // Use this nextSyncTime computation for no skip
     // nextSyncTime = sim->getCurrentSimCycle() + max_period;
-    
-    
-    // No need to barrier.  SyncManger already barriers before calling
-    // this function
-
-    // totalWaitTime += barrier.wait();
-
 
     // Use this nextSyncTime computation for skipping
 
     // if ( thread == 0 ) localMinimumNextActivityTime = sim->getLocalMinimumNextActivityTime();
-    // totalWaitTime += barrier.wait();
     // nextSyncTime = localMinimumNextActivityTime + max_period;
     nextSyncTime = sim->getLocalMinimumNextActivityTime() + max_period;
-    totalWaitTime += barrier.wait();
-
 }
 
 void
@@ -151,41 +128,7 @@ ThreadSyncSimpleSkip::execute()
     before();
     totalWaitTime = barrier.wait();
     after();
-    
-
-    // // TraceFunction trace(CALL_INFO_LONG);
-    // totalWaitTime += barrier.wait();
-    // // if ( disabled ) return;
-    // // Empty all the queues and send events on the links
-    // for ( int i = 0; i < queues.size(); i++ ) {
-    //     ThreadSyncQueue* queue = queues[i];
-    //     std::vector<Activity*>& vec = queue->getVector();
-    //     for ( int j = 0; j < vec.size(); j++ ) {
-    //         Event* ev = static_cast<Event*>(vec[j]);
-    //         auto link = link_map.find(ev->getLinkId());
-    //         if (link == link_map.end()) {
-    //             printf("Link not found in map!\n");
-    //             abort();
-    //         } else {
-    //             SimTime_t delay = ev->getDeliveryTime() - sim->getCurrentSimCycle();
-    //             link->second->send(delay,ev);
-    //         }
-    //     }
-    //     queue->clear();
-    // }
-
-    // // Use this nextSyncTime computation for no skip
-    // // nextSyncTime = sim->getCurrentSimCycle() + max_period;
-
-
-    // // Use this nextSyncTime computation for skipping
-    // totalWaitTime += barrier.wait();
-
-    // // if ( thread == 0 ) localMinimumNextActivityTime = sim->getLocalMinimumNextActivityTime();
-    // // totalWaitTime += barrier.wait();
-    // // nextSyncTime = localMinimumNextActivityTime + max_period;
-    // nextSyncTime = sim->getLocalMinimumNextActivityTime() + max_period;
-    
+    totalWaitTime += barrier.wait();
 }
 
 void

--- a/src/sst/core/threadSyncSimpleSkip.h
+++ b/src/sst/core/threadSyncSimpleSkip.h
@@ -58,7 +58,7 @@ public:
 private:
     std::vector<ThreadSyncQueue*> queues;
     std::unordered_map<LinkId_t, Link*> link_map;
-    SimTime_t max_period;
+    SimTime_t my_max_period;
     int num_threads;
     int thread;
     static SimTime_t localMinimumNextActivityTime;

--- a/src/sst/core/threadsafe.h
+++ b/src/sst/core/threadsafe.h
@@ -39,7 +39,7 @@ namespace ThreadSafe {
 #endif
 
 
-class Barrier {
+class CACHE_ALIGNED_T Barrier {
     size_t origCount;
     std::atomic<bool> enabled;
     std::atomic<size_t> count, generation;

--- a/src/sst/core/threadsafe.h
+++ b/src/sst/core/threadsafe.h
@@ -73,10 +73,12 @@ public:
             auto startTime = SST::Core::Profile::now();
 
             size_t gen = generation.load();
+            asm("":::"memory");
             size_t c = --count;
             if ( 0 == c ) {
                 /* We should release */
                 count = origCount;
+                asm("":::"memory");
                 ++generation; /* Incrementing generation causes release */
             } else {
                 /* Try spinning first */


### PR DESCRIPTION
A couple of things in here:

- Break apart uses of Barrier objects so fewer barriers are re-used across different locations
- Remove some blocks of commented-out code
- Add / move some barriers to fix at least one race-condition that would lead to deadlock.