### PR TITLE
Filter out certain sst-core compile-only flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,12 @@ AC_SUBST(MPICC_VERSION)
 
 AC_CACHE_SAVE
 
+dnl Remove flags like -g, -O, and -W, that are not needed by other elements
+SST_EXPORT_CXXFLAGS=`echo "$CXXFLAGS" | sed -E -e 's/ *-(g|O.|W@<:@^\s@:>@+)//g'`
+SST_EXPORT_CFLAGS=`echo "$CFLAGS" | sed -E -e 's/ *-(g|O.|W@<:@^\s@:>@+)//g'`
+AC_SUBST(SST_EXPORT_CXXFLAGS)
+AC_SUBST(SST_EXPORT_CFLAGS)
+
 AC_CONFIG_FILES([
   Makefile
   doc/Makefile

--- a/src/sst/sst.conf
+++ b/src/sst/sst.conf
@@ -9,9 +9,9 @@
 # ===================================================================
 [SSTCore]
 CXX=@CXX@
-CXXFLAGS=@CXXFLAGS@
+CXXFLAGS=@SST_EXPORT_CXXFLAGS@
 CC=@CC@
-CFLAGS=@CFLAGS@
+CFLAGS=@SST_EXPORT_CFLAGS@
 LD=@LD@
 LDFLAGS=@LDFLAGS@
 LIBS=@LIBS@


### PR DESCRIPTION
Addresses #205 

Filter out flags like warnings and optimization level from the flag presented to the SST Core configuration file.