### PR TITLE
Changes to new ELI

### DIFF
--- a/src/sst/core/elementinfo.h
+++ b/src/sst/core/elementinfo.h
@@ -267,12 +267,9 @@ class checkForELI_getParamsFunction
     typedef char Match;
     typedef long NotMatch;
 
-    struct FunctionSignature
-    {
-        typedef const std::vector<ElementInfoParam>& (*function)();
-    };
+    typedef const std::vector<ElementInfoParam>& (*functionsig)();
 
-    template <typename F> static Match HasFunction(check< typename FunctionSignature::function, &F::ELI_getParams >*);
+    template <typename F> static Match HasFunction(check<functionsig, &F::ELI_getParams >*);
     template <typename F> static NotMatch HasFunction(...);
 
 public:
@@ -283,14 +280,12 @@ public:
 template<class T>
 typename std::enable_if<checkForELI_getParamsFunction<T>::value, const std::vector<ElementInfoParam>& >::type
 ELI_templatedGetParams() {
-    // std::cout << "Match for params of type " << typeid(T).name() << std::endl;
     return T::ELI_getParams();
 }
 
 template<class T>
 typename std::enable_if<not checkForELI_getParamsFunction<T>::value, std::vector<ElementInfoParam>& >::type
 ELI_templatedGetParams() {
-    // std::cout << "Not match for paramsof type " << typeid(T).name() << std::endl;
     static std::vector<ElementInfoParam> var;
     return var;
 }
@@ -307,12 +302,9 @@ class checkForELI_getStatisticsFunction
     typedef char Match;
     typedef long NotMatch;
 
-    struct FunctionSignature
-    {
-        typedef const std::vector<ElementInfoStatistic>& (*function)();
-    };
+    typedef const std::vector<ElementInfoStatistic>& (*functionsig)();
 
-    template <typename F> static Match HasFunction(check< typename FunctionSignature::function, &F::ELI_getStatistics>*);
+    template <typename F> static Match HasFunction(check<functionsig, &F::ELI_getStatistics>*);
     template <typename F> static NotMatch HasFunction(...);
 
 public:
@@ -322,14 +314,12 @@ public:
 template<class T>
 typename std::enable_if<checkForELI_getStatisticsFunction<T>::value, const std::vector<ElementInfoStatistic>& >::type
 ELI_templatedGetStatistics() {
-    // std::cout << "Match for stats of type " << typeid(T).name() << std::endl;
     return T::ELI_getStatistics();
 }
 
 template<class T>
 typename std::enable_if<not checkForELI_getStatisticsFunction<T>::value, const std::vector<ElementInfoStatistic>& >::type
 ELI_templatedGetStatistics() {
-    // std::cout << "Not match for stats of type " << typeid(T).name() << std::endl;
     static std::vector<ElementInfoStatistic> var;
     return var;
 }
@@ -346,12 +336,9 @@ class checkForELI_getPortsFunction
     typedef char Match;
     typedef long NotMatch;
 
-    struct FunctionSignature
-    {
-        typedef const std::vector<ElementInfoPort2>& (*function)();
-    };
+    typedef const std::vector<ElementInfoPort2>& (*functionsig)();
 
-    template <typename F> static Match HasFunction(check< typename FunctionSignature::function, &F::ELI_getPorts>*);
+    template <typename F> static Match HasFunction(check<functionsig, &F::ELI_getPorts>*);
     template <typename F> static NotMatch HasFunction(...);
 
 public:
@@ -361,14 +348,12 @@ public:
 template<class T>
 typename std::enable_if<checkForELI_getPortsFunction<T>::value, const std::vector<ElementInfoPort2>& >::type
 ELI_templatedGetPorts() {
-    // std::cout << "Match for ports of type " << typeid(T).name() << std::endl;
     return T::ELI_getPorts();
 }
 
 template<class T>
 typename std::enable_if<not checkForELI_getPortsFunction<T>::value, const std::vector<ElementInfoPort2>& >::type
 ELI_templatedGetPorts() {
-    // std::cout << "Not match for ports of type " << typeid(T).name() << std::endl;
     static std::vector<ElementInfoPort2> var;
     return var;
 }
@@ -385,12 +370,9 @@ class checkForELI_getSubComponentSlotsFunction
     typedef char Match;
     typedef long NotMatch;
 
-    struct FunctionSignature
-    {
-        typedef const std::vector<ElementInfoSubComponentSlot>& (*function)();
-    };
+    typedef const std::vector<ElementInfoSubComponentSlot>& (*functionsig)();
 
-    template <typename F> static Match HasFunction(check< typename FunctionSignature::function, &F::ELI_getSubComponentSlots>*);
+    template <typename F> static Match HasFunction(check<functionsig, &F::ELI_getSubComponentSlots>*);
     template <typename F> static NotMatch HasFunction(...);
 
 public:
@@ -400,14 +382,12 @@ public:
 template<class T>
 typename std::enable_if<checkForELI_getSubComponentSlotsFunction<T>::value, const std::vector<ElementInfoSubComponentSlot>& >::type
 ELI_templatedGetSubComponentSlots() {
-    std::cout << "Match for slots of type " << typeid(T).name() << std::endl;
     return T::ELI_getSubComponentSlots();
 }
 
 template<class T>
 typename std::enable_if<not checkForELI_getSubComponentSlotsFunction<T>::value, const std::vector<ElementInfoSubComponentSlot>& >::type
 ELI_templatedGetSubComponentSlots() {
-    std::cout << "Not match for slots of type " << typeid(T).name() << std::endl;
     static std::vector<ElementInfoSubComponentSlot> var;
     return var;
 }
@@ -424,12 +404,9 @@ class checkForELI_CustomCreateFunctionforComponent
     typedef char Match;
     typedef long NotMatch;
 
-    struct FunctionSignature
-    {
-        typedef Component* (*function)(ComponentId_t, Params&);
-    };
+    typedef Component* (*functionsig)(ComponentId_t, Params&);
 
-    template <typename F> static Match HasFunction(check< typename FunctionSignature::function, &F::ELI_CustomCreate>*);
+    template <typename F> static Match HasFunction(check<functionsig, &F::ELI_CustomCreate>*);
     template <typename F> static NotMatch HasFunction(...);
 
 public:
@@ -439,14 +416,12 @@ public:
 template<class T>
 typename std::enable_if<checkForELI_CustomCreateFunctionforComponent<T>::value, Component* >::type
 ELI_templatedCreateforComponent(ComponentId_t id, Params& params) {
-    std::cout << "Match for custom create of type " << typeid(T).name() << std::endl;
     return T::ELI_CustomCreate(id, params);
 }
 
 template<class T>
 typename std::enable_if<not checkForELI_CustomCreateFunctionforComponent<T>::value, Component* >::type
 ELI_templatedCreateforComponent(ComponentId_t id, Params& params) {
-    std::cout << "Not match for custom create of type " << typeid(T).name() << std::endl;
     return new T(id, params);
 }
 
