### PR TITLE
Partition fixes

### DIFF
--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -628,6 +628,16 @@ ConfigGraph::addLink(ComponentId_t comp_id, string link_name, string port, strin
 	findComponent(comp_id)->links.push_back(link.id);
 }
 
+void
+ConfigGraph::setLinkNoCut(string link_name)
+{
+    // If link doesn't exist, return
+    if ( link_names.find(link_name) == link_names.end() ) return;
+
+    ConfigLink &link = links[link_names[link_name]];
+    link.no_cut = true;
+}
+
 
 
 bool ConfigGraph::containsComponent(ComponentId_t id) const {

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -353,6 +353,9 @@ public:
     /** Add a Link to a Component on a given Port */
     void addLink(ComponentId_t comp_id, std::string link_name, std::string port, std::string latency_str, bool no_cut = false);
 
+    /** Set a Link to be no-cut */
+    void setLinkNoCut(std::string link_name);
+
     /** Perform any post-creation cleanup processes */
     void postCreationCleanup();
 

--- a/src/sst/core/model/pymodel.h
+++ b/src/sst/core/model/pymodel.h
@@ -73,7 +73,8 @@ class SSTPythonModelDefinition : public SSTModelDescription {
             return ( itr != compNameMap.end() ) ? itr->second : UNSET_COMPONENT_ID;
         }
 
-        void addLink(ComponentId_t id, const char *name, const char *port, const char *latency, bool no_cut) const {graph->addLink(id, name, port, latency, no_cut); }
+        void addLink(ComponentId_t id, const char *link_name, const char *port, const char *latency, bool no_cut) const {graph->addLink(id, link_name, port, latency, no_cut); }
+        void setLinkNoCut(const char *link_name) const {graph->setLinkNoCut(link_name); }
 
         void pushNamePrefix(const char *name);
         void popNamePrefix(void);

--- a/src/sst/core/model/pymodel_link.cc
+++ b/src/sst/core/model/pymodel_link.cc
@@ -116,6 +116,7 @@ static PyObject* linkSetNoCut(PyObject* self, PyObject *UNUSED(args))
     LinkPy_t *link = (LinkPy_t*)self;
     bool prev = link->no_cut;
     link->no_cut = true;
+    gModel->setLinkNoCut(link->name);
     return PyBool_FromLong(prev ? 1 : 0);
 }
 

--- a/src/sst/core/part/Makefile.inc
+++ b/src/sst/core/part/Makefile.inc
@@ -4,6 +4,7 @@
 
 sst_core_sources += \
 	part/selfpart.h \
+	part/selfpart.cc \
 	part/singlepart.cc \
 	part/singlepart.h \
 	part/simplepart.cc \

--- a/src/sst/core/part/selfpart.cc
+++ b/src/sst/core/part/selfpart.cc
@@ -1,0 +1,13 @@
+// Copyright 2009-2017 Sandia Corporation. Under the terms
+// of Contract DE-NA0003525 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2017, Sandia Corporation
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include <sst_config.h>
+#include <sst/core/part/selfpart.h>

--- a/src/sst/core/part/selfpart.h
+++ b/src/sst/core/part/selfpart.h
@@ -42,13 +42,13 @@ public:
     /**
        Creates a new self partition scheme.
     */
-    SSTSelfPartition(RankInfo total_ranks, RankInfo my_rank, int verbosity) {}
+    SSTSelfPartition(RankInfo UNUSED(total_ranks), RankInfo UNUSED(my_rank), int UNUSED(verbosity)) {}
     
     /**
        Performs a partition of an SST simulation configuration
        \param graph The simulation configuration to partition
     */
-    void performPartition(ConfigGraph* graph) { return; }
+    void performPartition(ConfigGraph* UNUSED(graph)) { return; }
     
     bool requiresConfigGraph() { return true; }
     bool spawnOnAllRanks() { return false; }


### PR DESCRIPTION
Fixes the issue of "self" partitioner not being found. Fixed an issue where calling setNoCut() after calling connect() in the python would not properly set the no-cut attribute in the config graph.