### PR TITLE
Add Support for Directory Output in SST

### DIFF
--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -59,7 +59,16 @@ Config::Config(RankInfo rankInfo)
     generator   = "NONE";
     generator_options   = "";
     dump_component_graph_file = "";
+
+    char* wd_buf = (char*) malloc( sizeof(char) * PATH_MAX );
+    getcwd(wd_buf, PATH_MAX);
+
     output_directory = "";
+    if( NULL != wd_buf ) {
+	output_directory.append(wd_buf);
+        free(wd_buf);
+    }
+
     model_options = "";
     verbose     = 0;
     world_size.rank = rankInfo.rank;
@@ -268,7 +277,6 @@ Config::parseCmdLine(int argc, char* argv[]) {
 
     if ( !ok ) return 1;
 
-
     /* Sanity check, and other duties */
     Output::setFileName( debugFile != "/dev/null" ? debugFile : "sst_output" );
 
@@ -276,6 +284,34 @@ Config::parseCmdLine(int argc, char* argv[]) {
         cout << "ERROR: no sdl-file and no generator specified" << endl;
         cout << "  Usage: " << run_name << " sdl-file [options]" << endl;
         return -1;
+    }
+
+    // Ensure output directory ends with a directory separator
+    if( output_directory.size() > 0 ) {
+	if( '/' != output_directory[output_directory.size() - 1] ) {
+		output_directory.append("/");
+	}
+    }
+
+    // Now make sure all the files we are generating go into a directory
+    if( output_config_graph.size() > 0 && isFileNameOnly(output_config_graph) ) {
+	output_config_graph.insert( 0, output_directory );
+    }
+
+    if( output_dot.size() > 0 && isFileNameOnly(output_dot) ) {
+	output_dot.insert( 0, output_directory );
+    }
+
+    if( output_xml.size() > 0 && isFileNameOnly(output_xml) ) {
+	output_xml.insert( 0, output_directory );
+    }
+
+    if( output_json.size() > 0 && isFileNameOnly(output_json) ) {
+	output_json.insert( 0, output_directory );
+    }
+
+    if( debugFile.size() > 0 && isFileNameOnly(debugFile) ) {
+	debugFile.insert( 0, output_directory );
     }
 
     return 0;

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -194,6 +194,19 @@ private:
     int rank;
 	int numRanks;
 
+    bool isFileNameOnly(const std::string name) {
+	bool nameOnly = true;
+
+	for( size_t i = 0; i < name.size(); ++i ) {
+		if( '/' == name[i] ) {
+			nameOnly = false;
+			break;
+		}
+	}
+
+	return nameOnly;
+    }
+
     ImplementSerializable(SST::Config)
 };
 


### PR DESCRIPTION
Can put output files into a specific directory. Useful when running large numbers of experiments. See Issue: #145.