### PR TITLE
Top-level stat-enablements should work on subComponents

### DIFF
--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -188,49 +188,6 @@ public:
     ImplementSerializable(SST::ConfigStatOutput)
 };
 
-// class ConfigComponent;
-
-// class SubComponentSlotDefinition : public SST::Core::Serialization::serializable {
-
-//     std::string name;
-//     std::vector<ConfigComponent*> slots;
-    
-// public:
-
-//     SubComponentSlotDefinition() {}
-//     SubComponentSlotDefinition(const SubComponentSlotDefinition& init) :
-//         name(init.name)
-//     {
-//         for ( auto &cc : init.slots ) {
-//             slots.push_back
-//         }
-//     }
-
-
-//     const std::string& getName() const { return name; }
-
-//     ConfigComponent* getSlot(uint32_t slot) const {
-//         if ( slot <= slots.size() ) return slots[slot];
-//         return NULL;
-//     }
-    
-//     int getMaxPopulatedSlotNumber() const { return slots.size(); }
-//     bool isPopulated(int slot_num) const;
-
-//     // bool isAllPopulated() const;
-
-//     // SubComponent* create(int slot_num, Params& params);
-//     // std::vector<SubComponent*> createAll(Params& params);
-
-
-//     void serialize_order(SST::Core::Serialization::serializer &ser) {
-//         ser & name;
-//         ser & slots;
-//     }
-
-//     ImplementSerializable(SST::SubComponentSlotDefinition)
-// };
-
 
 typedef SparseVectorMap<LinkId_t,ConfigLink> ConfigLinkMap_t;
 
@@ -267,9 +224,9 @@ public:
     ConfigComponent* addSubComponent(ComponentId_t, const std::string &name, const std::string &type, int slot);
     ConfigComponent* findSubComponent(ComponentId_t);
     const ConfigComponent* findSubComponent(ComponentId_t) const;
-    void enableStatistic(const std::string &statisticName);
-    void addStatisticParameter(const std::string &statisticName, const std::string &param, const std::string &value);
-    void setStatisticParameters(const std::string &statisticName, const Params &params);
+    void enableStatistic(const std::string &statisticName, bool recursively = false);
+    void addStatisticParameter(const std::string &statisticName, const std::string &param, const std::string &value, bool recursively = false);
+    void setStatisticParameters(const std::string &statisticName, const Params &params, bool recursively = false);
 
     std::vector<LinkId_t> allLinks() const;
 


### PR DESCRIPTION
Enable top-level python statistic enablement functions to work on SubComponents.

* `sst.enableAllStatisticsForAllComponents()`
* `sst.enableAllStatisticsForComponentType()`
* `sst.enableStatisitcForAllComponents()`
* `sst.enableStatisticForComponentType()`