### PR TITLE
Remove output from roundrobin partitioner

### DIFF
--- a/src/sst/core/part/rrobin.cc
+++ b/src/sst/core/part/rrobin.cc
@@ -29,7 +29,6 @@ SSTRoundRobinPartition::SSTRoundRobinPartition(RankInfo world_size, RankInfo UNU
 }
 
 void SSTRoundRobinPartition::performPartition(PartitionGraph* graph) {
-    std::cout << "Round robin partitioning" << std::endl;
     PartitionComponentMap_t& compMap = graph->getComponentMap();
     RankInfo rank(0, 0);
 


### PR DESCRIPTION
This is the only partitioner with unconditional output, so using roundrobin breaks all my scripts.