### PR TITLE
Python load 395

### DIFF
--- a/src/sst/core/model/element_python.h
+++ b/src/sst/core/model/element_python.h
@@ -84,7 +84,7 @@ private:
      *  \param parent_module parent module (passed as PyObject*)to load this module under
      *  \return pointer (as PyObject*) to the created module
      */
-    void* load(void* parent_module);
+    virtual void* load(void* parent_module);
  
     //! Vector of sub_modules
     std::vector<SSTElementPythonModuleCode*> sub_modules;


### PR DESCRIPTION
This needs to go in before macro can completely get rid of old ELI.... which needs to happen before the subcomponent refactor can go in.