### PR TITLE
Moved partitioners from sst/core/part to sst/core/impl/partitioners.

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -66,6 +66,7 @@ nobase_dist_sst_HEADERS = \
 	sparseVectorMap.h \
 	sst_types.h \
 	sstinfo.h \
+	sstpart.h \
 	stopAction.h \
 	stringize.h \
 	subcomponent.h \

--- a/src/sst/core/impl/Makefile.inc
+++ b/src/sst/core/impl/Makefile.inc
@@ -4,3 +4,4 @@
 #
 
 include impl/timevortex/Makefile.inc
+include impl/partitioners/Makefile.inc

--- a/src/sst/core/impl/partitioners/Makefile.inc
+++ b/src/sst/core/impl/partitioners/Makefile.inc
@@ -1,0 +1,21 @@
+# -*- Makefile -*-
+#
+#
+
+sst_core_sources += \
+	impl/partitioners/linpart.cc \
+	impl/partitioners/linpart.h \
+	impl/partitioners/rrobin.cc \
+	impl/partitioners/rrobin.h \
+	impl/partitioners/selfpart.h \
+	impl/partitioners/selfpart.cc \
+	impl/partitioners/simplepart.cc \
+	impl/partitioners/simplepart.h \
+	impl/partitioners/singlepart.cc \
+	impl/partitioners/singlepart.h 
+
+if HAVE_ZOLTAN
+sst_core_sources += \
+	impl/partitioners/zoltpart.h \
+	impl/partitioners/zoltpart.cc
+endif

--- a/src/sst/core/impl/partitioners/linpart.cc
+++ b/src/sst/core/impl/partitioners/linpart.cc
@@ -10,12 +10,15 @@
 // distribution.
 
 #include <sst_config.h>
+#include <sst/core/impl/partitioners/linpart.h>
+
 #include <sst/core/warnmacros.h>
-#include <sst/core/part/linpart.h>
+
 #include <sst/core/output.h>
 #include <sst/core/configGraph.h>
 
 using namespace std;
