### PR TITLE
Fixes #270 where Configuration Prefix is set to NONE and Configuration Cannot be Read

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_PREREQ([2.59])
 
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
+AC_PREFIX_DEFAULT([/usr/local])
 AM_INIT_AUTOMAKE([1.9.6 foreign dist-bzip2 subdir-objects no-define tar-pax])
 
 # If Automake supports silent rules, enable them.
@@ -97,8 +98,6 @@ AS_IF([test "x$have_zoltan" = "x1"], [AC_DEFINE_UNQUOTED([HAVE_ZOLTAN], [1],
 	[Define if you have the Zoltan library.])])
 AM_CONDITIONAL([HAVE_ZOLTAN], [test "$have_zoltan" = 1])
 
-AC_DEFINE_UNQUOTED([SST_INSTALL_PREFIX], ["$prefix"], [Defines the location SST will be installed in])
-
 AC_DEFINE_UNQUOTED([SST_CPPFLAGS], ["$CPPFLAGS"], [Defines the CPPFLAGS used to build SST])
 AC_DEFINE_UNQUOTED([SST_CFLAGS], ["$CFLAGS"], [Defines the CFLAGS used to build SST])
 AC_DEFINE_UNQUOTED([SST_CXXFLAGS], ["$CXXFLAGS"], [Defines the CXXFLAGS used to build SST])
@@ -160,6 +159,10 @@ AC_SUBST(CC_VERSION)
 
 MPICC_VERSION=`$MPICC --version | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/%/g' | awk -F'%' '{print $1}'`
 AC_SUBST(MPICC_VERSION)
+
+AC_CACHE_SAVE
+
+AC_DEFINE_UNQUOTED([SST_INSTALL_PREFIX], ["$prefix"], [Defines the location SST will be installed in])
 
 AC_CACHE_SAVE
 

--- a/src/sst/core/env/envquery.cc
+++ b/src/sst/core/env/envquery.cc
@@ -130,7 +130,13 @@ SST::Core::Environment::EnvironmentConfiguration*
 	EnvironmentConfiguration* envConfig = new EnvironmentConfiguration();
 
 	// LOWEST PRIORITY - GLOBAL INSTALL CONFIG
-	std::string prefixConfig = SST_INSTALL_PREFIX "/etc/sst/sstsimulator.conf";
+	std::string prefixConfig = "";
+
+	if( SST_INSTALL_PREFIX == "NONE" ) {
+		prefixConfig = "/usr/local/etc/sst/sstsimulator.conf";
+	} else {
+		prefixConfig = SST_INSTALL_PREFIX "/etc/sst/sstsimulator.conf";
+	}
 
 	SST::Core::Environment::populateEnvironmentConfig(prefixConfig, envConfig, true);
 


### PR DESCRIPTION
Reported in bug #270 and #182 if `--prefix` is not set for configuration then `sst-config` is unable to find any root for configuration information and errors. This detects the "NONE" setting (auto-configuration records the parameter is unset) and overrides this to `/usr/local`. Tested on Mac OS X.