### PR TITLE
Changing ELI change deprecation warning.  Removal of old ELI will be …

### DIFF
--- a/src/sst/core/element.h
+++ b/src/sst/core/element.h
@@ -124,7 +124,7 @@ struct ElementInfoGenerator {
 #if SST_BUILDING_CORE
 struct ElementLibraryInfo {
 #else
-struct __attribute__ ((deprecated("Old ELI support (defined in sst/core/element.h) will be removed in version 8.0.  Please convert to new ELI (defined in sst/core/elementinfo.h)."))) ElementLibraryInfo {
+struct __attribute__ ((deprecated("Old ELI support (defined in sst/core/element.h) will be removed in version 9.0.  Please convert to new ELI (defined in sst/core/elementinfo.h)."))) ElementLibraryInfo {
 #endif
     const char *name;										/*!< Name of the Library. */
     const char *description;								/*!< Brief description of the Library */


### PR DESCRIPTION
…deferred to version 9.0
