### PR TITLE
Added ability to specify the implemention of TimeVortex to be used.

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -183,7 +183,6 @@ sst_core_sources = \
 	threadSyncSimpleSkip.cc \
 	sharedRegion.cc \
 	timeLord.cc \
-	timeVortex.cc \
 	uninitializedQueue.cc \
 	unitAlgebra.cc \
 	serialization/serializable.cc \
@@ -295,6 +294,7 @@ sstinfo_x_LDFLAGS = \
 include tinyxml/Makefile.inc
 include part/Makefile.inc
 include model/Makefile.inc
+include impl/Makefile.inc
 
 if USE_LIBZ
 sstsim_x_LDADD += $(LIBZ_LIBS)

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -58,6 +58,7 @@ Config::Config(RankInfo rankInfo)
     partitioner = "sst.linear";
     generator   = "NONE";
     generator_options   = "";
+    timeVortex  = "sst.timevortex.priority_queue";
     dump_component_graph_file = "";
 
     char* wd_buf = (char*) malloc( sizeof(char) * PATH_MAX );
@@ -134,6 +135,7 @@ static const struct sstLongOpts_s sstOptions[] = {
     DEF_ARGOPT("partitioner",       "PARTITIONER",  "select the partitioner to be used. <lib.partitionerName>", &Config::setPartitioner),
     DEF_ARGOPT("generator",         "GENERATOR",    "select the generator to be used to build simulation <lib.generatorName>", &Config::setGenerator),
     DEF_ARGOPT("gen-options",       "OPTSTIRNG",    "options to be passed to generator function", &Config::setGeneratorOptions),
+    DEF_ARGOPT("timeVortex ",       "MODULE",       "select TimeVortex implementation <lib.timevortex>", &Config::setTimeVortex),
     DEF_ARGOPT("output-directory",  "DIR",          "directory into which all SST output files should reside", &Config::setOutputDir),
     DEF_ARGOPT("output-config",     "FILE",         "file to write SST configuration (in Python format)", &Config::setWriteConfig),
     DEF_ARGOPT("output-dot",        "FILE",         "file to write SST configuration graph (in GraphViz format)", &Config::setWriteDot),
@@ -455,6 +457,11 @@ bool Config::setGeneratorOptions(const std::string &arg) {
         generator_options = arg;
     else
         generator_options += std::string(" \"") + arg + std::string("\"");
+    return true;
+}
+
+bool Config::setTimeVortex(const std::string &arg) {
+    timeVortex = arg;
     return true;
 }
 

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -66,6 +66,7 @@ public:
     std::string     partitioner;        /*!< Partitioner to use */
     std::string     generator;          /*!< Generator to use */
     std::string     generator_options;  /*!< Options to pass to the generator */
+    std::string     timeVortex;         /*!< TimeVortex implementation to use */
     std::string     output_config_graph;  /*!< File to dump configuration graph */
     std::string     output_dot;         /*!< File to dump dot output */
     std::string     output_xml;         /*!< File to dump XML output */
@@ -109,6 +110,7 @@ public:
     bool setPartitioner(const std::string &arg);
     bool setGenerator(const std::string &arg);
     bool setGeneratorOptions(const std::string &arg);
+    bool setTimeVortex(const std::string &arg);
     bool setOutputDir(const std::string &arg);
     bool setWriteConfig(const std::string &arg);
     bool setWriteDot(const std::string &arg);

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -453,8 +453,12 @@ Factory::CreateModule(std::string type, Params& params)
     std::string elemlib, elem;
     std::tie(elemlib, elem) = parseLoadName(type);
 
+    // Check for legacy core modules.  These consist only of
+    // StatisticsOutputs at this point.  These should be moved to the
+    // new ELI infrastructure
     if("sst" == elemlib) {
-        return CreateCoreModule(elem, params);
+        Module* ret = CreateCoreModule(elem, params);
+        if ( ret != NULL ) return ret;
     }
 
     requireLibrary(elemlib);
@@ -528,21 +532,8 @@ Factory::LoadCoreModule_StatisticOutputs(std::string& type, Params& params)
 
 Module*
 Factory::CreateCoreModule(std::string type, Params& params) {
-    // Try to load the core modules    
-    Module* rtnModule = NULL;
-
-    // Check each type of Core Module to load them
-    if (NULL == rtnModule) {
-        rtnModule = LoadCoreModule_StatisticOutputs(type, params);
-    }
-    
-    // Try to load other core modules here...
-    
-    // Did we succeed in loading a core module? 
-    if (NULL == rtnModule) {
-        out.fatal(CALL_INFO, -1, "can't find requested core module %s\n", type.c_str());
-    }
-    return rtnModule;
+    // Try to load the legacy core modules    
+    return LoadCoreModule_StatisticOutputs(type, params);
 }
 
 Module*

--- a/src/sst/core/impl/Makefile.inc
+++ b/src/sst/core/impl/Makefile.inc
@@ -1,0 +1,6 @@
+
+# -*- Makefile -*-
+#
+#
+
+include impl/timevortex/Makefile.inc

--- a/src/sst/core/impl/timevortex/Makefile.inc
+++ b/src/sst/core/impl/timevortex/Makefile.inc
@@ -1,0 +1,9 @@
+
+# -*- Makefile -*-
+#
+#
+
+sst_core_sources += \
+	impl/timevortex/timeVortexPQ.cc \
+	impl/timevortex/timeVortexPQ.h
+

--- a/src/sst/core/impl/timevortex/timeVortexPQ.cc
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.cc
@@ -12,24 +12,26 @@
 
 #include "sst_config.h"
 
-#include <sst/core/timeVortex.h>
+#include <sst/core/impl/timevortex/timeVortexPQ.h>
+
 #include <sst/core/output.h>
 
 #include <sst/core/clock.h>
 #include <sst/core/simulation.h>
 
 namespace SST {
+namespace IMPL {
 
-TimeVortex::TimeVortex() :
-    ActivityQueue(),
+TimeVortexPQ::TimeVortexPQ(Params& UNUSED(params)) :
+    TimeVortex(),
     insertOrder(0),
     current_depth(0),
     max_depth(0)
 {}
 
-TimeVortex::~TimeVortex()
+TimeVortexPQ::~TimeVortexPQ()
 {
-    // Activities in TimeVortex all need to be deleted
+    // Activities in TimeVortexPQ all need to be deleted
     while ( !data.empty() ) {
         Activity *it = data.top();
         delete it;
@@ -37,17 +39,17 @@ TimeVortex::~TimeVortex()
     }
 }
 
-bool TimeVortex::empty()
+bool TimeVortexPQ::empty()
 {
     return data.empty();
 }
 
-int TimeVortex::size()
+int TimeVortexPQ::size()
 {
     return data.size();
 }
 
-void TimeVortex::insert(Activity* activity)
+void TimeVortexPQ::insert(Activity* activity)
 {
     activity->setQueueOrder(insertOrder++);
     data.push(activity);
@@ -57,7 +59,7 @@ void TimeVortex::insert(Activity* activity)
     }
 }
 
-Activity* TimeVortex::pop()
+Activity* TimeVortexPQ::pop()
 {
     if ( data.empty() ) return NULL;
     Activity* ret_val = data.top();
@@ -67,12 +69,12 @@ Activity* TimeVortex::pop()
 
 }
 
-Activity* TimeVortex::front()
+Activity* TimeVortexPQ::front()
 {
     return data.top();
 }
 
-void TimeVortex::print(Output &out) const
+void TimeVortexPQ::print(Output &out) const
 {
     out.output("TimeVortex state:\n");
 
@@ -85,5 +87,5 @@ void TimeVortex::print(Output &out) const
 }
 
 
-
+} // namespace IMPL
 } // namespace SST

