### PR TITLE
Add some missing includes, and squelch warning on GCC 4

### DIFF
--- a/src/sst/core/sharedRegion.cc
+++ b/src/sst/core/sharedRegion.cc
@@ -13,6 +13,7 @@
 #include <sst_config.h>
 #include <sst/core/warnmacros.h>
 
+#include <unistd.h>
 #include <string>
 #include <vector>
 #include <set>

--- a/src/sst/core/statapi/statgroup.cc
+++ b/src/sst/core/statapi/statgroup.cc
@@ -11,6 +11,8 @@
 
 #include <sst_config.h>
 
+#include <algorithm>
+
 #include <sst/core/statapi/statgroup.h>
 #include <sst/core/statapi/statbase.h>
 #include <sst/core/statapi/statengine.h>

--- a/src/sst/core/statapi/statoutputhdf5.cc
+++ b/src/sst/core/statapi/statoutputhdf5.cc
@@ -11,6 +11,8 @@
 
 #include <sst_config.h>
 
+#include <algorithm>
+
 #include <sst/core/simulation.h>
 #include <sst/core/warnmacros.h>
 #include <sst/core/baseComponent.h>

--- a/src/sst/core/warnmacros.h
+++ b/src/sst/core/warnmacros.h
@@ -53,9 +53,12 @@
 #define DISABLE_WARN_STRICT_ALIASING \
     DIAG_DISABLE(strict-aliasing)
 
+#if (__GNUC__ >= 5)
 #define DISABLE_WARN_MISSING_OVERRIDE \
     DIAG_DISABLE(suggest-override)
-
+#else
+#define DISABLE_WARN_MISSING_OVERRIDE
+#endif
 
 #else
 


### PR DESCRIPTION
GCC 4.x does not understand `-Wsuggest-override`.  Don't bother putting that in.
Adding includes that appear to be needed.  Not sure why they're showing up now, and not before.