### PR TITLE
Enable picky warnings in core

### DIFF
--- a/config/sst_check_picky.m4
+++ b/config/sst_check_picky.m4
@@ -1,0 +1,10 @@
+
+AC_DEFUN([SST_CHECK_PICKY], [
+  use_picky="yes"
+
+  AC_ARG_ENABLE([picky-warnings], [AS_HELP_STRING([--disable-picky-warnings],
+      [Disable the use of compiler flags -Wall -Wextra within the SST core.])])
+
+  AS_IF([test "x$enable_picky_warnings" = "xno"], [use_picky="no"])
+ 
+])

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,13 @@ AS_IF([test "x$found_cxx1y" = "xyes"],
         [CXXFLAGS="$CXXFLAGS $SST_CXX1Y_FLAGS"],
         [CXXFLAGS="$CXXFLAGS $SST_CXX0X_FLAGS"])
 
+SST_CHECK_PICKY
+AS_IF([test "x$use_picky" = "xyes"],
+      [WARNFLAGS="-Wall -Wextra"],
+      [WARNFLAGS=""])
+CFLAGS="$CFLAGS $WARNFLAGS"
+CXXFLAGS="$CXXFLAGS $WARNFLAGS"
+
 dnl Fix flags - seems to be only way to make libltdl play nice
 CPPFLAGS='-I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/src -I$(top_builddir)/src'" $CPPFLAGS"
 

--- a/src/sst/core/activity.h
+++ b/src/sst/core/activity.h
@@ -281,7 +281,7 @@ public:
 
         pool->free(ptr8);
     }
