### PR TITLE
element.h should include correct path to elibase.h

### DIFF
--- a/src/sst/core/element.h
+++ b/src/sst/core/element.h
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include <string>
 
-#include <elibase.h>
+#include <sst/core/elibase.h>
 
 namespace SST {
 class Component;


### PR DESCRIPTION
Found via customer:   Core header files should not `#include <foo.h>`, when `foo.h` is part of the core.  Supply the correct path.

