### PR TITLE
Add coordinates to Python API

### DIFF
--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -263,10 +263,8 @@ public:
     SubComponent* loadNamedSubComponent(std::string name, Params& params);
 
     /** Retrieve the X,Y,Z coordinates of this component */
-    void getCoordinates(double *x, double *y, double *z) const {
-        if ( x != NULL ) *x = my_info->coordinates[0];
-        if ( y != NULL ) *y = my_info->coordinates[1];
-        if ( z != NULL ) *z = my_info->coordinates[2];
+    const std::vector<double>& getCoordinates() const {
+        return my_info->coordinates;
     }
 
 protected:

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -262,6 +262,13 @@ public:
     SubComponent* loadNamedSubComponent(std::string name);
     SubComponent* loadNamedSubComponent(std::string name, Params& params);
 
+    /** Retrieve the X,Y,Z coordinates of this component */
+    void getCoordinates(double *x, double *y, double *z) const {
+        if ( x != NULL ) *x = my_info->coordinates[0];
+        if ( y != NULL ) *y = my_info->coordinates[1];
+        if ( z != NULL ) *z = my_info->coordinates[2];
+    }
+
 protected:
     friend class SST::Statistics::StatisticProcessingEngine;
 

--- a/src/sst/core/cfgoutput/pythonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.cc
@@ -75,6 +75,14 @@ void PythonConfigGraphOutput::generateCommonComponent( const char* objName, cons
         fprintf(outputFile, ")\n");
     }
 
+    fprintf(outputFile, "%s.setCoordinates(", objName);
+    bool first = true;
+    for ( double d : comp.coords ) {
+        fprintf(outputFile, first ? "%lg" : ", %lg", d);
+        first = false;
+    }
+    fprintf(outputFile, ")\n");
+
     for ( auto &si : comp.enabledStatistics ) {
         if ( si.name == STATALLFLAG ) {
             fprintf(outputFile, "%s.enableAllStatistics(", objName);
@@ -152,6 +160,46 @@ void PythonConfigGraphOutput::generateComponent( const ConfigComponent &comp )
 }
 
 
+void PythonConfigGraphOutput::generateStatGroup(const ConfigGraph* graph, const ConfigStatGroup &grp)
+{
+    char *pyGroupName = makePythonSafeWithPrefix(grp.name.c_str(), "statGroup_");
+    char *esGroupName = makeEscapeSafe(grp.name.c_str());
+
+    fprintf(outputFile, "%s = sst.StatisticGroup(\"%s\")\n", pyGroupName, esGroupName);
+    if ( grp.outputFrequency.getValue() != 0 ) {
+        fprintf(outputFile, "%s.setFrequency(\"%s\")\n", pyGroupName, grp.outputFrequency.toStringBestSI().c_str());
+    }
+    if ( grp.outputID != 0 ) {
+        const ConfigStatOutput &out = graph->getStatOutput(grp.outputID);
+        fprintf(outputFile, "%s.setOutput(sst.StatisticOutput(\"%s\"",
+                pyGroupName, out.type.c_str());
+        if ( !out.params.empty() ) {
+            fprintf(outputFile, ", ");
+            generateParams(out.params);
+        }
+		fprintf(outputFile, "))\n");
+    }
+
+    for ( auto &i : grp.statMap ) {
+        fprintf(outputFile, "%s.addStatistic(\"%s\"", pyGroupName, i.first.c_str());
+        if ( !i.second.empty() ) {
+            fprintf(outputFile, ", ");
+            generateParams(i.second);
+        }
+		fprintf(outputFile, ")\n");
+    }
+
+    for ( ComponentId_t id : grp.components ) {
+        const ConfigComponent *comp = graph->findComponent(id);
+        char* pyCompName = makePythonSafeWithPrefix(comp->name.c_str(), "comp_");
+        fprintf(outputFile, "%s.addComponent(%s)\n", pyGroupName, pyCompName);
+        free(pyCompName);
+    }
+
+    free(esGroupName);
+    free(pyGroupName);
+
+}
 
 void PythonConfigGraphOutput::generate(const Config* cfg,
 	ConfigGraph* graph) throw(ConfigGraphOutputException) {
@@ -196,6 +244,14 @@ void PythonConfigGraphOutput::generate(const Config* cfg,
         }
 		fprintf(outputFile, ")\n");
 	}
+
+    // Check for statisitc groups
+    if ( !graph->getStatGroups().empty() ) {
+        fprintf(outputFile, "\n# Statistic Groups:\n");
+        for ( auto &grp : graph->getStatGroups() ) {
+            generateStatGroup(graph, grp.second);
+        }
+    }
 
 	fprintf(outputFile, "# End of generated output.\n\n");
 

--- a/src/sst/core/cfgoutput/pythonConfigOutput.h
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.h
@@ -33,6 +33,7 @@ protected:
     void generateCommonComponent( const char* objName, const ConfigComponent &comp);
     void generateSubComponent( const char* owner, const ConfigComponent &comp );
     void generateComponent( const ConfigComponent &comp );
+    void generateStatGroup(const ConfigGraph* graph, const ConfigStatGroup &grp);
 
     const std::string& getLinkObject(LinkId_t id);
 

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -26,9 +26,9 @@ ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name) :
     link_map(NULL),
     component(NULL),
     params(NULL),
-    enabledStats(NULL)
+    enabledStats(NULL),
+    coordinates(3, 0.0)
 {
-    coordinates[0] = coordinates[1] = coordinates[2] = 0.0;
 }
 
 
@@ -39,11 +39,9 @@ ComponentInfo::ComponentInfo(const std::string &type, const Params *params, cons
     link_map(parent->link_map),
     component(NULL),
     params(params),
-    enabledStats(parent->enabledStats)
+    enabledStats(parent->enabledStats),
+    coordinates(parent->coordinates)
 {
-    coordinates[0] = parent->coordinates[0];
-    coordinates[1] = parent->coordinates[1];
-    coordinates[2] = parent->coordinates[2];
 }
 
 
@@ -54,15 +52,12 @@ ComponentInfo::ComponentInfo(ConfigComponent *ccomp, LinkMap* link_map) :
     link_map(link_map),
     component(NULL),
     params(&ccomp->params),
-    enabledStats(&ccomp->enabledStatistics)
+    enabledStats(&ccomp->enabledStatistics),
+    coordinates(ccomp->coords)
 {
     for ( auto &sc : ccomp->subComponents ) {
         subComponents.emplace(sc.first, ComponentInfo(&sc.second, new LinkMap()));
     }
-
-    coordinates[0] = ccomp->coords[0];
-    coordinates[1] = ccomp->coords[1];
-    coordinates[2] = ccomp->coords[2];
 }
 
 ComponentInfo::ComponentInfo(ComponentInfo &&o) :
@@ -72,14 +67,11 @@ ComponentInfo::ComponentInfo(ComponentInfo &&o) :
     link_map(o.link_map),
     component(o.component),
     params(o.params),
-    enabledStats(o.enabledStats)
+    enabledStats(o.enabledStats),
+    coordinates(o.coordinates)
 {
     o.link_map = NULL;
     o.component = NULL;
-
-    coordinates[0] = o.coordinates[0];
-    coordinates[1] = o.coordinates[1];
-    coordinates[2] = o.coordinates[2];
 }
 
 

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -27,7 +27,9 @@ ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name) :
     component(NULL),
     params(NULL),
     enabledStats(NULL)
-{ }
+{
+    coordinates[0] = coordinates[1] = coordinates[2] = 0.0;
+}
 
 
 ComponentInfo::ComponentInfo(const std::string &type, const Params *params, const ComponentInfo *parent) :
@@ -38,7 +40,11 @@ ComponentInfo::ComponentInfo(const std::string &type, const Params *params, cons
     component(NULL),
     params(params),
     enabledStats(parent->enabledStats)
-{ }
+{
+    coordinates[0] = parent->coordinates[0];
+    coordinates[1] = parent->coordinates[1];
+    coordinates[2] = parent->coordinates[2];
+}
 
 
 ComponentInfo::ComponentInfo(ConfigComponent *ccomp, LinkMap* link_map) :
@@ -53,6 +59,10 @@ ComponentInfo::ComponentInfo(ConfigComponent *ccomp, LinkMap* link_map) :
     for ( auto &sc : ccomp->subComponents ) {
         subComponents.emplace(sc.first, ComponentInfo(&sc.second, new LinkMap()));
     }
+
+    coordinates[0] = ccomp->coords[0];
+    coordinates[1] = ccomp->coords[1];
+    coordinates[2] = ccomp->coords[2];
 }
 
 ComponentInfo::ComponentInfo(ComponentInfo &&o) :
@@ -66,6 +76,10 @@ ComponentInfo::ComponentInfo(ComponentInfo &&o) :
 {
     o.link_map = NULL;
     o.component = NULL;
+
+    coordinates[0] = o.coordinates[0];
+    coordinates[1] = o.coordinates[1];
+    coordinates[2] = o.coordinates[2];
 }
 
 

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -49,7 +49,7 @@ private:
     const Params *params;
 
     statEnableList_t * enabledStats;
-    double coordinates[3];
+    std::vector<double> coordinates;
 
     inline void setComponent(BaseComponent* comp) { component = comp; }
 

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -49,6 +49,7 @@ private:
     const Params *params;
 
     statEnableList_t * enabledStats;
+    double coordinates[3];
 
     inline void setComponent(BaseComponent* comp) { component = comp; }
 

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -183,6 +183,13 @@ void ConfigComponent::setWeight(double w)
     }
 }
 
