### PR TITLE
Added an iterative complete() stage following the run() stage.

### DIFF
--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -127,6 +127,9 @@ public:
     /** Used during the init phase.  The method will be called each phase of initialization.
      Initialization ends when no components have sent any data. */
     virtual void init(unsigned int UNUSED(phase)) {}
+    /** Used during the init phase.  The method will be called each phase of initialization.
+     Initialization ends when no components have sent any data. */
+    virtual void complete(unsigned int UNUSED(phase)) {}
     /** Called after all components have been constructed and inialization has
 	completed, but before simulation time has begun. */
     virtual void setup( ) { }

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -112,6 +112,15 @@ void ComponentInfo::finalizeLinkConfiguration() {
     }
 }
 
+void ComponentInfo::prepareForComplete() {
+    for ( auto & i : link_map->getLinkMap() ) {
+        i.second->prepareForComplete();
+    }
+    for ( auto &s : subComponents ) {
+        s.prepareForComplete();
+    }
+}
+
 ComponentInfo* ComponentInfo::findSubComponent(ComponentId_t id)
 {
     /* See if it is us */

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -47,7 +47,7 @@ private:
     const std::string type;
     LinkMap* link_map;
     BaseComponent* component;
-    // std::map<std::string, ComponentInfo> subComponents;
+    
     std::vector<ComponentInfo> subComponents;
     const Params *params;
 
@@ -59,6 +59,7 @@ private:
     /* Lookup Key style constructor */
     ComponentInfo(ComponentId_t id, const std::string &name);
     void finalizeLinkConfiguration();
+    void prepareForComplete();
 
 public:
     /* Old ELI Style subcomponent constructor */

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -273,23 +273,33 @@ public:
     virtual Request* recvInitData() = 0;
 
     /**
-     * Sends a network request during the init() or complete() phase
+     * Sends a network request during untimed phases (init() and
+     * complete()).
+     * @see SST::Link::sendUntimedData()
      *
      * For now, simply call sendInitData.  Once that call is
      * deprecated and removed, this will become a pure virtual
-     * function.
+     * function.  This means that when classes implement
+     * SimpleNetwork, they will need to overload both sendUntimedData
+     * and sendInitData with identical functionality (or having the
+     * Init version call the Untimed version) until sendInitData is
+     * removed in SST 9.0.
      */
     virtual void sendUntimedData(Request *req) {
         sendInitData(req);
     }
         
     /**
-     * Receive any data during the init() or complete() phase.
-     * @see SST::Link::recvInitData()
+     * Receive any data during untimed phases (init() and complete()).
+     * @see SST::Link::recvUntimedData()
      *
      * For now, simply call recvInitData.  Once that call is
      * deprecated and removed, this will become a pure virtual
-     * function.
+     * function.  This means that when classes implement
+     * SimpleNetwork, they will need to overload both recvUntimedData
+     * and recvInitData with identical functionality (or having the
+     * Init version call the Untimed version) until recvInitData is
+     * removed in SST 9.0.
      */
     virtual Request* recvUntimedData() {
         return recvInitData();

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -272,6 +272,29 @@ public:
      */
     virtual Request* recvInitData() = 0;
 
+    /**
+     * Sends a network request during the init() or complete() phase
+     *
+     * For now, simply call sendInitData.  Once that call is
+     * deprecated and removed, this will become a pure virtual
+     * function.
+     */
+    virtual void sendUntimedData(Request *req) {
+        sendInitData(req);
+    }
+        
+    /**
+     * Receive any data during the init() or complete() phase.
+     * @see SST::Link::recvInitData()
+     *
+     * For now, simply call recvInitData.  Once that call is
+     * deprecated and removed, this will become a pure virtual
+     * function.
+     */
+    virtual Request* recvUntimedData() {
+        return recvInitData();
+    }
+
     // /**
     //  * Returns a handle to the underlying SST::Link
     //  */
@@ -296,6 +319,7 @@ public:
 
     virtual void setup() override {}
     virtual void init(unsigned int UNUSED(phase)) override {}
+    virtual void complete(unsigned int UNUSED(phase)) override {}
     virtual void finish() override {}
 
     /**

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -28,9 +28,10 @@
 
 namespace SST { 
 
-ActivityQueue* Link::uninitQueue = NULL;
-ActivityQueue* Link::afterInitQueue = NULL;
-ActivityQueue* Link::afterRunQueue = NULL;
+// ActivityQueue* Link::uninitQueue = NULL;
+ActivityQueue* Link::uninitQueue = new UninitializedQueue("ERROR: Trying to send or recv from link during initialization.  Send and Recv cannot be called before setup.");
+ActivityQueue* Link::afterInitQueue = new UninitializedQueue("ERROR: Trying to call sendUntimedData/sendInitData or recvUntimedData/recvInitData during the run phase.");
+ActivityQueue* Link::afterRunQueue = new UninitializedQueue("ERROR: Trying to call send or recv during complete phase.");
     
 Link::Link(LinkId_t id) :
     rFunctor( NULL ),
@@ -39,14 +40,6 @@ Link::Link(LinkId_t id) :
     type(HANDLER),
     id(id)
 {
-    if ( uninitQueue == NULL )
-	uninitQueue = new UninitializedQueue("ERROR: Trying to send or recv from link during initialization.  Send and Recv cannot be called before setup.");
-    if ( afterInitQueue == NULL )
-	afterRunQueue = new UninitializedQueue("ERROR: Trying to call sendInitData or recvInitData after initialziation phase.");
-    
-    if ( afterRunQueue == NULL )
-	afterRunQueue = new UninitializedQueue("ERROR: Trying to call send or recv during complete phase.");
-    
     recvQueue = uninitQueue;
     untimedQueue = NULL;
     configuredQueue = Simulation::getSimulation()->getTimeVortex();
@@ -59,14 +52,6 @@ Link::Link() :
     type(HANDLER),
     id(-1)
 {
-    if ( uninitQueue == NULL )
-	uninitQueue = new UninitializedQueue("ERROR: Trying to send or recv from link during initialization.  Send and Recv cannot be called before setup.");
-    if ( afterInitQueue == NULL )
-	afterInitQueue = new UninitializedQueue("ERROR: Trying to call sendInitData or recvInitData after initialziation phase.");
-    
-    if ( afterRunQueue == NULL )
-	afterRunQueue = new UninitializedQueue("ERROR: Trying to call send or recv during complete phase.");
-
     recvQueue = uninitQueue;
     untimedQueue = NULL;
     configuredQueue = Simulation::getSimulation()->getTimeVortex();

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -30,6 +30,7 @@ namespace SST {
 
 ActivityQueue* Link::uninitQueue = NULL;
 ActivityQueue* Link::afterInitQueue = NULL;
+ActivityQueue* Link::afterRunQueue = NULL;
     
 Link::Link(LinkId_t id) :
     rFunctor( NULL ),
@@ -41,10 +42,13 @@ Link::Link(LinkId_t id) :
     if ( uninitQueue == NULL )
 	uninitQueue = new UninitializedQueue("ERROR: Trying to send or recv from link during initialization.  Send and Recv cannot be called before setup.");
     if ( afterInitQueue == NULL )
-	afterInitQueue = new UninitializedQueue("ERROR: Trying to call sendInitData or recvInitData after initialziation phase.");
+	afterRunQueue = new UninitializedQueue("ERROR: Trying to call sendInitData or recvInitData after initialziation phase.");
+    
+    if ( afterRunQueue == NULL )
+	afterRunQueue = new UninitializedQueue("ERROR: Trying to call send or recv during complete phase.");
     
     recvQueue = uninitQueue;
-    initQueue = NULL;
+    untimedQueue = NULL;
     configuredQueue = Simulation::getSimulation()->getTimeVortex();
 }
 
@@ -60,29 +64,39 @@ Link::Link() :
     if ( afterInitQueue == NULL )
 	afterInitQueue = new UninitializedQueue("ERROR: Trying to call sendInitData or recvInitData after initialziation phase.");
     
+    if ( afterRunQueue == NULL )
+	afterRunQueue = new UninitializedQueue("ERROR: Trying to call send or recv during complete phase.");
+
     recvQueue = uninitQueue;
-    initQueue = NULL;
+    untimedQueue = NULL;
     configuredQueue = Simulation::getSimulation()->getTimeVortex();
 }
 
 Link::~Link() {
-    if ( type == POLL && recvQueue != uninitQueue && recvQueue != afterInitQueue ) {
+    if ( type == POLL && recvQueue != uninitQueue && recvQueue != afterInitQueue && recvQueue != afterRunQueue ) {
         delete recvQueue;
     }
     if ( rFunctor != NULL ) delete rFunctor;
 }
 
 void Link::finalizeConfiguration() {
-    // TraceFunction trace (CALL_INFO_LONG);
     recvQueue = configuredQueue;
-    configuredQueue = NULL;
-    if ( initQueue != NULL ) {
-	if ( dynamic_cast<InitQueue*>(initQueue) != NULL) {
-	    delete initQueue;
-	}
+    configuredQueue = untimedQueue;
+    if ( untimedQueue != NULL ) {
+        if ( dynamic_cast<InitQueue*>(untimedQueue) != NULL) {
+            delete untimedQueue;
+            configuredQueue = NULL;
+        }
     }
-    initQueue = afterInitQueue;
-    // trace.getOutput().output(CALL_INFO,"id: %ld: recvQueue = %p, initQueue = %p\n",id,recvQueue,initQueue);
+    untimedQueue = afterInitQueue;
+}
+
+void Link::prepareForComplete() {
+    if ( type == POLL && recvQueue != uninitQueue && recvQueue != afterInitQueue ) {
+        delete recvQueue;
+    }
+    recvQueue = afterRunQueue;
+    untimedQueue = configuredQueue;
 }
 
 void Link::setPolling() {
@@ -105,7 +119,6 @@ void Link::addRecvLatency(SimTime_t cycles, TimeConverter* timebase) {
 }
     
 void Link::send( SimTime_t delay, TimeConverter* tc, Event* event ) {  
-    // TraceFunction trace(CALL_INFO_LONG);
     if ( tc == NULL ) {
         Simulation::getSimulation()->getSimulationOutput().fatal(CALL_INFO, -1, "Cannot send an event on Link with NULL TimeConverter\n");
     }
@@ -150,59 +163,47 @@ Event* Link::recv()
     return event;
 } 
 
-void Link::sendInitData(Event* init_data)
+void Link::sendUntimedData(Event* data)
 {
-    if ( pair_link->initQueue == NULL ) {
-        pair_link->initQueue = new InitQueue();
+    if ( pair_link->untimedQueue == NULL ) {
+        pair_link->untimedQueue = new InitQueue();
     }
-    Simulation::getSimulation()->init_msg_count++;
-    init_data->setDeliveryTime(Simulation::getSimulation()->init_phase + 1);
-    init_data->setDeliveryLink(id,pair_link);
+    Simulation::getSimulation()->untimed_msg_count++;
+    data->setDeliveryTime(Simulation::getSimulation()->untimed_phase + 1);
+    data->setDeliveryLink(id,pair_link);
     
-    pair_link->initQueue->insert(init_data);
+    pair_link->untimedQueue->insert(data);
 #if __SST_DEBUG_EVENT_TRACKING__
-    init_data->addSendComponent(comp,ctype,port);
-    init_data->addRecvComponent(pair_link->comp, pair_link->ctype, pair_link->port);
+    data->addSendComponent(comp,ctype,port);
+    data->addRecvComponent(pair_link->comp, pair_link->ctype, pair_link->port);
 #endif
 }
 
-void Link::sendInitData_sync(Event* init_data)
+void Link::sendUntimedData_sync(Event* data)
 {
-    if ( pair_link->initQueue == NULL ) {
-        pair_link->initQueue = new InitQueue();
+    if ( pair_link->untimedQueue == NULL ) {
+        pair_link->untimedQueue = new InitQueue();
     }
-    // init_data->setDeliveryLink(id,pair_link);
+    // data->setDeliveryLink(id,pair_link);
 
-    pair_link->initQueue->insert(init_data);
+    pair_link->untimedQueue->insert(data);
 }
 
-Event* Link::recvInitData()
+Event* Link::recvUntimedData()
 {
-    if ( initQueue == NULL ) return NULL;
+    if ( untimedQueue == NULL ) return NULL;
 
     Event* event = NULL;
-    if ( !initQueue->empty() ) {
-	Activity* activity = initQueue->front();
-	if ( activity->getDeliveryTime() <= Simulation::getSimulation()->init_phase ) {
+    if ( !untimedQueue->empty() ) {
+	Activity* activity = untimedQueue->front();
+	if ( activity->getDeliveryTime() <= Simulation::getSimulation()->untimed_phase ) {
 	    event = static_cast<Event*>(activity);
-	    initQueue->pop();
+	    untimedQueue->pop();
 	}
     }
     return event;
 }
 
-// UnitAlgebra
-// Link::getTotalInputLatency()
-// {
-    
-// }
-    
-// UnitAlgebra
-// Link::getTotalOutputLatency()
-// {
-    
-// }
-    
 void Link::setDefaultTimeBase(TimeConverter* tc) {
     defaultTimeBase = tc;
 }

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -119,9 +119,18 @@ public:
     LinkId_t getId() { return id; }
 
     /** Send data during the init() phase. */
-    void sendInitData(Event* init_data);
+    void sendUntimedData(Event* data);
     /** Receive an event (if any) during the init() phase */
-    Event* recvInitData();
+    Event* recvUntimedData();
+    
+    /** Send data during the complete() phase. */
+    void sendInitData(Event* init_data) {
+        sendUntimedData(init_data);
+    }
+    /** Receive an event (if any) during the complete() phase */
+    Event* recvInitData() {
+        return recvUntimedData();
+    }
 
 #ifdef __SST_DEBUG_EVENT_TRACKING__
     void setSendingComponentInfo(const std::string& comp_in, const std::string& type_in, const std::string& port_in) {
@@ -135,8 +144,6 @@ public:
     const std::string& getSendingPort() { return port; }
 
 #endif
-    // UnitAlgebra getTotalInputLatency();
-    // UnitAlgebra getTotalOutputLatency();
 
 protected:
     Link();
@@ -144,13 +151,15 @@ protected:
     /** Queue of events to be received by the owning component */
     ActivityQueue* recvQueue;
     /** Queue of events to be received during init by the owning component */
-    ActivityQueue* initQueue;
+    ActivityQueue* untimedQueue;
     /** Currently active Queue */
     ActivityQueue* configuredQueue;
     /** Unitialized queue.  Used for error detection */
     static ActivityQueue* uninitQueue;
     /** Unitialized queue.  Used for error detection */
     static ActivityQueue* afterInitQueue;
+    /** Unitialized queue.  Used for error detection */
+    static ActivityQueue* afterRunQueue;
 
     /** Recieve functor. This functor is set when the link is connected.
       Determines what the receiver wants to be called
@@ -176,8 +185,9 @@ protected:
 private:
     Link( const Link& l );
 
-    void sendInitData_sync(Event* init_data);
+    void sendUntimedData_sync(Event* data);
     void finalizeConfiguration();
+    void prepareForComplete();
     
     Type_t type;
     LinkId_t id;
@@ -187,8 +197,6 @@ private:
     std::string ctype;
     std::string port;
 #endif
-    
-    //    friend class SST::Sync;
     
 };
 

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -328,12 +328,17 @@ static void start_simulation(uint32_t tid, SimThreadInfo_t &info, Core::ThreadSa
 
         /* Run Simulation */
         sim->run();
-    // fprintf(stderr, "thread %u waiting on run finish barrier\n", tid);
+
         barrier.wait();
-    // fprintf(stderr, "thread %u release from run finish barrier\n", tid);
+
+
+        sim->complete();
+
+        barrier.wait();
+
 
         sim->finish();
-    // fprintf(stderr, "thread %u waiting on finish() finish barrier\n", tid);
+
         barrier.wait();
     // fprintf(stderr, "thread %u release from finish() finish barrier\n", tid);
 
@@ -349,7 +354,6 @@ static void start_simulation(uint32_t tid, SimThreadInfo_t &info, Core::ThreadSa
 
     info.max_tv_depth = sim->getTimeVortexMaxDepth();
     info.current_tv_depth = sim->getTimeVortexCurrentDepth();
-//    info.sync_data_size = sim->getSyncQueueDataSize();
 
     delete sim;
 
@@ -561,7 +565,6 @@ main(int argc, char *argv[])
         //     min_part = Simulation::getTimeLord()->getSimCycles("1us","");
         // }
 
-        // broadcast(world, min_part, 0);
         Comms::broadcast(min_part, 0);
 #endif
     }
@@ -628,7 +631,7 @@ main(int argc, char *argv[])
             delete your_graph;
         }
 
-        if ( *my_ranks.begin() != myRank.rank) cout << "ERROR" << endl;
+        if ( *my_ranks.begin() != myRank.rank) printf("ERROR\n");
 
     }
 #endif
@@ -694,7 +697,6 @@ main(int argc, char *argv[])
     double total_end_time = sst_get_cpu_time();
 
     for ( uint32_t i = 1 ; i < world_size.thread ; i++ ) {
-        // g_output.output(CALL_INFO,"simulated_time = %s, %s\n",threadInfo[0].simulated_time.toStringBestSI().c_str(),threadInfo[1].simulated_time.toStringBestSI().c_str());
         threadInfo[0].simulated_time = std::max(threadInfo[0].simulated_time, threadInfo[i].simulated_time);
         threadInfo[0].run_time = std::max(threadInfo[0].run_time, threadInfo[i].run_time);
         threadInfo[0].build_time = std::max(threadInfo[0].build_time, threadInfo[i].build_time);
@@ -840,7 +842,6 @@ main(int argc, char *argv[])
 
 
 #ifdef SST_CONFIG_HAVE_MPI
-    // delete mpiEnv;
     MPI_Finalize();
 #endif
 

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -317,31 +317,23 @@ static void start_simulation(uint32_t tid, SimThreadInfo_t &info, Core::ThreadSa
 #endif
         }
         barrier.wait();
-        
-        sim->initialize();
 
+        sim->initialize();
         barrier.wait();
         
-        /* Run Simulation */
+        /* Run Set */
         sim->setup();
         barrier.wait();
 
         /* Run Simulation */
         sim->run();
-
         barrier.wait();
-
 
         sim->complete();
-
         barrier.wait();
-
 
         sim->finish();
-
         barrier.wait();
-    // fprintf(stderr, "thread %u release from finish() finish barrier\n", tid);
-
     }
 
     barrier.wait();
@@ -630,9 +622,6 @@ main(int argc, char *argv[])
             your_ranks.clear();
             delete your_graph;
         }