@@ -476,14 +451,12 @@ public:
 template<class T>
 typename std::enable_if<checkForELI_CustomCreateFunctionforSubComponent<T>::value, SubComponent* >::type
 ELI_templatedCreateforSubComponent(Component* comp, Params& params) {
-    std::cout << "Match for custom create of type " << typeid(T).name() << std::endl;
     return T::ELI_CustomCreate(comp, params);
 }
 
 template<class T>
 typename std::enable_if<not checkForELI_CustomCreateFunctionforSubComponent<T>::value, SubComponent* >::type
 ELI_templatedCreateforSubComponent(Component* comp, Params& params) {
-    std::cout << "Not match for custom create of type " << typeid(T).name() << std::endl;
     return new T(comp, params);
 }
 
@@ -532,7 +505,7 @@ template <class T>
 class ComponentDoc : public ComponentElementInfo {
 private:
     static const bool loaded;
-    
+
 public:
 
     ComponentDoc() : ComponentElementInfo() {
@@ -562,6 +535,7 @@ public:
 };
 
 
+// template<class T, int A> const bool SST::ComponentDoc<T, A>::loaded = SST::ElementLibraryDatabase::addComponent(new SST::ComponentDoc<T,T::ELI_getMajorVersion()>());
 template<class T> const bool SST::ComponentDoc<T>::loaded = SST::ElementLibraryDatabase::addComponent(new SST::ComponentDoc<T>());
 
 
@@ -801,9 +775,28 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
     }
 
 
-#define SST_ELI_REGISTER_COMPONENT(cls,lib,name,desc,cat) \
+// #define SST_ELI_REGISTER_COMPONENT(cls,lib,name,desc,cat) \
+//     bool ELI_isLoaded() {                           \
+//         return SST::ComponentDoc<cls>::isLoaded(); \
+//     } \
+//     static const std::string ELI_getLibrary() { \
+//       return lib; \
+//     } \
+//     static const std::string ELI_getName() { \
+//       return name; \
+//     } \
+//     static const std::string ELI_getDescription() {  \
+//       return desc; \
+//     } \
+//     static const uint32_t ELI_getCategory() {  \
+//       return cat; \
+//     } \
+//     SST_ELI_INSERT_COMPILE_INFO()
+
+// For now, description and category will be unavailable
+#define SST_ELI_REGISTER_COMPONENT(cls,lib,name,...)    \
     bool ELI_isLoaded() {                           \
-        return SST::ComponentDoc<cls>::isLoaded();     \
+        return SST::ComponentDoc<cls>::isLoaded(); \
     } \
     static const std::string ELI_getLibrary() { \
       return lib; \
@@ -812,19 +805,26 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
       return name; \
     } \
     static const std::string ELI_getDescription() {  \
-      return desc; \
+      return "Description temporarily unavailable"; \
     } \
     static const uint32_t ELI_getCategory() {  \
-      return cat; \
+      return COMPONENT_CATEGORY_UNCATEGORIZED; \
+    } \
+    static const std::vector<int>& ELI_getVersion() { \
+        static std::vector<int> var = { 0, 0, 0 } ; \
+        return var; \
     } \
     SST_ELI_INSERT_COMPILE_INFO()
 
 
-#define SST_ELI_DOCUMENT_VERSION(major,minor,tertiary)  \
-    static const std::vector<int>& ELI_getVersion() { \
-        static std::vector<int> var = { major, minor, tertiary } ; \
-        return var; \
-    }
+// #define SST_ELI_DOCUMENT_VERSION(major,minor,tertiary)  \
+//     static const std::vector<int>& ELI_getVersion() { \
+//         static std::vector<int> var = { major, minor, tertiary } ; \
+//         return var; \
+//     }
+
+#define SST_ELI_DOCUMENT_VERSION(major,minor,tertiary)
+
 
 #define SST_ELI_DOCUMENT_PARAMS(...)                              \
     static const std::vector<SST::ElementInfoParam>& ELI_getParams() { \
@@ -853,7 +853,27 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
     }
 
 
-#define SST_ELI_REGISTER_SUBCOMPONENT(cls,lib,name,desc,interface)   \
+// #define SST_ELI_REGISTER_SUBCOMPONENT(cls,lib,name,desc,interface)   \
+//     bool ELI_isLoaded() {                           \
+//       return SST::SubComponentDoc<cls>::isLoaded(); \
+//     } \
+//     static const std::string ELI_getLibrary() { \
+//       return lib; \
+//     } \
+//     static const std::string ELI_getName() { \
+//       return name; \
+//     } \
+//     static const std::string ELI_getDescription() {  \
+//       return desc; \
+//     } \
+//     static const std::string ELI_getInterface() {  \
+//       return interface; \
+//     } \
+//     SST_ELI_INSERT_COMPILE_INFO()
+
+
+// Description and interface will be temporarily unavailable
+#define SST_ELI_REGISTER_SUBCOMPONENT(cls,lib,name,...)   \
     bool ELI_isLoaded() {                           \
       return SST::SubComponentDoc<cls>::isLoaded(); \
     } \
@@ -864,16 +884,40 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
       return name; \
     } \
     static const std::string ELI_getDescription() {  \
-      return desc; \
+      return "Description temporarily unavailable"; \
     } \
     static const std::string ELI_getInterface() {  \
-      return interface; \
+                                                 return "Interface temporarily unavailable"; \
+    } \
+    static const std::vector<int>& ELI_getVersion() { \
+        static std::vector<int> var = { 0, 0, 0 } ; \
+        return var; \
     } \
     SST_ELI_INSERT_COMPILE_INFO()
 
 
+// #define SST_ELI_REGISTER_MODULE(cls,lib,name,desc,interface) \
+//     friend class SST::ModuleDoc<cls>; \
+//     bool ELI_isLoaded() {                           \
+//       return SST::ModuleDoc<cls>::isLoaded(); \
+//     } \
+//     static const std::string ELI_getLibrary() { \
+//       return lib; \
+//     } \
+//     static const std::string ELI_getName() { \
+//       return name; \
+//     } \
+//     static const std::string ELI_getDescription() {  \
+//     return desc; \
+//     } \
+//     static const std::string ELI_getInterface() {  \
+//         return interface;                          \
+//     } \
+//     SST_ELI_INSERT_COMPILE_INFO()
 
-#define SST_ELI_REGISTER_MODULE(cls,lib,name,desc,interface) \
+
+// Description and interface will be temporarily unavailable
+#define SST_ELI_REGISTER_MODULE(cls,lib,name,...)  \
     friend class SST::ModuleDoc<cls>; \
     bool ELI_isLoaded() {                           \
       return SST::ModuleDoc<cls>::isLoaded(); \
@@ -885,16 +929,37 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
       return name; \
     } \
     static const std::string ELI_getDescription() {  \
-      return desc; \
+      return "Description temporarily unavailable"; \
     } \
     static const std::string ELI_getInterface() {  \
-      return interface; \
+        return "Interface temporarily unavailable"; \
+    } \
+    static const std::vector<int>& ELI_getVersion() { \
+        static std::vector<int> var = { 0, 0, 0 } ; \
+        return var; \
     } \
     SST_ELI_INSERT_COMPILE_INFO()
 
 
 