+void ConfigComponent::setCoordinates(double x, double y, double z)
+{
+    coords[0] = x;
+    coords[1] = y;
+    coords[2] = z;
+}
+
 
 void ConfigComponent::addParameter(const std::string &key, const std::string &value, bool overwrite)
 {

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -141,6 +141,7 @@ ConfigComponent::cloneWithoutLinks() const
     ret.rank = rank;
     ret.params = params;
     ret.enabledStatistics = enabledStatistics;
+    ret.coords = coords;
     for ( auto &i : subComponents ) {
         ret.subComponents.emplace_back(i.first, i.second.cloneWithoutLinks());
     }
@@ -158,6 +159,7 @@ ConfigComponent::cloneWithoutLinksOrParams() const
     ret.weight = weight;
     ret.rank = rank;
     ret.enabledStatistics = enabledStatistics;
+    ret.coords = coords;
     for ( auto &i : subComponents ) {
         ret.subComponents.emplace_back(i.first, i.second.cloneWithoutLinksOrParams());
     }
@@ -183,11 +185,12 @@ void ConfigComponent::setWeight(double w)
     }
 }
 
-void ConfigComponent::setCoordinates(double x, double y, double z)
+void ConfigComponent::setCoordinates(const std::vector<double> &c)
 {
-    coords[0] = x;
-    coords[1] = y;
-    coords[2] = z;
+    coords = c;
+    /* Maintain minimum of 3D information */
+    while ( coords.size() < 3 )
+        coords.push_back(0.0);
 }
 
 

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -203,7 +203,7 @@ public:
     Params                        params;            /*!< Set of Parameters */
     std::vector<Statistics::StatisticInfo> enabledStatistics; /*!< List of statistics to be enabled */
     std::vector<std::pair<std::string, ConfigComponent> > subComponents; /*!< List of subcomponents */
