### PR TITLE
Fixed an issue with interaction between named and unnamed SubComponents.

### DIFF
--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -328,7 +328,8 @@ SubComponent*
 BaseComponent::loadSubComponent(std::string type, Component* comp, Params& params)
 {
     /* Old Style SubComponents end up with their parent's Id, name, etc. */
-    ComponentInfo *sub_info = new ComponentInfo(type, &params, comp->my_info);
+    // ComponentInfo *sub_info = new ComponentInfo(type, &params, comp->my_info);
+    ComponentInfo *sub_info = new ComponentInfo(type, &params, getTrueComponent()->currentlyLoadingSubComponent);
     ComponentInfo *oldLoadingSubcomponent = getTrueComponent()->currentlyLoadingSubComponent;
     /* By "magic", the new component will steal ownership of this pointer */
     getTrueComponent()->currentlyLoadingSubComponent = sub_info;

--- a/src/sst/core/component.cc
+++ b/src/sst/core/component.cc
@@ -25,6 +25,7 @@ Component::Component(ComponentId_t id) : BaseComponent(),
     id(id)
 {
     my_info = sim->getComponentInfo(id);
+    currentlyLoadingSubComponent = my_info;
 }
 
 


### PR DESCRIPTION
In the case where a named SubComponent loaded an unnamed SubComponent,
the unnamed SubComponent was seeing the link map from the parent
Component instead of from the named SubComponent.  Now, it will see
the link map from the closest named SubComponent in the load tree.