-
-        if ( *my_ranks.begin() != myRank.rank) printf("ERROR\n");
-
     }
 #endif
     ////// End Broadcast Graph //////

--- a/src/sst/core/rankSyncParallelSkip.h
+++ b/src/sst/core/rankSyncParallelSkip.h
@@ -33,7 +33,6 @@ class TimeConverter;
 class RankSyncParallelSkip : public NewRankSync {
 public:
     /** Create a new Sync object which fires with a specified period */
-    // Sync(TimeConverter* period);
     RankSyncParallelSkip(RankInfo num_ranks, TimeConverter* minPartTC);
     virtual ~RankSyncParallelSkip();
     
@@ -41,10 +40,12 @@ public:
     ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, LinkId_t link_id, Link* link) override;
     void execute(int thread) override;
 
-    /** Cause an exchange of Initialization Data to occur */
-    void exchangeLinkInitData(int thread, std::atomic<int>& msg_count) override;
+    /** Cause an exchange of Untimed Data to occur */
+    void exchangeLinkUntimedData(int thread, std::atomic<int>& msg_count) override;
     /** Finish link configuration */
     void finalizeLinkConfigurations() override;
+    /** Prepare for complete() stage */
+    void prepareForComplete() override;
 
     SimTime_t getNextSyncTime() override { return myNextSyncTime; }
     