+using namespace SST::IMPL::Partition;
 
 SSTLinearPartition::SSTLinearPartition(RankInfo mpiranks, RankInfo UNUSED(my_rank), int verbosity) {
 	rankcount = mpiranks;

--- a/src/sst/core/impl/partitioners/linpart.h
+++ b/src/sst/core/impl/partitioners/linpart.h
@@ -10,23 +10,19 @@
 // distribution.
 
 
-#ifndef SST_CORE_PART_LINEAR
-#define SST_CORE_PART_LINEAR
+#ifndef SST_CORE_IMPL_PARTITONERS_LINPART_H
+#define SST_CORE_IMPL_PARTITONERS_LINPART_H
 
-#include <sst/core/part/sstpart.h>
+#include <sst/core/sstpart.h>
 #include <sst/core/elementinfo.h>
-
-using namespace SST;
-using namespace SST::Partition;
 
 namespace SST {
 
 class Output;
 
+namespace IMPL {
 namespace Partition {
 
-
-    
 /**
 Performs a linear partition scheme of an SST simulation configuration. In this
 scheme a list of components (supplied as a graph) are grouped by slicing the list
@@ -71,12 +67,9 @@ public:
     bool requiresConfigGraph() override { return false; }
     bool spawnOnAllRanks() override { return false; }
     
-    // static SSTPartitioner* allocate(RankInfo total_ranks, RankInfo my_rank, int verbosity) {
-    //     return new SSTLinearPartition(total_ranks, my_rank, verbosity);
-    // }
-    
 };
 
+}
 }
 }
 

--- a/src/sst/core/impl/partitioners/rrobin.cc
+++ b/src/sst/core/impl/partitioners/rrobin.cc
@@ -10,7 +10,8 @@
 // distribution.
 
 #include <sst_config.h>
-#include "sst/core/part/rrobin.h"
+#include "sst/core/impl/partitioners/rrobin.h"
+
 #include <sst/core/warnmacros.h>
 
 #include <string>
@@ -20,6 +21,7 @@
 using namespace std;
 
 namespace SST {
+namespace IMPL {
 namespace Partition {
 
 SSTRoundRobinPartition::SSTRoundRobinPartition(RankInfo world_size, RankInfo UNUSED(my_rank), int UNUSED(verbosity)) :
@@ -47,4 +49,5 @@ void SSTRoundRobinPartition::performPartition(PartitionGraph* graph) {
 }
 
 } // namespace Partition
+} // namespace IMPL
 } // namespace SST

--- a/src/sst/core/impl/partitioners/rrobin.h
+++ b/src/sst/core/impl/partitioners/rrobin.h
@@ -1,61 +1,52 @@
 // Copyright 2009-2017 Sandia Corporation. Under the terms
 // of Contract DE-NA0003525 with Sandia Corporation, the U.S.
 // Government retains certain rights in this software.
-//
+// 
 // Copyright (c) 2009-2017, Sandia Corporation
 // All rights reserved.
-//
+// 
 // This file is part of the SST software package. For license
 // information, see the LICENSE file in the top level directory of the
 // distribution.
+#ifndef SST_CORE_IMPL_PARTITONERS_RROBIN_H
+#define SST_CORE_IMPL_PARTITONERS_RROBIN_H
 
-
-#ifndef SST_CORE_PART_SINGLE
-#define SST_CORE_PART_SINGLE
-
-#include <sst/core/part/sstpart.h>
+#include <sst/core/sstpart.h>
 #include <sst/core/elementinfo.h>
 
-using namespace SST;
-using namespace SST::Partition;
-
 namespace SST {
+namespace IMPL {
 namespace Partition {
 
-
-    
-/**
-   Single partitioner is a virtual partitioner used for serial jobs.
-   It simply ensures that all components are assigned to rank 0.
-*/
-class SSTSinglePartition : public SST::Partition::SSTPartitioner {
+class SSTRoundRobinPartition : public SST::Partition::SSTPartitioner {
 
 public:
     SST_ELI_REGISTER_PARTITIONER(
-        SSTSinglePartition,
+        SSTRoundRobinPartition,
         "sst",
-        "single",
+        "roundrobin",
         SST_ELI_ELEMENT_VERSION(1,0,0),
-        "Allocates all components to rank 0.  Automatically selected for serial jobs.")
+        "Partitions components using a simple round robin scheme based on ComponentID.  Sequential IDs will be placed on different ranks.")
 
-    /**
-       Creates a new single partition scheme.
-    */
-    SSTSinglePartition(RankInfo total_ranks, RankInfo my_rank, int verbosity);
+private:
+    RankInfo world_size;
+
+public:
+    SSTRoundRobinPartition(RankInfo world_size, RankInfo my_rank, int verbosity);
     
     /**
        Performs a partition of an SST simulation configuration
        \param graph The simulation configuration to partition
     */
-    void performPartition(PartitionGraph* graph) override;
-    
+	void performPartition(PartitionGraph* graph) override;
+
     bool requiresConfigGraph() override { return false; }
     bool spawnOnAllRanks() override { return false; }
     
-    
+        
 };
 
-}
-}
-
-#endif
+} // namespace Partition
+} // namespace IMPL
+} //namespace SST
+#endif //SST_CORE_IMPL_PARTITONERS_RROBIN_H

--- a/src/sst/core/impl/partitioners/selfpart.cc
+++ b/src/sst/core/impl/partitioners/selfpart.cc
@@ -10,4 +10,4 @@
 // distribution.
 
 #include <sst_config.h>
-#include <sst/core/part/selfpart.h>
+#include <sst/core/impl/partitioners/selfpart.h>

--- a/src/sst/core/impl/partitioners/selfpart.h
+++ b/src/sst/core/impl/partitioners/selfpart.h
@@ -10,16 +10,15 @@
 // distribution.
 
 
