### PR TITLE
Fix missing functional Header to get SST to compile with GCC 8.0

### DIFF
--- a/src/sst/core/elibase.h
+++ b/src/sst/core/elibase.h
@@ -14,6 +14,7 @@
 
 #include <sst/core/sst_types.h>
 
+#include <functional>
 #include <string>
 #include <vector>
 #include <set>


### PR DESCRIPTION
Required to get SST to compile with GCC 8.0.