@@ -77,7 +78,6 @@ private:
 #endif   
     };
     
-    // typedef std::map<int, std::pair<SyncQueueC*, std::vector<char>* > > comm_map_t;
     typedef std::map<RankInfo, comm_send_pair > comm_send_map_t;
     typedef std::map<RankInfo, comm_recv_pair > comm_recv_map_t;
     typedef std::map<LinkId_t, Link*> link_map_t;

--- a/src/sst/core/rankSyncSerialSkip.h
+++ b/src/sst/core/rankSyncSerialSkip.h
@@ -26,7 +26,6 @@ class TimeConverter;
 class RankSyncSerialSkip : public NewRankSync {
 public:
     /** Create a new Sync object which fires with a specified period */
-    // Sync(TimeConverter* period);
     RankSyncSerialSkip(TimeConverter* minPartTC);
     virtual ~RankSyncSerialSkip();
     
@@ -34,10 +33,12 @@ public:
     ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, LinkId_t link_id, Link* link) override;
     void execute(int thread) override;
 
-    /** Cause an exchange of Initialization Data to occur */
-    void exchangeLinkInitData(int thread, std::atomic<int>& msg_count) override;
+    /** Cause an exchange of Untimed Data to occur */
+    void exchangeLinkUntimedData(int thread, std::atomic<int>& msg_count) override;
     /** Finish link configuration */
     void finalizeLinkConfigurations() override;
