### PR TITLE
Fix Runtime Error when using getopt_long

### DIFF
--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -231,9 +231,12 @@ Config::parseCmdLine(int argc, char* argv[]) {
     bool ok = true;
     while (ok) {
         int option_index = 0;
-        char c = getopt_long(argc, argv, sst_short_options, sst_long_options, &option_index);
-        if ( c == -1 ) /* We're done */
+        const int intC = getopt_long(argc, argv, sst_short_options, sst_long_options, &option_index);
+
+        if ( intC == -1 ) /* We're done */
             break;
+
+	const char c = static_cast<char>(intC);
 
         switch (c) {
         case 0:
@@ -260,6 +263,7 @@ Config::parseCmdLine(int argc, char* argv[]) {
         case 'h':
         case '?':
         default:
+	    
             ok = usage();
         }
     }

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -323,9 +323,11 @@ int SSTInfoConfig::parseCmdLine(int argc, char* argv[])
     };
     while (1) {
         int opt_idx = 0;
-        char c = getopt_long(argc, argv, "hvqdnxo:l:", longOpts, &opt_idx);
-        if ( c == -1 )
+        const int intC = getopt_long(argc, argv, "hvqdnxo:l:", longOpts, &opt_idx);
+        if ( intC == -1 )
             break;
+
+  	const char c = static_cast<char>(intC);
 
         switch (c) {
         case 'h':


### PR DESCRIPTION
The calls to getopt_long currently assume return type will be `char`. The return type is actually `int` and GCC 4.8.5 on POWER8 complains that the check to `-1` will always be false, causing the compiler to generate code in which SST will not run. This fixes the behavior on POWER8 w/ GCC 4.8.5. This is also a problem on `sst-info`.