-#ifndef SST_CORE_PART_SELF
-#define SST_CORE_PART_SELF
+#ifndef SST_CORE_IMPL_PARTITONERS_SELF_H
+#define SST_CORE_IMPL_PARTITONERS_SELF_H
 
-#include <sst/core/part/sstpart.h>
+#include <sst/core/sstpart.h>
+
 #include <sst/core/elementinfo.h>
 
-using namespace SST;
-using namespace SST::Partition;
-
 namespace SST {
+namespace IMPL {
 namespace Partition {
 
 
@@ -56,6 +55,7 @@ public:
 
 };
 
+}
 }
 }
 

--- a/src/sst/core/impl/partitioners/simplepart.cc
+++ b/src/sst/core/impl/partitioners/simplepart.cc
@@ -10,7 +10,8 @@
 // distribution.
 
 #include <sst_config.h>
-#include "sst/core/part/simplepart.h"
+#include "sst/core/impl/partitioners/simplepart.h"
+
 #include <sst/core/warnmacros.h>
 
 #include <string>
@@ -23,6 +24,7 @@
 using namespace std;
 
 namespace SST {
+namespace IMPL {
 namespace Partition {
 
 SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo UNUSED(my_rank), int UNUSED(verbosity)) :
@@ -245,4 +247,5 @@ SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo UNUSED(my_ra
 		}
 	}
 } // namespace partition
+} // namespace IMPL
 } // namespace SST

--- a/src/sst/core/impl/partitioners/simplepart.h
+++ b/src/sst/core/impl/partitioners/simplepart.h
@@ -8,17 +8,20 @@
 // This file is part of the SST software package. For license
 // information, see the LICENSE file in the top level directory of the
 // distribution.
-#ifndef SST_CORE_PART_SIMPLEPART_H
-#define SST_CORE_PART_SIMPLEPART_H
+#ifndef SST_CORE_IMPL_PARTITONERS_SIMPLEPART_H
+#define SST_CORE_IMPL_PARTITONERS_SIMPLEPART_H
 
 #include <map>
+
 #include <sst/core/sst_types.h>
