### PR TITLE
Remove unused sync from Simulation.  Fixes #207

### DIFF
--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -73,8 +73,6 @@ Simulation::~Simulation()
     // in the queue, as well as the Sync, Exit and Clock objects.
     delete timeVortex;
 
-    if ( sync && (my_rank.thread == 0) ) delete sync;
-
     // Delete all the components
     // for ( CompMap_t::iterator it = compMap.begin(); it != compMap.end(); ++it ) {
 	// delete it->second;
@@ -480,15 +478,6 @@ void Simulation::initialize() {
         }
     }
 #endif
-#if 0
-    if ( num_ranks.rank > 1 && my_rank.thread == 0 ) {
-        sync->finalizeLinkConfigurations();
-    }
-
-    if ( num_ranks.thread > 1 ) {
-        threadSync->finalizeLinkConfigurations();
-    }
-#endif
     syncManager->finalizeLinkConfigurations();
 
 }
@@ -813,8 +802,7 @@ uint64_t Simulation::getTimeVortexCurrentDepth() const {
 }
 
 uint64_t Simulation::getSyncQueueDataSize() const {
-    if ( num_ranks.rank == 1 || my_rank.thread > 0 ) return 0;
-    return sync->getDataSize();
+    return syncManager->getDataSize();
 }
 
     
@@ -861,7 +849,6 @@ Core::ThreadSafe::Barrier Simulation::exitBarrier;
 std::mutex Simulation::simulationMutex;
 TimeConverter* Simulation::minPartTC = NULL;
 SimTime_t Simulation::minPart;
-SyncBase* Simulation::sync = NULL;
 
 
 

--- a/src/sst/core/simulation.h
+++ b/src/sst/core/simulation.h
@@ -337,7 +337,6 @@ private:
     TimeVortex*      timeVortex;
     TimeConverter*   threadMinPartTC;
     Activity*        current_activity;
-    static SyncBase* sync;
     static SimTime_t minPart;
     static TimeConverter*   minPartTC;
     std::vector<SimTime_t> interThreadLatencies;

--- a/src/sst/core/syncManager.cc
+++ b/src/sst/core/syncManager.cc
@@ -266,6 +266,13 @@ SyncManager::print(const std::string& header, Output &out) const
                " with priority %d\n",
                header.c_str(), getDeliveryTime(), getPriority());
 }
+
+uint64_t SyncManager::getDataSize() const
+{
+    return rankSync->getDataSize();
+}
+
+
 } // namespace SST
 
 

--- a/src/sst/core/syncManager.h
+++ b/src/sst/core/syncManager.h
@@ -116,6 +116,8 @@ public:
 
     void print(const std::string& header, Output &out) const;
 
+    uint64_t getDataSize() const;
+
 private:
     enum sync_type_t { RANK, THREAD};
 


### PR DESCRIPTION
Address #207 by removing old (unused) `sync` variable from Simulation.  Rather, gather that information from `SyncManager`