### PR TITLE
sstinfo tweaks

### DIFF
--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -258,15 +258,17 @@ void OverallOutputter::outputXML(int UNUSED(Index), TiXmlNode* UNUSED(XMLParentE
         g_libInfoArray[x].outputXML(x, XMLTopLevelElement);
     }
 
-	// General Info on the Data
-    xmlComment(&XMLDocument, "SSTInfo XML Data Generated on %s", TimeStamp);
-    xmlComment(&XMLDocument, "%d .so FILES FOUND IN DIRECTORY(s) %s\n", g_fileProcessedCount, g_searchPath.c_str());
 
 
 	// Add the entries into the XML Document
     // XML Declaration
 	TiXmlDeclaration* XMLDecl = new TiXmlDeclaration("1.0", "", "");
 	XMLDocument.LinkEndChild(XMLDecl);
+    //
+	// General Info on the Data
+    xmlComment(&XMLDocument, "SSTInfo XML Data Generated on %s", TimeStamp);
+    xmlComment(&XMLDocument, "%d .so FILES FOUND IN DIRECTORY(s) %s\n", g_fileProcessedCount, g_searchPath.c_str());
+
 	XMLDocument.LinkEndChild(XMLTopLevelElement);
 
     // Save the XML Document

--- a/src/sst/core/sstinfo.h
+++ b/src/sst/core/sstinfo.h
@@ -27,6 +27,7 @@ namespace SST {
 // CONFIGURATION BITS    
 #define CFG_OUTPUTHUMAN 0x00000001
 #define CFG_OUTPUTXML   0x00000002
+#define CFG_VERBOSE     0x00000004
 
 /**
  * The SSTInfo Configuration class.
@@ -68,6 +69,7 @@ public:
     /** Is debugging output enabled? */
     bool                      debugEnabled() const { return m_debugEnabled; }
     bool                      processAllElements() const { return m_filters.empty(); }
+    bool                      doVerbose() const { return m_optionBits & CFG_VERBOSE; }
 
 private:
     void outputUsage();


### PR DESCRIPTION
Tweaks to SSTINFO to support ACS's SST templating GUI.   Specifically, make the XML valid, and able to print to `stdout`.