### PR TITLE
Cleanup warning handing / override keyword

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -137,6 +137,7 @@ nobase_dist_sst_HEADERS = \
 	threadsafe.h \
 	cputimer.h \
 	sst_config.h \
+	warnmacros.h \
 	model/element_python.h
 
 nobase_nodist_sst_HEADERS = \

--- a/src/sst/core/action.h
+++ b/src/sst/core/action.h
@@ -36,7 +36,7 @@ public:
     }
     ~Action() {}
 
-    void print(const std::string& header, Output &out) const {
+    void print(const std::string& header, Output &out) const override {
         out.output("%s Generic Action to be delivered at %" PRIu64 " with priority %d\n",
                 header.c_str(), getDeliveryTime(), getPriority());
     }

--- a/src/sst/core/activity.h
+++ b/src/sst/core/activity.h
@@ -14,6 +14,7 @@
 #define SST_CORE_ACTIVITY_H
 
 #include <sst/core/sst_types.h>
+#include <sst/core/warnmacros.h>
 
 #include <sst/core/serialization/serializable.h>
 
@@ -281,7 +282,7 @@ public:
 
         pool->free(ptr8);
     }
-    void operator delete(void* ptr, std::size_t sz __attribute__((unused))){
+    void operator delete(void* ptr, std::size_t UNUSED(sz)){
         /* 1) Decrement pointer
          * 2) Determine Pool Pointer
          * 2b) Set Pointer field to NULL to allow tracking

--- a/src/sst/core/activity.h
+++ b/src/sst/core/activity.h
@@ -343,7 +343,7 @@ protected:
     // Function used by derived classes to serialize data members.
     // This class is not serializable, becuase not all class that
     // inherit from it need to be serializable.
-    void serialize_order(SST::Core::Serialization::serializer &ser){
+    void serialize_order(SST::Core::Serialization::serializer &ser) override {
         ser & queue_order;
         ser & delivery_time;
         ser & priority;

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -10,6 +10,7 @@
 // distribution.
 
 #include <sst_config.h>
+#include <sst/core/warnmacros.h>
 
 #include <string>
 
@@ -219,7 +220,7 @@ BaseComponent::configureSelfLink( std::string name, Event::HandlerBase* handler)
     return configureLink(name,handler);
 }
 
-Link* BaseComponent::selfLink( std::string name __attribute__((unused)), Event::HandlerBase* handler )
+Link* BaseComponent::selfLink( std::string UNUSED(name), Event::HandlerBase* handler )
 {
     Link* link = new SelfLink();
     link->setLatency(0);

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -13,6 +13,7 @@
 #define SST_CORE_BASECOMPONENT_H
 
 #include <sst/core/sst_types.h>
+#include <sst/core/warnmacros.h>
 
 #include <map>
 #include <string>
@@ -67,7 +68,7 @@ public:
 
     /** Used during the init phase.  The method will be called each phase of initialization.
      Initialization ends when no components have sent any data. */
-    virtual void init(unsigned int phase __attribute__((unused))) {}
+    virtual void init(unsigned int UNUSED(phase)) {}
     /** Called after all components have been constructed and inialization has
 	completed, but before simulation time has begun. */
     virtual void setup( ) { }
@@ -83,7 +84,7 @@ public:
      * print it's current status.  Useful for debugging.
      * @param out The Output class which should be used to print component status.
      */
-    virtual void printStatus(Output &out __attribute__((unused))) { return; }
+    virtual void printStatus(Output &UNUSED(out)) { return; }
 
     /** Determine if a port name is connected to any links */
     bool isPortConnected(const std::string &name) const;

--- a/src/sst/core/bootshared.cc
+++ b/src/sst/core/bootshared.cc
@@ -18,9 +18,10 @@
 #include <string>
 
 #include "bootshared.h"
+#include <sst/core/warnmacros.h>
 #include "sst/core/env/envquery.h"
 
-void update_env_var(const char* name, const int verbose __attribute__((unused)), char* argv[] __attribute__((unused)), const int argc __attribute__((unused))) {
+void update_env_var(const char* name, const int UNUSED(verbose), char* UNUSED(argv[]), const int UNUSED(argc)) {
         char* current_ld_path  = getenv(name);
 	char* new_ld_path      = (char*) malloc(sizeof(char) * 32768);
 	char* new_ld_path_copy = (char*) malloc(sizeof(char) * 32768);
@@ -70,7 +71,7 @@ void boot_sst_configure_env(const int verbose, char* argv[], const int argc) {
         update_env_var("DYLD_LIBRARY_PATH", verbose, argv, argc);
 }
 
-void boot_sst_executable(const char* binary, const int verbose, char* argv[], const int argc __attribute__((unused))) {
+void boot_sst_executable(const char* binary, const int verbose, char* argv[], const int UNUSED(argc)) {
 	char* real_binary_path = (char*) malloc(sizeof(char) * PATH_MAX);
 
 	if(strcmp(SST_INSTALL_PREFIX, "NONE") == 0) {

--- a/src/sst/core/cfgoutput/dotConfigOutput.h
+++ b/src/sst/core/cfgoutput/dotConfigOutput.h
@@ -23,7 +23,7 @@ class DotConfigGraphOutput : public ConfigGraphOutput {
 public:
         DotConfigGraphOutput(const char* path);
 	virtual void generate(const Config* cfg,
-                ConfigGraph* graph) throw(ConfigGraphOutputException);
+                ConfigGraph* graph) throw(ConfigGraphOutputException) override;
 protected:
 	void generateDot(const ConfigComponent& comp, const ConfigLinkMap_t& linkMap) const;
 	void generateDot(const ConfigLink& link) const;

--- a/src/sst/core/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.cc
@@ -12,6 +12,7 @@
 
 #include <sst_config.h>
 
+#include <sst/core/warnmacros.h>
 #include <sst/core/config.h>
 #include <sst/core/configGraph.h>
 #include <sst/core/configGraphOutput.h>
@@ -27,7 +28,7 @@ JSONConfigGraphOutput::JSONConfigGraphOutput(const char* path) :
 
 }
 
-void JSONConfigGraphOutput::generate(const Config* cfg __attribute__((unused)),
+void JSONConfigGraphOutput::generate(const Config* UNUSED(cfg),
                 ConfigGraph* graph) throw(ConfigGraphOutputException) {
 
 	if(NULL == outputFile) {
@@ -59,7 +60,7 @@ void JSONConfigGraphOutput::generate(const Config* cfg __attribute__((unused)),
 }
 
 void JSONConfigGraphOutput::generateJSON(const std::string indent, const ConfigComponent& comp,
-                const ConfigLinkMap_t& linkMap __attribute__((unused))) const {
+                const ConfigLinkMap_t& UNUSED(linkMap)) const {
 
 	fprintf(outputFile, "%s  {\n", indent.c_str());
 	fprintf(outputFile, "%s    \"name\" : \"%s\",\n", indent.c_str(), comp.name.c_str());

--- a/src/sst/core/cfgoutput/jsonConfigOutput.h
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.h
@@ -23,7 +23,7 @@ class JSONConfigGraphOutput : public ConfigGraphOutput {
 public:
         JSONConfigGraphOutput(const char* path);
 	virtual void generate(const Config* cfg,
-                ConfigGraph* graph) throw(ConfigGraphOutputException);
+                ConfigGraph* graph) throw(ConfigGraphOutputException) override;
 protected:
 	void generateJSON(const std::string indent, const ConfigComponent& comp,
                 const ConfigLinkMap_t& linkMap) const;

--- a/src/sst/core/cfgoutput/pythonConfigOutput.h
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.h
@@ -25,7 +25,7 @@ public:
     PythonConfigGraphOutput(const char* path);
 
     virtual void generate(const Config* cfg,
-            ConfigGraph* graph) throw(ConfigGraphOutputException);
+            ConfigGraph* graph) throw(ConfigGraphOutputException) override;
 
 protected:
     ConfigGraph* getGraph() { return graph; }

--- a/src/sst/core/cfgoutput/xmlConfigOutput.cc
+++ b/src/sst/core/cfgoutput/xmlConfigOutput.cc
@@ -11,6 +11,7 @@
 //
 
 #include <sst_config.h>
+#include <sst/core/warnmacros.h>
 #include <sst/core/configGraphOutput.h>
 #include "xmlConfigOutput.h"
 
@@ -21,7 +22,7 @@ XMLConfigGraphOutput::XMLConfigGraphOutput(const char* path) :
 
 }
 
-void XMLConfigGraphOutput::generate(const Config* cfg __attribute__((unused)),
+void XMLConfigGraphOutput::generate(const Config* UNUSED(cfg),
                 ConfigGraph* graph) throw(ConfigGraphOutputException) {
 
 	if(NULL == outputFile) {
@@ -48,7 +49,7 @@ void XMLConfigGraphOutput::generate(const Config* cfg __attribute__((unused)),
 }
 
 void XMLConfigGraphOutput::generateXML(const std::string indent, const ConfigComponent& comp,
-                const ConfigLinkMap_t& linkMap __attribute__((unused))) const {
+                const ConfigLinkMap_t& UNUSED(linkMap)) const {
 
 	fprintf(outputFile, "%s<component id=\"system.%s\" name=\"%s\" type=\"%s\">\n",
 		indent.c_str(), comp.name.c_str(), comp.name.c_str(), comp.type.c_str());

--- a/src/sst/core/cfgoutput/xmlConfigOutput.h
+++ b/src/sst/core/cfgoutput/xmlConfigOutput.h
@@ -23,7 +23,7 @@ class XMLConfigGraphOutput : public ConfigGraphOutput {
 public:
         XMLConfigGraphOutput(const char* path);
 	virtual void generate(const Config* cfg,
-                ConfigGraph* graph) throw(ConfigGraphOutputException);
+                ConfigGraph* graph) throw(ConfigGraphOutputException) override;
 protected:
         void generateXML(const std::string indent, const ConfigComponent& comp,
 		const ConfigLinkMap_t& linkMap) const;

--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -73,7 +73,7 @@ public:
             data(data)
         {}
 
-        bool operator()(Cycle_t cycle) {
+        bool operator()(Cycle_t cycle) override {
             return (object->*member)(cycle,data);
         }
     };
@@ -98,7 +98,7 @@ public:
             member(member)
         {}
 
-        bool operator()(Cycle_t cycle) {
+        bool operator()(Cycle_t cycle) override {
             return (object->*member)(cycle);
         }
     };
@@ -117,7 +117,7 @@ public:
     /** Remove a handler from the list of handlers to be called on the clock tick */
     bool unregisterHandler( Clock::HandlerBase* handler, bool& empty );
 
-    void print(const std::string& header, Output &out) const;
+    void print(const std::string& header, Output &out) const override;
     
 private:
 /*     typedef std::list<Clock::HandlerBase*> HandlerMap_t; */
@@ -126,7 +126,7 @@ private:
 
     Clock() { }
 
-    void execute( void );
+    void execute( void ) override;
 
     Cycle_t            currentCycle;
     TimeConverter*     period;

--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -105,12 +105,12 @@ protected:
     friend class SubComponent;
     Component() {} // Unused, but previously available
 
-    Component* getTrueComponent() const final { return const_cast<Component*>(this); }
-    BaseComponent* getStatisticOwner() const final { return const_cast<Component*>(this); }
+    Component* getTrueComponent() const final override { return const_cast<Component*>(this); }
+    BaseComponent* getStatisticOwner() const final override { return const_cast<Component*>(this); }
 
 
     // Does the statisticName exist in the ElementInfoStatistic
-    virtual bool doesComponentInfoStatisticExist(const std::string &statisticName) const final;
+    virtual bool doesComponentInfoStatisticExist(const std::string &statisticName) const final override;
 
 private:
 

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -26,8 +26,11 @@
 #include <iostream>
 #include <cstdlib>
 
+#include <sst/core/warnmacros.h>
 #ifdef SST_CONFIG_HAVE_MPI
+DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
+REENABLE_WARNING
 #endif
 
 #include "sst/core/build_info.h"

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -161,7 +161,7 @@ public:
         return old;
     }
 
-    void serialize_order(SST::Core::Serialization::serializer &ser)
+    void serialize_order(SST::Core::Serialization::serializer &ser) override
     {
         ser & debugFile;
         ser & runMode;

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -24,10 +24,6 @@
 
 #include <string.h>
 
-#ifdef SST_CONFIG_HAVE_MPI
-#include <mpi.h>
-#endif
-
 using namespace std;
 
 namespace SST {

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -82,7 +82,7 @@ public:
     /* Do not use.  For serialization only */
     ConfigLink() {}
 
-    void serialize_order(SST::Core::Serialization::serializer &ser) {
+    void serialize_order(SST::Core::Serialization::serializer &ser) override {
         ser & id;
         ser & name;
         ser & component[0];
@@ -154,7 +154,7 @@ public:
 
 
 
-    void serialize_order(SST::Core::Serialization::serializer &ser) {
+    void serialize_order(SST::Core::Serialization::serializer &ser) override {
         ser & name;
         ser & statMap;
         ser & components;
@@ -180,7 +180,7 @@ public:
         params.insert(key, val);
     }
 
-    void serialize_order(SST::Core::Serialization::serializer &ser) {
+    void serialize_order(SST::Core::Serialization::serializer &ser) override {
         ser & type;
         ser & params;
     }
@@ -229,7 +229,7 @@ public:
 
     std::vector<LinkId_t> allLinks() const;
 
-    void serialize_order(SST::Core::Serialization::serializer &ser) {
+    void serialize_order(SST::Core::Serialization::serializer &ser) override {
         ser & id;
         ser & name;
         ser & type;
@@ -379,7 +379,7 @@ public:
     void annotateRanks(PartitionGraph* graph);
     void getConnectedNoCutComps(ComponentId_t start, ComponentIdMap_t& group);
 
-    void serialize_order(SST::Core::Serialization::serializer &ser)
+    void serialize_order(SST::Core::Serialization::serializer &ser) override
 	{
 		ser & links;
 		ser & comps;

--- a/src/sst/core/configGraphOutput.h
+++ b/src/sst/core/configGraphOutput.h
@@ -30,7 +30,7 @@ public:
 		std::strcpy(exMsg, msg);
 	}
 
-	virtual const char* what() const throw() {
+	virtual const char* what() const throw() override {
 		return exMsg;
 	}
 

--- a/src/sst/core/elementinfo.h
+++ b/src/sst/core/elementinfo.h
@@ -436,14 +436,14 @@ private:
 
 public:
     
-    virtual Partition::SSTPartitioner* create(RankInfo total_ranks, RankInfo my_rank, int verbosity) {
+    virtual Partition::SSTPartitioner* create(RankInfo total_ranks, RankInfo my_rank, int verbosity) override {
         return new T(total_ranks,my_rank,verbosity);
     }
     
     static bool isLoaded() { return loaded; }
-    const std::string getDescription() { return T::ELI_getDescription(); }
-    const std::string getName() { return T::ELI_getName(); }
-    const std::string getLibrary() { return T::ELI_getLibrary(); }
+    const std::string getDescription() override { return T::ELI_getDescription(); }
+    const std::string getName() override { return T::ELI_getName(); }
+    const std::string getLibrary() override { return T::ELI_getLibrary(); }
 };
 
 template<class T> const bool PartitionerDoc<T>::loaded = ElementLibraryDatabase::addPartitioner(new PartitionerDoc<T>());

--- a/src/sst/core/elementinfo.h
+++ b/src/sst/core/elementinfo.h
@@ -13,6 +13,7 @@
 #define SST_CORE_ELEMENTINFO_H
 
 #include <sst/core/sst_types.h>
+#include <sst/core/warnmacros.h>
 #include <sst/core/params.h>
 
 #include <string>
@@ -107,8 +108,8 @@ class ModuleElementInfo : public BaseElementInfo {
 protected:
 
 public:
-    virtual Module* create(Component* comp __attribute__((unused)), Params& params __attribute__((unused))) { /* Need to print error */ return NULL; }
-    virtual Module* create(Params& params __attribute__((unused))) { /* Need to print error */ return NULL; }
+    virtual Module* create(Component* UNUSED(comp), Params& UNUSED(params)) { /* Need to print error */ return NULL; }
+    virtual Module* create(Params& UNUSED(params)) { /* Need to print error */ return NULL; }
     virtual const std::string getInterface() = 0;
     
     std::string toString();

--- a/src/sst/core/env/envquery.cc
+++ b/src/sst/core/env/envquery.cc
@@ -18,6 +18,7 @@
 #include <string>
 #include <sys/file.h>
 
+#include <sst/core/warnmacros.h>
 #include "envquery.h"
 #include "envconfig.h"
 
@@ -47,7 +48,7 @@ void SST::Core::Environment::configReadLine(FILE* theFile, char* lineBuffer) {
 	}
 }
 
-void SST::Core::Environment::populateEnvironmentConfig(FILE* configFile, EnvironmentConfiguration* cfg, bool errorOnNotOpen __attribute__((unused))) {
+void SST::Core::Environment::populateEnvironmentConfig(FILE* configFile, EnvironmentConfiguration* cfg, bool UNUSED(errorOnNotOpen)) {
 
 	// Get the file descriptor and lock the file using a shared lock so
 	// people don't come and change it from under us

--- a/src/sst/core/event.h
+++ b/src/sst/core/event.h
@@ -47,7 +47,7 @@ public:
     virtual ~Event() = 0;
 
     /** Cause this event to fire */
-    void execute(void);
+    void execute(void) override;
 
     /** Clones the event in for the case of a broadcast */
     virtual Event* clone();
@@ -146,7 +146,7 @@ public:
         };
 
     /** Virtual function to "pretty-print" this event.  Should be implemented by subclasses. */
-    virtual void print(const std::string& header, Output &out) const {
+    virtual void print(const std::string& header, Output &out) const override {
         out.output("%s Generic Event to be delivered at %" PRIu64 " with priority %d\n",
                 header.c_str(), getDeliveryTime(), getPriority());
     }
@@ -181,7 +181,7 @@ public:
 
 #endif
 
-    void serialize_order(SST::Core::Serialization::serializer &ser){
+    void serialize_order(SST::Core::Serialization::serializer &ser) override{
         Activity::serialize_order(ser);
 #ifndef SST_ENFORCE_EVENT_ORDERING        
         ser & link_id;
@@ -234,9 +234,9 @@ public:
     NullEvent() : Event() {}
     ~NullEvent() {}
 
-    void execute(void);
+    void execute(void) override;
 
-    virtual void print(const std::string& header, Output &out) const {
+    virtual void print(const std::string& header, Output &out) const override {
         out.output("%s NullEvent to be delivered at %" PRIu64 " with priority %d\n",
                 header.c_str(), getDeliveryTime(), getPriority());
     }

--- a/src/sst/core/exit.cc
+++ b/src/sst/core/exit.cc
@@ -13,8 +13,11 @@
 #include "sst_config.h"
 #include "sst/core/exit.h"
 
+#include <sst/core/warnmacros.h>
 #ifdef SST_CONFIG_HAVE_MPI
+DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
+REENABLE_WARNING
 #endif
 
 #include "sst/core/component.h"

--- a/src/sst/core/exit.h
+++ b/src/sst/core/exit.h
@@ -58,10 +58,10 @@ public:
     unsigned int getRefCount();
     SimTime_t getEndTime() { return end_time; }
     
-    void execute(void);
+    void execute(void) override;
     void check();
 
-    void print(const std::string& header, Output &out) const {
+    void print(const std::string& header, Output &out) const override {
         out.output("%s Exit Action to be delivered at %" PRIu64 " with priority %d\n",
                 header.c_str(), getDeliveryTime(), getPriority());
     }

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -11,6 +11,7 @@
 
 
 #include "sst_config.h"
+#include <sst/core/warnmacros.h>
 #include "sst/core/factory.h"
 
 #include <set>
@@ -618,7 +619,7 @@ Factory::CreateCoreModule(std::string type, Params& params) {
 }
 
 Module*
-Factory::CreateCoreModuleWithComponent(std::string type, Component* comp __attribute__((unused)), Params& params __attribute__((unused))) {
+Factory::CreateCoreModuleWithComponent(std::string type, Component* UNUSED(comp), Params& UNUSED(params)) {
     out.fatal(CALL_INFO, -1, "can't find requested core module %s when loading with component\n", type.c_str());
     return NULL;
 }

--- a/src/sst/core/heartbeat.cc
+++ b/src/sst/core/heartbeat.cc
@@ -17,8 +17,11 @@
 #include "sst/core/simulation.h"
 #include "sst/core/timeConverter.h"
 
+#include <sst/core/warnmacros.h>
 #ifdef SST_CONFIG_HAVE_MPI
+DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
+REENABLE_WARNING
 #endif
 
 namespace SST {

--- a/src/sst/core/heartbeat.cc
+++ b/src/sst/core/heartbeat.cc
@@ -26,7 +26,7 @@ REENABLE_WARNING
 
 namespace SST {
 
-SimulatorHeartbeat::SimulatorHeartbeat( Config* cfg __attribute__((unused)), int this_rank, Simulation* sim, TimeConverter* period) :
+SimulatorHeartbeat::SimulatorHeartbeat( Config* UNUSED(cfg), int this_rank, Simulation* sim, TimeConverter* period) :
     Action(),
     rank(this_rank),
     m_period( period )

--- a/src/sst/core/heartbeat.h
+++ b/src/sst/core/heartbeat.h
@@ -41,7 +41,7 @@ private:
     SimulatorHeartbeat() { };
     SimulatorHeartbeat(const SimulatorHeartbeat&);
     void operator=(SimulatorHeartbeat const&);
-    void execute(void);
+    void execute(void) override;
     int rank;
     TimeConverter*  m_period;
     double lastTime;

--- a/src/sst/core/initQueue.h
+++ b/src/sst/core/initQueue.h
@@ -26,11 +26,11 @@ public:
     InitQueue();
     ~InitQueue();
 
-    bool empty();
-    int size();
-    void insert(Activity* activity);
-    Activity* pop();
-    Activity* front();
+    bool empty() override;
+    int size() override;
+    void insert(Activity* activity) override;
+    Activity* pop() override;
+    Activity* front() override;
     
 private:
     std::deque<Activity*> data;

--- a/src/sst/core/interfaces/TestEvent.h
+++ b/src/sst/core/interfaces/TestEvent.h
@@ -31,7 +31,7 @@ public:
     bool print_on_delete;
 
 public:   
-    void serialize_order(SST::Core::Serialization::serializer &ser) {
+    void serialize_order(SST::Core::Serialization::serializer &ser) override {
         Event::serialize_order(ser);
         ser & count;
     }

--- a/src/sst/core/interfaces/simpleMem.h
+++ b/src/sst/core/interfaces/simpleMem.h
@@ -20,6 +20,7 @@
 #include <atomic>
 
 #include <sst/core/sst_types.h>
+#include <sst/core/warnmacros.h>
 #include <sst/core/subcomponent.h>
 #include <sst/core/params.h>
 #include <sst/core/link.h>
@@ -278,7 +279,7 @@ public:
 
 
     /** Constructor, designed to be used via 'loadSubComponent'. */
-    SimpleMem(SST::Component *comp, Params &params __attribute__((unused))) :
+    SimpleMem(SST::Component *comp, Params &UNUSED(params)) :
         SubComponent(comp)
         { }
 

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -133,7 +133,7 @@ public:
         int getTraceID() {return traceID;}
         TraceType getTraceType() {return trace;}
         
-        void serialize_order(SST::Core::Serialization::serializer &ser) {
+        void serialize_order(SST::Core::Serialization::serializer &ser) override {
             ser & dest;
             ser & src;
             ser & vn;
@@ -293,9 +293,9 @@ public:
      */
     virtual Request* recv(int vn) = 0;
 
-    virtual void setup() {}
-    virtual void init(unsigned int phase __attribute__((unused))) {}
-    virtual void finish() {}
+    virtual void setup() override {}
+    virtual void init(unsigned int phase __attribute__((unused))) override {}
+    virtual void finish() override {}
 
     /**
      * Checks if there is sufficient space to send on the specified

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -18,6 +18,7 @@
 #include <unordered_map>
 
 #include <sst/core/sst_types.h>
+#include <sst/core/warnmacros.h>
 #include <sst/core/subcomponent.h>
 #include <sst/core/params.h>
 
@@ -294,7 +295,7 @@ public:
     virtual Request* recv(int vn) = 0;
 
     virtual void setup() override {}
-    virtual void init(unsigned int phase __attribute__((unused))) override {}
+    virtual void init(unsigned int UNUSED(phase)) override {}
     virtual void finish() override {}
 
     /**

--- a/src/sst/core/iouse.cc
+++ b/src/sst/core/iouse.cc
@@ -15,8 +15,11 @@
 #include "sst/core/iouse.h"
 
 #include <sys/resource.h>
+#include <sst/core/warnmacros.h>
 #ifdef SST_CONFIG_HAVE_MPI
+DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
+REENABLE_WARNING
 #endif
 
 

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -13,8 +13,11 @@
 #include <sst_config.h>
 #include <Python.h>
 
+#include <sst/core/warnmacros.h>
 #ifdef SST_CONFIG_HAVE_MPI
+DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
+REENABLE_WARNING
 #endif
 
 #include <iomanip>

--- a/src/sst/core/memuse.cc
+++ b/src/sst/core/memuse.cc
@@ -13,10 +13,13 @@
 #include "sst_config.h"
 
 #include "sst/core/memuse.h"
-
+#include <sst/core/warnmacros.h>
 #include <sys/resource.h>
+
 #ifdef SST_CONFIG_HAVE_MPI
+DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
+REENABLE_WARNING
 #endif
 
 

--- a/src/sst/core/model/element_python.h
+++ b/src/sst/core/model/element_python.h
@@ -59,7 +59,7 @@ public:
         {
         }
 
-    void* load() {
+    void* load() override {
         return (*func)();
     }
 };

--- a/src/sst/core/model/pymodel.cc
+++ b/src/sst/core/model/pymodel.cc
@@ -12,10 +12,14 @@
 // distribution.
 
 #include "sst_config.h"
+#include <sst/core/warnmacros.h>
 #include <Python.h>
 
+
 #ifdef SST_CONFIG_HAVE_MPI
+DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
+REENABLE_WARNING
 #endif
 
 #include <string.h>
@@ -32,13 +36,7 @@
 #include <sst/core/factory.h>
 #include <sst/core/component.h>
 #include <sst/core/configGraph.h>
-
-
-/* Disable GCC's strict-aliasing warnings for Python macros */
-#if defined(__GNUC__) && ((__GNUC__ == 4 && 3 <= __GNUC_MINOR__) || 4 < __GNUC__)
-# pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif
-
+DISABLE_WARN_STRICT_ALIASING
 
 using namespace SST::Core;
 
@@ -644,20 +642,13 @@ void SSTPythonModelDefinition::initModel(const std::string script_file, int verb
     // Add our built in methods to the Python engine
     PyObject *module = Py_InitModule("sst", sstModuleMethods);
 
-#if ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif
     Py_INCREF(&PyModel_ComponentType);
     Py_INCREF(&PyModel_SubComponentType);
     Py_INCREF(&PyModel_LinkType);
     Py_INCREF(&PyModel_StatGroupType);
     Py_INCREF(&PyModel_StatOutputType);
     Py_INCREF(&ModuleLoaderType);
-#if ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
-#pragma GCC diagnostic pop
-#endif
-    
+
     PyModule_AddObject(module, "Link", (PyObject*)&PyModel_LinkType);
     PyModule_AddObject(module, "Component", (PyObject*)&PyModel_ComponentType);
     PyModule_AddObject(module, "SubComponent", (PyObject*)&PyModel_SubComponentType);
@@ -872,3 +863,4 @@ std::map<std::string,std::string> SST::Core::generateStatisticParameters(PyObjec
     return p;
 }
 
+REENABLE_WARNING

--- a/src/sst/core/model/pymodel.cc
+++ b/src/sst/core/model/pymodel.cc
@@ -156,7 +156,7 @@ static PyMethodDef emptyModMethods[] = {
     {NULL, NULL, 0, NULL }
 };
 
-static PyObject* mlLoadModule(PyObject *self __attribute__((unused)), PyObject *args)
+static PyObject* mlLoadModule(PyObject *UNUSED(self), PyObject *args)
 {
     char *name;
     if ( !PyArg_ParseTuple(args, "s", &name) )
@@ -186,7 +186,7 @@ static PyObject* mlLoadModule(PyObject *self __attribute__((unused)), PyObject *
 
 /***** Module information *****/
 
-static PyObject* findComponentByName(PyObject* self __attribute__((unused)), PyObject* args)
+static PyObject* findComponentByName(PyObject* UNUSED(self), PyObject* args)
 {
     if ( ! PyString_Check(args) ) {
         Py_INCREF(Py_None);
@@ -204,7 +204,7 @@ static PyObject* findComponentByName(PyObject* self __attribute__((unused)), PyO
     return Py_None;
 }
 
-static PyObject* setProgramOption(PyObject* self __attribute__((unused)), PyObject* args)
+static PyObject* setProgramOption(PyObject* UNUSED(self), PyObject* args)
 {
     char *param, *value;
     PyErr_Clear();
@@ -221,7 +221,7 @@ static PyObject* setProgramOption(PyObject* self __attribute__((unused)), PyObje
 }
 
 
-static PyObject* setProgramOptions(PyObject* self __attribute__((unused)), PyObject* args)
+static PyObject* setProgramOptions(PyObject* UNUSED(self), PyObject* args)
 {
     if ( !PyDict_Check(args) ) {
         return NULL;
@@ -237,7 +237,7 @@ static PyObject* setProgramOptions(PyObject* self __attribute__((unused)), PyObj
 }
 
 
-static PyObject* getProgramOptions(PyObject*self __attribute__((unused)), PyObject *args __attribute__((unused)))
+static PyObject* getProgramOptions(PyObject*UNUSED(self), PyObject *UNUSED(args))
 {
     // Load parameters already set.
     Config *cfg = gModel->getConfig();
@@ -267,7 +267,7 @@ static PyObject* getProgramOptions(PyObject*self __attribute__((unused)), PyObje
 }
 
 
-static PyObject* pushNamePrefix(PyObject* self __attribute__((unused)), PyObject* arg)
+static PyObject* pushNamePrefix(PyObject* UNUSED(self), PyObject* arg)
 {
     char *name = NULL;
     PyErr_Clear();
@@ -282,20 +282,20 @@ static PyObject* pushNamePrefix(PyObject* self __attribute__((unused)), PyObject
 }
 
 
-static PyObject* popNamePrefix(PyObject* self __attribute__((unused)), PyObject* args __attribute__((unused)))
+static PyObject* popNamePrefix(PyObject* UNUSED(self), PyObject* UNUSED(args))
 {
     gModel->popNamePrefix();
     return PyInt_FromLong(0);
 }
 
 
-static PyObject* exitsst(PyObject* self __attribute__((unused)), PyObject* args __attribute__((unused)))
+static PyObject* exitsst(PyObject* UNUSED(self), PyObject* UNUSED(args))
 {
     exit(-1);
     return NULL;
 }
 
-static PyObject* getSSTMPIWorldSize(PyObject* self __attribute__((unused)), PyObject* args __attribute__((unused))) {
+static PyObject* getSSTMPIWorldSize(PyObject* UNUSED(self), PyObject* UNUSED(args)) {
     int ranks = 1;
 #ifdef SST_CONFIG_HAVE_MPI
     MPI_Comm_size(MPI_COMM_WORLD, &ranks);
@@ -303,12 +303,12 @@ static PyObject* getSSTMPIWorldSize(PyObject* self __attribute__((unused)), PyOb
     return PyInt_FromLong(ranks);
 }
 
-static PyObject* getSSTThreadCount(PyObject* self __attribute__((unused)), PyObject* args __attribute__((unused))) {
+static PyObject* getSSTThreadCount(PyObject* UNUSED(self), PyObject* UNUSED(args)) {
     Config *cfg = gModel->getConfig();
     return PyLong_FromLong(cfg->getNumThreads());
 }
 
-static PyObject* setSSTThreadCount(PyObject* self __attribute__((unused)), PyObject* args) {
+static PyObject* setSSTThreadCount(PyObject* UNUSED(self), PyObject* args) {
     Config *cfg = gModel->getConfig();
     long oldNThr = cfg->getNumThreads();
     long nThr = PyLong_AsLong(args);
@@ -318,7 +318,7 @@ static PyObject* setSSTThreadCount(PyObject* self __attribute__((unused)), PyObj
 }
 
 
-static PyObject* setStatisticOutput(PyObject* self __attribute__((unused)), PyObject* args)
+static PyObject* setStatisticOutput(PyObject* UNUSED(self), PyObject* args)
 {
     char*      statOutputName;
     int        argOK = 0;
@@ -342,7 +342,7 @@ static PyObject* setStatisticOutput(PyObject* self __attribute__((unused)), PyOb
     return PyInt_FromLong(0);
 }
 
-static PyObject* setStatisticOutputOption(PyObject* self __attribute__((unused)), PyObject* args)
+static PyObject* setStatisticOutputOption(PyObject* UNUSED(self), PyObject* args)
 {
     char* param;
     char* value;
@@ -361,7 +361,7 @@ static PyObject* setStatisticOutputOption(PyObject* self __attribute__((unused))
 }
 
 
-static PyObject* setStatisticOutputOptions(PyObject* self __attribute__((unused)), PyObject* args)
+static PyObject* setStatisticOutputOptions(PyObject* UNUSED(self), PyObject* args)
 {
     PyErr_Clear();
 
@@ -377,7 +377,7 @@ static PyObject* setStatisticOutputOptions(PyObject* self __attribute__((unused)
 }
 
 
-static PyObject* setStatisticLoadLevel(PyObject* self __attribute__((unused)), PyObject* arg)
+static PyObject* setStatisticLoadLevel(PyObject* UNUSED(self), PyObject* arg)
 {
     PyErr_Clear();
 
@@ -393,7 +393,7 @@ static PyObject* setStatisticLoadLevel(PyObject* self __attribute__((unused)), P
 }
 
 
-static PyObject* enableAllStatisticsForAllComponents(PyObject* self __attribute__((unused)), PyObject* args)
+static PyObject* enableAllStatisticsForAllComponents(PyObject* UNUSED(self), PyObject* args)
 {
     int           argOK = 0;
     PyObject*     statParamDict = NULL;
@@ -419,7 +419,7 @@ static PyObject* enableAllStatisticsForAllComponents(PyObject* self __attribute_
 }
 
 
-static PyObject* enableAllStatisticsForComponentName(PyObject *self __attribute__((unused)), PyObject *args)
+static PyObject* enableAllStatisticsForComponentName(PyObject *UNUSED(self), PyObject *args)
 {
     int           argOK = 0;
     char*         compName = NULL;
@@ -446,7 +446,7 @@ static PyObject* enableAllStatisticsForComponentName(PyObject *self __attribute_
 }
 
 
-static PyObject* enableAllStatisticsForComponentType(PyObject *self __attribute__((unused)), PyObject *args)
+static PyObject* enableAllStatisticsForComponentType(PyObject *UNUSED(self), PyObject *args)
 {
     int           argOK = 0;
     char*         compType = NULL;
@@ -472,7 +472,7 @@ static PyObject* enableAllStatisticsForComponentType(PyObject *self __attribute_
 }
 
 
-static PyObject* enableStatisticForComponentName(PyObject *self __attribute__((unused)), PyObject *args)
+static PyObject* enableStatisticForComponentName(PyObject *UNUSED(self), PyObject *args)
 {
     int           argOK = 0;
     char*         compName = NULL;
@@ -499,7 +499,7 @@ static PyObject* enableStatisticForComponentName(PyObject *self __attribute__((u
 }
 
 
-static PyObject* enableStatisticForComponentType(PyObject *self __attribute__((unused)), PyObject *args)
+static PyObject* enableStatisticForComponentType(PyObject *UNUSED(self), PyObject *args)
 {
     int           argOK = 0;
     char*         compType = NULL;
@@ -590,7 +590,7 @@ static PyMethodDef sstModuleMethods[] = {
 }  /* extern C */
 
 
-void SSTPythonModelDefinition::initModel(const std::string script_file, int verbosity, Config* config __attribute__((unused)), int argc, char** argv)
+void SSTPythonModelDefinition::initModel(const std::string script_file, int verbosity, Config* UNUSED(config), int argc, char** argv)
 {
     output = new Output("SSTPythonModel ", verbosity, 0, SST::Output::STDOUT);
 

--- a/src/sst/core/model/pymodel.h
+++ b/src/sst/core/model/pymodel.h
@@ -42,7 +42,7 @@ class SSTPythonModelDefinition : public SSTModelDescription {
 		SSTPythonModelDefinition(const std::string script_file, int verbosity, Config* config);
 		virtual ~SSTPythonModelDefinition();
 
-		ConfigGraph* createConfigGraph();
+		ConfigGraph* createConfigGraph() override;
 
 	protected:
 		void initModel(const std::string script_file, int verbosity, Config* config, int argc, char** argv);

--- a/src/sst/core/model/pymodel_comp.cc
+++ b/src/sst/core/model/pymodel_comp.cc
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <sstream>
 
+#include <sst/core/warnmacros.h>
 #include <sst/core/model/pymodel.h>
 #include <sst/core/model/pymodel_comp.h>
 #include <sst/core/model/pymodel_link.h>
@@ -100,7 +101,7 @@ int PySubComponent::compare(ComponentHolder *other) {
 
 
 
-static int compInit(ComponentPy_t *self, PyObject *args, PyObject *kwds __attribute__((unused)))
+static int compInit(ComponentPy_t *self, PyObject *args, PyObject *UNUSED(kwds))
 {
     char *name, *type;
     ComponentId_t useID = UNSET_COMPONENT_ID;
@@ -235,7 +236,7 @@ static PyObject* compAddLink(PyObject *self, PyObject *args)
 }
 
 
-static PyObject* compGetFullName(PyObject *self, PyObject *args __attribute__((unused)))
+static PyObject* compGetFullName(PyObject *self, PyObject *UNUSED(args))
 {
     return PyString_FromString(getComp(self)->name.c_str());
 }
@@ -464,7 +465,7 @@ PyTypeObject PyModel_ComponentType = {
 
 
 
-static int subCompInit(ComponentPy_t *self, PyObject *args, PyObject *kwds __attribute__((unused)))
+static int subCompInit(ComponentPy_t *self, PyObject *args, PyObject *UNUSED(kwds))
 {
     char *name, *type;
     PyObject *parent;

--- a/src/sst/core/model/pymodel_comp.h
+++ b/src/sst/core/model/pymodel_comp.h
@@ -41,10 +41,10 @@ struct PyComponent : ComponentHolder {
 
     PyComponent(ComponentPy_t *pobj) : ComponentHolder(pobj), subCompId(0) { }
     ~PyComponent() {}
-    const char* getName() const ;
-    ConfigComponent* getComp();
-    PyComponent* getBaseObj();
-    int compare(ComponentHolder *other);
+    const char* getName() const override;
+    ConfigComponent* getComp() override;
+    PyComponent* getBaseObj() override;
+    int compare(ComponentHolder *other) override;
 };
 
 struct PySubComponent : ComponentHolder {
@@ -52,10 +52,10 @@ struct PySubComponent : ComponentHolder {
 
     PySubComponent(ComponentPy_t *pobj) : ComponentHolder(pobj) { }
     ~PySubComponent() {}
-    const char* getName() const ;
-    ConfigComponent* getComp();
-    PyComponent* getBaseObj();
-    int compare(ComponentHolder *other);
+    const char* getName() const override;
+    ConfigComponent* getComp() override;
+    PyComponent* getBaseObj() override;
+    int compare(ComponentHolder *other) override;
 };
 
 

--- a/src/sst/core/model/pymodel_link.cc
+++ b/src/sst/core/model/pymodel_link.cc
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <sstream>
 
+#include <sst/core/warnmacros.h>
 #include <sst/core/model/pymodel.h>
 #include <sst/core/model/pymodel_comp.h>
 #include <sst/core/model/pymodel_link.h>
@@ -33,7 +34,7 @@ extern SST::Core::SSTPythonModelDefinition *gModel;
 extern "C" {
 
 
-static int linkInit(LinkPy_t *self, PyObject *args, PyObject *kwds __attribute__((unused)))
+static int linkInit(LinkPy_t *self, PyObject *args, PyObject *UNUSED(kwds))
 {
     char *name = NULL, *lat = NULL;
     if ( !PyArg_ParseTuple(args, "s|s", &name, &lat) ) return -1;
@@ -110,7 +111,7 @@ static PyObject* linkConnect(PyObject* self, PyObject *args)
 }
 
 
-static PyObject* linkSetNoCut(PyObject* self, PyObject *args __attribute__((unused)))
+static PyObject* linkSetNoCut(PyObject* self, PyObject *UNUSED(args))
 {
     LinkPy_t *link = (LinkPy_t*)self;
     bool prev = link->no_cut;

--- a/src/sst/core/model/pymodel_statgroup.cc
+++ b/src/sst/core/model/pymodel_statgroup.cc
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <sstream>
 
+#include <sst/core/warnmacros.h>
 #include <sst/core/model/pymodel.h>
 #include <sst/core/model/pymodel_comp.h>
 #include <sst/core/model/pymodel_statgroup.h>
@@ -48,7 +49,7 @@ static Params convertToParams(PyObject *dict)
 
 
 
-static int sgInit(StatGroupPy_t *self, PyObject *args, PyObject *kwds __attribute__((unused)))
+static int sgInit(StatGroupPy_t *self, PyObject *args, PyObject *UNUSED(kwds))
 {
     char *name = NULL;
     if ( !PyArg_ParseTuple(args, "s", &name) ) return -1;
@@ -218,7 +219,7 @@ PyTypeObject PyModel_StatGroupType = {
 
 
 
-static int soInit(StatOutputPy_t *self, PyObject *args, PyObject *kwds __attribute__((unused)))
+static int soInit(StatOutputPy_t *self, PyObject *args, PyObject *UNUSED(kwds))
 {
     char *type = NULL;
     PyObject *params = NULL;

--- a/src/sst/core/objectComms.h
+++ b/src/sst/core/objectComms.h
@@ -13,8 +13,11 @@
 #ifndef SST_CORE_OBJECTCOMMS_H
 #define SST_CORE_OBJECTCOMMS_H
 
+#include <sst/core/warnmacros.h>
 #ifdef SST_CONFIG_HAVE_MPI
+DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
+REENABLE_WARNING
 #endif
 
 #include <sst/core/serialization/serializer.h>

--- a/src/sst/core/oneshot.h
+++ b/src/sst/core/oneshot.h
@@ -73,7 +73,7 @@ public:
          *  by the OneShot object to execute the users callback.
          * @param data - The data passed in when the handler was created
          */
-        void operator()() {
+        void operator()() override {
             (object->*member)(data);
         }
     };
@@ -103,7 +103,7 @@ public:
         /** Operator to callback OneShot Handler; called 
          *  by the OneShot object to execute the users callback.
          */
-        void operator()() {
+        void operator()() override {
             (object->*member)();
         }
     };
@@ -125,7 +125,7 @@ public:
     void registerHandler(OneShot::HandlerBase* handler);
 
     /** Print details about the OneShot */
-    void print(const std::string& header, Output &out) const;
+    void print(const std::string& header, Output &out) const override;
     
 private:
     typedef std::vector<OneShot::HandlerBase*>  HandlerList_t;
@@ -135,7 +135,7 @@ private:
     OneShot() { }
 
     // Called by the Simulation (Activity Queue) when delay time as elapsed
-    void execute(void);
+    void execute(void) override;
 
     // Activates this OneShot object, by inserting into the simulation's
     // timeVortex for future execution.

--- a/src/sst/core/output.cc
+++ b/src/sst/core/output.cc
@@ -25,9 +25,12 @@
 
 // Core Headers
 #include "sst/core/simulation.h"
+#include <sst/core/warnmacros.h>
 
 #ifdef SST_CONFIG_HAVE_MPI
+DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
+REENABLE_WARNING
 #endif
 
 namespace SST {

--- a/src/sst/core/params.h
+++ b/src/sst/core/params.h
@@ -522,7 +522,7 @@ public:
     }
 
 
-    void serialize_order(SST::Core::Serialization::serializer &ser) {
+    void serialize_order(SST::Core::Serialization::serializer &ser) override {
         ser & data;
     }    
     

--- a/src/sst/core/part/linpart.cc
+++ b/src/sst/core/part/linpart.cc
@@ -10,13 +10,14 @@
 // distribution.
 
 #include <sst_config.h>
+#include <sst/core/warnmacros.h>
 #include <sst/core/part/linpart.h>
 #include <sst/core/output.h>
 #include <sst/core/configGraph.h>
 
 using namespace std;
 
-SSTLinearPartition::SSTLinearPartition(RankInfo mpiranks, RankInfo my_rank __attribute__((unused)), int verbosity) {
+SSTLinearPartition::SSTLinearPartition(RankInfo mpiranks, RankInfo UNUSED(my_rank), int verbosity) {
 	rankcount = mpiranks;
 	partOutput = new Output("LinearPartition ", verbosity, 0, SST::Output::STDOUT);
 }

--- a/src/sst/core/part/linpart.h
+++ b/src/sst/core/part/linpart.h
@@ -58,10 +58,10 @@ public:
        Performs a partition of an SST simulation configuration
        \param graph The simulation configuration to partition
     */
-    void performPartition(PartitionGraph* graph);
+    void performPartition(PartitionGraph* graph) override;
     
-    bool requiresConfigGraph() { return false; }
-    bool spawnOnAllRanks() { return false; }
+    bool requiresConfigGraph() override { return false; }
+    bool spawnOnAllRanks() override { return false; }
     
     // static SSTPartitioner* allocate(RankInfo total_ranks, RankInfo my_rank, int verbosity) {
     //     return new SSTLinearPartition(total_ranks, my_rank, verbosity);

--- a/src/sst/core/part/rrobin.cc
+++ b/src/sst/core/part/rrobin.cc
@@ -11,6 +11,7 @@
 
 #include <sst_config.h>
 #include "sst/core/part/rrobin.h"
+#include <sst/core/warnmacros.h>
 
 #include <string>
 
@@ -21,7 +22,7 @@ using namespace std;
 namespace SST {
 namespace Partition {
 
-SSTRoundRobinPartition::SSTRoundRobinPartition(RankInfo world_size, RankInfo my_rank __attribute__((unused)), int verbosity __attribute__((unused))) :
+SSTRoundRobinPartition::SSTRoundRobinPartition(RankInfo world_size, RankInfo UNUSED(my_rank), int UNUSED(verbosity)) :
     SSTPartitioner(),
     world_size(world_size)
 {

--- a/src/sst/core/part/rrobin.h
+++ b/src/sst/core/part/rrobin.h
@@ -29,10 +29,10 @@ public:
        Performs a partition of an SST simulation configuration
        \param graph The simulation configuration to partition
     */
-	void performPartition(PartitionGraph* graph);
+	void performPartition(PartitionGraph* graph) override;
 
-    bool requiresConfigGraph() { return false; }
-    bool spawnOnAllRanks() { return false; }
+    bool requiresConfigGraph() override { return false; }
+    bool spawnOnAllRanks() override { return false; }
     
         
     SST_ELI_REGISTER_PARTITIONER(SSTRoundRobinPartition,"sst","roundrobin","Partitions components using a simple round robin scheme based on ComponentID.  Sequential IDs will be placed on different ranks.")

--- a/src/sst/core/part/simplepart.cc
+++ b/src/sst/core/part/simplepart.cc
@@ -11,6 +11,7 @@
 
 #include <sst_config.h>
 #include "sst/core/part/simplepart.h"
+#include <sst/core/warnmacros.h>
 
 #include <string>
 #include <vector>
@@ -24,7 +25,7 @@ using namespace std;
 namespace SST {
 namespace Partition {
 
-SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo my_rank __attribute__((unused)), int verbosity __attribute__((unused))) :
+SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo UNUSED(my_rank), int UNUSED(verbosity)) :
         SSTPartitioner(),
         world_size(total_ranks),
         total_parts(world_size.rank * world_size.thread)

--- a/src/sst/core/part/simplepart.h
+++ b/src/sst/core/part/simplepart.h
@@ -41,10 +41,10 @@ public:
     SimplePartitioner();
     ~SimplePartitioner() {}
 
-    void performPartition(PartitionGraph* graph);
+    void performPartition(PartitionGraph* graph) override;
 
-    bool requiresConfigGraph() { return false; }
-    bool spawnOnAllRanks() { return false; }
+    bool requiresConfigGraph() override { return false; }
+    bool spawnOnAllRanks() override { return false; }
 
     SST_ELI_REGISTER_PARTITIONER(SimplePartitioner,"sst","simple","Simple partitioning scheme which attempts to partition on high latency links while balancing number of components per rank.")
     

--- a/src/sst/core/part/singlepart.cc
+++ b/src/sst/core/part/singlepart.cc
@@ -13,12 +13,13 @@
 
 #include <sst/core/configGraph.h>
 #include <sst/core/part/singlepart.h>
+#include <sst/core/warnmacros.h>
 
 using namespace std;
 
 using namespace SST::Partition;
 
-SSTSinglePartition::SSTSinglePartition(RankInfo total_ranks __attribute__((unused)), RankInfo my_rank __attribute__((unused)), int verbosity __attribute__((unused))) {}
+SSTSinglePartition::SSTSinglePartition(RankInfo UNUSED(total_ranks), RankInfo UNUSED(my_rank), int UNUSED(verbosity)) {}
 
 void SSTSinglePartition::performPartition(PartitionGraph* graph) {
 

--- a/src/sst/core/part/singlepart.h
+++ b/src/sst/core/part/singlepart.h
@@ -40,10 +40,10 @@ public:
        Performs a partition of an SST simulation configuration
        \param graph The simulation configuration to partition
     */
-    void performPartition(PartitionGraph* graph);
+    void performPartition(PartitionGraph* graph) override;
     
-    bool requiresConfigGraph() { return false; }
-    bool spawnOnAllRanks() { return false; }
+    bool requiresConfigGraph() override { return false; }
+    bool spawnOnAllRanks() override { return false; }
     
     
     SST_ELI_REGISTER_PARTITIONER(SSTSinglePartition,"sst","single","Allocates all components to rank 0.  Automatically selected for serial jobs.")

--- a/src/sst/core/part/sstpart.h
+++ b/src/sst/core/part/sstpart.h
@@ -14,6 +14,7 @@
 #define SST_CORE_PART_BASE
 
 #include <sst/core/rankInfo.h>
+#include <sst/core/warnmacros.h>
 
 #include <map>
 
@@ -42,7 +43,7 @@ public:
      * Result of this function is that every ConfigComponent in
      * graph has a Rank applied to it.
      */
-    virtual void performPartition(PartitionGraph* graph __attribute__((unused))) {}
+    virtual void performPartition(PartitionGraph* UNUSED(graph)) {}
 
     /** Function to be overriden by subclasses
      *
@@ -53,7 +54,7 @@ public:
      * Result of this function is that every ConfigComponent in
      * graph has a Rank applied to it.
      */
-    virtual void performPartition(ConfigGraph* graph __attribute__((unused))) {}
+    virtual void performPartition(ConfigGraph* UNUSED(graph)) {}
     
     virtual bool requiresConfigGraph() { return false; }
     

--- a/src/sst/core/part/zoltpart.cc
+++ b/src/sst/core/part/zoltpart.cc
@@ -10,6 +10,7 @@
 // distribution.
 
 #include <sst_config.h>
+#include <sst/core/warnmacros.h>
 #include <sst/core/part/zoltpart.h>
 #include <sst/core/configGraph.h>
 
@@ -21,7 +22,7 @@ using namespace SST;
 static SST::Output* partOutput;
 
 extern "C" {
-static int sst_zoltan_count_vertices(void* data, int* ierr __attribute__((unused))) {
+static int sst_zoltan_count_vertices(void* data, int* UNUSED(ierr)) {
 	int rank = 0;
 	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
@@ -36,9 +37,9 @@ static int sst_zoltan_count_vertices(void* data, int* ierr __attribute__((unused
 	}
 }
 
-static void sst_zoltan_get_vertex_list(void* data, int sizeGID __attribute__((unused)), int sizeLID __attribute__((unused)),
+static void sst_zoltan_get_vertex_list(void* data, int UNUSED(sizeGID), int UNUSED(sizeLID),
 	ZOLTAN_ID_PTR globalIDs, ZOLTAN_ID_PTR localIDs,
-	int wgt_dim __attribute__((unused)), float* obj_wgts, int* ierr) {
+	int UNUSED(wgt_dim), float* obj_wgts, int* ierr) {
 
 	int rank = 0;
 	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -68,8 +69,8 @@ static void sst_zoltan_get_vertex_list(void* data, int sizeGID __attribute__((un
 	}
 }
 
-static void sst_zoltan_get_num_edges_list(void *data, int sizeGID __attribute__((unused)), int sizeLID __attribute__((unused)), int num_obj,
-             ZOLTAN_ID_PTR globalID __attribute__((unused)), ZOLTAN_ID_PTR localID __attribute__((unused)),
+static void sst_zoltan_get_num_edges_list(void *data, int UNUSED(sizeGID), int UNUSED(sizeLID), int num_obj,
+             ZOLTAN_ID_PTR UNUSED(globalID), ZOLTAN_ID_PTR UNUSED(localID),
              int *numEdges, int *ierr) {
 
  	int rank = 0;
@@ -107,11 +108,11 @@ static void sst_zoltan_get_num_edges_list(void *data, int sizeGID __attribute__(
 	}
 }
 
-static void sst_zoltan_get_edge_list(void *data, int sizeGID __attribute__((unused)), int sizeLID __attribute__((unused)),
-        int num_obj, ZOLTAN_ID_PTR globalID __attribute__((unused)), ZOLTAN_ID_PTR localID __attribute__((unused)),
+static void sst_zoltan_get_edge_list(void *data, int UNUSED(sizeGID), int UNUSED(sizeLID),
+        int num_obj, ZOLTAN_ID_PTR UNUSED(globalID), ZOLTAN_ID_PTR UNUSED(localID),
         int *num_edges,
         ZOLTAN_ID_PTR nborGID, int *nborProc,
-        int wgt_dim __attribute__((unused)), float *ewgts __attribute__((unused)), int *ierr) {
+        int UNUSED(wgt_dim), float *UNUSED(ewgts), int *ierr) {
 
     int rank = 0;
     MPI_Comm_rank(MPI_COMM_WORLD, & rank);

--- a/src/sst/core/part/zoltpart.h
+++ b/src/sst/core/part/zoltpart.h
@@ -64,11 +64,11 @@ public:
        by Zoltan.
        \param graph An SST partition graph
     */
-    void performPartition(PartitionGraph* graph);
+    void performPartition(PartitionGraph* graph) override;
     
-    bool requiresConfigGraph() { return false; }
+    bool requiresConfigGraph() override { return false; }
     
-    bool spawnOnAllRanks() { return true; }
+    bool spawnOnAllRanks() override { return true; }
     
     SST_ELI_REGISTER_PARTITIONER(SSTZoltanPartition,"sst","zoltan","zoltan parallel partitioner")
 };

--- a/src/sst/core/pollingLinkQueue.h
+++ b/src/sst/core/pollingLinkQueue.h
@@ -26,11 +26,11 @@ public:
     PollingLinkQueue();
     ~PollingLinkQueue();
 
-    bool empty();
-    int size();
-    void insert(Activity* activity);
-    Activity* pop();
-    Activity* front();
+    bool empty() override;
+    int size() override;
+    void insert(Activity* activity) override;
+    Activity* pop() override;
+    Activity* front() override;
     
     
 private:

--- a/src/sst/core/profile.h
+++ b/src/sst/core/profile.h
@@ -13,6 +13,7 @@
 #define SST_CORE_CORE_PROFILE_H
 
 #include <chrono>
+#include <sst/core/warnmacros.h>
 
 namespace SST {
 namespace Core {
@@ -57,13 +58,13 @@ inline ProfData_t now()
     return 0.0;
 }
 
-inline double getElapsed(const ProfData_t &begin __attribute__((unused)), const ProfData_t &end __attribute__((unused)))
+inline double getElapsed(const ProfData_t &UNUSED(begin), const ProfData_t &UNUSED(end))
 {
     return 0.0;
 }
 
 
-inline double getElapsed(const ProfData_t &since __attribute__((unused)))
+inline double getElapsed(const ProfData_t &UNUSED(since))
 {
     return 0.0;
 }

--- a/src/sst/core/rankInfo.h
+++ b/src/sst/core/rankInfo.h
@@ -70,7 +70,7 @@ public:
         return rank >= other.rank;
     }
 
-    void serialize_order(SST::Core::Serialization::serializer &ser)
+    void serialize_order(SST::Core::Serialization::serializer &ser) override
     {
         ser & rank;
         ser & thread;

--- a/src/sst/core/rankSyncParallelSkip.cc
+++ b/src/sst/core/rankSyncParallelSkip.cc
@@ -10,6 +10,7 @@
 // distribution.
 
 #include "sst_config.h"
+#include <sst/core/warnmacros.h>
 #include "sst/core/rankSyncParallelSkip.h"
 
 #include "sst/core/serialization/serializer.h"
@@ -23,9 +24,9 @@
 #include "sst/core/profile.h"
 
 #ifdef SST_CONFIG_HAVE_MPI
-#define UNUSED_WO_MPI
+#define UNUSED_WO_MPI(x) x
 #else
-#define UNUSED_WO_MPI __attribute__((unused))
+#define UNUSED_WO_MPI(x) UNUSED(x)
 #endif
 
 
@@ -37,7 +38,7 @@ SimTime_t RankSyncParallelSkip::myNextSyncTime = 0;
 
 ///// RankSyncParallelSkip class /////
     
-RankSyncParallelSkip::RankSyncParallelSkip(RankInfo num_ranks, TimeConverter* minPartTC __attribute__((unused))) :
+RankSyncParallelSkip::RankSyncParallelSkip(RankInfo num_ranks, TimeConverter* UNUSED(minPartTC)) :
     NewRankSync(),
     mpiWaitTime(0.0),
     deserializeTime(0.0),
@@ -217,7 +218,7 @@ RankSyncParallelSkip::exchange_slave(int thread)
 }
 
 void
-RankSyncParallelSkip::exchange_master(int thread __attribute__((unused)))
+RankSyncParallelSkip::exchange_master(int UNUSED(thread))
 {
     // TraceFunction trace(CALL_INFO_LONG);
     // Simulation::getSimulation()->getSimulationOutput().output("Entering RankSyncParallelSkip::execute()\n");
@@ -395,7 +396,7 @@ RankSyncParallelSkip::exchange_master(int thread __attribute__((unused)))
 }
 
 void
-RankSyncParallelSkip::exchangeLinkInitData(int thread UNUSED_WO_MPI, std::atomic<int>& msg_count UNUSED_WO_MPI)
+RankSyncParallelSkip::exchangeLinkInitData(int UNUSED_WO_MPI(thread), std::atomic<int>& UNUSED_WO_MPI(msg_count))
 {
     // TraceFunction trace(CALL_INFO_LONG);
 #ifdef SST_CONFIG_HAVE_MPI

--- a/src/sst/core/rankSyncParallelSkip.cc
+++ b/src/sst/core/rankSyncParallelSkip.cc
@@ -23,7 +23,6 @@
 #include "sst/core/profile.h"
 
 #ifdef SST_CONFIG_HAVE_MPI
-#include <mpi.h>
 #define UNUSED_WO_MPI
 #else
 #define UNUSED_WO_MPI __attribute__((unused))

--- a/src/sst/core/rankSyncParallelSkip.h
+++ b/src/sst/core/rankSyncParallelSkip.h
@@ -15,11 +15,14 @@
 #include "sst/core/sst_types.h"
 #include <sst/core/syncManager.h>
 #include <sst/core/threadsafe.h>
+#include <sst/core/warnmacros.h>
 
 #include <map>
 
 #ifdef SST_CONFIG_HAVE_MPI
+DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
+REENABLE_WARNING
 #endif   
 
 namespace SST {
@@ -35,17 +38,17 @@ public:
     virtual ~RankSyncParallelSkip();
     
     /** Register a Link which this Sync Object is responsible for */
-    ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, LinkId_t link_id, Link* link);
-    void execute(int thread);
+    ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, LinkId_t link_id, Link* link) override;
+    void execute(int thread) override;
 
     /** Cause an exchange of Initialization Data to occur */
-    void exchangeLinkInitData(int thread, std::atomic<int>& msg_count);
+    void exchangeLinkInitData(int thread, std::atomic<int>& msg_count) override;
     /** Finish link configuration */
-    void finalizeLinkConfigurations();
+    void finalizeLinkConfigurations() override;
 
-    SimTime_t getNextSyncTime() { return myNextSyncTime; }
+    SimTime_t getNextSyncTime() override { return myNextSyncTime; }
     
-    uint64_t getDataSize() const;
+    uint64_t getDataSize() const override;
     
 private:
 

--- a/src/sst/core/rankSyncSerialSkip.cc
+++ b/src/sst/core/rankSyncSerialSkip.cc
@@ -27,9 +27,9 @@
 DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
 REENABLE_WARNING
-#define UNUSED_WO_MPI
+#define UNUSED_WO_MPI(x) x
 #else
-#define UNUSED_WO_MPI __attribute__((unused))
+#define UNUSED_WO_MPI(x) UNUSED(x)
 #endif
 
 
@@ -39,7 +39,7 @@ namespace SST {
 SimTime_t RankSyncSerialSkip::myNextSyncTime = 0;
 
 
-RankSyncSerialSkip::RankSyncSerialSkip(TimeConverter* minPartTC __attribute__((unused))) :
+RankSyncSerialSkip::RankSyncSerialSkip(TimeConverter* UNUSED(minPartTC)) :
     NewRankSync(),
     mpiWaitTime(0.0),
     deserializeTime(0.0)
@@ -64,7 +64,7 @@ RankSyncSerialSkip::~RankSyncSerialSkip()
         Output::getDefaultObject().verbose(CALL_INFO, 1, 0, "RankSyncSerialSkip mpiWait: %lg sec  deserializeWait:  %lg sec\n", mpiWaitTime, deserializeTime);
 }
     
-ActivityQueue* RankSyncSerialSkip::registerLink(const RankInfo& to_rank, const RankInfo& from_rank __attribute__((unused)), LinkId_t link_id, Link* link)
+ActivityQueue* RankSyncSerialSkip::registerLink(const RankInfo& to_rank, const RankInfo& UNUSED(from_rank), LinkId_t link_id, Link* link)
 {
     // TraceFunction trace(CALL_INFO_LONG);
     SyncQueue* queue;
@@ -265,7 +265,7 @@ RankSyncSerialSkip::exchange(void)
 }
 
 void
-RankSyncSerialSkip::exchangeLinkInitData(int thread UNUSED_WO_MPI, std::atomic<int>& msg_count UNUSED_WO_MPI)
+RankSyncSerialSkip::exchangeLinkInitData(int UNUSED_WO_MPI(thread), std::atomic<int>& UNUSED_WO_MPI(msg_count))
 {
     // TraceFunction trace(CALL_INFO_LONG);
 #ifdef SST_CONFIG_HAVE_MPI

--- a/src/sst/core/rankSyncSerialSkip.cc
+++ b/src/sst/core/rankSyncSerialSkip.cc
@@ -22,8 +22,11 @@
 #include "sst/core/timeConverter.h"
 #include "sst/core/profile.h"
 
+#include <sst/core/warnmacros.h>
 #ifdef SST_CONFIG_HAVE_MPI
+DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
+REENABLE_WARNING
 #define UNUSED_WO_MPI
 #else
 #define UNUSED_WO_MPI __attribute__((unused))

--- a/src/sst/core/rankSyncSerialSkip.h
+++ b/src/sst/core/rankSyncSerialSkip.h
@@ -31,17 +31,17 @@ public:
     virtual ~RankSyncSerialSkip();
     
     /** Register a Link which this Sync Object is responsible for */
-    ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, LinkId_t link_id, Link* link);
-    void execute(int thread);
+    ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, LinkId_t link_id, Link* link) override;
+    void execute(int thread) override;
 
     /** Cause an exchange of Initialization Data to occur */
-    void exchangeLinkInitData(int thread, std::atomic<int>& msg_count);
+    void exchangeLinkInitData(int thread, std::atomic<int>& msg_count) override;
     /** Finish link configuration */
-    void finalizeLinkConfigurations();
+    void finalizeLinkConfigurations() override;
 
-    SimTime_t getNextSyncTime() { return myNextSyncTime; }
+    SimTime_t getNextSyncTime() override { return myNextSyncTime; }
     
-    uint64_t getDataSize() const;
+    uint64_t getDataSize() const override;
     
 private:
 

--- a/src/sst/core/rng/marsaglia.h
+++ b/src/sst/core/rng/marsaglia.h
@@ -64,27 +64,27 @@ class MarsagliaRNG : public SSTRandom {
 	/**
 		Generates the next random number as a double in the range 0 to 1.
 	*/
-	double   nextUniform();
+	double   nextUniform() override;
 
 	/**
 		Generates the next random number as an unsigned 32-bit integer.
 	*/
-	uint32_t generateNextUInt32();
+	uint32_t generateNextUInt32() override;
 
 	/**
 		Generates the next random number as an unsigned 64-bit integer.
 	*/
-	uint64_t generateNextUInt64();
+	uint64_t generateNextUInt64() override;
 
 	/**
 		Generates the next number as a signed 64-bit integer.
 	*/
-	int64_t  generateNextInt64();
+	int64_t  generateNextInt64() override;
 
 	/**
 		Generates the next number as a signed 32-bit integer.
 	*/
-    int32_t   generateNextInt32();
+    int32_t   generateNextInt32() override;
     
     /**
 		Seed the XOR RNG

--- a/src/sst/core/rng/mersenne.h
+++ b/src/sst/core/rng/mersenne.h
@@ -50,27 +50,27 @@ class MersenneRNG : public SSTRandom {
 	/**
 		Generates the next random number as a double value between 0 and 1.
 	*/
-	double   nextUniform();
+	double   nextUniform() override;
 
 	/**
 		Generates the next random number as an unsigned 32-bit integer
 	*/
-	uint32_t generateNextUInt32();
+	uint32_t generateNextUInt32() override;
 
 	/**
 		Generates the next random number as an unsigned 64-bit integer
 	*/
-	uint64_t generateNextUInt64();
+	uint64_t generateNextUInt64() override;
 
 	/**
 		Generates the next random number as a signed 64-bit integer
 	*/
-	int64_t  generateNextInt64();
+	int64_t  generateNextInt64() override;
 
 	/**
 		Generates the next random number as a signed 32-bit integer
 	*/
-    	int32_t  generateNextInt32();
+    	int32_t  generateNextInt32() override;
 
     	/**
 		Seed the XOR RNG

--- a/src/sst/core/rng/xorshift.h
+++ b/src/sst/core/rng/xorshift.h
@@ -51,27 +51,27 @@ class XORShiftRNG : public SSTRandom {
 	/**
 		Generates the next random number as a double value between 0 and 1.
 	*/
-	double   nextUniform();
+	double   nextUniform() override;
 
 	/**
 		Generates the next random number as an unsigned 32-bit integer
 	*/
-	uint32_t generateNextUInt32();
+	uint32_t generateNextUInt32() override;
 
 	/**
 		Generates the next random number as an unsigned 64-bit integer
 	*/
-	uint64_t generateNextUInt64();
+	uint64_t generateNextUInt64() override;
 
 	/**
 		Generates the next random number as a signed 64-bit integer
 	*/
-	int64_t  generateNextInt64();
+	int64_t  generateNextInt64() override;
 
 	/**
 		Generates the next random number as a signed 32-bit integer
 	*/
-    int32_t  generateNextInt32();
+    int32_t  generateNextInt32() override;
 
 	/**
 		Seed the XOR RNG

--- a/src/sst/core/serialization/serializable.h
+++ b/src/sst/core/serialization/serializable.h
@@ -13,6 +13,7 @@
 #define SST_CORE_SERIALIZATION_SERIALIZABLE_H
 
 #include <sst/core/serialization/serializer.h>
+#include <sst/core/warnmacros.h>
 #include <unordered_map>
 #include <typeinfo>
 #include <stdint.h>
@@ -116,6 +117,7 @@ public:
     
     virtual uint32_t
     cls_id() const = 0;
+    virtual std::string serialization_name() const = 0;
     
     virtual ~serializable() { }
     
@@ -141,11 +143,11 @@ class serializable_type
      serializable_abort(CALL_INFO_LONG, #obj); \
   } \
   virtual void \
-  serialize_order(SST::Core::Serialization::serializer& sst __attribute__((unused))){    \
+  serialize_order(SST::Core::Serialization::serializer& sst __attribute__((unused))) override {    \
     throw_exc(); \
   } \
   virtual uint32_t \
-  cls_id() const { \
+  cls_id() const override { \
     throw_exc(); \
     return -1; \
   } \
@@ -155,12 +157,12 @@ class serializable_type
     return 0; \
   } \
   virtual std::string \
-  serialization_name() const { \
+  serialization_name() const override { \
     throw_exc(); \
     return ""; \
   } \
   virtual const char* \
-  cls_name() const { \
+  cls_name() const override { \
     throw_exc(); \
     return ""; \
   }
@@ -168,11 +170,11 @@ class serializable_type
 #define ImplementSerializableDefaultConstructor(obj)    \
  public: \
   virtual const char* \
-  cls_name() const { \
+  cls_name() const override { \
     return #obj; \
   } \
   virtual uint32_t \
-  cls_id() const { \
+  cls_id() const override { \
     return SST::Core::Serialization::serializable_builder_impl<obj>::static_cls_id(); \
   }           \
   static obj* \
@@ -180,7 +182,7 @@ class serializable_type
     return new obj; \
   } \
   virtual std::string \
-  serialization_name() const { \
+  serialization_name() const override { \
     return #obj; \
   } \
 private:\
@@ -222,17 +224,17 @@ class serializable_builder_impl : public serializable_builder
 
  public:
   serializable*
-  build() const {
+  build() const override {
       return T::construct_deserialize_stub();
   }
 
   const char*
-  name() const {
+  name() const override {
     return name_;
   }
 
   uint32_t
-  cls_id() const {
+  cls_id() const override {
       return cls_id_;
   }
 
@@ -247,7 +249,7 @@ class serializable_builder_impl : public serializable_builder
   }
     
   bool
-  sanity(serializable* ser) {
+  sanity(serializable* ser) override {
     return (typeid(T) == typeid(*ser));
   }
 };

--- a/src/sst/core/serialization/serializable.h
+++ b/src/sst/core/serialization/serializable.h
@@ -69,7 +69,7 @@ constexpr uint32_t ct_hash_rec(const char* str)
 // End of the recursion (i.e. when you've walked back off the front of
 // the string
 template<>
-constexpr uint32_t ct_hash_rec<size_t(-1)>(const char* str __attribute__((unused)))
+constexpr uint32_t ct_hash_rec<size_t(-1)>(const char* UNUSED(str))
 {
     return 0;
 }
@@ -143,7 +143,7 @@ class serializable_type
      serializable_abort(CALL_INFO_LONG, #obj); \
   } \
   virtual void \
-  serialize_order(SST::Core::Serialization::serializer& sst __attribute__((unused))) override {    \
+  serialize_order(SST::Core::Serialization::serializer& UNUSED(sst)) override {    \
     throw_exc(); \
   } \
   virtual uint32_t \

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -13,6 +13,7 @@
 #define SERIALIZE_H
 
 #include <sst/core/serialization/serializer.h>
+#include <sst/core/warnmacros.h>
 //#include <sprockit/debug.h>
 //DeclareDebugSlot(serialize);
 
@@ -31,7 +32,7 @@ namespace Serialization {
 template <class T, class Enable = void>
 class serialize {
 public:
-    inline void operator()(T& t __attribute__((unused)), serializer& ser __attribute__((unused))){
+    inline void operator()(T& UNUSED(t), serializer& UNUSED(ser)){
         // If the default gets called, then it's actually invalid
         // because we don't know how to serialize it.
         

--- a/src/sst/core/serialization/serialize_buffer_accessor.h
+++ b/src/sst/core/serialization/serialize_buffer_accessor.h
@@ -12,6 +12,7 @@
 #ifndef SERIALIZE_ACCESSOR_H
 #define SERIALIZE_ACCESSOR_H
 
+#include <sst/core/warnmacros.h>
 #include <cstring>
 #include <exception>
 //#include <sst/core/serialization/errors.h>
@@ -24,7 +25,7 @@ namespace pvt {
 // class ser_buffer_overrun : public spkt_error {
 class ser_buffer_overrun : public std::exception {
  public:
-    ser_buffer_overrun(int maxsize __attribute__((unused)))
+    ser_buffer_overrun(int UNUSED(maxsize))
     // ser_buffer_overrun(int maxsize) :
       //spkt_error(sprockit::printf("serialization overrun buffer of size %d", maxsize))
   {

--- a/src/sst/core/serialization/serialize_sizer.h
+++ b/src/sst/core/serialization/serialize_sizer.h
@@ -12,6 +12,7 @@
 #ifndef SERIALIZE_SIZER_H
 #define SERIALIZE_SIZER_H
 
+#include <sst/core/warnmacros.h>
 namespace SST {
 namespace Core {
 namespace Serialization {
@@ -27,7 +28,7 @@ class ser_sizer
 
   template <class T>
   void
-  size(T& t __attribute__((unused))){
+  size(T& UNUSED(t)){
     size_ += sizeof(T);
   }
 

--- a/src/sst/core/sharedRegion.cc
+++ b/src/sst/core/sharedRegion.cc
@@ -11,6 +11,7 @@
 
 
 #include <sst_config.h>
+#include <sst/core/warnmacros.h>
 
 #include <string>
 #include <vector>
@@ -28,7 +29,7 @@
 namespace SST {
 
 
-bool SharedRegionMerger::merge(uint8_t *target __attribute__((unused)), const uint8_t *newData __attribute__((unused)), size_t size __attribute__((unused)))
+bool SharedRegionMerger::merge(uint8_t *UNUSED(target), const uint8_t *UNUSED(newData), size_t UNUSED(size))
 {
     return false;
 }

--- a/src/sst/core/sharedRegion.h
+++ b/src/sst/core/sharedRegion.h
@@ -48,7 +48,7 @@ public:
         defVal = defaultValue;
     }
 
-    bool merge(uint8_t *target, const uint8_t *newData, size_t size);
+    bool merge(uint8_t *target, const uint8_t *newData, size_t size) override;
 
 };
 

--- a/src/sst/core/sharedRegionImpl.h
+++ b/src/sst/core/sharedRegionImpl.h
@@ -13,6 +13,7 @@
 #define SST_CORE_CORE_SHAREDREGIONIMPL_H
 
 #include <sst/core/sst_types.h>
+#include <sst/core/warnmacros.h>
 
 #include <string>
 #include <vector>
@@ -69,7 +70,7 @@ public:
         RegionMergeInfo(int rank, const std::string &key) : rank(rank), key(key) { }
         virtual ~RegionMergeInfo() { }
 
-        virtual bool merge(RegionInfo *ri __attribute__((unused))) { return true; }
+        virtual bool merge(RegionInfo *UNUSED(ri)) { return true; }
         const std::string& getKey() const { return key; }
 
         void serialize_order(SST::Core::Serialization::serializer &ser) override {

--- a/src/sst/core/sharedRegionImpl.h
+++ b/src/sst/core/sharedRegionImpl.h
@@ -37,7 +37,7 @@ public:
     
     ChangeSet(size_t offset, size_t length, /*const*/ uint8_t *data = NULL) : offset(offset), length(length), data(data) { }
 
-    void serialize_order(SST::Core::Serialization::serializer &ser) {
+    void serialize_order(SST::Core::Serialization::serializer &ser) override {
         ser & offset;
         // ser & length;
         // if ( ser.mode() == SST::Core::Serialization::serializer::UNPACK ) {
@@ -72,7 +72,7 @@ public:
         virtual bool merge(RegionInfo *ri __attribute__((unused))) { return true; }
         const std::string& getKey() const { return key; }
 
-        void serialize_order(SST::Core::Serialization::serializer &ser) {
+        void serialize_order(SST::Core::Serialization::serializer &ser) override {
             ser & rank;
             ser & key;
         }    
@@ -92,13 +92,13 @@ public:
             length(length), data(data)
         { }
 
-        bool merge(RegionInfo *ri) {
+        bool merge(RegionInfo *ri) override {
             bool ret = ri->getMerger()->merge((uint8_t*)ri->getMemory(), (const uint8_t*)data, length);
             free(data);
             return ret;
         }
 
-        void serialize_order(SST::Core::Serialization::serializer &ser) {
+        void serialize_order(SST::Core::Serialization::serializer &ser) override {
             RegionInfo::RegionMergeInfo::serialize_order(ser);
 
             ser & length;
@@ -126,11 +126,11 @@ public:
                 std::vector<ChangeSet> & changeSets) : RegionMergeInfo(rank, key),
             changeSets(changeSets)
         { }
-        bool merge(RegionInfo *ri) {
+        bool merge(RegionInfo *ri) override {
             return ri->getMerger()->merge((uint8_t*)ri->getMemory(), ri->getSize(), changeSets);
         }
 
-        void serialize_order(SST::Core::Serialization::serializer &ser) {
+        void serialize_order(SST::Core::Serialization::serializer &ser) override {
             RegionInfo::RegionMergeInfo::serialize_order(ser);
             ser & changeSets;
         }    
@@ -221,22 +221,22 @@ class SharedRegionManagerImpl : public SharedRegionManager {
     std::mutex mtx;
 
 protected:
-    void modifyRegion(SharedRegion *sr, size_t offset, size_t length, const void *data);
-    void* getMemory(SharedRegion *sr);
-    const void* getConstPtr(const SharedRegion *sr) const;
+    void modifyRegion(SharedRegion *sr, size_t offset, size_t length, const void *data) override;
+    void* getMemory(SharedRegion *sr) override;
+    const void* getConstPtr(const SharedRegion *sr) const override;
 
 public:
     SharedRegionManagerImpl();
     ~SharedRegionManagerImpl();
 
-    virtual SharedRegion* getLocalSharedRegion(const std::string &key, size_t size, uint8_t initByte = 0);
-    virtual SharedRegion* getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger = NULL, uint8_t initByte = 0);
+    virtual SharedRegion* getLocalSharedRegion(const std::string &key, size_t size, uint8_t initByte = 0) override;
+    virtual SharedRegion* getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger = NULL, uint8_t initByte = 0) override;
 
-    virtual void publishRegion(SharedRegion*);
-    virtual bool isRegionReady(const SharedRegion*);
-    virtual void shutdownSharedRegion(SharedRegion*);
+    virtual void publishRegion(SharedRegion*) override;
+    virtual bool isRegionReady(const SharedRegion*) override;
+    virtual void shutdownSharedRegion(SharedRegion*) override;
 
-    void updateState(bool finalize);
+    void updateState(bool finalize) override;
 };
 
 

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -12,6 +12,7 @@
 
 #include "sst_config.h"
 #include <sst/core/simulation.h>
+#include <sst/core/warnmacros.h>
 
 #include <utility>
 
@@ -206,7 +207,7 @@ Simulation::getLocalMinimumNextActivityTime()
 }
 
 void
-Simulation::processGraphInfo( ConfigGraph& graph, const RankInfo& myRank __attribute__((unused)), SimTime_t min_part )
+Simulation::processGraphInfo( ConfigGraph& graph, const RankInfo& UNUSED(myRank), SimTime_t min_part )
 {
     // TraceFunction trace(CALL_INFO_LONG);    
     // Set minPartTC (only thread 0 will do this)
@@ -288,7 +289,7 @@ Simulation::processGraphInfo( ConfigGraph& graph, const RankInfo& myRank __attri
     // if ( independent ) std::cout << "thread " << my_rank.thread <<  " is independent" << std::endl;
 }
     
-int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTime_t min_part __attribute__((unused)))
+int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTime_t UNUSED(min_part))
 {
     // TraceFunction trace(CALL_INFO_LONG);    
     
@@ -796,7 +797,7 @@ Statistics::StatisticProcessingEngine* Simulation::getStatisticsProcessingEngine
 
 // Function to allow for easy serialization of threads while debugging
 // code
-void wait_my_turn_start(Core::ThreadSafe::Barrier& barrier, int thread, int total_threads __attribute__((unused))) {
+void wait_my_turn_start(Core::ThreadSafe::Barrier& barrier, int thread, int UNUSED(total_threads)) {
     // Everyone barriers
     barrier.wait();
     // Now barrier until it's my turn

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -10,6 +10,7 @@
 // distribution.
 
 #include <sst_config.h>
+#include <sst/core/warnmacros.h>
 
 #include <cstdio>
 #include <cerrno>
@@ -115,7 +116,7 @@ static void addELI(ElemLoader &loader, const std::string &lib, bool optional)
 }
 
 
-static void processSSTElementFiles(std::string searchPath __attribute__((unused)))
+static void processSSTElementFiles(std::string UNUSED(searchPath))
 {
     std::vector<bool>       EntryProcessedArray;
     ElemLoader              loader(g_searchPath);
@@ -796,7 +797,7 @@ void SSTInfoElement_StatisticInfo::outputStatisticInfo(int index)
     fprintf(stdout, "            STATISTIC %d = %s [%s] (%s) Enable Level = %d\n", index, getName(), getUnits(), getDesc(), getEnableLevel());
 }
 
-void SSTInfoElement_StatisticInfo::generateStatisticXMLData(int Index __attribute__((unused)), TiXmlNode* XMLParentElement __attribute__((unused)))
+void SSTInfoElement_StatisticInfo::generateStatisticXMLData(int UNUSED(Index), TiXmlNode* UNUSED(XMLParentElement))
 {
 // TODO: Dump Statistic info to XML.  Turned off for 5.0 since SSTWorkbench
 //       chokes if format is changed.  

--- a/src/sst/core/statapi/stataccumulator.h
+++ b/src/sst/core/statapi/stataccumulator.h
@@ -14,6 +14,7 @@
 #define _H_SST_CORE_ACCUMULATOR_STATISTIC_
 
 #include <sst/core/sst_types.h>
+#include <sst/core/warnmacros.h>
 
 #include <sst/core/statapi/statbase.h>
 #include <sst/core/statapi/statoutput.h>
@@ -138,7 +139,7 @@ public:
         Field3 = statOutput->registerField<uint64_t>  ("Count");
     }
     
-    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag __attribute__((unused))) override
+    void outputStatisticData(StatisticOutput* statOutput, bool UNUSED(EndOfSimFlag)) override
     {
         statOutput->outputField(Field1, m_sum);
         statOutput->outputField(Field2, m_sum_sq);  

--- a/src/sst/core/statapi/stataccumulator.h
+++ b/src/sst/core/statapi/stataccumulator.h
@@ -61,7 +61,7 @@ protected:
         Present a new value to the class to be included in the statistics.
         @param value New value to be presented
     */
-    void addData_impl(NumberBase value) 
+    void addData_impl(NumberBase value) override
     {
         m_sum += value;
         m_sum_sq += (value * value);
@@ -124,28 +124,28 @@ public:
         return this->getCollectionCount();
     }
     
-    void clearStatisticData()
+    void clearStatisticData() override
     {
         m_sum = 0;
         m_sum_sq =0;
         this->setCollectionCount(0);
     }
     
-    void registerOutputFields(StatisticOutput* statOutput)
+    void registerOutputFields(StatisticOutput* statOutput) override
     {
         Field1 = statOutput->registerField<NumberBase>("Sum");
         Field2 = statOutput->registerField<NumberBase>("SumSQ");
         Field3 = statOutput->registerField<uint64_t>  ("Count");
     }
     
-    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag __attribute__((unused)))
+    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag __attribute__((unused))) override
     {
         statOutput->outputField(Field1, m_sum);
         statOutput->outputField(Field2, m_sum_sq);  
         statOutput->outputField(Field3, getCount());  
     }
     
-    bool isStatModeSupported(StatisticBase::StatMode_t mode) const 
+    bool isStatModeSupported(StatisticBase::StatMode_t mode) const override
     {
         if (mode == StatisticBase::STAT_MODE_COUNT) {
             return true;

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -38,7 +38,7 @@ public:
     StatisticInfo(const std::string &name, const Params &params) : name(name), params(params) { }
     StatisticInfo() { } /* DO NOT USE:  For serialization */
 
-    void serialize_order(SST::Core::Serialization::serializer &ser) {
+    void serialize_order(SST::Core::Serialization::serializer &ser) override {
         ser & name;
         ser & params;
     }

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -15,6 +15,7 @@
 #include <string>
 
 #include <sst/core/sst_types.h>
+#include <sst/core/warnmacros.h>
 #include <sst/core/params.h>
 #include <sst/core/oneshot.h>
 #include <sst/core/statapi/statfieldinfo.h>
@@ -229,7 +230,7 @@ private:
       * by default, both modes are supported.
       * @param mode - Mode to test
       */
-    virtual bool isStatModeSupported(StatMode_t mode __attribute__((unused))) const {return true;}      // Default is to accept all modes
+    virtual bool isStatModeSupported(StatMode_t UNUSED(mode)) const {return true;}      // Default is to accept all modes
 
     /** Verify that the statistic names match */
     bool operator==(StatisticBase& checkStat); 

--- a/src/sst/core/statapi/statengine.cc
+++ b/src/sst/core/statapi/statengine.cc
@@ -11,6 +11,7 @@
 
 #include <sst_config.h>
 
+#include <sst/core/warnmacros.h>
 #include <sst/core/output.h>
 #include <sst/core/factory.h>
 #include <sst/core/timeLord.h>
@@ -494,7 +495,7 @@ void StatisticProcessingEngine::performGlobalStatisticOutput(bool endOfSimFlag /
 
 
 
-bool StatisticProcessingEngine::handleStatisticEngineClockEvent(Cycle_t CycleNum __attribute__((unused)), SimTime_t timeFactor) 
+bool StatisticProcessingEngine::handleStatisticEngineClockEvent(Cycle_t UNUSED(CycleNum), SimTime_t timeFactor) 
 {
     StatArray_t*     statArray;
     StatisticBase*   stat;
@@ -516,7 +517,7 @@ bool StatisticProcessingEngine::handleStatisticEngineClockEvent(Cycle_t CycleNum
 
 
 
-bool StatisticProcessingEngine::handleGroupClockEvent(Cycle_t CycleNum __attribute__((unused)), StatisticGroup *group)
+bool StatisticProcessingEngine::handleGroupClockEvent(Cycle_t UNUSED(CycleNum), StatisticGroup *group)
 {
     m_barrier.wait();
     if ( Simulation::getSimulation()->getRank().thread == 0 ) {
@@ -592,7 +593,7 @@ StatisticBase* StatisticProcessingEngine::isStatisticInCompStatMap(const std::st
     return NULL;
 }
 
-void StatisticProcessingEngine::addStatisticToCompStatMap(StatisticBase* Stat, StatisticFieldInfo::fieldType_t fieldType __attribute__((unused)))
+void StatisticProcessingEngine::addStatisticToCompStatMap(StatisticBase* Stat, StatisticFieldInfo::fieldType_t UNUSED(fieldType))
 {
     StatArray_t*        statArray;
     ComponentId_t compId = Stat->getComponent()->getId();

--- a/src/sst/core/statapi/stathistogram.h
+++ b/src/sst/core/statapi/stathistogram.h
@@ -81,7 +81,7 @@ protected:
         Adds a new value to the histogram. The correct bin is identified and then incremented. If no bin can be found
         to hold the value then a new bin is created.
     */
-    void addData_impl(BinDataType value) 
+    void addData_impl(BinDataType value) override
     {
         // Check to see if the value is above or below the min/max values
         if (value < getBinsMinValue()) {   
@@ -215,7 +215,7 @@ private:
         return m_totalSummedSqr;
     }
 
-    void clearStatisticData()
+    void clearStatisticData() override
     {
         m_totalSummed = 0;
         m_totalSummedSqr = 0;
@@ -226,7 +226,7 @@ private:
         this->setCollectionCount(0);
     }
     
-    void registerOutputFields(StatisticOutput* statOutput)
+    void registerOutputFields(StatisticOutput* statOutput) override
     {
         // Check to see if we have registered the Startup Fields        
         m_Fields.push_back(statOutput->registerField<BinDataType>("BinsMinValue"));
@@ -261,7 +261,7 @@ private:
         }
     }
 
-    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag __attribute__((unused)))
+    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag __attribute__((unused))) override
     {
         uint32_t x = 0;
         statOutput->outputField(m_Fields[x++], getBinsMinValue());
@@ -290,7 +290,7 @@ private:
         }
     }
 
-    bool isStatModeSupported(StatisticBase::StatMode_t mode) const 
+    bool isStatModeSupported(StatisticBase::StatMode_t mode) const override
     {
         if (mode == StatisticBase::STAT_MODE_COUNT) {
             return true;

--- a/src/sst/core/statapi/stathistogram.h
+++ b/src/sst/core/statapi/stathistogram.h
@@ -14,6 +14,7 @@
 #define _H_SST_CORE_HISTOGRAM_STATISTIC_
 
 #include <sst/core/sst_types.h>
+#include <sst/core/warnmacros.h>
 
 #include <sst/core/statapi/statbase.h>
 #include <sst/core/statapi/statoutput.h>
@@ -261,7 +262,7 @@ private:
         }
     }
 
-    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag __attribute__((unused))) override
+    void outputStatisticData(StatisticOutput* statOutput, bool UNUSED(EndOfSimFlag)) override
     {
         uint32_t x = 0;
         statOutput->outputField(m_Fields[x++], getBinsMinValue());

--- a/src/sst/core/statapi/statnull.h
+++ b/src/sst/core/statapi/statnull.h
@@ -14,6 +14,7 @@
 #define _H_SST_CORE_NULL_STATISTIC_
 
 #include <sst/core/sst_types.h>
+#include <sst/core/warnmacros.h>
 
 #include <sst/core/statapi/statbase.h>
 
@@ -55,12 +56,12 @@ public:
         // Do Nothing
     }
 
-    void registerOutputFields(StatisticOutput* statOutput __attribute__((unused))) override
+    void registerOutputFields(StatisticOutput* UNUSED(statOutput)) override
     {
         // Do Nothing
     }
 
-    void outputStatisticData(StatisticOutput* statOutput __attribute__((unused)), bool EndOfSimFlag __attribute__((unused))) override
+    void outputStatisticData(StatisticOutput* UNUSED(statOutput), bool UNUSED(EndOfSimFlag)) override
     {
         // Do Nothing
     }
@@ -76,7 +77,7 @@ public:
     }
 
 protected:
-    void addData_impl(T data __attribute__((unused))) override
+    void addData_impl(T UNUSED(data)) override
     {
         // Do Nothing
     }

--- a/src/sst/core/statapi/statnull.h
+++ b/src/sst/core/statapi/statnull.h
@@ -50,33 +50,33 @@ public:
 
     ~NullStatistic(){};
 
-    void clearStatisticData()
+    void clearStatisticData() override
     {
         // Do Nothing
     }
 
-    void registerOutputFields(StatisticOutput* statOutput __attribute__((unused)))
+    void registerOutputFields(StatisticOutput* statOutput __attribute__((unused))) override
     {
         // Do Nothing
     }
 
-    void outputStatisticData(StatisticOutput* statOutput __attribute__((unused)), bool EndOfSimFlag __attribute__((unused)))
+    void outputStatisticData(StatisticOutput* statOutput __attribute__((unused)), bool EndOfSimFlag __attribute__((unused))) override
     {
         // Do Nothing
     }
 
-    bool isReady() const
+    bool isReady() const override
     {
         return true;
     }
 
-    bool isNullStatistic() const
+    bool isNullStatistic() const override
     {
         return true;
     }
 
 protected:
-    void addData_impl(T data __attribute__((unused)))
+    void addData_impl(T data __attribute__((unused))) override
     {
         // Do Nothing
     }

--- a/src/sst/core/statapi/statoutput.h
+++ b/src/sst/core/statapi/statoutput.h
@@ -13,6 +13,7 @@
 #define _H_SST_CORE_STATISTICS_OUTPUT
 
 #include "sst/core/sst_types.h"
+#include <sst/core/warnmacros.h>
 #include <sst/core/module.h>
 #include <sst/core/params.h>
 #include <sst/core/statapi/statfieldinfo.h>
@@ -175,8 +176,8 @@ protected:
     virtual void printUsage() = 0;
 
 
-    virtual void implStartRegisterFields(StatisticBase *statistic __attribute__((unused))) {}
-    virtual void implRegisteredField(fieldHandle_t fieldHandle __attribute__((unused))) {}
+    virtual void implStartRegisterFields(StatisticBase *UNUSED(statistic)) {}
+    virtual void implRegisteredField(fieldHandle_t UNUSED(fieldHandle)) {}
     virtual void implStopRegisterFields() {}
 
     // Simulation Events
@@ -197,9 +198,9 @@ protected:
       * Allows object to perform any cleanup. */ 
     virtual void implStopOutputEntries() = 0;
 
-    virtual void implStartRegisterGroup(StatisticGroup* group __attribute__((unused))) {}
+    virtual void implStartRegisterGroup(StatisticGroup* UNUSED(group)) {}
     virtual void implStopRegisterGroup() {}
-    virtual void implStartOutputGroup(StatisticGroup* group __attribute__((unused))) {}
+    virtual void implStartOutputGroup(StatisticGroup* UNUSED(group)) {}
     virtual void implStopOutputGroup() {}
     // Field Outputs
     /** Implementation of outputField() for derived classes.  

--- a/src/sst/core/statapi/statoutputconsole.h
+++ b/src/sst/core/statapi/statoutputconsole.h
@@ -37,20 +37,20 @@ protected:
     /** Perform a check of provided parameters
      * @return True if all required parameters and options are acceptable 
      */
-    bool checkOutputParameters();
+    bool checkOutputParameters() override;
     
     /** Print out usage for this Statistic Output */
-    void printUsage();
+    void printUsage() override;
     
     /** Indicate to Statistic Output that simulation started.
      *  Statistic output may perform any startup code here as necessary. 
      */
-    void startOfSimulation(); 
+    void startOfSimulation() override;
 
     /** Indicate to Statistic Output that simulation ended.
      *  Statistic output may perform any shutdown code here as necessary. 
      */
-    void endOfSimulation(); 
+    void endOfSimulation() override;
 
     /** Implementation function for the start of output.
      * This will be called by the Statistic Processing Engine to indicate that  
@@ -58,14 +58,14 @@ protected:
      * @param statistic - Pointer to the statistic object than the output can 
      * retrieve data from.
      */
-    void implStartOutputEntries(StatisticBase* statistic); 
+    void implStartOutputEntries(StatisticBase* statistic) override;
     
     /** Implementation function for the end of output.
      * This will be called by the Statistic Processing Engine to indicate that  
      * a Statistic is finished sendind data to the Statistic Output for processing.
      * The Statisic Output can perform any output related functions here.
      */
-    void implStopOutputEntries(); 
+    void implStopOutputEntries() override;
 
     /** Implementation functions for output.
      * These will be called by the statistic to provide Statistic defined 
@@ -73,12 +73,12 @@ protected:
      * @param fieldHandle - The handle to the registered statistic field.
      * @param data - The data related to the registered field to be output.
      */
-    void implOutputField(fieldHandle_t fieldHandle, int32_t data);
-    void implOutputField(fieldHandle_t fieldHandle, uint32_t data);
-    void implOutputField(fieldHandle_t fieldHandle, int64_t data);
-    void implOutputField(fieldHandle_t fieldHandle, uint64_t data); 
-    void implOutputField(fieldHandle_t fieldHandle, float data);
-    void implOutputField(fieldHandle_t fieldHandle, double data);
+    void implOutputField(fieldHandle_t fieldHandle, int32_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, uint32_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, int64_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, uint64_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, float data) override;
+    void implOutputField(fieldHandle_t fieldHandle, double data) override;
 
 protected: 
     StatisticOutputConsole() {;} // For serialization

--- a/src/sst/core/statapi/statoutputcsv.h
+++ b/src/sst/core/statapi/statoutputcsv.h
@@ -40,20 +40,20 @@ protected:
     /** Perform a check of provided parameters
      * @return True if all required parameters and options are acceptable 
      */
-    bool checkOutputParameters();
+    bool checkOutputParameters() override;
     
     /** Print out usage for this Statistic Output */
-    void printUsage();
+    void printUsage() override;
     
     /** Indicate to Statistic Output that simulation started.
      *  Statistic output may perform any startup code here as necessary. 
      */
-    void startOfSimulation(); 
+    void startOfSimulation() override;
 
     /** Indicate to Statistic Output that simulation ended.
      *  Statistic output may perform any shutdown code here as necessary. 
      */
-    void endOfSimulation(); 
+    void endOfSimulation() override;
 
     /** Implementation function for the start of output.
      * This will be called by the Statistic Processing Engine to indicate that  
@@ -61,14 +61,14 @@ protected:
      * @param statistic - Pointer to the statistic object than the output can 
      * retrieve data from.
      */
-    void implStartOutputEntries(StatisticBase* statistic); 
+    void implStartOutputEntries(StatisticBase* statistic) override;
     
     /** Implementation function for the end of output.
      * This will be called by the Statistic Processing Engine to indicate that  
      * a Statistic is finished sendind data to the Statistic Output for processing.
      * The Statisic Output can perform any output related functions here.
      */
-    void implStopOutputEntries(); 
+    void implStopOutputEntries() override;
 
     /** Implementation functions for output.
      * These will be called by the statistic to provide Statistic defined 
@@ -76,12 +76,12 @@ protected:
      * @param fieldHandle - The handle to the registered statistic field.
      * @param data - The data related to the registered field to be output.
      */
-    void implOutputField(fieldHandle_t fieldHandle, int32_t data);
-    void implOutputField(fieldHandle_t fieldHandle, uint32_t data);
-    void implOutputField(fieldHandle_t fieldHandle, int64_t data);
-    void implOutputField(fieldHandle_t fieldHandle, uint64_t data); 
-    void implOutputField(fieldHandle_t fieldHandle, float data);
-    void implOutputField(fieldHandle_t fieldHandle, double data);
+    void implOutputField(fieldHandle_t fieldHandle, int32_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, uint32_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, int64_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, uint64_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, float data) override;
+    void implOutputField(fieldHandle_t fieldHandle, double data) override;
 
 protected:
     StatisticOutputCSV() {;} // For serialization

--- a/src/sst/core/statapi/statoutputhdf5.cc
+++ b/src/sst/core/statapi/statoutputhdf5.cc
@@ -12,6 +12,7 @@
 #include <sst_config.h>
 
 #include <sst/core/simulation.h>
+#include <sst/core/warnmacros.h>
 #include <sst/core/baseComponent.h>
 #include <sst/core/statapi/statoutputhdf5.h>
 #include <sst/core/statapi/statgroup.h>
@@ -209,7 +210,7 @@ StatisticOutputHDF5::StatisticInfo* StatisticOutputHDF5::getStatisticInfo(Statis
 
 
 
-void StatisticOutputHDF5::StatisticInfo::startNewEntry(StatisticBase *stat __attribute__((unused)))
+void StatisticOutputHDF5::StatisticInfo::startNewEntry(StatisticBase *UNUSED(stat))
 {
     for ( StatData_u &i : currentData ) {
         memset(&i, '\0', sizeof(i));
@@ -600,7 +601,7 @@ void StatisticOutputHDF5::GroupInfo::GroupStat::startNewGroupEntry() {
 }
 
 
-void StatisticOutputHDF5::GroupInfo::GroupStat::startNewEntry(size_t componentIndex, StatisticBase *stat __attribute__((unused)))
+void StatisticOutputHDF5::GroupInfo::GroupStat::startNewEntry(size_t componentIndex, StatisticBase *UNUSED(stat))
 {
     currentCompOffset = componentIndex * registeredFields.size();
 }

--- a/src/sst/core/statapi/statoutputhdf5.h
+++ b/src/sst/core/statapi/statoutputhdf5.h
@@ -15,8 +15,12 @@
 #include "sst/core/sst_types.h"
 
 #include <sst/core/statapi/statoutput.h>
+#include <sst/core/warnmacros.h>
 
+DISABLE_WARN_MISSING_OVERRIDE
 #include "H5Cpp.h"
+REENABLE_WARNING
+
 #include <map>
 #include <string>
 
@@ -36,32 +40,32 @@ public:
      */
     StatisticOutputHDF5(Params& outputParameters);
 
-    bool acceptsGroups() const { return true; }
+    bool acceptsGroups() const override { return true; }
 protected:
     /** Perform a check of provided parameters
      * @return True if all required parameters and options are acceptable
      */
-    bool checkOutputParameters();
+    bool checkOutputParameters() override;
 
     /** Print out usage for this Statistic Output */
-    void printUsage();
+    void printUsage() override;
 
-    void implStartRegisterFields(StatisticBase *stat);
-    void implRegisteredField(fieldHandle_t fieldHandle);
-    void implStopRegisterFields();
+    void implStartRegisterFields(StatisticBase *stat) override;
+    void implRegisteredField(fieldHandle_t fieldHandle) override;
+    void implStopRegisterFields() override;
 
-    void implStartRegisterGroup(StatisticGroup* group );
-    void implStopRegisterGroup();
+    void implStartRegisterGroup(StatisticGroup* group ) override;
+    void implStopRegisterGroup() override;
 
     /** Indicate to Statistic Output that simulation started.
      *  Statistic output may perform any startup code here as necessary.
      */
-    void startOfSimulation();
+    void startOfSimulation() override;
 
     /** Indicate to Statistic Output that simulation ended.
      *  Statistic output may perform any shutdown code here as necessary.
      */
-    void endOfSimulation();
+    void endOfSimulation() override;
 
     /** Implementation function for the start of output.
      * This will be called by the Statistic Processing Engine to indicate that
@@ -69,17 +73,17 @@ protected:
      * @param statistic - Pointer to the statistic object than the output can
      * retrieve data from.
      */
-    void implStartOutputEntries(StatisticBase* statistic);
+    void implStartOutputEntries(StatisticBase* statistic) override;
 
     /** Implementation function for the end of output.
      * This will be called by the Statistic Processing Engine to indicate that
      * a Statistic is finished sendind data to the Statistic Output for processing.
      * The Statisic Output can perform any output related functions here.
      */
-    void implStopOutputEntries();
+    void implStopOutputEntries() override;
 
-    void implStartOutputGroup(StatisticGroup* group);
-    void implStopOutputGroup();
+    void implStartOutputGroup(StatisticGroup* group) override;
+    void implStopOutputGroup() override;
 
     /** Implementation functions for output.
      * These will be called by the statistic to provide Statistic defined
@@ -87,12 +91,12 @@ protected:
      * @param fieldHandle - The handle to the registered statistic field.
      * @param data - The data related to the registered field to be output.
      */
-    void implOutputField(fieldHandle_t fieldHandle, int32_t data);
-    void implOutputField(fieldHandle_t fieldHandle, uint32_t data);
-    void implOutputField(fieldHandle_t fieldHandle, int64_t data);
-    void implOutputField(fieldHandle_t fieldHandle, uint64_t data);
-    void implOutputField(fieldHandle_t fieldHandle, float data);
-    void implOutputField(fieldHandle_t fieldHandle, double data);
+    void implOutputField(fieldHandle_t fieldHandle, int32_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, uint32_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, int64_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, uint64_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, float data) override;
+    void implOutputField(fieldHandle_t fieldHandle, double data) override;
 
 protected:
     StatisticOutputHDF5() {;} // For serialization
@@ -159,13 +163,13 @@ private:
             if ( dataset ) delete dataset;
             if ( memType ) delete memType;
         }
-        void registerField(StatisticFieldInfo *fi);
-        void finalizeCurrentStatistic();
+        void registerField(StatisticFieldInfo *fi) override;
+        void finalizeCurrentStatistic() override;
 
-        bool isGroup() const { return false; }
-        void startNewEntry(StatisticBase *stat);
-        StatData_u& getFieldLoc(fieldHandle_t fieldHandle);
-        void finishEntry();
+        bool isGroup() const override { return false; }
+        void startNewEntry(StatisticBase *stat) override;
+        StatData_u& getFieldLoc(fieldHandle_t fieldHandle) override;
+        void finishEntry() override;
     };
 
     class GroupInfo : public DataSet {
@@ -210,19 +214,19 @@ private:
 
     public:
         GroupInfo(StatisticGroup *group, H5::H5File *file);
-        void beginGroupRegistration(StatisticGroup *group __attribute__((unused))) { }
-        void setCurrentStatistic(StatisticBase *stat);
-        void registerField(StatisticFieldInfo *fi);
-        void finalizeCurrentStatistic();
-        void finalizeGroupRegistration();
+        void beginGroupRegistration(StatisticGroup *group __attribute__((unused))) override { }
+        void setCurrentStatistic(StatisticBase *stat) override;
+        void registerField(StatisticFieldInfo *fi) override;
+        void finalizeCurrentStatistic() override;
+        void finalizeGroupRegistration() override;
 
-        bool isGroup() const { return true; }
-        void startNewEntry(StatisticBase *stat);
-        StatData_u& getFieldLoc(fieldHandle_t fieldHandle) { return m_currentStat->getFieldLoc(fieldHandle); }
-        void finishEntry();
+        bool isGroup() const override { return true; }
+        void startNewEntry(StatisticBase *stat) override;
+        StatData_u& getFieldLoc(fieldHandle_t fieldHandle) override { return m_currentStat->getFieldLoc(fieldHandle); }
+        void finishEntry() override;
 
-        void startNewGroupEntry();
-        void finishGroupEntry();
+        void startNewGroupEntry() override;
+        void finishGroupEntry() override;
         size_t getNumComponents() const { return m_components.size(); }
 
         const std::string& getName() const { return m_statGroup->name; }

--- a/src/sst/core/statapi/statoutputhdf5.h
+++ b/src/sst/core/statapi/statoutputhdf5.h
@@ -120,11 +120,11 @@ private:
         H5::H5File* getFile() { return file; }
         virtual bool isGroup() const = 0;
 
-        virtual void setCurrentStatistic(StatisticBase *stat __attribute__((unused))) { }
+        virtual void setCurrentStatistic(StatisticBase *UNUSED(stat)) { }
         virtual void registerField(StatisticFieldInfo *fi) = 0;
         virtual void finalizeCurrentStatistic() = 0;
 
-        virtual void beginGroupRegistration(StatisticGroup *group __attribute__((unused))) { }
+        virtual void beginGroupRegistration(StatisticGroup *UNUSED(group)) { }
         virtual void finalizeGroupRegistration() { }
 
 
@@ -214,7 +214,7 @@ private:
 
     public:
         GroupInfo(StatisticGroup *group, H5::H5File *file);
-        void beginGroupRegistration(StatisticGroup *group __attribute__((unused))) override { }
+        void beginGroupRegistration(StatisticGroup *UNUSED(group)) override { }
         void setCurrentStatistic(StatisticBase *stat) override;
         void registerField(StatisticFieldInfo *fi) override;
         void finalizeCurrentStatistic() override;

--- a/src/sst/core/statapi/statoutputtxt.h
+++ b/src/sst/core/statapi/statoutputtxt.h
@@ -40,20 +40,20 @@ protected:
     /** Perform a check of provided parameters
      * @return True if all required parameters and options are acceptable 
      */
-    bool checkOutputParameters();
+    bool checkOutputParameters() override;
     
     /** Print out usage for this Statistic Output */
-    void printUsage();
+    void printUsage() override;
     
     /** Indicate to Statistic Output that simulation started.
      *  Statistic output may perform any startup code here as necessary. 
      */
-    void startOfSimulation(); 
+    void startOfSimulation() override;
 
     /** Indicate to Statistic Output that simulation ended.
      *  Statistic output may perform any shutdown code here as necessary. 
      */
-    void endOfSimulation(); 
+    void endOfSimulation() override;
 
     /** Implementation function for the start of output.
      * This will be called by the Statistic Processing Engine to indicate that  
@@ -61,14 +61,14 @@ protected:
      * @param statistic - Pointer to the statistic object than the output can 
      * retrieve data from.
      */
-    void implStartOutputEntries(StatisticBase* statistic); 
+    void implStartOutputEntries(StatisticBase* statistic) override;
     
     /** Implementation function for the end of output.
      * This will be called by the Statistic Processing Engine to indicate that  
      * a Statistic is finished sendind data to the Statistic Output for processing.
      * The Statisic Output can perform any output related functions here.
      */
-    void implStopOutputEntries(); 
+    void implStopOutputEntries() override;
 
     /** Implementation functions for output.
      * These will be called by the statistic to provide Statistic defined 
@@ -76,12 +76,12 @@ protected:
      * @param fieldHandle - The handle to the registered statistic field.
      * @param data - The data related to the registered field to be output.
      */
-    void implOutputField(fieldHandle_t fieldHandle, int32_t data);
-    void implOutputField(fieldHandle_t fieldHandle, uint32_t data);
-    void implOutputField(fieldHandle_t fieldHandle, int64_t data);
-    void implOutputField(fieldHandle_t fieldHandle, uint64_t data); 
-    void implOutputField(fieldHandle_t fieldHandle, float data);
-    void implOutputField(fieldHandle_t fieldHandle, double data);
+    void implOutputField(fieldHandle_t fieldHandle, int32_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, uint32_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, int64_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, uint64_t data) override;
+    void implOutputField(fieldHandle_t fieldHandle, float data) override;
+    void implOutputField(fieldHandle_t fieldHandle, double data) override;
 
 protected:
     StatisticOutputTxt() {;} // For serialization

--- a/src/sst/core/statapi/statuniquecount.h
+++ b/src/sst/core/statapi/statuniquecount.h
@@ -14,6 +14,7 @@
 #define _H_SST_CORE_UNIQUE_COUNT_STATISTIC_
 
 #include <sst/core/sst_types.h>
+#include <sst/core/warnmacros.h>
 
 #include <sst/core/statapi/statbase.h>
 
@@ -63,7 +64,7 @@ private:
 	uniqueCountField = statOutput->registerField<uint64_t>("UniqueItems");
     }
 
-    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag __attribute__((unused))) override
+    void outputStatisticData(StatisticOutput* statOutput, bool UNUSED(EndOfSimFlag)) override
     {
 	statOutput->outputField(uniqueCountField, (uint64_t) uniqueSet.size());
     }

--- a/src/sst/core/statapi/statuniquecount.h
+++ b/src/sst/core/statapi/statuniquecount.h
@@ -48,22 +48,22 @@ protected:
 	Present a new value to the Statistic to be included in the unique set
         @param data New data item to be included in the unique set
     */
-    void addData_impl(T data) {
+    void addData_impl(T data) override {
 	uniqueSet.insert(data);
     }
 
 private:
-    void clearStatisticData()
+    void clearStatisticData() override
     {
 	uniqueSet.clear();
     }
 
-    void registerOutputFields(StatisticOutput* statOutput)
+    void registerOutputFields(StatisticOutput* statOutput) override
     {
 	uniqueCountField = statOutput->registerField<uint64_t>("UniqueItems");
     }
 
-    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag __attribute__((unused)))
+    void outputStatisticData(StatisticOutput* statOutput, bool EndOfSimFlag __attribute__((unused))) override
     {
 	statOutput->outputField(uniqueCountField, (uint64_t) uniqueSet.size());
     }

--- a/src/sst/core/stopAction.h
+++ b/src/sst/core/stopAction.h
@@ -44,14 +44,14 @@ public:
         message = msg;
     }
 
-    void execute() {
+    void execute() override {
         if ( print_message ) {
             Output::getDefaultObject().output("%s\n", message.c_str());
         }
         endSimulation();
     }
 
-    void print(const std::string &header, Output &out) const {
+    void print(const std::string &header, Output &out) const override {
         out.output("%s StopAction to be delivered at %" PRIu64 "\n", header.c_str(), getDeliveryTime());
     }
 

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -13,6 +13,7 @@
 #ifndef SST_CORE_SUBCOMPONENT_H
 #define SST_CORE_SUBCOMPONENT_H
 
+#include <sst/core/warnmacros.h>
 #include <sst/core/baseComponent.h>
 #include <sst/core/component.h>
 #include <sst/core/module.h>
@@ -36,7 +37,7 @@ public:
 
     /** Used during the init phase.  The method will be called each phase of initialization.
      Initialization ends when no components have sent any data. */
-    virtual void init(unsigned int phase __attribute__((unused))) override {}
+    virtual void init(unsigned int UNUSED(phase)) override {}
     /** Called after all components have been constructed and inialization has
 	completed, but before simulation time has begun. */
     virtual void setup( ) override { }

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -36,19 +36,19 @@ public:
 
     /** Used during the init phase.  The method will be called each phase of initialization.
      Initialization ends when no components have sent any data. */
-    virtual void init(unsigned int phase __attribute__((unused))) {}
+    virtual void init(unsigned int phase __attribute__((unused))) override {}
     /** Called after all components have been constructed and inialization has
 	completed, but before simulation time has begun. */
-    virtual void setup( ) { }
+    virtual void setup( ) override { }
     /** Called after simulation completes, but before objects are
         destroyed. A good place to print out statistics. */
-    virtual void finish( ) { }
+    virtual void finish( ) override { }
 
 protected:
     Component* const parent;
 
-    Component* getTrueComponent() const final { return parent; }
-    BaseComponent* getStatisticOwner() const final {
+    Component* getTrueComponent() const final override { return parent; }
+    BaseComponent* getStatisticOwner() const final override {
         /* If our ID == parent ID, then we're a legacy subcomponent that doesn't own stats. */
         if ( this->getId() == parent->getId() )
             return parent;
@@ -61,7 +61,7 @@ protected:
     }
 
     // Does the statisticName exist in the ElementInfoStatistic
-    virtual bool doesComponentInfoStatisticExist(const std::string &statisticName) const final;
+    virtual bool doesComponentInfoStatisticExist(const std::string &statisticName) const final override;
 
 private:
     /** Component's type, set by the factory when the object is created.

--- a/src/sst/core/syncManager.cc
+++ b/src/sst/core/syncManager.cc
@@ -40,17 +40,17 @@ public:
     ~EmptyRankSync() {}
 
     /** Register a Link which this Sync Object is responsible for */
-    ActivityQueue* registerLink(const RankInfo& to_rank __attribute__((unused)), const RankInfo& from_rank __attribute__((unused)), LinkId_t link_id __attribute__((unused)), Link* link __attribute__((unused))) { return NULL; }
+    ActivityQueue* registerLink(const RankInfo& to_rank __attribute__((unused)), const RankInfo& from_rank __attribute__((unused)), LinkId_t link_id __attribute__((unused)), Link* link __attribute__((unused))) override { return NULL; }
 
-    void execute(int thread __attribute__((unused))) {}
-    void exchangeLinkInitData(int thread __attribute__((unused)), std::atomic<int>& msg_count __attribute__((unused))) {}
-    void finalizeLinkConfigurations() {}
+    void execute(int thread __attribute__((unused))) override {}
+    void exchangeLinkInitData(int thread __attribute__((unused)), std::atomic<int>& msg_count __attribute__((unused))) override {}
+    void finalizeLinkConfigurations() override {}
 
-    SimTime_t getNextSyncTime() { return nextSyncTime; }
+    SimTime_t getNextSyncTime() override { return nextSyncTime; }
 
     TimeConverter* getMaxPeriod() {return max_period;}
 
-    uint64_t getDataSize() const { return 0; }    
+    uint64_t getDataSize() const override { return 0; }
 };
 
 class EmptyThreadSync : public NewThreadSync {
@@ -60,15 +60,15 @@ public:
     }
     ~EmptyThreadSync() {}
 
-    void before() {}
-    void after() {}
-    void execute() {}
-    void processLinkInitData() {}
-    void finalizeLinkConfigurations() {}
+    void before() override {}
+    void after() override {}
+    void execute() override {}
+    void processLinkInitData() override {}
+    void finalizeLinkConfigurations() override {}
 
     /** Register a Link which this Sync Object is responsible for */
-    void registerLink(LinkId_t link_id __attribute__((unused)), Link* link __attribute__((unused))) {}
-    ActivityQueue* getQueueForThread(int tid __attribute__((unused))) { return NULL; }
+    void registerLink(LinkId_t link_id __attribute__((unused)), Link* link __attribute__((unused))) override {}
+    ActivityQueue* getQueueForThread(int tid __attribute__((unused))) override { return NULL; }
 };
 
 

--- a/src/sst/core/syncManager.cc
+++ b/src/sst/core/syncManager.cc
@@ -11,6 +11,7 @@
 
 #include "sst_config.h"
 
+#include <sst/core/warnmacros.h>
 #include "sst/core/syncManager.h"
 
 #include "sst/core/exit.h"
@@ -40,10 +41,10 @@ public:
     ~EmptyRankSync() {}
 
     /** Register a Link which this Sync Object is responsible for */
-    ActivityQueue* registerLink(const RankInfo& to_rank __attribute__((unused)), const RankInfo& from_rank __attribute__((unused)), LinkId_t link_id __attribute__((unused)), Link* link __attribute__((unused))) override { return NULL; }
+    ActivityQueue* registerLink(const RankInfo& UNUSED(to_rank), const RankInfo& UNUSED(from_rank), LinkId_t UNUSED(link_id), Link* UNUSED(link)) override { return NULL; }
 
-    void execute(int thread __attribute__((unused))) override {}
-    void exchangeLinkInitData(int thread __attribute__((unused)), std::atomic<int>& msg_count __attribute__((unused))) override {}
+    void execute(int UNUSED(thread)) override {}
+    void exchangeLinkInitData(int UNUSED(thread), std::atomic<int>& UNUSED(msg_count)) override {}
     void finalizeLinkConfigurations() override {}
 
     SimTime_t getNextSyncTime() override { return nextSyncTime; }
@@ -67,12 +68,12 @@ public:
     void finalizeLinkConfigurations() override {}
 
     /** Register a Link which this Sync Object is responsible for */
-    void registerLink(LinkId_t link_id __attribute__((unused)), Link* link __attribute__((unused))) override {}
-    ActivityQueue* getQueueForThread(int tid __attribute__((unused))) override { return NULL; }
+    void registerLink(LinkId_t UNUSED(link_id), Link* UNUSED(link)) override {}
+    ActivityQueue* getQueueForThread(int UNUSED(tid)) override { return NULL; }
 };
 
 
-SyncManager::SyncManager(const RankInfo& rank, const RankInfo& num_ranks, TimeConverter* minPartTC, SimTime_t min_part, const std::vector<SimTime_t>& interThreadLatencies __attribute__((unused))) :
+SyncManager::SyncManager(const RankInfo& rank, const RankInfo& num_ranks, TimeConverter* minPartTC, SimTime_t min_part, const std::vector<SimTime_t>& UNUSED(interThreadLatencies)) :
     Action(),
     rank(rank),
     num_ranks(num_ranks),

--- a/src/sst/core/syncManager.h
+++ b/src/sst/core/syncManager.h
@@ -107,14 +107,14 @@ public:
 
     /** Register a Link which this Sync Object is responsible for */
     ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, LinkId_t link_id, Link* link);
-    void execute(void);
+    void execute(void) override;
 
     /** Cause an exchange of Initialization Data to occur */
     void exchangeLinkInitData(std::atomic<int>& msg_count);
     /** Finish link configuration */
     void finalizeLinkConfigurations();
 
-    void print(const std::string& header, Output &out) const;
+    void print(const std::string& header, Output &out) const override;
 
     uint64_t getDataSize() const;
 

--- a/src/sst/core/syncQueue.h
+++ b/src/sst/core/syncQueue.h
@@ -40,11 +40,11 @@ public:
     SyncQueue();
     ~SyncQueue();
 
-    bool empty();
-    int size();
-    void insert(Activity* activity);
-    Activity* pop(); // Not a good idea for this particular class
-    Activity* front();
+    bool empty() override;
+    int size() override;
+    void insert(Activity* activity) override;
+    Activity* pop() override; // Not a good idea for this particular class
+    Activity* front() override;
 
     // Not part of the ActivityQueue interface
     /** Clear elements from the queue */

--- a/src/sst/core/threadSync.h
+++ b/src/sst/core/threadSync.h
@@ -44,7 +44,7 @@ public:
     void registerLink(LinkId_t link_id, Link* link);
     ActivityQueue* getQueueForThread(int tid);
 
-    void execute(void);
+    void execute(void) override;
 
     /** Cause an exchange of Initialization Data to occur */
     void processLinkInitData();
@@ -53,7 +53,7 @@ public:
 
     uint64_t getDataSize() const;
 
-    void print(const std::string& header, Output &out) const;
+    void print(const std::string& header, Output &out) const override;
 
     static void disable() { disabled = true; barrier.disable(); }
 

--- a/src/sst/core/threadSyncQueue.h
+++ b/src/sst/core/threadSyncQueue.h
@@ -27,28 +27,28 @@ public:
     ~ThreadSyncQueue() {}
 
     /** Returns true if the queue is empty */
-    bool empty() {
+    bool empty() override {
         return activities.empty();
     }
     
     /** Returns the number of activities in the queue */
-    int size() {
+    int size() override {
         return activities.size();
     }
     
     /** Not supported */
-    Activity* pop() {
+    Activity* pop() override {
         // Need to fatal
         return NULL;
     }
     
     /** Insert a new activity into the queue */
-    void insert(Activity* activity) {
+    void insert(Activity* activity) override {
         activities.push_back(activity);
     }
     
     /** Not supported */
-    Activity* front() {
+    Activity* front() override {
         // Need to fatal
         return NULL;
     }

--- a/src/sst/core/threadSyncSimpleSkip.h
+++ b/src/sst/core/threadSyncSimpleSkip.h
@@ -38,18 +38,18 @@ public:
 
     void setMaxPeriod(TimeConverter* period);
     
-    void before();
-    void after();
-    void execute(void);
+    void before() override;
+    void after() override;
+    void execute(void) override;
 
     /** Cause an exchange of Initialization Data to occur */
-    void processLinkInitData();
+    void processLinkInitData() override;
     /** Finish link configuration */
-    void finalizeLinkConfigurations();
+    void finalizeLinkConfigurations() override;
 
     /** Register a Link which this Sync Object is responsible for */
-    void registerLink(LinkId_t link_id, Link* link);
-    ActivityQueue* getQueueForThread(int tid);
+    void registerLink(LinkId_t link_id, Link* link) override;
+    ActivityQueue* getQueueForThread(int tid) override;
 
     uint64_t getDataSize() const;
 

--- a/src/sst/core/timeLord.cc
+++ b/src/sst/core/timeLord.cc
@@ -11,6 +11,7 @@
 
 
 #include "sst_config.h"
+#include <sst/core/warnmacros.h>
 #include <sst/core/timeLord.h>
 
 #include <cstdio>
@@ -104,7 +105,7 @@ TimeLord::~TimeLord() {
     parseCache.clear();
 }
 
-SimTime_t TimeLord::getSimCycles(std::string ts, std::string where __attribute__((unused)))
+SimTime_t TimeLord::getSimCycles(std::string ts, std::string UNUSED(where))
 {
     // See if this is in the cache
     std::lock_guard<std::recursive_mutex> lock(slock);

--- a/src/sst/core/timeVortex.h
+++ b/src/sst/core/timeVortex.h
@@ -30,11 +30,11 @@ public:
 	TimeVortex();
     ~TimeVortex();
 
-    bool empty();
-    int size();
-    void insert(Activity* activity);
-    Activity* pop();
-    Activity* front();
+    bool empty() override;
+    int size() override;
+    void insert(Activity* activity) override;
+    Activity* pop() override;
+    Activity* front() override;
 
     /** Print the state of the TimeVortex */
     void print(Output &out) const;

--- a/src/sst/core/tinyxml/tinyxml.h
+++ b/src/sst/core/tinyxml/tinyxml.h
@@ -38,6 +38,9 @@ distribution.
 #include <string.h>
 #include <assert.h>
 
+#include <sst/core/warnmacros.h>
+DISABLE_WARN_MISSING_OVERRIDE
+
 // Help out windows:
 #if defined( _DEBUG ) && !defined( DEBUG )
 #define DEBUG
@@ -1800,5 +1803,7 @@ private:
 #ifdef _MSC_VER
 #pragma warning( pop )
 #endif
+
+REENABLE_WARNING
 
 #endif

--- a/src/sst/core/uninitializedQueue.cc
+++ b/src/sst/core/uninitializedQueue.cc
@@ -14,6 +14,7 @@
 
 #include <ostream>
 
+#include <sst/core/warnmacros.h>
 #include <sst/core/uninitializedQueue.h>
 
 namespace SST {
@@ -38,7 +39,7 @@ namespace SST {
 	abort();
     }
     
-    void UninitializedQueue::insert(Activity* activity __attribute__((unused)))
+    void UninitializedQueue::insert(Activity* UNUSED(activity))
     {
 	std::cout << message << std::endl;
 	abort();

--- a/src/sst/core/uninitializedQueue.h
+++ b/src/sst/core/uninitializedQueue.h
@@ -30,11 +30,11 @@ public:
     UninitializedQueue(); // Only used for serialization
     ~UninitializedQueue();
 
-    bool empty();
-    int size();
-    void insert(Activity* activity);
-    Activity* pop();
-    Activity* front();
+    bool empty() override;
+    int size() override;
+    void insert(Activity* activity) override;
+    Activity* pop() override;
+    Activity* front() override;
 
 
 private:

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -23,16 +23,11 @@
 #include <vector>
 #include <mutex>
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-register"
-#endif
+#include <sst/core/warnmacros.h>
 
+DISABLE_WARN_DEPRECATED_REGISTER
 #include <boost/multiprecision/cpp_dec_float.hpp>
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+REENABLE_WARNING
 
 #include <boost/version.hpp>
 
@@ -191,7 +186,7 @@ public:
     /** Return the rounded value as a 64bit integer */
     int64_t getRoundedValue() const;
 
-    void serialize_order(SST::Core::Serialization::serializer &ser) {
+    void serialize_order(SST::Core::Serialization::serializer &ser) override {
         // Do the unit
         ser & unit.numerator;
         ser & unit.denominator;

--- a/src/sst/core/warnmacros.h
+++ b/src/sst/core/warnmacros.h
@@ -1,0 +1,69 @@
+// -*- c++ -*-
+
+// Copyright 2009-2017 Sandia Corporation. Under the terms
+// of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2017, Sandia Corporation
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_WARNMACROS_H
+#define SST_CORE_WARNMACROS_H
+
+
+#define UNUSED(x) x __attribute__((unused))
+
+
+#define DIAG_STR(s) #s
+#define DIAG_JOINSTR(x,y) DIAG_STR(x ## y)
+#define DIAG_DO_PRAGMA(x) _Pragma(#x)
+#define DIAG_PRAGMA(compiler,x) DIAG_DO_PRAGMA(compiler diagnostic x)
+
+
+#define DIAG_DISABLE(option) \
+    DIAG_PRAGMA(DIAG_COMPILER,push) \
+    DIAG_PRAGMA(DIAG_COMPILER,ignored DIAG_JOINSTR(-W,option))
+
+#define REENABLE_WARNING \
+    DIAG_PRAGMA(DIAG_COMPILER,pop)
+
+#if defined(__clang__)
+#define DIAG_COMPILER clang
+
+
+#define DISABLE_WARN_DEPRECATED_REGISTER \
+    DIAG_DISABLE(deprecated-register)
+
+#define DISABLE_WARN_STRICT_ALIASING \
+    DIAG_DISABLE(strict-aliasing)
+
+#define DISABLE_WARN_MISSING_OVERRIDE \
+    DIAG_DISABLE(inconsistent-missing-override)
+
+
+#elif defined(__GNUC__)
+#define DIAG_COMPILER GCC
+
+#define DISABLE_WARN_DEPRECATED_REGISTER
+
+#define DISABLE_WARN_STRICT_ALIASING \
+    DIAG_DISABLE(strict-aliasing)
+
+#define DISABLE_WARN_MISSING_OVERRIDE \
+    DIAG_DISABLE(suggest-override)
+
+
+#else
+
+#undef REENABLE_WARNING
+#define REENABLE_WARNING
+#define DISABLE_WARN_DEPRECATED_REGISTER
+#define DISABLE_WARN_STRICT_ALIASING
+#define DISABLE_WARN_MISSING_OVERRIDE
+#endif
+
+#endif


### PR DESCRIPTION
- Address Issue #153 
- Create a header file (`sst/core/warnmacros.h`) to simplify toggling warnings off and on
- Add override keyword wherever g++-6.3 wants it with `-Wsuggest-override`

'sst-elements' may want to conditionally set compiler flags to silence override warnings that crop up, until all elements have proper override keyword:  `Wno-suggest-override` for gcc, `-Wno-inconsistent-missing-override` for clang.