### PR TITLE
Adds SST Configuration Printing

### DIFF
--- a/src/sst/core/bootsst.cc
+++ b/src/sst/core/bootsst.cc
@@ -13,8 +13,11 @@
 #include <sst_config.h>
 #include <sst/core/bootshared.h>
 
+#include <cstdlib>
+
 int main(int argc, char* argv[]) {
 	int config_env = 1;
+	int print_env = 0;
 	int verbose = 0;
 
 	for(int i = 0; i < argc; ++i) {
@@ -22,6 +25,18 @@ int main(int argc, char* argv[]) {
 			config_env = 0;
 		} else if(strcmp("--verbose", argv[i]) == 0) {
 			verbose = 1;
+		} else if(strcmp("--print-env", argv[i]) == 0) {
+			print_env = 1;
+		}
+	}
+
+	if(print_env != 1) {
+		const char* check_print_env = std::getenv("SST_DISPLAY_ENV");
+
+		if( NULL != check_print_env ) {
+			if(strcmp("1", check_print_env) == 0) {
+				print_env = 1;
+			}
 		}
 	}
 
@@ -31,6 +46,17 @@ int main(int argc, char* argv[]) {
 
 	if(config_env) {
 		boot_sst_configure_env(verbose, argv, argc);
+	}
+
+	if(1 == print_env) {
+		int next_index = 0;
+
+		while( NULL != environ[next_index] ) {
+			const char* next_env = environ[next_index];
+			printf("%s\n", next_env);
+
+			next_index++;
+		}
 	}
 
 	boot_sst_executable("sstsim.x", verbose, argv, argc);

--- a/src/sst/core/bootsst.cc
+++ b/src/sst/core/bootsst.cc
@@ -31,7 +31,14 @@ int main(int argc, char* argv[]) {
 	}
 
 	if(print_env != 1) {
-		const char* check_print_env = std::getenv("SST_DISPLAY_ENV");
+		const char* check_print_env   = std::getenv("SST_PRINT_ENV");
+		const char* check_display_env = std::getenv("SST_DISPLAY_ENV");
+
+		if( NULL != check_display_env ) {
+			if(strcmp("1", check_display_env) == 0) {
+				print_env = 1;
+			}
+		}
 
 		if( NULL != check_print_env ) {
 			if(strcmp("1", check_print_env) == 0) {

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -120,6 +120,7 @@ static const struct sstLongOpts_s sstOptions[] = {
     DEF_FLAGOPT("disable-signal-handlers",  0,      "disable SST automatic dynamic library environment configuration", &Config::disableSigHandlers),
     DEF_FLAGOPT("no-env-config",            0,      "disable SST environment configuration", &Config::disableEnvConfig),
     DEF_FLAGOPT("print-timing-info",        0,      "print SST timing information", &Config::enablePrintTiming),
+    DEF_FLAGOPT("print-env",                0,      "print SST environment vairable", &Config::enablePrintEnv),
     /* HiddenNoConfigDesc */
     DEF_ARGOPT("sdl-file",          "FILE",         "SST Configuration file", &Config::setConfigFile),
     DEF_ARGOPT("stopAtCycle",       "TIME",         "set time at which simulation will end execution", &Config::setStopAt),

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -78,6 +78,7 @@ Config::Config(RankInfo rankInfo)
     enable_sig_handling = true;
     output_core_prefix = "@x SST Core: ";
     print_timing = false;
+    print_env = false;
 
 #ifdef __SST_DEBUG_EVENT_TRACKING__
     event_dump_file = "";

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -151,6 +151,7 @@ public:
         std::cout << "enable_sig_handling = " << enable_sig_handling << std::endl;
         std::cout << "output_core_prefix = " << output_core_prefix << std::endl;
         std::cout << "print_timing=" << print_timing << std::endl;
+	std::cout << "print_env" << print_env << std::endl;
     }
 
 

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -81,6 +81,7 @@ public:
     bool	        no_env_config;      /*!< Bypass compile-time environmental configuration */
     bool            enable_sig_handling; /*!< Enable signal handling */
     bool            print_timing;       /*!< Print SST timing information */
+    bool            print_env;          /*!< Print SST environment */
 
 #ifdef USE_MEMPOOL
     std::string     event_dump_file;    /*!< File to dump undeleted events to */
@@ -97,6 +98,7 @@ public:
     bool disableSigHandlers()   { enable_sig_handling = false; return true;}
     bool disableEnvConfig()     { no_env_config = true; return true;}
     bool enablePrintTiming()    { print_timing = true; return true;}
+    bool enablePrintEnv()       { print_env = true; return true; }
 
     bool setConfigFile(const std::string &arg);
     bool setDebugFile(const std::string &arg);


### PR DESCRIPTION
Returns options to print SST configuration for in-field debugging.

Options include: `sst --print-env` or `SST_DISPLAY_ENV=1` and `SST_PRINT_ENV=1` (consistent with our previous ways to print environment configuration).