-#include <sst/core/part/sstpart.h>
+#include <sst/core/sstpart.h>
+
 #include <sst/core/elementinfo.h>
 #include <sst/core/configGraph.h>
 
 namespace SST {
-namespace Partition{
+namespace IMPL {
+namespace Partition {
 
 class SimplePartitioner : public SST::Partition::SSTPartitioner {
 
@@ -58,5 +61,6 @@ public:
 };
 
 } // namespace partition
+} // namespace IMPL
 } //namespace SST
-#endif //SST_CORE_PART_SIMPLERPART_H
+#endif //SST_CORE_IMPL_PARTITONERS_SIMPLERPART_H

--- a/src/sst/core/impl/partitioners/singlepart.cc
+++ b/src/sst/core/impl/partitioners/singlepart.cc
@@ -11,13 +11,15 @@
 
 #include <sst_config.h>
 
-#include <sst/core/configGraph.h>
-#include <sst/core/part/singlepart.h>
+#include <sst/core/impl/partitioners/singlepart.h>
+
 #include <sst/core/warnmacros.h>
+
+#include <sst/core/configGraph.h>
 
 using namespace std;
 
-using namespace SST::Partition;
+using namespace SST::IMPL::Partition;
 
 SSTSinglePartition::SSTSinglePartition(RankInfo UNUSED(total_ranks), RankInfo UNUSED(my_rank), int UNUSED(verbosity)) {}
 

--- a/src/sst/core/impl/partitioners/singlepart.h
+++ b/src/sst/core/impl/partitioners/singlepart.h
@@ -1,50 +1,60 @@
 // Copyright 2009-2017 Sandia Corporation. Under the terms
 // of Contract DE-NA0003525 with Sandia Corporation, the U.S.
 // Government retains certain rights in this software.
-// 
+//
 // Copyright (c) 2009-2017, Sandia Corporation
 // All rights reserved.
-// 
+//
 // This file is part of the SST software package. For license
 // information, see the LICENSE file in the top level directory of the
 // distribution.
-#ifndef SST_CORE_PART_RROBIN_H
-#define SST_CORE_PART_RROBIN_H
 
-#include <sst/core/part/sstpart.h>
+
+#ifndef SST_CORE_IMPL_PARTITONERS_SINGLEPART_H
+#define SST_CORE_IMPL_PARTITONERS_SINGLEPART_H
+
+#include <sst/core/sstpart.h>
 #include <sst/core/elementinfo.h>
 
 namespace SST {
+namespace IMPL {
 namespace Partition {
 
-class SSTRoundRobinPartition : public SST::Partition::SSTPartitioner {
+
+    
+/**
+   Single partitioner is a virtual partitioner used for serial jobs.
+   It simply ensures that all components are assigned to rank 0.
+*/
+class SSTSinglePartition : public SST::Partition::SSTPartitioner {
 
 public:
     SST_ELI_REGISTER_PARTITIONER(
-        SSTRoundRobinPartition,
+        SSTSinglePartition,
         "sst",
-        "roundrobin",
+        "single",
         SST_ELI_ELEMENT_VERSION(1,0,0),
-        "Partitions components using a simple round robin scheme based on ComponentID.  Sequential IDs will be placed on different ranks.")
+        "Allocates all components to rank 0.  Automatically selected for serial jobs.")
 
-private:
-    RankInfo world_size;
-
-public:
-    SSTRoundRobinPartition(RankInfo world_size, RankInfo my_rank, int verbosity);
+    /**
+       Creates a new single partition scheme.
+    */
+    SSTSinglePartition(RankInfo total_ranks, RankInfo my_rank, int verbosity);
     
     /**
        Performs a partition of an SST simulation configuration
        \param graph The simulation configuration to partition
     */
-	void performPartition(PartitionGraph* graph) override;
-
+    void performPartition(PartitionGraph* graph) override;
+    
     bool requiresConfigGraph() override { return false; }
     bool spawnOnAllRanks() override { return false; }
     
-        
+    
 };
 
-} // namespace Partition
-} //namespace SST
-#endif //SST_CORE_PART_RROBIN_H
+}
+}
+}
+
+#endif

--- a/src/sst/core/impl/partitioners/zoltpart.cc
+++ b/src/sst/core/impl/partitioners/zoltpart.cc
@@ -10,16 +10,20 @@
 // distribution.
 
 #include <sst_config.h>
+#include <sst/core/impl/partitioners/zoltpart.h>
+
 #include <sst/core/warnmacros.h>
-#include <sst/core/part/zoltpart.h>
 #include <sst/core/configGraph.h>
 
 #ifdef HAVE_ZOLTAN
 
 using namespace std;
-using namespace SST;
 
 static SST::Output* partOutput;
+
+namespace SST {
+namespace IMPL {
+namespace Partition {
 
 extern "C" {
 static int sst_zoltan_count_vertices(void* data, int* UNUSED(ierr)) {
@@ -164,7 +168,7 @@ static void sst_zoltan_get_edge_list(void *data, int UNUSED(sizeGID), int UNUSED
 		return;
 	}
 }
-}
+} // extern "C"
 
 SSTZoltanPartition::SSTZoltanPartition(RankInfo world_size, RankInfo my_rank, int verbosity) {
 	// Get info for MPI.
@@ -314,6 +318,10 @@ void SSTZoltanPartition::performPartition(PartitionGraph* graph) {
   	Zoltan_LB_Free_Part(&export_global_ids, &export_local_ids,
   		&export_ranks, &export_part);
   	partOutput->verbose(CALL_INFO, 1, 0, "Partitioning is complete.\n");
+}
+
+}
+}
 }
 
 #endif

