### PR TITLE
Add MPI to SST Configuration Saving

### DIFF
--- a/src/sst/sst.conf
+++ b/src/sst/sst.conf
@@ -8,6 +8,9 @@
 #
 # ===================================================================
 [SSTCore]
+MPICXX=@MPICXX@
+MPICC=@MPICC@
+MPI_CPPFLAGS=@MPI_CPPFLAGS@
 CXX=@CXX@
 CXXFLAGS=@SST_EXPORT_CXXFLAGS@
 CC=@CC@
@@ -26,7 +29,6 @@ ZOLTAN_LDFLAGS=@ZOLTAN_LDFLAGS@
 LIBZ_CPPFLAGS=@LIBZ_CPPFLAGS@
 LIBZ_LDFLAGS=@LIBZ_LDFLAGS@
 LIBZ_LIBS=@LIBZ_LIBS@
-MPI_CPPFLAGS=@MPI_CPPFLAGS@
 ELEMENT_CXXFLAGS=@SST_EXPORT_CXXFLAGS@ @SST_ELEMENT_FPIC_FLAGS@ -DHAVE_CONFIG_H -I@prefix@/include
 ELEMENT_LDFLAGS=-shared -fno-common -Wl,-undefined -Wl,dynamic_lookup
 pkgconfig=@prefix@/lib/pkgconfig/SST-@PACKAGE_VERSION@.pc


### PR DESCRIPTION
We need to be able to detect if the core is built with MPI so we can build support libraries for elements later. This should not be used to built elements. We do however build some libraries for our elements that may require MPI when they interact with applications etc.