-    double                        coords[3];
+    std::vector<double>           coords;
 
     inline const ComponentId_t& key()const { return id; }
 
@@ -218,7 +218,7 @@ public:
 
     void setRank(RankInfo r);
     void setWeight(double w);
-    void setCoordinates(double x, double y, double z);
+    void setCoordinates(const std::vector<double> &c);
     void addParameter(const std::string &key, const std::string &value, bool overwrite);
     ConfigComponent* addSubComponent(ComponentId_t, const std::string &name, const std::string &type);
     ConfigComponent* findSubComponent(ComponentId_t);
@@ -255,7 +255,7 @@ private:
         weight(weight),
         rank(rank)
     {
-        coords[0] = coords[1] = coords[2] = 0.0;
+        coords.resize(3, 0.0);
     }
 
 

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -203,6 +203,7 @@ public:
     Params                        params;            /*!< Set of Parameters */
     std::vector<Statistics::StatisticInfo> enabledStatistics; /*!< List of statistics to be enabled */
     std::vector<std::pair<std::string, ConfigComponent> > subComponents; /*!< List of subcomponents */
+    double                        coords[3];
 
     inline const ComponentId_t& key()const { return id; }
 
@@ -217,6 +218,7 @@ public:
 
     void setRank(RankInfo r);
     void setWeight(double w);