-    void operator delete(void* ptr, std::size_t sz){
+    void operator delete(void* ptr, std::size_t sz __attribute__((unused))){
         /* 1) Decrement pointer
          * 2) Determine Pool Pointer
          * 2b) Set Pointer field to NULL to allow tracking

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -144,7 +144,6 @@ Link*
 BaseComponent::configureLink(std::string name, TimeConverter* time_base, Event::HandlerBase* handler)
 {
     LinkMap* myLinks = my_info->getLinkMap();
-    const std::string& type = my_info->getType();
     Link* tmp = myLinks->getLink(name);
     if ( tmp == NULL ) return NULL;
 
@@ -170,7 +169,6 @@ Link*
 BaseComponent::configureLink(std::string name, Event::HandlerBase* handler)
 {
     LinkMap* myLinks = my_info->getLinkMap();
-    const std::string& type = my_info->getType();
     Link* tmp = myLinks->getLink(name);
     if ( tmp == NULL ) return NULL;
 

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -221,16 +221,13 @@ BaseComponent::configureSelfLink( std::string name, Event::HandlerBase* handler)
     return configureLink(name,handler);
 }
 
-Link* BaseComponent::selfLink( std::string name, Event::HandlerBase* handler )
+Link* BaseComponent::selfLink( std::string name __attribute__((unused)), Event::HandlerBase* handler )
 {
-//     Link* link = new Link(handler);
-//     link->Connect(link,0);
-//     return link;
     Link* link = new SelfLink();
     link->setLatency(0);
     link->setFunctor(handler);
     if ( handler == NULL ) {
-	link->setPolling();
+        link->setPolling();
     }
     return link;
 }

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -72,7 +72,7 @@ public:
 
     /** Used during the init phase.  The method will be called each phase of initialization.
      Initialization ends when no components have sent any data. */
-    virtual void init(unsigned int phase) {}
+    virtual void init(unsigned int phase __attribute__((unused))) {}
     /** Called after all components have been constructed and inialization has
 	completed, but before simulation time has begun. */
     virtual void setup( ) { }
@@ -88,7 +88,7 @@ public:
      * print it's current status.  Useful for debugging.
      * @param out The Output class which should be used to print component status.
      */
-    virtual void printStatus(Output &out) { return; }
+    virtual void printStatus(Output &out __attribute__((unused))) { return; }
 
     /** Determine if a port name is connected to any links */
     bool isPortConnected(const std::string &name) const;

--- a/src/sst/core/bootshared.cc
+++ b/src/sst/core/bootshared.cc
@@ -20,7 +20,7 @@
 #include "bootshared.h"
 #include "sst/core/env/envquery.h"
 
-void update_env_var(const char* name, const int verbose, char* argv[], const int argc) {
+void update_env_var(const char* name, const int verbose __attribute__((unused)), char* argv[] __attribute__((unused)), const int argc __attribute__((unused))) {
         char* current_ld_path  = getenv(name);
 	char* new_ld_path      = (char*) malloc(sizeof(char) * 32768);
 	char* new_ld_path_copy = (char*) malloc(sizeof(char) * 32768);
@@ -70,7 +70,7 @@ void boot_sst_configure_env(const int verbose, char* argv[], const int argc) {
         update_env_var("DYLD_LIBRARY_PATH", verbose, argv, argc);
 }
 
-void boot_sst_executable(const char* binary, const int verbose, char* argv[], const int argc) {
+void boot_sst_executable(const char* binary, const int verbose, char* argv[], const int argc __attribute__((unused))) {
 	char* real_binary_path = (char*) malloc(sizeof(char) * PATH_MAX);
 
 	if(strcmp(SST_INSTALL_PREFIX, "NONE") == 0) {

--- a/src/sst/core/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.cc
@@ -27,7 +27,7 @@ JSONConfigGraphOutput::JSONConfigGraphOutput(const char* path) :
 
 }
 
-void JSONConfigGraphOutput::generate(const Config* cfg,
+void JSONConfigGraphOutput::generate(const Config* cfg __attribute__((unused)),
                 ConfigGraph* graph) throw(ConfigGraphOutputException) {
 
 	if(NULL == outputFile) {
@@ -59,7 +59,7 @@ void JSONConfigGraphOutput::generate(const Config* cfg,
 }
 
 void JSONConfigGraphOutput::generateJSON(const std::string indent, const ConfigComponent& comp,
-                const ConfigLinkMap_t& linkMap) const {
+                const ConfigLinkMap_t& linkMap __attribute__((unused))) const {
 
 	fprintf(outputFile, "%s  {\n", indent.c_str());
 	fprintf(outputFile, "%s    \"name\" : \"%s\",\n", indent.c_str(), comp.name.c_str());

--- a/src/sst/core/cfgoutput/xmlConfigOutput.cc
+++ b/src/sst/core/cfgoutput/xmlConfigOutput.cc
@@ -21,7 +21,7 @@ XMLConfigGraphOutput::XMLConfigGraphOutput(const char* path) :
 
 }
 
-void XMLConfigGraphOutput::generate(const Config* cfg,
+void XMLConfigGraphOutput::generate(const Config* cfg __attribute__((unused)),
                 ConfigGraph* graph) throw(ConfigGraphOutputException) {
 
 	if(NULL == outputFile) {
@@ -48,7 +48,7 @@ void XMLConfigGraphOutput::generate(const Config* cfg,
 }
 
 void XMLConfigGraphOutput::generateXML(const std::string indent, const ConfigComponent& comp,
-                const ConfigLinkMap_t& linkMap) const {
+                const ConfigLinkMap_t& linkMap __attribute__((unused))) const {
 
 	fprintf(outputFile, "%s<component id=\"system.%s\" name=\"%s\" type=\"%s\">\n",
 		indent.c_str(), comp.name.c_str(), comp.name.c_str(), comp.type.c_str());

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -23,8 +23,8 @@ ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name) :
     name(name),
     type(""),
     link_map(NULL),
-    params(NULL),
     component(NULL),
+    params(NULL),
     enabledStats(NULL),
     statParams(NULL)
 { }
@@ -35,8 +35,8 @@ ComponentInfo::ComponentInfo(const std::string &type, const Params *params, cons
     name(parent->name),
     type(type),
     link_map(parent->link_map),
-    params(params),
     component(NULL),
+    params(params),
     enabledStats(parent->enabledStats),
     statParams(parent->statParams)
 { }

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -28,7 +28,7 @@ class BaseComponent;
 
 class ComponentInfoMap;
 
-struct ComponentInfo {
+class ComponentInfo {
 
 public:
     typedef std::vector<std::string>      statEnableList_t;        /*!< List of Enabled Statistics */

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -298,7 +298,7 @@ bool Config::setConfigEntryFromModel(const string &entryName, const string &valu
 
 bool Config::printVersion() {
     printf("SST-Core Version (" PACKAGE_VERSION);
-    if (SSTCORE_GIT_HEADSHA != PACKAGE_VERSION) { 
+    if (strcmp(SSTCORE_GIT_HEADSHA, PACKAGE_VERSION)) { 
         printf(", git branch : " SSTCORE_GIT_BRANCH);
         printf(", SHA: " SSTCORE_GIT_HEADSHA);
     }
@@ -368,7 +368,7 @@ bool Config::setStopAfter(const std::string &arg) {
         "%Ss"
     };
     const size_t n_templ = sizeof(templates) / sizeof(templates[0]);
-    struct tm res = {};
+    struct tm res = {}; /* This warns on GCC 4.8 due to a bug in GCC */
     char *p;
 
     for ( size_t i = 0 ; i < n_templ ; i++ ) {

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -169,7 +169,7 @@ bool Config::usage() {
             "Usage: sst [options] config-file\n"
             "\n");
     for ( size_t i = 0 ; i < nLongOpts ; i++ ) {
-        int npos = 0;
+        uint32_t npos = 0;
         if ( sstOptions[i].opt.val ) {
             npos += fprintf(stderr, "  -%c, ", (char)sstOptions[i].opt.val);
         } else {
@@ -368,7 +368,7 @@ bool Config::setStopAfter(const std::string &arg) {
         "%Ss"
     };
     const size_t n_templ = sizeof(templates) / sizeof(templates[0]);
-    struct tm res = {0};
+    struct tm res = {};
     char *p;
 
     for ( size_t i = 0 ; i < n_templ ; i++ ) {

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -348,7 +348,7 @@ public:
     // PartitionComponent(ComponentId_t id, ConfigGraph* graph, const ComponentIdMap_t& group);
     void print(std::ostream &os, const PartitionGraph* graph) const;
 
-    inline const ComponentId_t key() const { return id; }
+    inline ComponentId_t key() const { return id; }
 
 };
 
@@ -368,7 +368,7 @@ public:
         no_cut = cl.no_cut;
     }
 
-    inline const LinkId_t key() const { return id; }
+    inline LinkId_t key() const { return id; }
 
     /** Return the minimum latency of this link (from both sides) */
     SimTime_t getMinLatency() const {

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -130,7 +130,7 @@ static std::vector<std::string> splitPath(const std::string & searchPaths)
     }
 
     delete [] pathCopy;
-    return std::move( paths );
+    return paths;
 }
 
 

--- a/src/sst/core/elementinfo.h
+++ b/src/sst/core/elementinfo.h
@@ -85,7 +85,7 @@ public:
     ComponentElementInfo() {  }
     
     virtual Component* create(ComponentId_t id, Params& params) = 0;
-    virtual const uint32_t getCategory() = 0;
+    virtual uint32_t getCategory() = 0;
     
     std::string toString();
 };
@@ -107,8 +107,8 @@ class ModuleElementInfo : public BaseElementInfo {
 protected:
 
 public:
-    virtual Module* create(Component* comp, Params& params) { /* Need to print error */ return NULL; }
-    virtual Module* create(Params& params) { /* Need to print error */ return NULL; }
+    virtual Module* create(Component* comp __attribute__((unused)), Params& params __attribute__((unused))) { /* Need to print error */ return NULL; }
+    virtual Module* create(Params& params __attribute__((unused))) { /* Need to print error */ return NULL; }
     virtual const std::string getInterface() = 0;
     
     std::string toString();
@@ -261,14 +261,14 @@ public:
         return T::create(id,params);
     }
 
-    static const bool isLoaded() { return loaded; }
+    static bool isLoaded() { return loaded; }
     const std::string getLibrary() { return T::ELI_getLibrary(); }
     const std::string getName() { return T::ELI_getName(); }
     const std::string getDescription() { return T::ELI_getDescription(); }
     const std::vector<ElementInfoParam>& getValidParams() { return T::ELI_getParams(); }
     const std::vector<ElementInfoStatistic>& getValidStats() { return T::ELI_getStatistics(); }
     const std::vector<ElementInfoPort2>& getValidPorts() { return T::ELI_getPorts(); }
-    const uint32_t getCategory() { return T::ELI_getCategory(); };
+    uint32_t getCategory() { return T::ELI_getCategory(); };
 };
 
 
@@ -297,7 +297,7 @@ public:
         return T::create(comp,params);
     }
 
-    static const bool isLoaded() { return loaded; }
+    static bool isLoaded() { return loaded; }
     const std::string getLibrary() { return T::ELI_getLibrary(); }
     const std::string getName() { return T::ELI_getName(); }
     const std::string getDescription() { return T::ELI_getDescription(); }
@@ -336,7 +336,7 @@ public:
         return new T(params);
     }
 
-    static const bool isLoaded() { return loaded; }
+    static bool isLoaded() { return loaded; }
     const std::string getLibrary() { return T::ELI_getLibrary(); }
     const std::string getName() { return T::ELI_getName(); }
     const std::string getDescription() { return T::ELI_getDescription(); }
@@ -359,7 +359,7 @@ public:
         return new T(comp,params);
     }
 
-    static const bool isLoaded() { return loaded; }
+    static bool isLoaded() { return loaded; }
     const std::string getLibrary() { return T::ELI_getLibrary(); }
     const std::string getName() { return T::ELI_getName(); }
     const std::string getDescription() { return T::ELI_getDescription(); }
@@ -382,7 +382,7 @@ public:
         return new T(params);
     }
 
-    static const bool isLoaded() { return loaded; }
+    static bool isLoaded() { return loaded; }
     const std::string getLibrary() { return T::ELI_getLibrary(); }
     const std::string getName() { return T::ELI_getName(); }
     const std::string getDescription() { return T::ELI_getDescription(); }
@@ -433,7 +433,7 @@ public:
         return new T(total_ranks,my_rank,verbosity);
     }
     
-    static const bool isLoaded() { return loaded; }
+    static bool isLoaded() { return loaded; }
     const std::string getDescription() { return T::ELI_getDescription(); }
     const std::string getName() { return T::ELI_getName(); }
     const std::string getLibrary() { return T::ELI_getLibrary(); }
@@ -460,7 +460,7 @@ public:
         return instance; 
     }
     
-    static const bool isLoaded() { return loaded; }
+    static bool isLoaded() { return loaded; }
     const std::string getLibrary() { return T::ELI_getLibrary(); }
 };
 

--- a/src/sst/core/env/envquery.cc
+++ b/src/sst/core/env/envquery.cc
@@ -37,7 +37,7 @@ void SST::Core::Environment::configReadLine(FILE* theFile, char* lineBuffer) {
 	}
 }
 
-void SST::Core::Environment::populateEnvironmentConfig(FILE* configFile, EnvironmentConfiguration* cfg, bool errorOnNotOpen) {
+void SST::Core::Environment::populateEnvironmentConfig(FILE* configFile, EnvironmentConfiguration* cfg, bool errorOnNotOpen __attribute__((unused))) {
 
 	// Get the file descriptor and lock the file using a shared lock so
 	// people don't come and change it from under us
@@ -46,7 +46,7 @@ void SST::Core::Environment::populateEnvironmentConfig(FILE* configFile, Environ
 
 	constexpr size_t maxBufferLength = 4096;
 	char* lineBuffer = (char*) malloc(sizeof(char) * maxBufferLength);
-	for(auto i = 0; i < maxBufferLength; i++) {
+	for(size_t i = 0; i < maxBufferLength; i++) {
 		lineBuffer[i] = '\0';
 	}
 	int currentLine = 0;
@@ -78,7 +78,7 @@ void SST::Core::Environment::populateEnvironmentConfig(FILE* configFile, Environ
 			std::string lineStr(lineBuffer);
 			int equalsIndex = 0;
 
-			for(int i = 0; i < strlen(lineBuffer); i++) {
+			for(size_t i = 0; i < strlen(lineBuffer); i++) {
 				if('=' == lineBuffer[i]) {
 					equalsIndex = i;
 					break;

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -536,7 +536,7 @@ Factory::CreateCoreModule(std::string type, Params& params) {
 }
 
 Module*
-Factory::CreateCoreModuleWithComponent(std::string type, Component* comp, Params& params) {
+Factory::CreateCoreModuleWithComponent(std::string type, Component* comp __attribute__((unused)), Params& params __attribute__((unused))) {
     out.fatal(CALL_INFO, -1, "can't find requested core module %s when loading with component\n", type.c_str());
     return NULL;
 }

--- a/src/sst/core/heartbeat.cc
+++ b/src/sst/core/heartbeat.cc
@@ -23,7 +23,7 @@
 
 namespace SST {
 
-SimulatorHeartbeat::SimulatorHeartbeat( Config* cfg, int this_rank, Simulation* sim, TimeConverter* period) :
+SimulatorHeartbeat::SimulatorHeartbeat( Config* cfg __attribute__((unused)), int this_rank, Simulation* sim, TimeConverter* period) :
     Action(),
     rank(this_rank),
     m_period( period )

--- a/src/sst/core/interfaces/simpleMem.h
+++ b/src/sst/core/interfaces/simpleMem.h
@@ -278,7 +278,7 @@ public:
 
 
     /** Constructor, designed to be used via 'loadSubComponent'. */
-    SimpleMem(SST::Component *comp, Params &params) :
+    SimpleMem(SST::Component *comp, Params &params __attribute__((unused))) :
         SubComponent(comp)
         { }
 

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -294,7 +294,7 @@ public:
     virtual Request* recv(int vn) = 0;
 
     virtual void setup() {}
-    virtual void init(unsigned int phase) {}
+    virtual void init(unsigned int phase __attribute__((unused))) {}
     virtual void finish() {}
 
     /**

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -148,7 +148,7 @@ static void dump_partition(Config& cfg, ConfigGraph* graph, const RankInfo &size
 }
 
 static void do_graph_wireup(ConfigGraph* graph,
-        SST::Simulation* sim, SST::Config* cfg, const RankInfo &world_size,
+        SST::Simulation* sim,
         const RankInfo &myRank, SimTime_t min_part) {
 
     if ( !graph->containsComponentInRank( myRank ) ) {
@@ -234,7 +234,7 @@ static void start_simulation(uint32_t tid, SimThreadInfo_t &info, Core::ThreadSa
     for ( uint32_t i = 0; i < info.world_size.thread; ++i ) {
         if ( i == info.myRank.thread ) {
             // g_output.output("wiring up this thread %u\n", info.myRank.thread);
-            do_graph_wireup(info.graph, sim, info.config, info.world_size, info.myRank, info.min_part);
+            do_graph_wireup(info.graph, sim, info.myRank, info.min_part);
         }
         barrier.wait();
     }

--- a/src/sst/core/model/element_python.cc
+++ b/src/sst/core/model/element_python.cc
@@ -13,9 +13,9 @@
 
 #include "sst_config.h"
 
-#include "sst/core/model/element_python.h"
-
 #include <Python.h>
+
+#include "sst/core/model/element_python.h"
 
 namespace SST {
 

--- a/src/sst/core/model/pymodel.cc
+++ b/src/sst/core/model/pymodel.cc
@@ -33,6 +33,12 @@
 #include <sst/core/configGraph.h>
 
 
+/* Disable GCC's strict-aliasing warnings for Python macros */
+#if defined(__GNUC__) && ((__GNUC__ == 4 && 3 <= __GNUC_MINOR__) || 4 < __GNUC__)
+# pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+
+
 using namespace SST::Core;
 
 SST::Core::SSTPythonModelDefinition *gModel = NULL;

--- a/src/sst/core/model/pymodel.cc
+++ b/src/sst/core/model/pymodel.cc
@@ -108,6 +108,15 @@ static PyTypeObject ModuleLoaderType = {
     0,                         /* tp_init */
     0,                         /* tp_alloc */
     0,                         /* tp_new */
+    0,                         /* tp_free */
+    0,                         /* tp_is_gc */
+    0,                         /* tp_bases */
+    0,                         /* tp_mro */
+    0,                         /* tp_cache */
+    0,                         /* tp_subclasses */
+    0,                         /* tp_weaklist */
+    0,                         /* tp_del */
+    0,                         /* tp_version_tag */
 };
 
 
@@ -142,7 +151,7 @@ static PyMethodDef emptyModMethods[] = {
     {NULL, NULL, 0, NULL }
 };
 
-static PyObject* mlLoadModule(PyObject *self, PyObject *args)
+static PyObject* mlLoadModule(PyObject *self __attribute__((unused)), PyObject *args)
 {
     char *name;
     if ( !PyArg_ParseTuple(args, "s", &name) )
@@ -172,7 +181,7 @@ static PyObject* mlLoadModule(PyObject *self, PyObject *args)
 
 /***** Module information *****/
 
-static PyObject* findComponentByName(PyObject* self, PyObject* args)
+static PyObject* findComponentByName(PyObject* self __attribute__((unused)), PyObject* args)
 {
     if ( ! PyString_Check(args) ) {
         Py_INCREF(Py_None);
@@ -190,7 +199,7 @@ static PyObject* findComponentByName(PyObject* self, PyObject* args)
     return Py_None;
 }
 
-static PyObject* setProgramOption(PyObject* self, PyObject* args)
+static PyObject* setProgramOption(PyObject* self __attribute__((unused)), PyObject* args)
 {
     char *param, *value;
     PyErr_Clear();
@@ -207,7 +216,7 @@ static PyObject* setProgramOption(PyObject* self, PyObject* args)
 }
 
 
-static PyObject* setProgramOptions(PyObject* self, PyObject* args)
+static PyObject* setProgramOptions(PyObject* self __attribute__((unused)), PyObject* args)
 {
     if ( !PyDict_Check(args) ) {
         return NULL;
@@ -223,7 +232,7 @@ static PyObject* setProgramOptions(PyObject* self, PyObject* args)
 }
 
 
-static PyObject* getProgramOptions(PyObject*self, PyObject *args)
+static PyObject* getProgramOptions(PyObject*self __attribute__((unused)), PyObject *args __attribute__((unused)))
 {
     // Load parameters already set.
     Config *cfg = gModel->getConfig();
@@ -253,7 +262,7 @@ static PyObject* getProgramOptions(PyObject*self, PyObject *args)
 }
 
 
-static PyObject* pushNamePrefix(PyObject* self, PyObject* arg)
+static PyObject* pushNamePrefix(PyObject* self __attribute__((unused)), PyObject* arg)
 {
     char *name = NULL;
     PyErr_Clear();
@@ -268,20 +277,20 @@ static PyObject* pushNamePrefix(PyObject* self, PyObject* arg)
 }
 
 
-static PyObject* popNamePrefix(PyObject* self, PyObject* args)
+static PyObject* popNamePrefix(PyObject* self __attribute__((unused)), PyObject* args __attribute__((unused)))
 {
     gModel->popNamePrefix();
     return PyInt_FromLong(0);
 }
 
 
-static PyObject* exitsst(PyObject* self, PyObject* args)
+static PyObject* exitsst(PyObject* self __attribute__((unused)), PyObject* args __attribute__((unused)))
 {
     exit(-1);
     return NULL;
 }
 
-static PyObject* getSSTMPIWorldSize(PyObject* self, PyObject* args) {
+static PyObject* getSSTMPIWorldSize(PyObject* self __attribute__((unused)), PyObject* args __attribute__((unused))) {
     int ranks = 1;
 #ifdef SST_CONFIG_HAVE_MPI
     MPI_Comm_size(MPI_COMM_WORLD, &ranks);
@@ -289,12 +298,12 @@ static PyObject* getSSTMPIWorldSize(PyObject* self, PyObject* args) {
     return PyInt_FromLong(ranks);
 }
 
-static PyObject* getSSTThreadCount(PyObject* self, PyObject* args) {
+static PyObject* getSSTThreadCount(PyObject* self __attribute__((unused)), PyObject* args __attribute__((unused))) {
     Config *cfg = gModel->getConfig();
     return PyLong_FromLong(cfg->getNumThreads());
 }
 
-static PyObject* setSSTThreadCount(PyObject* self, PyObject* args) {
+static PyObject* setSSTThreadCount(PyObject* self __attribute__((unused)), PyObject* args) {
     Config *cfg = gModel->getConfig();
     long oldNThr = cfg->getNumThreads();
     long nThr = PyLong_AsLong(args);
@@ -304,7 +313,7 @@ static PyObject* setSSTThreadCount(PyObject* self, PyObject* args) {
 }
 
 
-static PyObject* setStatisticOutput(PyObject* self, PyObject* args)
+static PyObject* setStatisticOutput(PyObject* self __attribute__((unused)), PyObject* args)
 {
     char*      statOutputName;
     int        argOK = 0;
@@ -328,7 +337,7 @@ static PyObject* setStatisticOutput(PyObject* self, PyObject* args)
     return PyInt_FromLong(0);
 }
 
-static PyObject* setStatisticOutputOption(PyObject* self, PyObject* args)
+static PyObject* setStatisticOutputOption(PyObject* self __attribute__((unused)), PyObject* args)
 {
     char* param;
     char* value;
@@ -347,7 +356,7 @@ static PyObject* setStatisticOutputOption(PyObject* self, PyObject* args)
 }
 
 
-static PyObject* setStatisticOutputOptions(PyObject* self, PyObject* args)
+static PyObject* setStatisticOutputOptions(PyObject* self __attribute__((unused)), PyObject* args)
 {
     PyErr_Clear();
 
@@ -363,7 +372,7 @@ static PyObject* setStatisticOutputOptions(PyObject* self, PyObject* args)
 }
 
 
-static PyObject* setStatisticLoadLevel(PyObject*self, PyObject* arg)
+static PyObject* setStatisticLoadLevel(PyObject* self __attribute__((unused)), PyObject* arg)
 {
     PyErr_Clear();
 
@@ -379,7 +388,7 @@ static PyObject* setStatisticLoadLevel(PyObject*self, PyObject* arg)
 }
 
 
-static PyObject* enableAllStatisticsForAllComponents(PyObject* self, PyObject* args)
+static PyObject* enableAllStatisticsForAllComponents(PyObject* self __attribute__((unused)), PyObject* args)
 {
     int           argOK = 0;
     PyObject*     statParamDict = NULL;
@@ -405,7 +414,7 @@ static PyObject* enableAllStatisticsForAllComponents(PyObject* self, PyObject* a
 }
 
 
-static PyObject* enableAllStatisticsForComponentName(PyObject *self, PyObject *args)
+static PyObject* enableAllStatisticsForComponentName(PyObject *self __attribute__((unused)), PyObject *args)
 {
     int           argOK = 0;
     char*         compName = NULL;
@@ -432,7 +441,7 @@ static PyObject* enableAllStatisticsForComponentName(PyObject *self, PyObject *a
 }
 
 
-static PyObject* enableAllStatisticsForComponentType(PyObject *self, PyObject *args)
+static PyObject* enableAllStatisticsForComponentType(PyObject *self __attribute__((unused)), PyObject *args)
 {
     int           argOK = 0;
     char*         compType = NULL;
@@ -458,7 +467,7 @@ static PyObject* enableAllStatisticsForComponentType(PyObject *self, PyObject *a
 }
 
 
-static PyObject* enableStatisticForComponentName(PyObject *self, PyObject *args)
+static PyObject* enableStatisticForComponentName(PyObject *self __attribute__((unused)), PyObject *args)
 {
     int           argOK = 0;
     char*         compName = NULL;
@@ -485,7 +494,7 @@ static PyObject* enableStatisticForComponentName(PyObject *self, PyObject *args)
 }
 
 
-static PyObject* enableStatisticForComponentType(PyObject *self, PyObject *args)
+static PyObject* enableStatisticForComponentType(PyObject *self __attribute__((unused)), PyObject *args)
 {
     int           argOK = 0;
     char*         compType = NULL;
@@ -576,7 +585,7 @@ static PyMethodDef sstModuleMethods[] = {
 }  /* extern C */
 
 
-void SSTPythonModelDefinition::initModel(const std::string script_file, int verbosity, Config* config, int argc, char** argv)
+void SSTPythonModelDefinition::initModel(const std::string script_file, int verbosity, Config* config __attribute__((unused)), int argc, char** argv)
 {
     output = new Output("SSTPythonModel ", verbosity, 0, SST::Output::STDOUT);
 

--- a/src/sst/core/model/pymodel_comp.cc
+++ b/src/sst/core/model/pymodel_comp.cc
@@ -426,7 +426,6 @@ static int subCompInit(ComponentPy_t *self, PyObject *args, PyObject *kwds)
 {
     char *name, *type;
     PyObject *parent;
-    ComponentId_t useID = UNSET_COMPONENT_ID;
     if ( !PyArg_ParseTuple(args, "Oss", &parent, &name, &type) )
         return -1;
 

--- a/src/sst/core/model/pymodel_comp.cc
+++ b/src/sst/core/model/pymodel_comp.cc
@@ -100,7 +100,7 @@ int PySubComponent::compare(ComponentHolder *other) {
 
 
 
-static int compInit(ComponentPy_t *self, PyObject *args, PyObject *kwds)
+static int compInit(ComponentPy_t *self, PyObject *args, PyObject *kwds __attribute__((unused)))
 {
     char *name, *type;
     ComponentId_t useID = UNSET_COMPONENT_ID;
@@ -235,7 +235,7 @@ static PyObject* compAddLink(PyObject *self, PyObject *args)
 }
 
 
-static PyObject* compGetFullName(PyObject *self, PyObject *args)
+static PyObject* compGetFullName(PyObject *self, PyObject *args __attribute__((unused)))
 {
     return PyString_FromString(getComp(self)->name.c_str());
 }
@@ -416,13 +416,22 @@ PyTypeObject PyModel_ComponentType = {
     (initproc)compInit,        /* tp_init */
     0,                         /* tp_alloc */
     0,                         /* tp_new */
+    0,                         /* tp_free */
+    0,                         /* tp_is_gc */
+    0,                         /* tp_bases */
+    0,                         /* tp_mro */
+    0,                         /* tp_cache */
+    0,                         /* tp_subclasses */
+    0,                         /* tp_weaklist */
+    0,                         /* tp_del */
+    0,                         /* tp_version_tag */
 };
 
 
 
 
 
-static int subCompInit(ComponentPy_t *self, PyObject *args, PyObject *kwds)
+static int subCompInit(ComponentPy_t *self, PyObject *args, PyObject *kwds __attribute__((unused)))
 {
     char *name, *type;
     PyObject *parent;
@@ -518,6 +527,15 @@ PyTypeObject PyModel_SubComponentType = {
     (initproc)subCompInit,     /* tp_init */
     0,                         /* tp_alloc */
     0,                         /* tp_new */
+    0,                         /* tp_free */
+    0,                         /* tp_is_gc */
+    0,                         /* tp_bases */
+    0,                         /* tp_mro */
+    0,                         /* tp_cache */
+    0,                         /* tp_subclasses */
+    0,                         /* tp_weaklist */
+    0,                         /* tp_del */
+    0,                         /* tp_version_tag */
 };
 
 

--- a/src/sst/core/model/pymodel_link.cc
+++ b/src/sst/core/model/pymodel_link.cc
@@ -33,7 +33,7 @@ extern SST::Core::SSTPythonModelDefinition *gModel;
 extern "C" {
 
 
-static int linkInit(LinkPy_t *self, PyObject *args, PyObject *kwds)
+static int linkInit(LinkPy_t *self, PyObject *args, PyObject *kwds __attribute__((unused)))
 {
     char *name = NULL, *lat = NULL;
     if ( !PyArg_ParseTuple(args, "s|s", &name, &lat) ) return -1;
@@ -104,7 +104,7 @@ static PyObject* linkConnect(PyObject* self, PyObject *args)
 }
 
 
-static PyObject* linkSetNoCut(PyObject* self, PyObject *args)
+static PyObject* linkSetNoCut(PyObject* self, PyObject *args __attribute__((unused)))
 {
     LinkPy_t *link = (LinkPy_t*)self;
     bool prev = link->no_cut;
@@ -166,6 +166,15 @@ PyTypeObject PyModel_LinkType = {
     (initproc)linkInit,        /* tp_init */
     0,                         /* tp_alloc */
     0,                         /* tp_new */
+    0,                         /* tp_free */
+    0,                         /* tp_is_gc */
+    0,                         /* tp_bases */
+    0,                         /* tp_mro */
+    0,                         /* tp_cache */
+    0,                         /* tp_subclasses */
+    0,                         /* tp_weaklist */
+    0,                         /* tp_del */
+    0,                         /* tp_version_tag */
 };
 
 

--- a/src/sst/core/objectComms.h
+++ b/src/sst/core/objectComms.h
@@ -73,7 +73,7 @@ std::vector<char> serialize(dataType &data)
 template <typename dataType>
 dataType* deserialize(std::vector<char> &buffer)
 {
-    dataType *tgt;
+    dataType *tgt = NULL;
 
     SST::Core::Serialization::serializer ser;
 

--- a/src/sst/core/output.h
+++ b/src/sst/core/output.h
@@ -326,6 +326,14 @@ public:
                 va_end(arg);
             }
         }
+#else
+        /* When debug is disabled, silence warnings of unused parameters */
+        (void)line;
+        (void)file;
+        (void)func;
+        (void)output_level;
+        (void)output_bits;
+        (void)format;
 #endif
     }
 

--- a/src/sst/core/part/linpart.cc
+++ b/src/sst/core/part/linpart.cc
@@ -15,7 +15,7 @@
 
 using namespace std;
 
-SSTLinearPartition::SSTLinearPartition(RankInfo mpiranks, RankInfo my_rank, int verbosity) {
+SSTLinearPartition::SSTLinearPartition(RankInfo mpiranks, RankInfo my_rank __attribute__((unused)), int verbosity) {
 	rankcount = mpiranks;
 	partOutput = new Output("LinearPartition ", verbosity, 0, SST::Output::STDOUT);
 }

--- a/src/sst/core/part/rrobin.cc
+++ b/src/sst/core/part/rrobin.cc
@@ -21,7 +21,7 @@ using namespace std;
 namespace SST {
 namespace Partition {
 
-SSTRoundRobinPartition::SSTRoundRobinPartition(RankInfo world_size, RankInfo my_rank, int verbosity) :
+SSTRoundRobinPartition::SSTRoundRobinPartition(RankInfo world_size, RankInfo my_rank __attribute__((unused)), int verbosity __attribute__((unused))) :
     SSTPartitioner(),
     world_size(world_size)
 {

--- a/src/sst/core/part/simplepart.cc
+++ b/src/sst/core/part/simplepart.cc
@@ -24,7 +24,7 @@ using namespace std;
 namespace SST {
 namespace Partition {
 
-SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo my_rank, int verbosity) :
+SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo my_rank __attribute__((unused)), int verbosity __attribute__((unused))) :
         SSTPartitioner(),
         world_size(total_ranks),
         total_parts(world_size.rank * world_size.thread)
@@ -123,8 +123,8 @@ SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo my_rank, int
 			component_map[setB[i]].rank = convertPartNum(rankB);
 		}
 
-		const int A1_rank = rankA;
-		const int A2_rank = rankA + pow2(step);
+		const uint32_t A1_rank = rankA;
+		const uint32_t A2_rank = rankA + pow2(step);
 
 		if(A2_rank < total_parts) {
 			const int lengthA1 = lengthA % 2 == 1 ? (lengthA / 2) + 1 : (lengthA / 2);
@@ -151,8 +151,8 @@ SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo my_rank, int
 			free(setA2);
 		}
 
-		const int B1_rank = rankB;
-		const int B2_rank = rankB + pow2(step);
+		const uint32_t B1_rank = rankB;
+		const uint32_t B2_rank = rankB + pow2(step);
 
 		if(B2_rank < total_parts) {
 			const int lengthB1 = lengthB % 2 == 1 ? (lengthB / 2) + 1 : (lengthB / 2);

--- a/src/sst/core/part/singlepart.cc
+++ b/src/sst/core/part/singlepart.cc
@@ -18,7 +18,7 @@ using namespace std;
 
 using namespace SST::Partition;
 
-SSTSinglePartition::SSTSinglePartition(RankInfo total_ranks, RankInfo my_rank, int verbosity) {}
+SSTSinglePartition::SSTSinglePartition(RankInfo total_ranks __attribute__((unused)), RankInfo my_rank __attribute__((unused)), int verbosity __attribute__((unused))) {}
 
 void SSTSinglePartition::performPartition(PartitionGraph* graph) {
 

--- a/src/sst/core/part/sstpart.h
+++ b/src/sst/core/part/sstpart.h
@@ -39,7 +39,7 @@ public:
      * Result of this function is that every ConfigComponent in
      * graph has a Rank applied to it.
      */
-    virtual void performPartition(PartitionGraph* graph) {}
+    virtual void performPartition(PartitionGraph* graph __attribute__((unused))) {}
 
     /** Function to be overriden by subclasses
      *
@@ -50,7 +50,7 @@ public:
      * Result of this function is that every ConfigComponent in
      * graph has a Rank applied to it.
      */
-    virtual void performPartition(ConfigGraph* graph) {}
+    virtual void performPartition(ConfigGraph* graph __attribute__((unused))) {}
     
     virtual bool requiresConfigGraph() { return false; }
     

--- a/src/sst/core/profile.h
+++ b/src/sst/core/profile.h
@@ -57,13 +57,13 @@ inline ProfData_t now()
     return 0.0;
 }
 
-inline double getElapsed(const ProfData_t &begin, const ProfData_t &end)
+inline double getElapsed(const ProfData_t &begin __attribute__((unused)), const ProfData_t &end __attribute__((unused)))
 {
     return 0.0;
 }
 
 
-inline double getElapsed(const ProfData_t &since)
+inline double getElapsed(const ProfData_t &since __attribute__((unused)))
 {
     return 0.0;
 }

--- a/src/sst/core/rankSyncParallelSkip.cc
+++ b/src/sst/core/rankSyncParallelSkip.cc
@@ -37,7 +37,6 @@ SimTime_t RankSyncParallelSkip::myNextSyncTime = 0;
     
 RankSyncParallelSkip::RankSyncParallelSkip(RankInfo num_ranks, TimeConverter* minPartTC) :
     NewRankSync(),
-    minPartTC(minPartTC),
     mpiWaitTime(0.0),
     deserializeTime(0.0),
     send_count(0),
@@ -191,8 +190,6 @@ RankSyncParallelSkip::exchange_slave(int thread)
             // comm_recv_pair* recv = link_send_queue[thread].remove();        
             my_recv_count--;
 
-            std::vector<Activity*>& activities = recv->activity_vec;
-        
             for ( int i = 0; i < recv->activity_vec.size(); i++ ) {
                 Event* ev = static_cast<Event*>(recv->activity_vec[i]);
                 link_map_t::iterator link = link_map.find(ev->getLinkId());
@@ -228,9 +225,7 @@ RankSyncParallelSkip::exchange_master(int thread)
     //Maximum number of outstanding requests is 3 times the number
     // of ranks I communicate with (1 recv, 2 sends per rank)
     MPI_Request sreqs[2 * comm_send_map.size()];
-    MPI_Request rreqs[comm_recv_map.size()];
     int sreq_count = 0;
-    int rreq_count = 0;
 
     // First thing to do is fill the serialize_queue.
     for (auto i = comm_send_map.begin() ; i != comm_send_map.end() ; ++i) {
@@ -245,8 +240,6 @@ RankSyncParallelSkip::exchange_master(int thread)
         // Post all the receives
         int tag = 2 * i->second.local_thread;
         i->second.recv_done = false;
-        // MPI_Irecv(i->second.rbuf, i->second.local_size, MPI_BYTE,
-        //           i->second.remote_rank, tag, MPI_COMM_WORLD, &rreqs[rreq_count++]);
         MPI_Irecv(i->second.rbuf, i->second.local_size, MPI_BYTE,
                   i->second.remote_rank, tag, MPI_COMM_WORLD, &i->second.req);
     }

--- a/src/sst/core/rankSyncParallelSkip.cc
+++ b/src/sst/core/rankSyncParallelSkip.cc
@@ -35,7 +35,7 @@ SimTime_t RankSyncParallelSkip::myNextSyncTime = 0;
 
 ///// RankSyncParallelSkip class /////
     
-RankSyncParallelSkip::RankSyncParallelSkip(RankInfo num_ranks, TimeConverter* minPartTC) :
+RankSyncParallelSkip::RankSyncParallelSkip(RankInfo num_ranks, TimeConverter* minPartTC __attribute__((unused))) :
     NewRankSync(),
     mpiWaitTime(0.0),
     deserializeTime(0.0),
@@ -48,7 +48,7 @@ RankSyncParallelSkip::RankSyncParallelSkip(RankInfo num_ranks, TimeConverter* mi
     max_period = Simulation::getSimulation()->getMinPartTC();
     myNextSyncTime = max_period->getFactor();
     recv_count = new int[num_ranks.thread];
-    for ( int i = 0; i < num_ranks.thread; i++ ) {
+    for ( uint32_t i = 0; i < num_ranks.thread; i++ ) {
         recv_count[i] = 0;
     }
     link_send_queue = new SST::Core::ThreadSafe::UnboundedQueue<comm_recv_pair*>[num_ranks.thread];
@@ -190,7 +190,7 @@ RankSyncParallelSkip::exchange_slave(int thread)
             // comm_recv_pair* recv = link_send_queue[thread].remove();        
             my_recv_count--;
 
-            for ( int i = 0; i < recv->activity_vec.size(); i++ ) {
+            for ( size_t i = 0; i < recv->activity_vec.size(); i++ ) {
                 Event* ev = static_cast<Event*>(recv->activity_vec[i]);
                 link_map_t::iterator link = link_map.find(ev->getLinkId());
                 if (link == link_map.end()) {
@@ -215,7 +215,7 @@ RankSyncParallelSkip::exchange_slave(int thread)
 }
 
 void
-RankSyncParallelSkip::exchange_master(int thread)
+RankSyncParallelSkip::exchange_master(int thread __attribute__((unused)))
 {
     // TraceFunction trace(CALL_INFO_LONG);
     // Simulation::getSimulation()->getSimulationOutput().output("Entering RankSyncParallelSkip::execute()\n");

--- a/src/sst/core/rankSyncParallelSkip.h
+++ b/src/sst/core/rankSyncParallelSkip.h
@@ -50,8 +50,7 @@ public:
 private:
 
     static SimTime_t myNextSyncTime;
-    TimeConverter* minPartTC;
-    
+
     // Function that actually does the exchange during run
     void exchange_master(int thread);
     void exchange_slave(int thread);

--- a/src/sst/core/rankSyncSerialSkip.cc
+++ b/src/sst/core/rankSyncSerialSkip.cc
@@ -33,7 +33,7 @@ namespace SST {
 SimTime_t RankSyncSerialSkip::myNextSyncTime = 0;
 
 
-RankSyncSerialSkip::RankSyncSerialSkip(TimeConverter* minPartTC) :
+RankSyncSerialSkip::RankSyncSerialSkip(TimeConverter* minPartTC __attribute__((unused))) :
     NewRankSync(),
     mpiWaitTime(0.0),
     deserializeTime(0.0)
@@ -58,7 +58,7 @@ RankSyncSerialSkip::~RankSyncSerialSkip()
         Output::getDefaultObject().verbose(CALL_INFO, 1, 0, "RankSyncSerialSkip mpiWait: %lg sec  deserializeWait:  %lg sec\n", mpiWaitTime, deserializeTime);
 }
     
-ActivityQueue* RankSyncSerialSkip::registerLink(const RankInfo& to_rank, const RankInfo& from_rank, LinkId_t link_id, Link* link)
+ActivityQueue* RankSyncSerialSkip::registerLink(const RankInfo& to_rank, const RankInfo& from_rank __attribute__((unused)), LinkId_t link_id, Link* link)
 {
     // TraceFunction trace(CALL_INFO_LONG);
     SyncQueue* queue;

--- a/src/sst/core/rankSyncSerialSkip.cc
+++ b/src/sst/core/rankSyncSerialSkip.cc
@@ -35,7 +35,6 @@ SimTime_t RankSyncSerialSkip::myNextSyncTime = 0;
 
 RankSyncSerialSkip::RankSyncSerialSkip(TimeConverter* minPartTC) :
     NewRankSync(),
-    minPartTC(minPartTC),
     mpiWaitTime(0.0),
     deserializeTime(0.0)
 {

--- a/src/sst/core/rankSyncSerialSkip.h
+++ b/src/sst/core/rankSyncSerialSkip.h
@@ -46,8 +46,7 @@ public:
 private:
 
     static SimTime_t myNextSyncTime;
-    TimeConverter* minPartTC;
-    
+
     // Function that actually does the exchange during run
     void exchange();
     

--- a/src/sst/core/rng/marsaglia.cc
+++ b/src/sst/core/rng/marsaglia.cc
@@ -73,7 +73,7 @@ uint64_t MarsagliaRNG::generateNextUInt64() {
 	char* returnUInt64Ptr = (char*) &returnUInt64;
 	const char* nextInt64Ptr = (const char*) &nextInt64;
 
-	for(int i = 0; i < sizeof(nextInt64); i++) {
+	for(size_t i = 0; i < sizeof(nextInt64); i++) {
 		returnUInt64Ptr[i] = nextInt64Ptr[i];
 	}
 
@@ -89,11 +89,11 @@ int64_t  MarsagliaRNG::generateNextInt64() {
 	const char* lowerHalfPtr = (const char*) &lowerHalf;
 	const char* upperHalfPtr = (const char*) &upperHalf;
 
-	for(int i = 0; i < sizeof(lowerHalf); i++) {
+	for(size_t i = 0; i < sizeof(lowerHalf); i++) {
 		returnInt64Ptr[i] = lowerHalfPtr[i];
 	}
 
-	for(int i = 0; i < sizeof(lowerHalf); i++) {
+	for(size_t i = 0; i < sizeof(lowerHalf); i++) {
 		returnInt64Ptr[i+4] = upperHalfPtr[i];
 	}
 
@@ -107,7 +107,7 @@ int32_t  MarsagliaRNG::generateNextInt32() {
 	char* returnInt32Ptr = (char*) &returnInt32;
 	const char* nextRNPtr = (const char*) &nextRN;
 
-	for(int i = 0; i < sizeof(returnInt32); i++) {
+	for(size_t i = 0; i < sizeof(returnInt32); i++) {
 		returnInt32Ptr[i] = nextRNPtr[i];
 	}
 
@@ -126,7 +126,7 @@ uint32_t MarsagliaRNG::generateNextUInt32() {
 	char* returnUInt32Ptr = (char*) &returnUInt32;
 	const char* nextInt32Ptr = (const char*) &nextInt32;
 
-	for(int i = 0; i < sizeof(nextInt32); i++) {
+	for(size_t i = 0; i < sizeof(nextInt32); i++) {
 		returnUInt32Ptr[i] = nextInt32Ptr[i];
 	}
 

--- a/src/sst/core/rng/mersenne.cc
+++ b/src/sst/core/rng/mersenne.cc
@@ -99,11 +99,11 @@ int64_t  MersenneRNG::generateNextInt64() {
 	const char* lowerHalfPtr = (const char*) &lowerHalf;
 	const char* upperHalfPtr = (const char*) &upperHalf;
 
-	for(int i = 0; i < sizeof(lowerHalf); i++) {
+	for(size_t i = 0; i < sizeof(lowerHalf); i++) {
 		returnNumberPtr[i] = lowerHalfPtr[i];
 	}
 
-	for(int i = 0; i < sizeof(upperHalf); i++) {
+	for(size_t i = 0; i < sizeof(upperHalf); i++) {
 		returnNumberPtr[i + 4] = upperHalfPtr[i];
 	}
 

--- a/src/sst/core/rng/xorshift.cc
+++ b/src/sst/core/rng/xorshift.cc
@@ -62,7 +62,7 @@ uint64_t XORShiftRNG::generateNextUInt64() {
 	char* returnUInt64Ptr = (char*) &returnUInt64;
 	const char* nextInt64Ptr = (const char*) &nextInt64;
 
-	for(int i = 0; i < sizeof(nextInt64); i++) {
+	for(size_t i = 0; i < sizeof(nextInt64); i++) {
 		returnUInt64Ptr[i] = nextInt64Ptr[i];
 	}
 
@@ -78,11 +78,11 @@ int64_t  XORShiftRNG::generateNextInt64() {
 	const char* lowerHalfPtr = (const char*) &lowerHalf;
 	const char* upperHalfPtr = (const char*) &upperHalf;
 
-	for(int i = 0; i < sizeof(lowerHalf); i++) {
+	for(size_t i = 0; i < sizeof(lowerHalf); i++) {
 		returnInt64Ptr[i] = lowerHalfPtr[i];
 	}
 
-	for(int i = 0; i < sizeof(lowerHalf); i++) {
+	for(size_t i = 0; i < sizeof(lowerHalf); i++) {
 		returnInt64Ptr[i+4] = upperHalfPtr[i];
 	}
 
@@ -96,7 +96,7 @@ int32_t  XORShiftRNG::generateNextInt32() {
 	char* returnInt32Ptr = (char*) &returnInt32;
 	const char* nextUInt32Ptr = (const char*) &nextUInt32;
 
-	for(int i = 0; i < sizeof(returnInt32); i++) {
+	for(size_t i = 0; i < sizeof(returnInt32); i++) {
 		returnInt32Ptr[i] = nextUInt32Ptr[i];
 	}
 

--- a/src/sst/core/serialization/serializable.h
+++ b/src/sst/core/serialization/serializable.h
@@ -68,7 +68,7 @@ constexpr uint32_t ct_hash_rec(const char* str)
 // End of the recursion (i.e. when you've walked back off the front of
 // the string
 template<>
-constexpr uint32_t ct_hash_rec<size_t(-1)>(const char* str)
+constexpr uint32_t ct_hash_rec<size_t(-1)>(const char* str __attribute__((unused)))
 {
     return 0;
 }
@@ -141,7 +141,7 @@ class serializable_type
      serializable_abort(CALL_INFO_LONG, #obj); \
   } \
   virtual void \
-  serialize_order(SST::Core::Serialization::serializer& sst){    \
+  serialize_order(SST::Core::Serialization::serializer& sst __attribute__((unused))){    \
     throw_exc(); \
   } \
   virtual uint32_t \
@@ -206,7 +206,7 @@ class serializable_builder
   virtual const char*
   name() const = 0;
 
-  virtual const uint32_t
+  virtual uint32_t
   cls_id() const = 0;
 
   virtual bool
@@ -231,7 +231,7 @@ class serializable_builder_impl : public serializable_builder
     return name_;
   }
 
-  const uint32_t
+  uint32_t
   cls_id() const {
       return cls_id_;
   }

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -31,7 +31,7 @@ namespace Serialization {
 template <class T, class Enable = void>
 class serialize {
 public:
-    inline void operator()(T& t, serializer& ser){
+    inline void operator()(T& t __attribute__((unused)), serializer& ser __attribute__((unused))){
         // If the default gets called, then it's actually invalid
         // because we don't know how to serialize it.
         

--- a/src/sst/core/serialization/serialize_buffer_accessor.h
+++ b/src/sst/core/serialization/serialize_buffer_accessor.h
@@ -24,7 +24,7 @@ namespace pvt {
 // class ser_buffer_overrun : public spkt_error {
 class ser_buffer_overrun : public std::exception {
  public:
-    ser_buffer_overrun(int maxsize)
+    ser_buffer_overrun(int maxsize __attribute__((unused)))
     // ser_buffer_overrun(int maxsize) :
       //spkt_error(sprockit::printf("serialization overrun buffer of size %d", maxsize))
   {

--- a/src/sst/core/serialization/serialize_deque.h
+++ b/src/sst/core/serialization/serialize_deque.h
@@ -26,7 +26,6 @@ class serialize<std::deque<T> > {
 public:
   void
   operator()(Deque& v, serializer& ser) {
-      typedef typename std::set<T>::iterator iterator;
       switch(ser.mode()) {
       case serializer::SIZER: {
           size_t size = v.size();

--- a/src/sst/core/serialization/serialize_map.h
+++ b/src/sst/core/serialization/serialize_map.h
@@ -52,8 +52,8 @@ class serialize<std::map<Key,Value> > {
       size_t size;
       ser.unpack(size);
       for (size_t i=0; i < size; ++i){
-        Key k;
-        Value v;
+        Key k = {};
+        Value v = {};
         serialize<Key>()(k, ser);
         serialize<Value>()(v, ser);
         m[k] = v;

--- a/src/sst/core/serialization/serialize_map.h
+++ b/src/sst/core/serialization/serialize_map.h
@@ -51,7 +51,7 @@ class serialize<std::map<Key,Value> > {
     case serializer::UNPACK: {
       size_t size;
       ser.unpack(size);
-      for (int i=0; i < size; ++i){
+      for (size_t i=0; i < size; ++i){
         Key k;
         Value v;
         serialize<Key>()(k, ser);

--- a/src/sst/core/serialization/serialize_set.h
+++ b/src/sst/core/serialization/serialize_set.h
@@ -52,7 +52,7 @@ public:
     case serializer::UNPACK: {
       size_t size;
       ser.unpack(size);
-      for (int i=0; i < size; ++i){
+      for (size_t i=0; i < size; ++i){
         T t;
         serialize<T>()(t,ser);
         v.insert(t);

--- a/src/sst/core/serialization/serialize_sizer.h
+++ b/src/sst/core/serialization/serialize_sizer.h
@@ -27,7 +27,7 @@ class ser_sizer
 
   template <class T>
   void
-  size(T& t){
+  size(T& t __attribute__((unused))){
     size_ += sizeof(T);
   }
 

--- a/src/sst/core/serialization/serialize_vector.h
+++ b/src/sst/core/serialization/serialize_vector.h
@@ -45,7 +45,7 @@ class serialize<std::vector<T> > {
     }
     }
   
-    for (int i=0; i < v.size(); ++i){
+    for (size_t i=0; i < v.size(); ++i){
       serialize<T>()(v[i], ser);
     }
   }

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -210,6 +210,7 @@ public:
         case PACK: return packer_.size();
         case UNPACK: return unpacker_.size();
         }
+        return 0;
     }
 
 protected:

--- a/src/sst/core/sharedRegion.cc
+++ b/src/sst/core/sharedRegion.cc
@@ -28,7 +28,7 @@
 namespace SST {
 
 
-bool SharedRegionMerger::merge(uint8_t *target, const uint8_t *newData, size_t size)
+bool SharedRegionMerger::merge(uint8_t *target __attribute__((unused)), const uint8_t *newData __attribute__((unused)), size_t size __attribute__((unused)))
 {
     return false;
 }

--- a/src/sst/core/sharedRegionImpl.h
+++ b/src/sst/core/sharedRegionImpl.h
@@ -69,7 +69,7 @@ public:
         RegionMergeInfo(int rank, const std::string &key) : rank(rank), key(key) { }
         virtual ~RegionMergeInfo() { }
 
-        virtual bool merge(RegionInfo *ri) { return true; }
+        virtual bool merge(RegionInfo *ri __attribute__((unused))) { return true; }
         const std::string& getKey() const { return key; }
 
         void serialize_order(SST::Core::Serialization::serializer &ser) {

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -223,7 +223,7 @@ Simulation::getLocalMinimumNextActivityTime()
 }
 
 void
-Simulation::processGraphInfo( ConfigGraph& graph, const RankInfo& myRank, SimTime_t min_part )
+Simulation::processGraphInfo( ConfigGraph& graph, const RankInfo& myRank __attribute__((unused)), SimTime_t min_part )
 {
     // TraceFunction trace(CALL_INFO_LONG);    
     // Set minPartTC (only thread 0 will do this)
@@ -234,7 +234,7 @@ Simulation::processGraphInfo( ConfigGraph& graph, const RankInfo& myRank, SimTim
 
     // Get the minimum latencies for links between the various threads
     interThreadLatencies.resize(num_ranks.thread);
-    for ( int i = 0; i < interThreadLatencies.size(); i++ ) {
+    for ( size_t i = 0; i < interThreadLatencies.size(); i++ ) {
         interThreadLatencies[i] = MAX_SIMTIME_T;
     }
 
@@ -305,7 +305,7 @@ Simulation::processGraphInfo( ConfigGraph& graph, const RankInfo& myRank, SimTim
     // if ( independent ) std::cout << "thread " << my_rank.thread <<  " is independent" << std::endl;
 }
     
-int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTime_t min_part )
+int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTime_t min_part __attribute__((unused)))
 {
     // TraceFunction trace(CALL_INFO_LONG);    
     
@@ -820,7 +820,7 @@ uint64_t Simulation::getSyncQueueDataSize() const {
     
 // Function to allow for easy serialization of threads while debugging
 // code
-void wait_my_turn_start(Core::ThreadSafe::Barrier& barrier, int thread, int total_threads) {
+void wait_my_turn_start(Core::ThreadSafe::Barrier& barrier, int thread, int total_threads __attribute__((unused))) {
     // Everyone barriers
     barrier.wait();
     // Now barrier until it's my turn

--- a/src/sst/core/simulation.h
+++ b/src/sst/core/simulation.h
@@ -165,8 +165,8 @@ public:
     /** Return the exit event */
     Exit* getExit() const { return m_exit; }
 
-    const std::vector<SimTime_t>& getInterThreadLatencies() { return interThreadLatencies; }
-    const SimTime_t getInterThreadMinLatency() { return interThreadMinLatency; }
+    const std::vector<SimTime_t>& getInterThreadLatencies() const { return interThreadLatencies; }
+    SimTime_t getInterThreadMinLatency() const { return interThreadMinLatency; }
     static TimeConverter* getMinPartTC() { return minPartTC; }
 
     /** Return the TimeLord associated with this Simulation */

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -335,9 +335,6 @@ void SSTInfoConfig::outputVersion()
 
 int SSTInfoConfig::parseCmdLine(int argc, char* argv[])
 {
-    unsigned int              x;
-    size_t                    foundIndex;
-
     m_AppName = argv[0];
 
     static const struct option longOpts[] = {

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -115,7 +115,7 @@ static void addELI(ElemLoader &loader, const std::string &lib, bool optional)
 }
 
 
-static void processSSTElementFiles(std::string searchPath)
+static void processSSTElementFiles(std::string searchPath __attribute__((unused)))
 {
     std::vector<bool>       EntryProcessedArray;
     ElemLoader              loader(g_searchPath);
@@ -796,7 +796,7 @@ void SSTInfoElement_StatisticInfo::outputStatisticInfo(int index)
     fprintf(stdout, "            STATISTIC %d = %s [%s] (%s) Enable Level = %d\n", index, getName(), getUnits(), getDesc(), getEnableLevel());
 }
 
-void SSTInfoElement_StatisticInfo::generateStatisticXMLData(int Index, TiXmlNode* XMLParentElement)
+void SSTInfoElement_StatisticInfo::generateStatisticXMLData(int Index __attribute__((unused)), TiXmlNode* XMLParentElement __attribute__((unused)))
 {
 // TODO: Dump Statistic info to XML.  Turned off for 5.0 since SSTWorkbench
 //       chokes if format is changed.  

--- a/src/sst/core/sstinfo.h
+++ b/src/sst/core/sstinfo.h
@@ -224,7 +224,7 @@ public:
     const char* getUnits() {return m_elstat->units;}
 
     /** Return the enable level of the Statistic. */
-    const uint8_t getEnableLevel() {return m_elstat->enableLevel;}
+    uint8_t getEnableLevel() {return m_elstat->enableLevel;}
     
     /** Output the Statistic Information. 
      * @param Index The Index of the Statistic.

--- a/src/sst/core/sstregistertool.cc
+++ b/src/sst/core/sstregistertool.cc
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
 	std::string groupName(argv[1]);
 	std::string keyValPair(argv[2]);
 
-	int equalsIndex = 0;
+	size_t equalsIndex = 0;
 
 	for(equalsIndex = 0; equalsIndex < keyValPair.size(); equalsIndex++) {
 		if('=' == argv[2][equalsIndex]) {

--- a/src/sst/core/statapi/stataccumulator.h
+++ b/src/sst/core/statapi/stataccumulator.h
@@ -138,7 +138,7 @@ private:
         Field3 = statOutput->registerField<uint64_t>  ("Count");
     }
     
-    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag)
+    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag __attribute__((unused)))
     {
         statOutput->outputField(Field1, m_sum);
         statOutput->outputField(Field2, m_sum_sq);  

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -202,7 +202,7 @@ private:
       * by default, both modes are supported.
       * @param mode - Mode to test
       */
-    virtual bool isStatModeSupported(StatMode_t mode) const {return true;}      // Default is to accept all modes
+    virtual bool isStatModeSupported(StatMode_t mode __attribute__((unused))) const {return true;}      // Default is to accept all modes
 
     /** Verify that the statistic names match */
     bool operator==(StatisticBase& checkStat); 

--- a/src/sst/core/statapi/statengine.cc
+++ b/src/sst/core/statapi/statengine.cc
@@ -306,7 +306,7 @@ void StatisticProcessingEngine::addStatisticClock(const UnitAlgebra& freq, Stati
     statArray->push_back(stat);
 }
 
-bool StatisticProcessingEngine::handleStatisticEngineClockEvent(Cycle_t CycleNum, SimTime_t timeFactor) 
+bool StatisticProcessingEngine::handleStatisticEngineClockEvent(Cycle_t CycleNum __attribute__((unused)), SimTime_t timeFactor) 
 {
     StatArray_t*     statArray;
     StatisticBase*   stat;
@@ -392,7 +392,7 @@ StatisticBase* StatisticProcessingEngine::isStatisticInCompStatMap(const std::st
     return NULL;
 }
 
-void StatisticProcessingEngine::addStatisticToCompStatMap(const ComponentId_t& compId, StatisticBase* Stat, StatisticFieldInfo::fieldType_t fieldType)
+void StatisticProcessingEngine::addStatisticToCompStatMap(const ComponentId_t& compId, StatisticBase* Stat, StatisticFieldInfo::fieldType_t fieldType __attribute__((unused)))
 {
     StatArray_t*        statArray;
     

--- a/src/sst/core/statapi/statfieldinfo.h
+++ b/src/sst/core/statapi/statfieldinfo.h
@@ -74,7 +74,7 @@ public:
     static const char* getFieldTypeFullName(fieldType_t type);
 
     template<typename T>
-    static const fieldType_t getFieldTypeFromTemplate()
+    static fieldType_t getFieldTypeFromTemplate()
     {
         if (is_type_same<T, int32_t    >::value){return INT32; }
         if (is_type_same<T, uint32_t   >::value){return UINT32;}

--- a/src/sst/core/statapi/stathistogram.h
+++ b/src/sst/core/statapi/stathistogram.h
@@ -262,7 +262,7 @@ private:
         }
     }
 
-    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag)
+    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag __attribute__((unused)))
     {
         uint32_t x = 0;
         statOutput->outputField(m_Fields[x++], getBinsMinValue());

--- a/src/sst/core/statapi/statnull.h
+++ b/src/sst/core/statapi/statnull.h
@@ -54,7 +54,7 @@ private:
     ~NullStatistic(){};
 
 protected:    
-    void addData_impl(T data)
+    void addData_impl(T data __attribute__((unused)))
     {
         // Do Nothing
     }
@@ -65,12 +65,12 @@ private:
         // Do Nothing
     }
     
-    void registerOutputFields(StatisticOutput* statOutput)
+    void registerOutputFields(StatisticOutput* statOutput __attribute__((unused)))
     {
         // Do Nothing
     }
     
-    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag)
+    void outputStatisticData(StatisticOutput* statOutput __attribute__((unused)), bool EndOfSimFlag __attribute__((unused)))
     {
         // Do Nothing
     }

--- a/src/sst/core/statapi/statoutput.h
+++ b/src/sst/core/statapi/statoutput.h
@@ -187,8 +187,8 @@ protected:
     virtual void printUsage() = 0;
 
 
-    virtual void implStartRegisterFields(StatisticBase *statistic) {}
-    virtual void implRegisteredField(fieldHandle_t fieldHandle) {}
+    virtual void implStartRegisterFields(StatisticBase *statistic __attribute__((unused))) {}
+    virtual void implRegisteredField(fieldHandle_t fieldHandle __attribute__((unused))) {}
     virtual void implStopRegisterFields() {}
 
     // Simulation Events

--- a/src/sst/core/statapi/statoutputhdf5.cc
+++ b/src/sst/core/statapi/statoutputhdf5.cc
@@ -238,7 +238,6 @@ void StatisticOutputHDF5::StatisticInfo::finalizeRegistration()
     size_t nFields = typeList.size() -1;
     currentData.resize(nFields);
 
-    StatData_u* dataPointer = currentData.data();
     /* Build HDF5 datatypes */
     size_t dataSize = currentData.size() * sizeof(StatData_u);
     memType = new H5::CompType(dataSize);

--- a/src/sst/core/statapi/statuniquecount.h
+++ b/src/sst/core/statapi/statuniquecount.h
@@ -64,7 +64,7 @@ private:
 	uniqueCountField = statOutput->registerField<uint64_t>("UniqueItems");
     }
 
-    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag)
+    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag __attribute__((unused)))
     {
 	statOutput->outputField(uniqueCountField, (uint64_t) uniqueSet.size());
     }

--- a/src/sst/core/stringize.h
+++ b/src/sst/core/stringize.h
@@ -123,7 +123,7 @@ struct escaped_list_separator {
     std::string s;
 
     escaped_list_separator(const std::string &esc="\\", const std::string &sep=",", const std::string &quote="\"")
-        : e(esc), s(sep), q(quote) { }
+        : e(esc), q(quote), s(sep) { }
 
 
     /**

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -35,7 +35,7 @@ public:
 
     /** Used during the init phase.  The method will be called each phase of initialization.
      Initialization ends when no components have sent any data. */
-    virtual void init(unsigned int phase) {}
+    virtual void init(unsigned int phase __attribute__((unused))) {}
     /** Called after all components have been constructed and inialization has
 	completed, but before simulation time has begun. */
     virtual void setup( ) { }

--- a/src/sst/core/syncManager.cc
+++ b/src/sst/core/syncManager.cc
@@ -40,10 +40,10 @@ public:
     ~EmptyRankSync() {}
 
     /** Register a Link which this Sync Object is responsible for */
-    ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, LinkId_t link_id, Link* link) { return NULL; }
+    ActivityQueue* registerLink(const RankInfo& to_rank __attribute__((unused)), const RankInfo& from_rank __attribute__((unused)), LinkId_t link_id __attribute__((unused)), Link* link __attribute__((unused))) { return NULL; }
 
-    void execute(int thread) {}
-    void exchangeLinkInitData(int thread, std::atomic<int>& msg_count) {}
+    void execute(int thread __attribute__((unused))) {}
+    void exchangeLinkInitData(int thread __attribute__((unused)), std::atomic<int>& msg_count __attribute__((unused))) {}
     void finalizeLinkConfigurations() {}
 
     SimTime_t getNextSyncTime() { return nextSyncTime; }
@@ -67,12 +67,12 @@ public:
     void finalizeLinkConfigurations() {}
 
     /** Register a Link which this Sync Object is responsible for */
-    void registerLink(LinkId_t link_id, Link* link) {}
-    ActivityQueue* getQueueForThread(int tid) { return NULL; }
+    void registerLink(LinkId_t link_id __attribute__((unused)), Link* link __attribute__((unused))) {}
+    ActivityQueue* getQueueForThread(int tid __attribute__((unused))) { return NULL; }
 };
 
 
-SyncManager::SyncManager(const RankInfo& rank, const RankInfo& num_ranks, TimeConverter* minPartTC, SimTime_t min_part, const std::vector<SimTime_t>& interThreadLatencies) :
+SyncManager::SyncManager(const RankInfo& rank, const RankInfo& num_ranks, TimeConverter* minPartTC, SimTime_t min_part, const std::vector<SimTime_t>& interThreadLatencies __attribute__((unused))) :
     Action(),
     rank(rank),
     num_ranks(num_ranks),

--- a/src/sst/core/syncManager.cc
+++ b/src/sst/core/syncManager.cc
@@ -77,7 +77,6 @@ SyncManager::SyncManager(const RankInfo& rank, const RankInfo& num_ranks, TimeCo
     rank(rank),
     num_ranks(num_ranks),
     threadSync(NULL),
-    next_threadSync(0),
     min_part(min_part)
 {
     // TraceFunction trace(CALL_INFO_LONG);    

--- a/src/sst/core/syncManager.h
+++ b/src/sst/core/syncManager.h
@@ -129,7 +129,6 @@ private:
     static NewRankSync*     rankSync;
     static SimTime_t        next_rankSync;
     NewThreadSync*   threadSync;
-    SimTime_t        next_threadSync;
     Exit* exit;
     Simulation * sim;
     

--- a/src/sst/core/syncQueue.h
+++ b/src/sst/core/syncQueue.h
@@ -58,7 +58,7 @@ public:
     
 private:
     char* buffer;
-    int buf_size;
+    size_t buf_size;
     std::vector<Activity*> activities;
 
     Core::ThreadSafe::Spinlock slock;

--- a/src/sst/core/threadSync.cc
+++ b/src/sst/core/threadSync.cc
@@ -78,10 +78,10 @@ ThreadSync::execute()
     totalWaitTime += barrier.wait();
     if ( disabled ) return;
     // Empty all the queues and send events on the links
-    for ( int i = 0; i < queues.size(); i++ ) {
+    for ( size_t i = 0; i < queues.size(); i++ ) {
         ThreadSyncQueue* queue = queues[i];
         std::vector<Activity*>& vec = queue->getVector();
-        for ( int j = 0; j < vec.size(); j++ ) {
+        for ( size_t j = 0; j < vec.size(); j++ ) {
             Event* ev = static_cast<Event*>(vec[j]);
             auto link = link_map.find(ev->getLinkId());
             if (link == link_map.end()) {
@@ -115,7 +115,7 @@ ThreadSync::processLinkInitData()
     for ( int i = 0; i < num_threads; i++ ) {
         ThreadSyncQueue* queue = queues[i];
         std::vector<Activity*>& vec = queue->getVector();
-        for ( int j = 0; j < vec.size(); j++ ) {
+        for ( size_t j = 0; j < vec.size(); j++ ) {
             Event* ev = static_cast<Event*>(vec[j]);
             auto link = link_map.find(ev->getLinkId());
             if (link == link_map.end()) {

--- a/src/sst/core/threadSyncSimpleSkip.cc
+++ b/src/sst/core/threadSyncSimpleSkip.cc
@@ -86,10 +86,10 @@ ThreadSyncSimpleSkip::before()
     // TraceFunction trace(CALL_INFO_LONG);
 
     // Empty all the queues and send events on the links
-    for ( int i = 0; i < queues.size(); i++ ) {
+    for ( size_t i = 0; i < queues.size(); i++ ) {
         ThreadSyncQueue* queue = queues[i];
         std::vector<Activity*>& vec = queue->getVector();
-        for ( int j = 0; j < vec.size(); j++ ) {
+        for ( size_t j = 0; j < vec.size(); j++ ) {
             Event* ev = static_cast<Event*>(vec[j]);
             auto link = link_map.find(ev->getLinkId());
             if (link == link_map.end()) {
@@ -142,7 +142,7 @@ ThreadSyncSimpleSkip::processLinkInitData()
     for ( int i = 0; i < num_threads; i++ ) {
         ThreadSyncQueue* queue = queues[i];
         std::vector<Activity*>& vec = queue->getVector();
-        for ( int j = 0; j < vec.size(); j++ ) {
+        for ( size_t j = 0; j < vec.size(); j++ ) {
             Event* ev = static_cast<Event*>(vec[j]);
             auto link = link_map.find(ev->getLinkId());
             if (link == link_map.end()) {

--- a/src/sst/core/timeLord.cc
+++ b/src/sst/core/timeLord.cc
@@ -104,7 +104,7 @@ TimeLord::~TimeLord() {
     parseCache.clear();
 }
 
-SimTime_t TimeLord::getSimCycles(std::string ts, std::string where)
+SimTime_t TimeLord::getSimCycles(std::string ts, std::string where __attribute__((unused)))
 {
     // See if this is in the cache
     std::lock_guard<std::recursive_mutex> lock(slock);

--- a/src/sst/core/uninitializedQueue.cc
+++ b/src/sst/core/uninitializedQueue.cc
@@ -38,7 +38,7 @@ namespace SST {
 	abort();
     }
     
-    void UninitializedQueue::insert(Activity* activity)
+    void UninitializedQueue::insert(Activity* activity __attribute__((unused)))
     {
 	std::cout << message << std::endl;
 	abort();


### PR DESCRIPTION
Addressing #104, enable (by default) '`-Wall -Wextra`' flags in the SST core.  (Can be disabled with `--disable-picky-warnings` )

Also, many cleanups to address warnings produced by Clang 8.0, and GCC 4.8 / GCC 6.3.