--- a/src/sst/core/impl/partitioners/zoltpart.h
+++ b/src/sst/core/impl/partitioners/zoltpart.h
@@ -10,13 +10,13 @@
 // distribution.
 
 
-#ifndef SST_CORE_PART_ZOLT
-#define SST_CORE_PART_ZOLT
+#ifndef SST_CORE_IMPL_PARTITONERS_ZOLTPART_H
+#define SST_CORE_IMPL_PARTITONERS_ZOLTPART_H
 
 
 #ifdef HAVE_ZOLTAN
 
-#include <sst/core/part/sstpart.h>
+#include <sst/core/sstpart.h>
 #include <sst/core/output.h>
 #include <sst/core/elementinfo.h>
 
@@ -30,10 +30,8 @@
 #define SST_CONFIG_HAVE_MPI
 #endif
 
-using namespace SST;
-using namespace SST::Partition;
-
 namespace SST {
+namespace IMPL {
 namespace Partition {
 
 /**
@@ -83,7 +81,7 @@ public:
 
 }
 }
-
+}
 #endif // End of HAVE_ZOLTAN
 
 #endif

--- a/src/sst/core/part/Makefile.inc
+++ b/src/sst/core/part/Makefile.inc
@@ -3,20 +3,4 @@
 #
 
 sst_core_sources += \
-	part/selfpart.h \
-	part/selfpart.cc \
-	part/singlepart.cc \
-	part/singlepart.h \
-	part/simplepart.cc \
-	part/simplepart.h \
-	part/rrobin.cc \
-	part/rrobin.h \
-	part/sstpart.h \
-	part/linpart.cc \
-	part/linpart.h	
-
-if HAVE_ZOLTAN
-sst_core_sources += \
-	part/zoltpart.h \
-	part/zoltpart.cc
-endif
+	part/sstpart.h

--- a/src/sst/core/sstpart.h
+++ b/src/sst/core/sstpart.h
@@ -1,0 +1,70 @@
+// Copyright 2009-2017 Sandia Corporation. Under the terms
+// of Contract DE-NA0003525 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2017, Sandia Corporation
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+#ifndef SST_CORE_PART_BASE
+#define SST_CORE_PART_BASE
+
+#include <sst/core/rankInfo.h>
+#include <sst/core/warnmacros.h>
+
+#include <map>
+
+namespace SST {
+
+class ConfigGraph;
+class PartitionGraph;
+
+namespace Partition {
+
+/**
+ * Base class for Partitioning graphs
+ */
+class SSTPartitioner
+{
+
+public:
+
+    SSTPartitioner() {}
+    virtual ~SSTPartitioner() {}
+    
+    /** Function to be overridden by subclasses
+     *
+     * Performs the partitioning of the Graph using the PartitionGraph object.
+     *
+     * Result of this function is that every ConfigComponent in
+     * graph has a Rank applied to it.
+     */
+    virtual void performPartition(PartitionGraph* UNUSED(graph)) {}
+
+    /** Function to be overridden by subclasses
+     *
+     * Performs the partitioning of the Graph using the ConfigGraph
+     * object.  The consequence of using ConfigGraphs is that no-cut
+     * links are not supported.
+     *
+     * Result of this function is that every ConfigComponent in
+     * graph has a Rank applied to it.
+     */
+    virtual void performPartition(ConfigGraph* UNUSED(graph)) {}
+    
+    virtual bool requiresConfigGraph() { return false; }
+    
+    virtual bool spawnOnAllRanks() { return false; }
+    // virtual bool supportsPartialPartitionInput() { return false; }
+
+
+};
+
+}
+}
+
+#endif


### PR DESCRIPTION
Partitioners are now in the core/impl directory to denote that the
implementations are not part of the public API, though they can still
be accessed through the module interface.

The file sst/core/part/sstpart.h has been deprecated and will be
removed in SST 9.0.  The file has been moved to sst/core/sstpart.h.
