### PR TITLE
Remove sst_config.h from Makefile.am

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -142,7 +142,8 @@ nobase_dist_sst_HEADERS = \
 	model/element_python.h
 
 nobase_nodist_sst_HEADERS = \
-	build_info.h
+	build_info.h \
+	sst_config.h
 
 sst_core_sources = \
 	action.cc \

--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -138,7 +138,6 @@ nobase_dist_sst_HEADERS = \
 	statapi/componentregisterstat_impl.h \
 	threadsafe.h \
 	cputimer.h \
-	sst_config.h \
 	warnmacros.h \
 	model/element_python.h
 


### PR DESCRIPTION
Removing sst-config.h from src/sst/core/Makefile.am  to prevent file from being added to distribution when running `make dist`.  

The sst_config.h is generated dynamically by the configure script, When it was in the Makefile.am, it was being distributed causing issues with out of source builds.

This change removes it from the distribution.

See issue #302.