-#define SST_ELI_REGISTER_PARTITIONER(cls,lib,name,desc) \
+// #define SST_ELI_REGISTER_PARTITIONER(cls,lib,name,desc) \
+//     friend class SST::PartitionerDoc<cls>; \
+//     bool ELI_isLoaded() { \
+//       return SST::PartitionerDoc<cls>::isLoaded(); \
+//     } \
+//     static const std::string ELI_getLibrary() { \
+//       return lib; \
+//     } \
+//     static const std::string ELI_getName() { \
+//       return name; \
+//     } \
+//     static const std::string ELI_getDescription() {  \
+//       return desc; \
+//     } \
+//     SST_ELI_INSERT_COMPILE_INFO()
+
+// Description wiil be temporarily unavailable
+#define SST_ELI_REGISTER_PARTITIONER(cls,lib,name,...) \
     friend class SST::PartitionerDoc<cls>; \
     bool ELI_isLoaded() { \
       return SST::PartitionerDoc<cls>::isLoaded(); \
@@ -906,11 +971,25 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
       return name; \
     } \
     static const std::string ELI_getDescription() {  \
-      return desc; \
+      return "Description temporarily unavailable"; \
+    } \
+    static const std::vector<int>& ELI_getVersion() { \
+        static std::vector<int> var = { 0, 0, 0 } ; \
+        return var; \
     } \
     SST_ELI_INSERT_COMPILE_INFO()
     
 
+
+// #define SST_ELI_REGISTER_PYTHON_MODULE(cls,lib) \
+//     friend class SST::PythonModuleDoc<cls>; \
+//     bool ELI_isLoaded() { \
+//       return SST::PythonModuleDoc<cls>::isLoaded(); \
+//     } \
+//     static const std::string ELI_getLibrary() { \
+//       return lib; \
+//     } \
+//     SST_ELI_INSERT_COMPILE_INFO()
 
 #define SST_ELI_REGISTER_PYTHON_MODULE(cls,lib) \
     friend class SST::PythonModuleDoc<cls>; \
@@ -919,6 +998,10 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
     } \
     static const std::string ELI_getLibrary() { \
       return lib; \
+    } \
+    static const std::vector<int>& ELI_getVersion() { \
+        static std::vector<int> var = { 0, 0, 0 } ; \
+        return var; \
     } \
     SST_ELI_INSERT_COMPILE_INFO()
 

--- a/src/sst/core/elementinfo.h
+++ b/src/sst/core/elementinfo.h
@@ -824,7 +824,7 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
 //         return var; \
 //     }
 
-#define SST_ELI_DOCUMENT_VERSION(major,minor,tertiary) static_assert(0,"ouch");
+#define SST_ELI_DOCUMENT_VERSION(major,minor,tertiary)
 
 
 #define SST_ELI_DOCUMENT_PARAMS(...)                              \

--- a/src/sst/core/elementinfo.h
+++ b/src/sst/core/elementinfo.h
@@ -795,6 +795,7 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
 
 // For now, description and category will be unavailable
 #define SST_ELI_REGISTER_COMPONENT(cls,lib,name,...)    \
+    friend class SST::ComponentDoc<cls>; \
     bool ELI_isLoaded() {                           \
         return SST::ComponentDoc<cls>::isLoaded(); \
     } \
@@ -874,6 +875,7 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
 
 // Description and interface will be temporarily unavailable
 #define SST_ELI_REGISTER_SUBCOMPONENT(cls,lib,name,...)   \
+    friend class SST::SubComponentDoc<cls>; \
     bool ELI_isLoaded() {                           \
       return SST::SubComponentDoc<cls>::isLoaded(); \
     } \