+    void setCoordinates(double x, double y, double z);
     void addParameter(const std::string &key, const std::string &value, bool overwrite);
     ConfigComponent* addSubComponent(ComponentId_t, const std::string &name, const std::string &type);
     ConfigComponent* findSubComponent(ComponentId_t);
@@ -252,7 +254,9 @@ private:
         type(type),
         weight(weight),
         rank(rank)
-    { }
+    {
+        coords[0] = coords[1] = coords[2] = 0.0;
+    }
 
 
 };

--- a/src/sst/core/model/pymodel_comp.cc
+++ b/src/sst/core/model/pymodel_comp.cc
@@ -270,6 +270,36 @@ static PyObject* compSetSubComponent(PyObject *self, PyObject *args)
     return NULL;
 }
 
+static PyObject* compSetCoords(PyObject *self, PyObject *args)
+{
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    if ( !PyArg_ParseTuple(args, "d|dd", &x, &y, &z) ) {
+        PyObject* list = NULL;
+        if ( PyArg_ParseTuple(args, "O!", &PyList_Type, &list) && PyList_Size(list) > 0 ) {
+            x = PyFloat_AsDouble(PyList_GetItem(list, 0));
+            if ( PyList_Size(list) > 1 ) y = PyFloat_AsDouble(PyList_GetItem(list, 1));
+            if ( PyList_Size(list) > 2 ) y = PyFloat_AsDouble(PyList_GetItem(list, 2));
+            if ( PyErr_Occurred() ) goto error;
+        } else if ( PyArg_ParseTuple(args, "O!", &PyTuple_Type, &list) && PyTuple_Size(list) > 0 ) {
+            x = PyFloat_AsDouble(PyTuple_GetItem(list, 0));
+            if ( PyList_Size(list) > 1 ) y = PyFloat_AsDouble(PyTuple_GetItem(list, 1));
+            if ( PyList_Size(list) > 2 ) y = PyFloat_AsDouble(PyTuple_GetItem(list, 2));
+            if ( PyErr_Occurred() ) goto error;
+        } else {
+error:
+            PyErr_SetString(PyExc_TypeError, "compSetCoords() expects arguments of 1-3 doubles, or a list/tuple of doubles");
+            return NULL;
+        }
+    }
+
+    ConfigComponent *c = getComp(self);
+    if ( NULL == c ) return NULL;
+    c->setCoordinates(x, y, z);
+
+    return PyInt_FromLong(0);
+}
 
 static PyObject* compEnableAllStatistics(PyObject *self, PyObject *args)
 {
@@ -372,6 +402,9 @@ static PyMethodDef componentMethods[] = {
     {   "setSubComponent",
         compSetSubComponent, METH_VARARGS,
         "Bind a subcomponent to slot <name>, with type <type>"},
+    {   "setCoordinates",
+        compSetCoords, METH_VARARGS,
+        "Set (X,Y,Z) coordinates of this component, for use with visualization"},
     {   NULL, NULL, 0, NULL }
 };
 
@@ -483,6 +516,9 @@ static PyMethodDef subComponentMethods[] = {
     {   "setSubComponent",
         compSetSubComponent, METH_VARARGS,
         "Bind a subcomponent to slot <name>, with type <type>"},
+    {   "setCoordinates",
+        compSetCoords, METH_VARARGS,
+        "Set (X,Y,Z) coordinates of this component, for use with visualization"},
     {   NULL, NULL, 0, NULL }
 };
 

--- a/src/sst/core/model/pymodel_comp.cc
+++ b/src/sst/core/model/pymodel_comp.cc
@@ -272,21 +272,21 @@ static PyObject* compSetSubComponent(PyObject *self, PyObject *args)
 
 static PyObject* compSetCoords(PyObject *self, PyObject *args)
 {
-    double x = 0.0;
-    double y = 0.0;
-    double z = 0.0;
-    if ( !PyArg_ParseTuple(args, "d|dd", &x, &y, &z) ) {
+    std::vector<double> coords(3, 0.0);
+    if ( !PyArg_ParseTuple(args, "d|dd", &coords[0], &coords[1], &coords[2]) ) {
         PyObject* list = NULL;
         if ( PyArg_ParseTuple(args, "O!", &PyList_Type, &list) && PyList_Size(list) > 0 ) {
-            x = PyFloat_AsDouble(PyList_GetItem(list, 0));
-            if ( PyList_Size(list) > 1 ) y = PyFloat_AsDouble(PyList_GetItem(list, 1));
-            if ( PyList_Size(list) > 2 ) y = PyFloat_AsDouble(PyList_GetItem(list, 2));
-            if ( PyErr_Occurred() ) goto error;
+            coords.clear();
+            for ( Py_ssize_t i = 0 ; i < PyList_Size(list) ; i++ ) {
+                coords.push_back(PyFloat_AsDouble(PyList_GetItem(list, 0)));
+                if ( PyErr_Occurred() ) goto error;
+            }
         } else if ( PyArg_ParseTuple(args, "O!", &PyTuple_Type, &list) && PyTuple_Size(list) > 0 ) {
-            x = PyFloat_AsDouble(PyTuple_GetItem(list, 0));
-            if ( PyList_Size(list) > 1 ) y = PyFloat_AsDouble(PyTuple_GetItem(list, 1));
-            if ( PyList_Size(list) > 2 ) y = PyFloat_AsDouble(PyTuple_GetItem(list, 2));
-            if ( PyErr_Occurred() ) goto error;
+            coords.clear();
+            for ( Py_ssize_t i = 0 ; i < PyTuple_Size(list) ; i++ ) {
+                coords.push_back(PyFloat_AsDouble(PyTuple_GetItem(list, 0)));
+                if ( PyErr_Occurred() ) goto error;
+            }
         } else {
 error:
             PyErr_SetString(PyExc_TypeError, "compSetCoords() expects arguments of 1-3 doubles, or a list/tuple of doubles");
@@ -296,7 +296,7 @@ error:
 
     ConfigComponent *c = getComp(self);
     if ( NULL == c ) return NULL;
-    c->setCoordinates(x, y, z);
+    c->setCoordinates(coords);
 
     return PyInt_FromLong(0);
 }

--- a/src/sst/core/statapi/statoutputhdf5.cc
+++ b/src/sst/core/statapi/statoutputhdf5.cc
@@ -459,11 +459,10 @@ void StatisticOutputHDF5::GroupInfo::finalizeGroupRegistration()
 
         idVec.push_back(comp->getId());
         nameVec.push_back(comp->getName().c_str());
-        double x = 0.0, y = 0.0, z = 0.0;
-        comp->getCoordinates(&x, &y, &z);
-        xVec.push_back(x);
-        yVec.push_back(y);
-        zVec.push_back(z);
+        const std::vector<double> &coords = comp->getCoordinates();
+        xVec.push_back(coords[0]);
+        yVec.push_back(coords[1]);
+        zVec.push_back(coords[2]);
     }
 
     idSet->write(idVec.data(), H5::PredType::NATIVE_UINT64);

--- a/src/sst/core/statapi/statoutputhdf5.cc
+++ b/src/sst/core/statapi/statoutputhdf5.cc
@@ -410,61 +410,73 @@ void StatisticOutputHDF5::GroupInfo::finalizeGroupRegistration()
         stat.second.finalizeRegistration();
     }
     /* Create:
-     *      /group/names
-     *          Array of Component information
+     *      /group/components
+     *          Arrays of Component information
+     *          /ids
+     *          /names
+     *          /coord_x
+     *          /coord_y
+     *          /coord_z
      *      /group/timestamp
      *          Array of timestamps for each entry
      */
 
-    /* Create ComponentInfo */
-    struct CInfo {
-        uint64_t id;
-        double x;
-        double y;
-        double z;
-        char name[224]; /*  256 - 8 * 4 */
-        CInfo(){}
-        CInfo(BaseComponent* comp)
-        {
-            id = comp->getId();
-            x = 0.0;
-            y = 0.0;
-            z = 0.0;
-            strncpy(name, comp->getName().c_str(), 223);
-            name[223] = '\0';
-        }
-    };
-    H5::CompType infoType(sizeof(CInfo));
-    infoType.insertMember("id", HOFFSET(CInfo, id), H5::PredType::NATIVE_UINT64);
-    infoType.insertMember("x", HOFFSET(CInfo, x), H5::PredType::NATIVE_DOUBLE);
-    infoType.insertMember("y", HOFFSET(CInfo, y), H5::PredType::NATIVE_DOUBLE);
-    infoType.insertMember("z", HOFFSET(CInfo, z), H5::PredType::NATIVE_DOUBLE);
-    infoType.insertMember("name", HOFFSET(CInfo, name), H5::StrType(H5::PredType::C_S1, 224));
+
+    /* Create components sub-group */
+    std::string groupName = "/" + getName() + "/components";
+    try {
+        H5::Group* statGroup = new H5::Group( getFile()->createGroup(groupName) );
+        statGroup->close();
+        delete statGroup;
+    } catch (H5::FileIException ie) {
+        /* Ignore - group already exists. */
+    }
 
     H5::DSetCreatPropList cparms;
     hsize_t chunk_dims[1] = {std::min(m_statGroup->components.size(), (size_t)64)};
     cparms.setChunk(1, chunk_dims);
     cparms.setDeflate(7);
 
-    hsize_t dim[1] = {m_statGroup->components.size()};
-    H5::DataSpace space (1, dim);
-    H5::DataSet* dset = NULL;
-    try {
-        dset = new H5::DataSet(getFile()->createDataSet("/" + getName() + "/componentInfo", infoType, space, cparms));
-    } catch (H5::FileIException ie) {
-        ie.printError(stderr);
-        throw ie;
-    }
 
-    CInfo* infoArray = new CInfo[m_statGroup->components.size()];
-    for ( size_t i = 0 ; i < m_components.size() ; i++ ) {
+
+    /* Create arrays */
+    hsize_t infoDim[1] = {m_statGroup->components.size()};
+    H5::DataSpace infoSpace(1, infoDim);
+    H5::DataSet *idSet = new H5::DataSet(getFile()->createDataSet(groupName + "/ids", H5::PredType::NATIVE_UINT64, infoSpace, cparms));
+    H5::DataSet *nameSet = new H5::DataSet(getFile()->createDataSet(groupName + "/names", H5::StrType(H5::PredType::C_S1, H5T_VARIABLE), infoSpace, cparms));
+    H5::DataSet *coordXSet = new H5::DataSet(getFile()->createDataSet(groupName + "/coord_x", H5::PredType::NATIVE_DOUBLE, infoSpace, cparms));
+    H5::DataSet *coordYSet = new H5::DataSet(getFile()->createDataSet(groupName + "/coord_y", H5::PredType::NATIVE_DOUBLE, infoSpace, cparms));
+    H5::DataSet *coordZSet = new H5::DataSet(getFile()->createDataSet(groupName + "/coord_z", H5::PredType::NATIVE_DOUBLE, infoSpace, cparms));
+
+    std::vector<uint64_t> idVec;
+    std::vector<const char*> nameVec;
+    std::vector<double> xVec;
+    std::vector<double> yVec;
+    std::vector<double> zVec;
+
+    for ( size_t i = 0 ; i < infoDim[0] ; i++ ) {
         BaseComponent* comp = m_components.at(i);
-        infoArray[i] = CInfo(comp);
+
+        idVec.push_back(comp->getId());
+        nameVec.push_back(comp->getName().c_str());
+        double x = 0.0, y = 0.0, z = 0.0;
+        comp->getCoordinates(&x, &y, &z);
+        xVec.push_back(x);
+        yVec.push_back(y);
+        zVec.push_back(z);
     }
 
-    dset->write(infoArray, infoType);
-    delete [] infoArray;
+    idSet->write(idVec.data(), H5::PredType::NATIVE_UINT64);
+    nameSet->write(nameVec.data(), H5::StrType(H5::PredType::C_S1, H5T_VARIABLE));
+    coordXSet->write(xVec.data(), H5::PredType::NATIVE_DOUBLE);
+    coordYSet->write(yVec.data(), H5::PredType::NATIVE_DOUBLE);
+    coordZSet->write(zVec.data(), H5::PredType::NATIVE_DOUBLE);
 
+    delete idSet;
+    delete nameSet;
+    delete coordXSet;
+    delete coordYSet;
+    delete coordZSet;
 
     /* Create timestamp array */
     hsize_t tdim[1] = {0};


### PR DESCRIPTION
Allow Python API to specify coordinates for Components.  HDF5 StatOutput will record these.