### PR TITLE
Update custom mutex class so it directly calls PAUSE assembly

### DIFF
--- a/src/sst/core/interprocess/sstmutex.h
+++ b/src/sst/core/interprocess/sstmutex.h
@@ -3,10 +3,6 @@
 #ifndef _H_SST_CORE_INTERPROCESS_MUTEX
 #define _H_SST_CORE_INTERPROCESS_MUTEX
 
-#if defined(__x86_64__)
-#include <immintrin.h>
-#endif
-
 #include <sched.h>
 #include <time.h>
 
@@ -27,7 +23,7 @@ public:
 	void processorPause(int currentCount) {
 		if( currentCount < 64 ) {
 #if defined(__x86_64__)
-			_mm_pause();
+			asm volatile ("pause" : : : "memory");
 #else
 			// Put some pause code in here
 #endif


### PR DESCRIPTION
Change custom mutex (`SSTMutex`) over to use assembly directly. Cannot call `_mm_*` functions if we want to use PIN-3.2 because these are not compatible with PIN's customized system header files.