--- a/src/sst/core/elementinfo.h
+++ b/src/sst/core/elementinfo.h
@@ -257,6 +257,273 @@ public:
 
 
 /**************************************************************************
+  Class to check for an ELI_getParams Function
+**************************************************************************/
+template <class T>
+class checkForELI_getParamsFunction
+{
+    template <typename F, F> struct check;
+
+    typedef char Match;
+    typedef long NotMatch;
+
+    struct FunctionSignature
+    {
+        typedef const std::vector<ElementInfoParam>& (*function)();
+    };
+
+    template <typename F> static Match HasFunction(check< typename FunctionSignature::function, &F::ELI_getParams >*);
+    template <typename F> static NotMatch HasFunction(...);
+
+public:
+    static bool const value = (sizeof(HasFunction<T>(0)) == sizeof(Match) );
+};
+
+
+template<class T>
+typename std::enable_if<checkForELI_getParamsFunction<T>::value, const std::vector<ElementInfoParam>& >::type
+ELI_templatedGetParams() {
+    // std::cout << "Match for params of type " << typeid(T).name() << std::endl;
+    return T::ELI_getParams();
+}
+
+template<class T>
+typename std::enable_if<not checkForELI_getParamsFunction<T>::value, std::vector<ElementInfoParam>& >::type
+ELI_templatedGetParams() {
+    // std::cout << "Not match for paramsof type " << typeid(T).name() << std::endl;
+    static std::vector<ElementInfoParam> var;
+    return var;
+}
+
+
+/**************************************************************************
+  Class to check for an ELI_getStatistics Function
+**************************************************************************/
+template <class T>
+class checkForELI_getStatisticsFunction
+{
+    template <typename F, F> struct check;
+
+    typedef char Match;
+    typedef long NotMatch;
+
+    struct FunctionSignature
+    {
+        typedef const std::vector<ElementInfoStatistic>& (*function)();
+    };
+
+    template <typename F> static Match HasFunction(check< typename FunctionSignature::function, &F::ELI_getStatistics>*);
+    template <typename F> static NotMatch HasFunction(...);
+
+public:
+    static bool const value = (sizeof(HasFunction<T>(0)) == sizeof(Match) );
+};
+
+template<class T>
+typename std::enable_if<checkForELI_getStatisticsFunction<T>::value, const std::vector<ElementInfoStatistic>& >::type
+ELI_templatedGetStatistics() {
+    // std::cout << "Match for stats of type " << typeid(T).name() << std::endl;
+    return T::ELI_getStatistics();
+}
+
+template<class T>
+typename std::enable_if<not checkForELI_getStatisticsFunction<T>::value, const std::vector<ElementInfoStatistic>& >::type
+ELI_templatedGetStatistics() {
+    // std::cout << "Not match for stats of type " << typeid(T).name() << std::endl;
+    static std::vector<ElementInfoStatistic> var;
+    return var;
+}
+
+
+/**************************************************************************
+  Class to check for an ELI_getPorts Function
+**************************************************************************/
+template <class T>
+class checkForELI_getPortsFunction
+{
+    template <typename F, F> struct check;
+
+    typedef char Match;
+    typedef long NotMatch;
+
+    struct FunctionSignature
+    {
+        typedef const std::vector<ElementInfoPort2>& (*function)();
+    };
+
+    template <typename F> static Match HasFunction(check< typename FunctionSignature::function, &F::ELI_getPorts>*);
+    template <typename F> static NotMatch HasFunction(...);
+
+public:
+    static bool const value = (sizeof(HasFunction<T>(0)) == sizeof(Match) );
+};
+
+template<class T>
+typename std::enable_if<checkForELI_getPortsFunction<T>::value, const std::vector<ElementInfoPort2>& >::type
+ELI_templatedGetPorts() {
+    // std::cout << "Match for ports of type " << typeid(T).name() << std::endl;
+    return T::ELI_getPorts();
+}
+
+template<class T>
+typename std::enable_if<not checkForELI_getPortsFunction<T>::value, const std::vector<ElementInfoPort2>& >::type
+ELI_templatedGetPorts() {
+    // std::cout << "Not match for ports of type " << typeid(T).name() << std::endl;
+    static std::vector<ElementInfoPort2> var;
+    return var;
+}
+
+
+/**************************************************************************
+  Class to check for an ELI_getSubComponentSlots Function
+**************************************************************************/
+template <class T>
+class checkForELI_getSubComponentSlotsFunction
+{
+    template <typename F, F> struct check;
+
+    typedef char Match;
+    typedef long NotMatch;
+
+    struct FunctionSignature
+    {
+        typedef const std::vector<ElementInfoSubComponentSlot>& (*function)();
+    };
+
+    template <typename F> static Match HasFunction(check< typename FunctionSignature::function, &F::ELI_getSubComponentSlots>*);
+    template <typename F> static NotMatch HasFunction(...);
+
+public:
+    static bool const value = (sizeof(HasFunction<T>(0)) == sizeof(Match) );
+};
+
+template<class T>
+typename std::enable_if<checkForELI_getSubComponentSlotsFunction<T>::value, const std::vector<ElementInfoSubComponentSlot>& >::type
+ELI_templatedGetSubComponentSlots() {
+    std::cout << "Match for slots of type " << typeid(T).name() << std::endl;
+    return T::ELI_getSubComponentSlots();
+}
+
+template<class T>
+typename std::enable_if<not checkForELI_getSubComponentSlotsFunction<T>::value, const std::vector<ElementInfoSubComponentSlot>& >::type
+ELI_templatedGetSubComponentSlots() {
+    std::cout << "Not match for slots of type " << typeid(T).name() << std::endl;
+    static std::vector<ElementInfoSubComponentSlot> var;
+    return var;
+}
+
+
+/**************************************************************************
+  Class to check for an ELI_CustomCreate Function for Components
+**************************************************************************/
+template <class T>
+class checkForELI_CustomCreateFunctionforComponent
+{
+    template <typename F, F> struct check;
+
+    typedef char Match;
+    typedef long NotMatch;
+
+    struct FunctionSignature
+    {
+        typedef Component* (*function)(ComponentId_t, Params&);
+    };
+
+    template <typename F> static Match HasFunction(check< typename FunctionSignature::function, &F::ELI_CustomCreate>*);
+    template <typename F> static NotMatch HasFunction(...);
+
+public:
+    static bool const value = (sizeof(HasFunction<T>(0)) == sizeof(Match) );
+};
+
+template<class T>
+typename std::enable_if<checkForELI_CustomCreateFunctionforComponent<T>::value, Component* >::type
+ELI_templatedCreateforComponent(ComponentId_t id, Params& params) {
+    std::cout << "Match for custom create of type " << typeid(T).name() << std::endl;
+    return T::ELI_CustomCreate(id, params);
+}
+
+template<class T>
+typename std::enable_if<not checkForELI_CustomCreateFunctionforComponent<T>::value, Component* >::type
+ELI_templatedCreateforComponent(ComponentId_t id, Params& params) {
+    std::cout << "Not match for custom create of type " << typeid(T).name() << std::endl;
+    return new T(id, params);
+}
+
+/**************************************************************************
+  Class to check for an ELI_CustomCreate Function for SubComponents
+**************************************************************************/
+template <class T>
+class checkForELI_CustomCreateFunctionforSubComponent
+{
+    template <typename F, F> struct check;
+
+    typedef char Match;
+    typedef long NotMatch;
+
+    struct FunctionSignature
+    {
+        typedef SubComponent* (*function)(Component*, Params&);
+    };
+
+    template <typename F> static Match HasFunction(check< typename FunctionSignature::function, &F::ELI_CustomCreate>*);
+    template <typename F> static NotMatch HasFunction(...);
+
+public:
+    static bool const value = (sizeof(HasFunction<T>(0)) == sizeof(Match) );
+};
+
+template<class T>
+typename std::enable_if<checkForELI_CustomCreateFunctionforSubComponent<T>::value, SubComponent* >::type
+ELI_templatedCreateforSubComponent(Component* comp, Params& params) {
+    std::cout << "Match for custom create of type " << typeid(T).name() << std::endl;
+    return T::ELI_CustomCreate(comp, params);
+}
+
+template<class T>
+typename std::enable_if<not checkForELI_CustomCreateFunctionforSubComponent<T>::value, SubComponent* >::type
+ELI_templatedCreateforSubComponent(Component* comp, Params& params) {
+    std::cout << "Not match for custom create of type " << typeid(T).name() << std::endl;
+    return new T(comp, params);
+}
+
+
+#if 0
+
+// This has code for looking for non-static class functions
+template <class T>
+class checkForCustomCreateComponent
+{
+    template <typename F, F> struct check;
+
+    typedef char Match;
+    typedef long NotMatch;
+
+    // Used for non-static
+    // template <typename F>
+    // struct FunctionSignature
+    // {
+    //     typedef Component* (F::*function)(ComponentId_t,Params&);
+    // };
+        
+    struct FunctionSignature
+    {
+        typedef Component* (*function)(ComponentId_t,Params&);
+    };
+
+    // Used for non-static functions
+    // template <typename F> static Match HasCustomCreate(check< typename FunctionSignature<F>::function, &F::ELI_Custom_Create >*);
+    template <typename F> static Match HasCustomCreate(check< typename FunctionSignature::function, &F::ELI_Custom_Create >*);
+    template <typename F> static NotMatch HasCustomCreate(...);
+
+public:
+    static bool const value = (sizeof(HasCustomCreate<T>(0)) == sizeof(Match) );
+};
+
+#endif
+
+
+/**************************************************************************
   Classes to support Components
 **************************************************************************/
 
@@ -276,17 +543,17 @@ public:
     
     Component* create(ComponentId_t id, Params& params) {
         // return new T(id, params);
-        return T::ELI_create(id,params);
+        return ELI_templatedCreateforComponent<T>(id,params);
     }
 
     static bool isLoaded() { return loaded; }
     const std::string getLibrary() { return T::ELI_getLibrary(); }
     const std::string getName() { return T::ELI_getName(); }
     const std::string getDescription() { return T::ELI_getDescription(); }
