### PR TITLE
Change to SharedRegion

### DIFF
--- a/src/sst/core/sharedRegion.cc
+++ b/src/sst/core/sharedRegion.cc
@@ -275,7 +275,7 @@ void SharedRegionManagerImpl::updateState(bool finalize)
 {
     std::lock_guard<std::mutex> lock(mtx);
     
-    if ( finalize ) {
+    if ( /*finalize*/ true ) {
 #ifdef SST_CONFIG_HAVE_MPI
         int myRank = Simulation::getSimulation()->getRank().rank;
         if ( Simulation::getSimulation()->getNumRanks().rank > 1 ) {


### PR DESCRIPTION
Changed the SharedRegionManager to always exchange data on an updateState() call, instead of just when it is being finalized.  This will make the shared region data available to other ranks during init, which is required for some of the elements to function properly.

I believe this fix will cause the change set state to be exchanged multiple times, but this is only an efficiency issue and not a correctness issue.  We can revisit with a more efficient fix at a later time.