--- a/src/sst/core/impl/timevortex/timeVortexPQ.h
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.h
@@ -1,0 +1,79 @@
+// Copyright 2009-2017 Sandia Corporation. Under the terms
+// of Contract DE-NA0003525 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+// 
+// Copyright (c) 2009-2017, Sandia Corporation
+// All rights reserved.
+// 
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_IMPL_TIMEVORTEX_TIMEVORTEXPQ_H
+#define SST_CORE_IMPL_TIMEVORTEX_TIMEVORTEXPQ_H
+
+#include <functional>
+#include <queue>
+#include <vector>
+
+#include <sst/core/timeVortex.h>
+#include <sst/core/elementinfo.h>
+
+namespace SST {
+
+class Output;
+
+namespace IMPL {
+
+
+/**
+ * Primary Event Queue
+ */
+class TimeVortexPQ : public TimeVortex {
+
+public:
+    SST_ELI_REGISTER_MODULE(
+        TimeVortexPQ,
+        "sst",
+        "timevortex.priority_queue",
+        SST_ELI_ELEMENT_VERSION(1,0,0),
+        "TimeVortex based on std::priority_queue.",
+        "SST::TimeVortex")
+
+
+public:
+	// TimeVortexPQ();
+	TimeVortexPQ(Params& params);
+    ~TimeVortexPQ();
+
+    bool empty() override;
+    int size() override;
+    void insert(Activity* activity) override;
+    Activity* pop() override;
+    Activity* front() override;
+
+    /** Print the state of the TimeVortex */
+    void print(Output &out) const override;
+
+    uint64_t getCurrentDepth() const override { return current_depth; }
+    uint64_t getMaxDepth() const override { return max_depth; }
+    
+private:
+#ifdef SST_ENFORCE_EVENT_ORDERING
+    typedef std::priority_queue<Activity*, std::vector<Activity*>, Activity::pq_less_time_priority_order> dataType_t;
+#else
+    typedef std::priority_queue<Activity*, std::vector<Activity*>, Activity::pq_less_time_priority> dataType_t;
+#endif
+    dataType_t data;
+    uint64_t insertOrder;
+
+    uint64_t current_depth;
+    uint64_t max_depth;
+    
+};
+
+} // namespace IMPL
+} //namespace SST
+
+#endif // SST_CORE_IMPL_TIMEVORTEX_TIMEVORTEXPQ_H
+

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -138,7 +138,8 @@ Simulation::Simulation( Config* cfg, RankInfo my_rank, RankInfo num_ranks, SimTi
     sim_output.init(cfg->output_core_prefix, cfg->getVerboseLevel(), 0, Output::STDOUT);
     output_directory = "";
 
-    timeVortex = new TimeVortex;
+    Params p;
+    timeVortex = static_cast<TimeVortex*>(factory->CreateModule(cfg->timeVortex,p));
     if( my_rank.thread == 0 ) {
         m_exit = new Exit( num_ranks.thread, timeLord.getTimeConverter("100ns"), min_part == MAX_SIMTIME_T );
     }

--- a/src/sst/core/timeVortex.h
+++ b/src/sst/core/timeVortex.h
@@ -12,11 +12,8 @@
 #ifndef SST_CORE_TIMEVORTEX_H
 #define SST_CORE_TIMEVORTEX_H
 
-#include <functional>
-#include <queue>
-#include <vector>
-
 #include <sst/core/activityQueue.h>
+#include <sst/core/module.h>
 
 namespace SST {
 
@@ -25,33 +22,27 @@ class Output;
 /**
  * Primary Event Queue
  */
-class TimeVortex : public ActivityQueue {
+class TimeVortex : public ActivityQueue, public Module {
 public:
-	TimeVortex();
-    ~TimeVortex();
+	TimeVortex() {
+        max_depth = MAX_SIMTIME_T;
+    }
+    ~TimeVortex() {}
 
-    bool empty() override;
-    int size() override;
-    void insert(Activity* activity) override;
-    Activity* pop() override;
-    Activity* front() override;
+    // Inherited from ActivityQueue
+    virtual bool empty() override = 0;
+    virtual int size() override = 0;
+    virtual void insert(Activity* activity) override = 0;
+    virtual Activity* pop() override = 0;
+    virtual Activity* front() override = 0;
 
     /** Print the state of the TimeVortex */
-    void print(Output &out) const;
+    virtual void print(Output &out) const = 0;
+    virtual uint64_t getMaxDepth() const { return max_depth; }
+    virtual uint64_t getCurrentDepth() const = 0;
 
-    uint64_t getCurrentDepth() const { return current_depth; }
-    uint64_t getMaxDepth() const { return max_depth; }
     
-private:
-#ifdef SST_ENFORCE_EVENT_ORDERING
-    typedef std::priority_queue<Activity*, std::vector<Activity*>, Activity::pq_less_time_priority_order> dataType_t;
-#else
-    typedef std::priority_queue<Activity*, std::vector<Activity*>, Activity::pq_less_time_priority> dataType_t;
-#endif
-    dataType_t data;
-    uint64_t insertOrder;
-
-    uint64_t current_depth;
+protected:
     uint64_t max_depth;
     
 };


### PR DESCRIPTION
TimeVortex is now a module which can be loaded.  The default is
sst.timevortex.priority_queue and is the same implementation
that has been used to this point.