-    const std::vector<ElementInfoParam>& getValidParams() { return T::ELI_getParams(); }
-    const std::vector<ElementInfoStatistic>& getValidStats() { return T::ELI_getStatistics(); }
-    const std::vector<ElementInfoPort2>& getValidPorts() { return T::ELI_getPorts(); }
-    const std::vector<ElementInfoSubComponentSlot>& getSubComponentSlots() { return T::ELI_getSubComponentSlots(); }
+    const std::vector<ElementInfoParam>& getValidParams() { return ELI_templatedGetParams<T>(); }
+    const std::vector<ElementInfoStatistic>& getValidStats() { return ELI_templatedGetStatistics<T>(); }
+    const std::vector<ElementInfoPort2>& getValidPorts() { return ELI_templatedGetPorts<T>(); }
+    const std::vector<ElementInfoSubComponentSlot>& getSubComponentSlots() { return ELI_templatedGetSubComponentSlots<T>(); }
     uint32_t getCategory() { return T::ELI_getCategory(); };
     const std::vector<int>& getELICompiledVersion() { return T::ELI_getELICompiledVersion(); }
     const std::vector<int>& getVersion() { return T::ELI_getVersion(); }
@@ -317,17 +584,17 @@ public:
 
     SubComponent* create(Component* comp, Params& params) {
         // return new T(comp,params);
-        return T::ELI_create(comp,params);
+        return ELI_templatedCreateforSubComponent<T>(comp,params);
     }
 
     static bool isLoaded() { return loaded; }
     const std::string getLibrary() { return T::ELI_getLibrary(); }
     const std::string getName() { return T::ELI_getName(); }
     const std::string getDescription() { return T::ELI_getDescription(); }
-    const std::vector<ElementInfoParam>& getValidParams() { return T::ELI_getParams(); }
-    const std::vector<ElementInfoStatistic>& getValidStats() { return T::ELI_getStatistics(); }
-    const std::vector<ElementInfoPort2>& getValidPorts() { return T::ELI_getPorts(); }
-    const std::vector<ElementInfoSubComponentSlot>& getSubComponentSlots() { return T::ELI_getSubComponentSlots(); }
+    const std::vector<ElementInfoParam>& getValidParams() { return ELI_templatedGetParams<T>(); }
+    const std::vector<ElementInfoStatistic>& getValidStats() { return ELI_templatedGetStatistics<T>(); }
+    const std::vector<ElementInfoPort2>& getValidPorts() { return ELI_templatedGetPorts<T>(); }
+    const std::vector<ElementInfoSubComponentSlot>& getSubComponentSlots() { return ELI_templatedGetSubComponentSlots<T>(); }
     const std::string getInterface() { return T::ELI_getInterface(); }
     const std::vector<int>& getELICompiledVersion() { return T::ELI_getELICompiledVersion(); }
     const std::vector<int>& getVersion() { return T::ELI_getVersion(); }
@@ -367,7 +634,7 @@ public:
     const std::string getLibrary() { return T::ELI_getLibrary(); }
     const std::string getName() { return T::ELI_getName(); }
     const std::string getDescription() { return T::ELI_getDescription(); }
-    const std::vector<ElementInfoParam>& getValidParams() { return T::ELI_getParams(); }
+    const std::vector<ElementInfoParam>& getValidParams() { return ELI_templatedGetParams<T>(); }
     const std::string getInterface() { return T::ELI_getInterface(); }
     const std::vector<int>& getELICompiledVersion() { return T::ELI_getELICompiledVersion(); }
     const std::vector<int>& getVersion() { return T::ELI_getVersion(); }
@@ -394,7 +661,7 @@ public:
     const std::string getLibrary() { return T::ELI_getLibrary(); }
     const std::string getName() { return T::ELI_getName(); }
     const std::string getDescription() { return T::ELI_getDescription(); }
-    const std::vector<ElementInfoParam>& getValidParams() { return T::ELI_getParams(); }
+    const std::vector<ElementInfoParam>& getValidParams() { return ELI_templatedGetParams<T>(); }
     const std::string getInterface() { return T::ELI_getInterface(); }
     const std::vector<int>& getELICompiledVersion() { return T::ELI_getELICompiledVersion(); }
     const std::vector<int>& getVersion() { return T::ELI_getVersion(); }
@@ -421,7 +688,7 @@ public:
     const std::string getLibrary() { return T::ELI_getLibrary(); }
     const std::string getName() { return T::ELI_getName(); }
     const std::string getDescription() { return T::ELI_getDescription(); }
-    const std::vector<ElementInfoParam>& getValidParams() { return T::ELI_getParams(); }
+    const std::vector<ElementInfoParam>& getValidParams() { return ELI_templatedGetParams<T>(); }
     const std::string getInterface() { return T::ELI_getInterface(); }
     const std::vector<int>& getELICompiledVersion() { return T::ELI_getELICompiledVersion(); }
     const std::vector<int>& getVersion() { return T::ELI_getVersion(); }
@@ -534,8 +801,7 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
     }
 
 
-#define SST_ELI_REGISTER_COMPONENT_CUSTOM_CREATE(cls,lib,name,desc,cat)   \
-    friend class SST::ComponentDoc<cls>; \
+#define SST_ELI_REGISTER_COMPONENT(cls,lib,name,desc,cat) \
     bool ELI_isLoaded() {                           \
         return SST::ComponentDoc<cls>::isLoaded();     \
     } \
@@ -552,12 +818,6 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
       return cat; \
     } \
     SST_ELI_INSERT_COMPILE_INFO()
-
-#define SST_ELI_REGISTER_COMPONENT(cls,lib,name,desc,cat) \
-    static SST::Component* ELI_create(SST::ComponentId_t id, SST::Params& params) { \
-      return new cls(id,params); \
-    } \
-    SST_ELI_REGISTER_COMPONENT_CUSTOM_CREATE(cls,lib,name,desc,cat)
 
 
 #define SST_ELI_DOCUMENT_VERSION(major,minor,tertiary)  \
@@ -593,8 +853,7 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
     }
 
 
-#define SST_ELI_REGISTER_SUBCOMPONENT_CUSTOM_CREATE(cls,lib,name,desc,interface)   \
-    friend class SST::SubComponentDoc<cls>; \
+#define SST_ELI_REGISTER_SUBCOMPONENT(cls,lib,name,desc,interface)   \
     bool ELI_isLoaded() {                           \
       return SST::SubComponentDoc<cls>::isLoaded(); \
     } \
@@ -612,11 +871,6 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
     } \
     SST_ELI_INSERT_COMPILE_INFO()
 
-#define SST_ELI_REGISTER_SUBCOMPONENT(cls,lib,name,desc,interface)   \
-    static SST::SubComponent* ELI_create(SST::Component* comp, SST::Params& params) { \
-    return new cls(comp,params); \
-    } \
-    SST_ELI_REGISTER_SUBCOMPONENT_CUSTOM_CREATE(cls,lib,name,desc,interface)
 
 
 #define SST_ELI_REGISTER_MODULE(cls,lib,name,desc,interface) \

--- a/src/sst/core/elementinfo.h
+++ b/src/sst/core/elementinfo.h
@@ -823,7 +823,7 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
 //         return var; \
 //     }
 