+    /** Prepare for the complete() stage */
+    void prepareForComplete() override;
 
     SimTime_t getNextSyncTime() override { return myNextSyncTime; }
     
@@ -57,7 +58,6 @@ private:
         uint32_t remote_size;
     };
     
-    // typedef std::map<int, std::pair<SyncQueueC*, std::vector<char>* > > comm_map_t;
     typedef std::map<int, comm_pair > comm_map_t;
     typedef std::map<LinkId_t, Link*> link_map_t;
 

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -130,7 +130,7 @@ Simulation::Simulation( Config* cfg, RankInfo my_rank, RankInfo num_ranks, SimTi
     endSim(false),
     my_rank(my_rank),
     num_ranks(num_ranks),
-    init_phase(0),
+    untimed_phase(0),
     lastRecvdSignal(0),
     shutdown_mode(SHUTDOWN_CLEAN),
     wireUpFinished(false)
@@ -140,7 +140,6 @@ Simulation::Simulation( Config* cfg, RankInfo my_rank, RankInfo num_ranks, SimTi
 
     timeVortex = new TimeVortex;
     if( my_rank.thread == 0 ) {
-        // m_exit = new Exit( num_ranks.thread, timeLord.getTimeConverter("100ns"), num_ranks.rank == 1 );
         m_exit = new Exit( num_ranks.thread, timeLord.getTimeConverter("100ns"), min_part == MAX_SIMTIME_T );
     }
 
@@ -209,7 +208,6 @@ Simulation::getLocalMinimumNextActivityTime()
 void
 Simulation::processGraphInfo( ConfigGraph& graph, const RankInfo& UNUSED(myRank), SimTime_t min_part )
 {
-    // TraceFunction trace(CALL_INFO_LONG);    
     // Set minPartTC (only thread 0 will do this)
     Simulation::minPart = min_part;
     if ( my_rank.thread == 0 ) {
@@ -274,25 +272,16 @@ Simulation::processGraphInfo( ConfigGraph& graph, const RankInfo& UNUSED(myRank)
 
     // Determine if this thread is independent.  That means there is
     // no need to synchronize with any other threads or ranks.
-    // if ( min_part == MAX_SIMTIME_T ) {
-    //     independent = true;
-    //     for ( int i = 0; i < num_ranks.thread; i++ ) {
-    //         if ( interThreadLatencies[i] != MAX_SIMTIME_T ) independent = false;
-    //     }
-    // }
     if ( min_part == MAX_SIMTIME_T && cross_thread_links == 0 ) {
         independent = true;
     }
     else {
         independent = false;
     }
-    // if ( independent ) std::cout << "thread " << my_rank.thread <<  " is independent" << std::endl;
 }
     
 int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTime_t UNUSED(min_part))
 {
-    // TraceFunction trace(CALL_INFO_LONG);    
-    
     // Create the Statistics Engine
     if ( myRank.thread == 0 ) {
     }
@@ -388,7 +377,7 @@ int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTi
             ActivityQueue* sync_q = syncManager->registerLink(rank[remote],rank[local],clink.id,lp.getRight());
 
             lp.getRight()->configuredQueue = sync_q;
-            lp.getRight()->initQueue = sync_q;
+            lp.getRight()->untimedQueue = sync_q;
         }
 
     }
@@ -426,29 +415,28 @@ int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTi
 }
 
 void Simulation::initialize() {
-    // TraceFunction trace(CALL_INFO_LONG);    
     bool done = false;
     initBarrier.wait();
     if ( my_rank.thread == 0 ) sharedRegionManager->updateState(false);
 
     do {
         initBarrier.wait();
-        if ( my_rank.thread == 0 ) init_msg_count = 0;
+        if ( my_rank.thread == 0 ) untimed_msg_count = 0;
         initBarrier.wait();
                 
         for ( auto iter = compInfoMap.begin(); iter != compInfoMap.end(); ++iter ) {
             // printf("Calling init on %s: %p\n",(*iter)->getName().c_str(),(*iter)->getComponent());
-            (*iter)->getComponent()->init(init_phase);
+            (*iter)->getComponent()->init(untimed_phase);
         }
 
         initBarrier.wait();
-        syncManager->exchangeLinkInitData(init_msg_count);
+        syncManager->exchangeLinkUntimedData(untimed_msg_count);
         initBarrier.wait();
         // We're done if no new messages were sent
-        if ( init_msg_count == 0 ) done = true;
+        if ( untimed_msg_count == 0 ) done = true;
         if ( my_rank.thread == 0 ) sharedRegionManager->updateState(false);
 
-        init_phase++;
+        untimed_phase++;
     } while ( !done);
 
     // Walk through all the links and call finalizeConfiguration
@@ -468,10 +456,41 @@ void Simulation::initialize() {
 
 }
 
-void Simulation::setup() {  
+void Simulation::complete() {
 
-    // TraceFunction(CALL_INFO_LONG);    
-    // Output tmp_debug("@r: @t:  ",5,-1,Output::FILE);
+    untimed_phase = 0;
+    // Walk through all the links and call prepareForComplete()
+    for ( auto &i : compInfoMap ) {
+        i->prepareForComplete();
+    }
+
+    syncManager->prepareForComplete();
+
+    bool done = false;
+    completeBarrier.wait();
+
+    do {
+        completeBarrier.wait();
+        if ( my_rank.thread == 0 ) untimed_msg_count = 0;
+        completeBarrier.wait();
+                
+        for ( auto iter = compInfoMap.begin(); iter != compInfoMap.end(); ++iter ) {
+            (*iter)->getComponent()->complete(untimed_phase);
+        }
+
+        completeBarrier.wait();
+        syncManager->exchangeLinkUntimedData(untimed_msg_count);
+        completeBarrier.wait();
+        // We're done if no new messages were sent
+        if ( untimed_msg_count == 0 ) done = true;
+
+        untimed_phase++;
+    } while ( !done);
+
+
+}
+
+void Simulation::setup() {  
 
     setupBarrier.wait();
     
@@ -487,8 +506,6 @@ void Simulation::setup() {
 }
 
 void Simulation::run() {
-    // TraceFunction trace(CALL_INFO_LONG);
-
     // Put a stop event at the end of the timeVortex. Simulation will
     // only get to this is there are no other events in the queue.
     // In general, this shouldn't happen, especially for parallel
@@ -514,18 +531,14 @@ void Simulation::run() {
     if ( my_rank.thread == 0 )
         StatisticProcessingEngine::getInstance()->startOfSimulation();
 
-    // wait_my_turn_start(runBarrier, my_rank.thread, num_ranks.thread);
-    // sim_output.output("%d: Start main event loop\n",my_rank.thread);
     std::string header = SST::to_string(my_rank.rank);
     header += ", ";
     header += SST::to_string(my_rank.thread);
     header += ":  ";
-    // wait_my_turn_end(runBarrier, my_rank.thread, num_ranks.thread);
     while( LIKELY( ! endSim ) ) {
         currentSimCycle = timeVortex->front()->getDeliveryTime();
         currentPriority = timeVortex->front()->getPriority();
         current_activity = timeVortex->pop();
-        //current_activity->print(header, sim_output);
         current_activity->execute();
 
 
@@ -552,9 +565,7 @@ void Simulation::run() {
     /* We shouldn't need to do this, but to be safe... */
     ThreadSync::disable();
 
-    // fprintf(stderr, "thread %u waiting on runLoop finish barrier\n", my_rank.thread);
     runBarrier.wait();  // TODO<- Is this needed?
-    // fprintf(stderr, "thread %u released from runLoop finish barrier\n", my_rank.thread);
     if (num_ranks.rank != 1 && num_ranks.thread == 0) delete m_exit;
 }
 
@@ -822,6 +833,7 @@ void wait_my_turn_end(Core::ThreadSafe::Barrier& barrier, int thread, int total_
 
 void Simulation::resizeBarriers(uint32_t nthr) {
     initBarrier.resize(nthr);
+    completeBarrier.resize(nthr);
     setupBarrier.resize(nthr);
     runBarrier.resize(nthr);
     exitBarrier.resize(nthr);
@@ -834,6 +846,7 @@ Factory* Simulation::factory;
 TimeLord Simulation::timeLord;
 Output Simulation::sim_output;
 Core::ThreadSafe::Barrier Simulation::initBarrier;
+Core::ThreadSafe::Barrier Simulation::completeBarrier;
 Core::ThreadSafe::Barrier Simulation::setupBarrier;
 Core::ThreadSafe::Barrier Simulation::runBarrier;
 Core::ThreadSafe::Barrier Simulation::exitBarrier;
@@ -848,7 +861,7 @@ SimTime_t Simulation::minPart;
 SharedRegionManager* Simulation::sharedRegionManager = new SharedRegionManagerImpl();
 std::unordered_map<std::thread::id, Simulation*> Simulation::instanceMap;
 std::vector<Simulation*> Simulation::instanceVec;
-std::atomic<int> Simulation::init_msg_count;
+std::atomic<int> Simulation::untimed_msg_count;
 Exit* Simulation::m_exit;
 
 

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -458,6 +458,7 @@ void Simulation::initialize() {
 
 void Simulation::complete() {
 
+    completeBarrier.wait();
     untimed_phase = 0;
     // Walk through all the links and call prepareForComplete()
     for ( auto &i : compInfoMap ) {

--- a/src/sst/core/simulation.h
+++ b/src/sst/core/simulation.h
@@ -117,6 +117,8 @@ public:
     void setStopAtCycle( Config* cfg );
     /** Perform the init() phase of simulation */
     void initialize();
+    /** Perform the complete() phase of simulation */
+    void complete();
     /** Perform the setup() and run phases of the simulation. */
     void setup();
     void run();
@@ -298,6 +300,7 @@ private:
     static Output sim_output;
     static void resizeBarriers(uint32_t nthr);
     static Core::ThreadSafe::Barrier initBarrier;
+    static Core::ThreadSafe::Barrier completeBarrier;
     static Core::ThreadSafe::Barrier setupBarrier;
     static Core::ThreadSafe::Barrier runBarrier;
     static Core::ThreadSafe::Barrier exitBarrier;
@@ -350,11 +353,10 @@ private:
     RankInfo         my_rank;
     RankInfo         num_ranks;
     bool             independent; // true if no links leave thread (i.e. no syncs required)
-    static std::atomic<int>       init_msg_count;
-    unsigned int     init_phase;
+    static std::atomic<int>       untimed_msg_count;
+    unsigned int     untimed_phase;
     volatile sig_atomic_t lastRecvdSignal;
     ShutdownMode_t   shutdown_mode;
-    // std::map<ComponentId_t,LinkMap*> component_links;
     std::string      output_directory;
     static SharedRegionManager* sharedRegionManager;
     bool             wireUpFinished;

--- a/src/sst/core/syncBase.cc
+++ b/src/sst/core/syncBase.cc
@@ -26,16 +26,12 @@ void
 SyncBase::setMaxPeriod(TimeConverter* period)
 {
     max_period = period;
-    // Simulation *sim = Simulation::getSimulation();
-    // SimTime_t next = sim->getCurrentSimCycle() + period->getFactor();
-    // setPriority(SYNCPRIORITY);
-    // sim->insertActivity( next, this );        
 }
     
 void
-SyncBase::sendInitData_sync(Link* link, Event* init_data)
+SyncBase::sendUntimedData_sync(Link* link, Event* data)
 {
-    link->sendInitData_sync(init_data);
+    link->sendUntimedData_sync(data);
 }
     
 void

--- a/src/sst/core/syncBase.h
+++ b/src/sst/core/syncBase.h
@@ -40,17 +40,13 @@ public:
     /** Register a Link which this Sync Object is responsible for */
     virtual ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, LinkId_t link_id, Link* link) = 0;
 
-    // void execute(void);
-
-    /** Cause an exchange of Initialization Data to occur */
-    virtual int exchangeLinkInitData(int msg_count) = 0;
+    /** Cause an exchange of Untimed Data to occur */
+    virtual int exchangeLinkUntimedData(int msg_count) = 0;
     /** Finish link configuration */
     virtual void finalizeLinkConfigurations() = 0;
 
     virtual void setExit(Exit* ex) { exit = ex; }
     virtual void setMaxPeriod(TimeConverter* period);
-
-    // void print(const std::string& header, Output &out) const;
 
     virtual uint64_t getDataSize() const = 0;
 
@@ -61,7 +57,7 @@ protected:
     Exit* exit;
     TimeConverter* max_period;
 
-    void sendInitData_sync(Link* link, Event* init_data);
+    void sendUntimedData_sync(Link* link, Event* data);
     void finalizeConfiguration(Link* link);
     
 

--- a/src/sst/core/syncManager.h
+++ b/src/sst/core/syncManager.h
@@ -39,8 +39,9 @@ public:
     virtual ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, LinkId_t link_id, Link* link) = 0;
 
     virtual void execute(int thread) = 0;
-    virtual void exchangeLinkInitData(int thread, std::atomic<int>& msg_count) = 0;
+    virtual void exchangeLinkUntimedData(int thread, std::atomic<int>& msg_count) = 0;
     virtual void finalizeLinkConfigurations() = 0;
+    virtual void prepareForComplete() = 0;
 
     virtual SimTime_t getNextSyncTime() { return nextSyncTime; }
 
@@ -57,8 +58,12 @@ protected:
         link->finalizeConfiguration();
     }
    
-    void sendInitData_sync(Link* link, Event* init_data) {
-        link->sendInitData_sync(init_data);
+    void prepareForCompleteInt(Link* link) {
+        link->prepareForComplete();
+    }
+   
+    void sendUntimedData_sync(Link* link, Event* data) {
+        link->sendUntimedData_sync(data);
     }
 
 private:
@@ -73,8 +78,9 @@ public:
     virtual void before() = 0;
     virtual void after() = 0;
     virtual void execute() = 0;
-    virtual void processLinkInitData() = 0;
+    virtual void processLinkUntimedData() = 0;
     virtual void finalizeLinkConfigurations() = 0;
+    virtual void prepareForComplete() = 0;
 
     virtual SimTime_t getNextSyncTime() { return nextSyncTime; }
 
@@ -93,8 +99,12 @@ protected:
         link->finalizeConfiguration();
     }
    
-    void sendInitData_sync(Link* link, Event* init_data) {
-        link->sendInitData_sync(init_data);
+    void prepareForCompleteInt(Link* link) {
+        link->prepareForComplete();
+    }
+   
+    void sendUntimedData_sync(Link* link, Event* data) {
+        link->sendUntimedData_sync(data);
     }
 
 private:
@@ -110,9 +120,10 @@ public:
     void execute(void) override;
 
     /** Cause an exchange of Initialization Data to occur */
-    void exchangeLinkInitData(std::atomic<int>& msg_count);
+    void exchangeLinkUntimedData(std::atomic<int>& msg_count);
     /** Finish link configuration */
     void finalizeLinkConfigurations();
+    void prepareForComplete();
 
     void print(const std::string& header, Output &out) const override;
 
@@ -124,7 +135,7 @@ private:
     RankInfo rank;
     RankInfo num_ranks;
     static Core::ThreadSafe::Barrier RankExecBarrier[6];
-    static Core::ThreadSafe::Barrier LinkInitBarrier[3];
+    static Core::ThreadSafe::Barrier LinkUntimedBarrier[3];
     // static SimTime_t min_next_time;
     // static int min_count;
     

--- a/src/sst/core/threadSync.cc
+++ b/src/sst/core/threadSync.cc
@@ -85,8 +85,7 @@ ThreadSync::execute()
             Event* ev = static_cast<Event*>(vec[j]);
             auto link = link_map.find(ev->getLinkId());
             if (link == link_map.end()) {
-                printf("Link not found in map!\n");
-                abort();
+                Simulation::getSimulationOutput().fatal(CALL_INFO,1,"Link not found in map!\n");
             } else {
                 SimTime_t delay = ev->getDeliveryTime() - sim->getCurrentSimCycle();
                 link->second->send(delay,ev);
@@ -96,7 +95,6 @@ ThreadSync::execute()
     }
 
     Exit* exit = sim->getExit();
-    // std::cout << "ThreadSync(" << Simulation::getSimulation()->getRank().thread << ")::ref_count = " << exit->getRefCount() << std::endl;
     if ( single_rank && exit->getRefCount() == 0 ) {
         endSimulation(exit->getEndTime());
     }
@@ -108,7 +106,7 @@ ThreadSync::execute()
 }
 
 void
-ThreadSync::processLinkInitData()
+ThreadSync::processLinkUntimedData()
 {
     // Need to walk through all the queues and send the data to the
     // correct links
@@ -119,10 +117,9 @@ ThreadSync::processLinkInitData()
             Event* ev = static_cast<Event*>(vec[j]);
             auto link = link_map.find(ev->getLinkId());
             if (link == link_map.end()) {
-                printf("Link not found in map!\n");
-                abort();
+                Simulation::getSimulationOutput().fatal(CALL_INFO,1,"Link not found in map!\n");
             } else {
-                link->second->sendInitData_sync(ev);
+                link->second->sendUntimedData_sync(ev);
             }
         }
         queue->clear();

--- a/src/sst/core/threadSync.h
+++ b/src/sst/core/threadSync.h
@@ -46,8 +46,8 @@ public:
 
     void execute(void) override;
 
-    /** Cause an exchange of Initialization Data to occur */
-    void processLinkInitData();
+    /** Cause an exchange of Untimed Data to occur */
+    void processLinkUntimedData();
     /** Finish link configuration */
     void finalizeLinkConfigurations();
 

--- a/src/sst/core/threadSyncSimpleSkip.h
+++ b/src/sst/core/threadSyncSimpleSkip.h
@@ -42,10 +42,11 @@ public:
     void after() override;
     void execute(void) override;
 
-    /** Cause an exchange of Initialization Data to occur */
-    void processLinkInitData() override;
+    /** Cause an exchange of Untimed Data to occur */
+    void processLinkUntimedData() override;
     /** Finish link configuration */
     void finalizeLinkConfigurations() override;
+    void prepareForComplete() override;
 
     /** Register a Link which this Sync Object is responsible for */
     void registerLink(LinkId_t link_id, Link* link) override;
@@ -63,7 +64,6 @@ private:
     int thread;
     static SimTime_t localMinimumNextActivityTime;
     Simulation* sim;
-    // static bool disabled;
     static Core::ThreadSafe::Barrier barrier[3];
     double totalWaitTime;
     bool single_rank;


### PR DESCRIPTION
As part of this, added calls sendUntimedData and recvUntimed data.
There will eventually replace the send/recvInitData calls to keep
the names more generic.  As part of this, changed all variables with
init in the name to use untimed instead (except for those which were
referring specifically to the init() stage.