-#define SST_ELI_DOCUMENT_VERSION(major,minor,tertiary)
+#define SST_ELI_DOCUMENT_VERSION(major,minor,tertiary) static_assert(0,"ouch");
 
 
 #define SST_ELI_DOCUMENT_PARAMS(...)                              \
@@ -887,7 +887,7 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
       return "Description temporarily unavailable"; \
     } \
     static const std::string ELI_getInterface() {  \
-                                                 return "Interface temporarily unavailable"; \
+      return "Interface temporarily unavailable"; \
     } \
     static const std::vector<int>& ELI_getVersion() { \
         static std::vector<int> var = { 0, 0, 0 } ; \
@@ -991,7 +991,7 @@ template<class T> const bool PythonModuleDoc<T>::loaded = ElementLibraryDatabase
 //     } \
 //     SST_ELI_INSERT_COMPILE_INFO()
 
-#define SST_ELI_REGISTER_PYTHON_MODULE(cls,lib) \
+#define SST_ELI_REGISTER_PYTHON_MODULE(cls,lib,...)    \
     friend class SST::PythonModuleDoc<cls>; \
     bool ELI_isLoaded() { \
       return SST::PythonModuleDoc<cls>::isLoaded(); \

--- a/src/sst/core/elibase.h
+++ b/src/sst/core/elibase.h
@@ -57,6 +57,33 @@ struct ElementInfoPort2 {
     const char *name;			/*!< Name of the port.  Can contain %d for a dynamic port, also %(xxx)d for dynamic port with xxx being the controlling component parameter */
     const char *description;	/*!< Brief description of the port (ie, what it is used for) */
     const std::vector<std::string> validEvents;	/*!< List of fully-qualified event types that this Port expects to send or receive */
+
+    // For backwards compatibility, convert from ElementInfoPort to ElementInfoPort2
+private:
+    std::vector<std::string> createVector(const char** events) {
+        std::vector<std::string> vec;
+        if ( events == NULL ) return vec;
+        const char** ev = events;
+        while ( NULL != *ev ) {
+            vec.push_back(*ev);
+            ev++;
+        }
+        return vec;
+    }
+
+public:
+    
+    ElementInfoPort2(const ElementInfoPort* port) :
+        name(port->name),
+        description(port->description),
+        validEvents(createVector(port->validEvents))
+        {}
+
+    ElementInfoPort2(const char* name, const char* description, const std::vector<std::string> validEvents) :
+        name(name),
+        description(description),
+        validEvents(validEvents)
+        {}
 };
 
 struct ElementInfoSubComponentSlot {

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -43,6 +43,8 @@ using namespace SST::Statistics;
 namespace SST {
 
 Factory* Factory::instance = NULL;
+SSTElementPythonModuleOldELI* PythonModuleDocOldELI::instance = NULL;
+
 
 ElementLibraryInfo empty_eli = {
     "empty-eli",
@@ -134,18 +136,6 @@ bool Factory::isPortNameValid(const std::string &type, const std::string port_na
     }
     
     std::string tmp = elemlib + "." + elem;
-    if ( portNames == NULL ) {
-        // now look for component
-
-
-        eic_map_t::iterator eii = found_components.find(tmp);
-        eis_map_t::iterator esii = found_subcomponents.find(tmp);
-        if ( eii != found_components.end() ) {
-            portNames = &eii->second.ports;
-        } else if ( esii != found_subcomponents.end() ) {
-            portNames = &esii->second.ports;
-        }
-    }
 
     if ( portNames == NULL ) {
         out.fatal(CALL_INFO, -1,"can't find requested component or subcomponent %s.\n ", tmp.c_str());
@@ -190,31 +180,9 @@ Factory::CreateComponent(ComponentId_t id,
             return ret;
         }
     }
-
-    // now look for component in old ELI
-    std::string tmp = elemlib + "." + elem;
-
-    eic_map_t::iterator eii = found_components.find(tmp);
-    if (eii == found_components.end()) {
-        out.fatal(CALL_INFO, -1,"can't find requested component %s.\n ", tmp.c_str());
-        return NULL;
-    }
-
-    const ComponentInfo ci = eii->second;
-
-    LinkMap *lm = Simulation::getSimulation()->getComponentLinkMap(id);
-    lm->setAllowedPorts(&ci.ports);
-    // lm->setAllowedPorts(GetComponentAllowedPorts(type));
-
-    loadingComponentType = type;    
-    params.pushAllowedKeys(ci.params);
-    Component *ret = ci.component->alloc(id, params);
-    params.popAllowedKeys();
-    loadingComponentType = "";
-
-    // if (NULL == ret) return ret;
-
-    return ret;
+    // If we make it to here, component not found
+    out.fatal(CALL_INFO, -1,"can't find requested component %s.\n ", type.c_str());
+    return NULL;
 }
 
 StatisticOutput* 
@@ -300,9 +268,6 @@ bool
 Factory::DoesSubComponentSlotExist(const std::string& type, const std::string& slotName)
 {
     std::string compTypeToLoad = type;
-    // if (true == type.empty()) { 
-    //     compTypeToLoad = loadingComponentType;
-    // }
     
     std::string elemlib, elem;
     std::tie(elemlib, elem) = parseLoadName(compTypeToLoad);
@@ -327,35 +292,8 @@ Factory::DoesSubComponentSlotExist(const std::string& type, const std::string& s
         }
     }
 
-    // now look for subcomponent
-    std::string tmp = elemlib + "." + elem;
-
-    eic_map_t::iterator eici = found_components.find(tmp);
-    eis_map_t::iterator eisi = found_subcomponents.find(tmp);
-    if (eici != found_components.end()) {
-        const ComponentInfo ci = eici->second;
-
-        // See if the slot exists
-        for ( auto item : ci.subcomponentslots ) {
-            if ( slotName == item ) {
-                return true;
-            }
-        }
-    }
-    else if (eisi != found_subcomponents.end()) {
-        const SubComponentInfo ci = eisi->second;
-
-        // See if the slot exists
-        for ( auto item : ci.subcomponentslots ) {
-            if ( slotName == item ) {
-                return true;
-            }
-        }
-    }
-    else {
-        out.fatal(CALL_INFO, -1,"can't find requested component/subcomponent %s.\n ", tmp.c_str());
-        return false;
-    }
+    // If we get to here, element doesn't exist
+    out.fatal(CALL_INFO, -1,"can't find requested component/subcomponent %s.\n ", type.c_str());
     return false;
 }
 
@@ -391,23 +329,8 @@ Factory::DoesComponentInfoStatisticNameExist(const std::string& type, const std:
     }
 
     
-    // now look for component
-    std::string tmp = elemlib + "." + elem;
-
-    eic_map_t::iterator eii = found_components.find(tmp);
-    if (eii == found_components.end()) {
-        out.fatal(CALL_INFO, -1,"can't find requested component %s.\n ", tmp.c_str());
-        return false;
-    }
-
-    const ComponentInfo ci = eii->second;
-
-    // See if the statistic exists
-    for (uint32_t x = 0; x <  ci.statNames.size(); x++) {
-        if (statisticName == ci.statNames[x]) {
-            return true;
-        }
-    }
+    // If we get to here, element doesn't exist
+    out.fatal(CALL_INFO, -1,"can't find requested component %s.\n ", type.c_str());
     return false;
 }
 
@@ -442,23 +365,8 @@ Factory::DoesSubComponentInfoStatisticNameExist(const std::string& type, const s
         }
     }
 
-    // now look for subcomponent
-    std::string tmp = elemlib + "." + elem;
-
-    eis_map_t::iterator eii = found_subcomponents.find(tmp);
-    if (eii == found_subcomponents.end()) {
-        out.fatal(CALL_INFO, -1,"can't find requested subcomponent %s.\n ", tmp.c_str());
-        return false;
-    }
-
-    const SubComponentInfo ci = eii->second;
-
-    // See if the statistic exists
-    for (uint32_t x = 0; x <  ci.statNames.size(); x++) {
-        if (statisticName == ci.statNames[x]) {
-            return true;
-        }
-    }
+    // If we get to here, element doesn't exist
+    out.fatal(CALL_INFO, -1,"can't find requested subcomponent %s.\n ", type.c_str());
     return false;
 }
 
@@ -493,33 +401,8 @@ Factory::GetComponentInfoStatisticEnableLevel(const std::string& type, const std
         }
     }
 
-    // now look for component
-    std::string tmp = elemlib + "." + elem;
-
-    eic_map_t::iterator eici = found_components.find(tmp);
-    eis_map_t::iterator eisi = found_subcomponents.find(tmp);
-    if (eici != found_components.end()) {
-        const ComponentInfo ci = eici->second;
-
-        // See if the statistic exists, if so return the enable level
-        for (uint32_t x = 0; x <  ci.statNames.size(); x++) {
-            if (statisticName == ci.statNames[x]) {
-                return ci.statEnableLevels[x];
-            }
-        }
-    } else if (eisi != found_subcomponents.end()) {
-        const SubComponentInfo ci = eisi->second;
-
-        // See if the statistic exists, if so return the enable level
-        for (uint32_t x = 0; x <  ci.statNames.size(); x++) {
-            if (statisticName == ci.statNames[x]) {
-                return ci.statEnableLevels[x];
-            }
-        }
-    } else {
-        out.fatal(CALL_INFO, -1,"can't find requested component %s.\n ", tmp.c_str());
-        return 0;
-    }
+    // If we get to here, element doesn't exist
+    out.fatal(CALL_INFO, -1,"can't find requested component %s.\n ", type.c_str());
     return 0;
 }
 
@@ -552,32 +435,8 @@ Factory::GetComponentInfoStatisticUnits(const std::string& type, const std::stri
         }
     }
 
-    // now look for component
-    std::string tmp = elemlib + "." + elem;
-    eic_map_t::iterator eici = found_components.find(tmp);
-    eis_map_t::iterator eisi = found_subcomponents.find(tmp);
-    if (eici != found_components.end()) {
-        const ComponentInfo ci = eici->second;
-
-        // See if the statistic exists, if so return the enable level
-        for (uint32_t x = 0; x <  ci.statNames.size(); x++) {
-            if (statisticName == ci.statNames[x]) {
-                return ci.statUnits[x];
-            }
-        }
-    } else if (eisi != found_subcomponents.end()) {
-        const SubComponentInfo ci = eisi->second;
-
-        // See if the statistic exists, if so return the enable level
-        for (uint32_t x = 0; x <  ci.statNames.size(); x++) {
-            if (statisticName == ci.statNames[x]) {
-                return ci.statUnits[x];
-            }
-        }
-    } else {
-        out.fatal(CALL_INFO, -1,"can't find requested component %s.\n ", tmp.c_str());
-        return 0;
-    }
+    // If we get to here, element doesn't exist
+    out.fatal(CALL_INFO, -1,"can't find requested component %s.\n ", type.c_str());
     return 0;
 }
 
@@ -614,22 +473,9 @@ Factory::CreateModule(std::string type, Params& params)
     }
 
     
-    // now look for module
-    std::string tmp = elemlib + "." + elem;
-    
-    // std::lock_guard<std::recursive_mutex> lock(factoryMutex);
-    eim_map_t::iterator eim = found_modules.find(tmp);
-    if (eim == found_modules.end()) {
-        out.fatal(CALL_INFO, -1, "can't find requested module %s.\n ", tmp.c_str());
-        return NULL;
-    }
-    
-    const ModuleInfo mi = eim->second;
-    
-    params.pushAllowedKeys(mi.params);
-    Module *ret = mi.module->alloc(params);
-    params.popAllowedKeys();
-    return ret;
+    // If we get to here, element doesn't exist
+    out.fatal(CALL_INFO, -1, "can't find requested module %s.\n ", type.c_str());
+    return NULL;
 }
 
 
@@ -729,22 +575,9 @@ Factory::CreateModuleWithComponent(std::string type, Component* comp, Params& pa
         }
     }
 
-    // now look for module
-    std::string tmp = elemlib + "." + elem;
-    
-    
-    eim_map_t::iterator eim = found_modules.find(tmp);
-    if (eim == found_modules.end()) {
-        out.fatal(CALL_INFO, -1,"can't find requested module %s.\n ", tmp.c_str());
-        return NULL;
-    }
-    
-    const ModuleInfo mi = eim->second;
-    
-    params.pushAllowedKeys(mi.params);
-    Module *ret = mi.module->alloc_with_comp(comp, params);
-    params.popAllowedKeys();
-    return ret;
+    // If we get to here, element doesn't exist
+    out.fatal(CALL_INFO, -1,"can't find requested module %s.\n ", type.c_str());
+    return NULL;
 }
 
 
@@ -754,10 +587,6 @@ Factory::CreateSubComponent(std::string type, Component* comp, Params& params)
 {
     std::string elemlib, elem;
     std::tie(elemlib, elem) = parseLoadName(type);
-
-    // if("sst" == elemlib) {
-    //     return CreateCoreModuleWithComponent(elem, comp, params);
-    // } else {
 
     // ensure library is already loaded...
     requireLibrary(elemlib);
@@ -776,21 +605,9 @@ Factory::CreateSubComponent(std::string type, Component* comp, Params& params)
         }
     }
 
-    // now look for module
-    std::string tmp = elemlib + "." + elem;
-
-    eis_map_t::iterator eis = found_subcomponents.find(tmp);
-    if (eis == found_subcomponents.end()) {
-        out.fatal(CALL_INFO, -1,"can't find requested subcomponent %s.\n ", tmp.c_str());
-        return NULL;
-    }
-
-    const SubComponentInfo si = eis->second;
-
-    params.pushAllowedKeys(si.params);
-    SubComponent* ret = si.subcomponent->alloc(comp, params);
-    params.popAllowedKeys();
-    return ret;
+    // If we get to here, element doesn't exist
+    out.fatal(CALL_INFO, -1,"can't find requested subcomponent %s.\n ", type.c_str());
+    return NULL;
 }
 
 
@@ -803,14 +620,17 @@ Factory::RequireEvent(std::string eventname)
     // ensure library is already loaded...
     requireLibrary(elemlib);
 
-    std::lock_guard<std::recursive_mutex> lock(factoryMutex);
+    // All we really need to do is make sure the library is loaded.
+    // We no longer have events in the ELI
 
-    // initializer fires at library load time, so all we have to do is
-    // make sure the event actually exists...
-    if (found_events.find(eventname) == found_events.end()) {
-        out.fatal(CALL_INFO, -1,"can't find event %s in %s\n ", eventname.c_str(),
-               searchPaths.c_str() );
-    }
+    // std::lock_guard<std::recursive_mutex> lock(factoryMutex);
+
+    // // initializer fires at library load time, so all we have to do is
+    // // make sure the event actually exists...
+    // if (found_events.find(eventname) == found_events.end()) {
+    //     out.fatal(CALL_INFO, -1,"can't find event %s in %s\n ", eventname.c_str(),
+    //            searchPaths.c_str() );
+    // }
 }
 
 Partition::SSTPartitioner*
@@ -832,17 +652,9 @@ Factory::CreatePartitioner(std::string name, RankInfo total_ranks, RankInfo my_r
         }
     }
 
-    // Look for the partitioner
-    std::string tmp = elemlib + "." + elem;
-    std::lock_guard<std::recursive_mutex> lock(factoryMutex);
-    eip_map_t::iterator eii = found_partitioners.find(tmp);
-    if ( eii == found_partitioners.end() ) {
-        out.fatal(CALL_INFO, -1,"Error: Unable to find requested partitioner %s, check --help for information on partitioners.\n ", tmp.c_str());
-        return NULL;
-    }
-
-    const ElementInfoPartitioner *ei = eii->second;
-    return ei->func(total_ranks, my_rank, verbosity);
+    // If we get to here, element doesn't exist
+    out.fatal(CALL_INFO, -1,"Error: Unable to find requested partitioner %s, check --help for information on partitioners.\n ", name.c_str());
+    return NULL;
 }
 
 generateFunction
@@ -860,7 +672,7 @@ Factory::GetGenerator(std::string name)
     std::lock_guard<std::recursive_mutex> lock(factoryMutex);
     eig_map_t::iterator eii = found_generators.find(tmp);
     if ( eii == found_generators.end() ) {
-        out.fatal(CALL_INFO, -1,"can't find requested partitioner %s.\n ", tmp.c_str());
+        out.fatal(CALL_INFO, -1,"can't find requested generator %s.\n ", tmp.c_str());
         return NULL;
     }
 
@@ -886,34 +698,7 @@ Factory::getPythonModule(std::string name)
         }
     }
 
-    // Didn't find it in new ELI, so look in old.
-    const ElementLibraryInfo *eli = findLibrary(elemlib, false);
-    if ( eli ) {
-        if ( eli->pythonModuleGenerator != NULL ) {
-            // This could create a small memory leak, but will go away
-            // once old ELI is dropped and shouldn't create a big
-            // enough leak to be a problem.  Could add a cache in the
-            // factory so that only one is created.
-            return new SSTElementPythonModuleOldELI(eli->pythonModuleGenerator);
-        }
-    }
     return NULL;
-}
-
-
-
-Params::KeySet_t Factory::create_params_set(const ElementInfoParam *params)
-{
-    Params::KeySet_t retset;
-
-    if (NULL != params) {
-        while (NULL != params->name) {
-            retset.insert(params->name);
-            params++;
-        }
-    }
-
-    return retset;
 }
 
 
@@ -964,33 +749,35 @@ Factory::findLibrary(std::string elemlib, bool showErrors)
     eli = loadLibrary(elemlib, showErrors);
     if (NULL == eli) return NULL;
 
+
+
+    // Convert the old ELI data structures into the new ELI data
+    // structures
     loaded_libraries[elemlib] = eli;
 
     if (NULL != eli->components) {
         const ElementInfoComponent *eic = eli->components;
         while (NULL != eic->name) {
-            std::string tmp = elemlib + "." + eic->name;
-            found_components[tmp] = ComponentInfo(eic, create_params_set(eic->params));
+            ElementLibraryDatabase::addComponent(new ComponentDocOldELI(elemlib, eic));
             eic++;
         }
     }
 
-    if (NULL != eli->events) {
-        const ElementInfoEvent *eie = eli->events;
-        while (NULL != eie->name) {
-            std::string tmp = elemlib + "." + eie->name;
-            found_events[tmp] = eie;
-            if (eie->init != NULL) eie->init();
-            eie++;
-        }
-    }
+    // if (NULL != eli->events) {
+    //     const ElementInfoEvent *eie = eli->events;
+    //     while (NULL != eie->name) {
+    //         std::string tmp = elemlib + "." + eie->name;
+    //         found_events[tmp] = eie;
+    //         if (eie->init != NULL) eie->init();
+    //         eie++;
+    //     }
+    // }
 
 
     if (NULL != eli->modules) {
         const ElementInfoModule *eim = eli->modules;
         while (NULL != eim->name) {
-            std::string tmp = elemlib + "." + eim->name;
-            found_modules[tmp] = ModuleInfo(eim, create_params_set(eim->params));
+            ElementLibraryDatabase::addModule(new ModuleDocOldELI(elemlib, eim));
             eim++;
         }
     }
@@ -998,8 +785,7 @@ Factory::findLibrary(std::string elemlib, bool showErrors)
     if (NULL != eli->subcomponents ) {
         const ElementInfoSubComponent *eis = eli->subcomponents;
         while (NULL != eis->name) {
-            std::string tmp = elemlib + "." + eis->name;
-            found_subcomponents[tmp] = SubComponentInfo(eis, create_params_set(eis->params));
+            ElementLibraryDatabase::addSubComponent(new SubComponentDocOldELI(elemlib, eis));
             eis++;
         }
     }
@@ -1007,8 +793,7 @@ Factory::findLibrary(std::string elemlib, bool showErrors)
     if (NULL != eli->partitioners) {
         const ElementInfoPartitioner *eip = eli->partitioners;
         while (NULL != eip->name) {
-            std::string tmp = elemlib + "." + eip->name;
-            found_partitioners[tmp] = eip;
+            ElementLibraryDatabase::addPartitioner(new PartitionerDocOldELI(elemlib, eip));
             eip++;
         }
     }
@@ -1022,6 +807,10 @@ Factory::findLibrary(std::string elemlib, bool showErrors)
         }
     }
 
+    if (NULL != eli->pythonModuleGenerator ) {
+        ElementLibraryDatabase::addPythonModule(new PythonModuleDocOldELI(elemlib, eli->pythonModuleGenerator));
+    }
+    
     return eli;
 }
 


### PR DESCRIPTION
Old ELI will now build new ELI data structures, so calls to old ELI data structures have been removed.  Documentation macros for params, ports, stats and subcomponent slots are now optional when there is nothing to document.  Preparing to remove the separate SST_ELI_DOCUMENENT_VERSION macro.  The version will now be part of the register calls.  This pull request temporarily disables element descriptions for all elements, category for components and interface for subcomponents and modules.  This will be added back in with the next pull request, but elements needs to be updated first.