### PR TITLE
GCC 4.8.2 workaround

### DIFF
--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -286,19 +286,21 @@ constexpr unsigned SST_ELI_getTertiaryNumberFromVersion(SST_ELI_element_version_
 
 #define SST_ELI_DECLARE_INFO(...) \
   using BuilderInfo = ::SST::ELI::BuilderInfoImpl<__VA_ARGS__,SST::ELI::ProvidesDefaultInfo,void>; \
-  SST_ELI_DECLARE_INFO_COMMON() \
-  template <class... __Args> static bool addInfo(const std::string& elemlib, const std::string& elem, \
-                                   ::SST::ELI::BuilderInfoImpl<__Args...>* info){ \
+  template <class BuilderImpl> static bool addInfo(const std::string& elemlib, const std::string& elem, \
+                                   	     BuilderImpl* info){ \
     return ::SST::ELI::InfoDatabase::getLibrary<__LocalEliBase>(elemlib)->addInfo(elem,info); \
-  }
+  } \
+  SST_ELI_DECLARE_INFO_COMMON() 
+
 
 #define SST_ELI_DECLARE_DEFAULT_INFO() \
   using BuilderInfo = ::SST::ELI::BuilderInfoImpl<SST::ELI::ProvidesDefaultInfo,void>; \
-  SST_ELI_DECLARE_INFO_COMMON() \
-  template <class... __Args> static bool addInfo(const std::string& elemlib, const std::string& elem, \
-                                   ::SST::ELI::BuilderInfoImpl<__Args...>* info){ \
+  template <class BuilderImpl> static bool addInfo(const std::string& elemlib, const std::string& elem, \
+                                                   BuilderImpl* info){ \
     return ::SST::ELI::InfoDatabase::getLibrary<__LocalEliBase>(elemlib)->addInfo(elem,info); \
-  }
+  } \
+  SST_ELI_DECLARE_INFO_COMMON() 
+
 
 #define SST_ELI_DECLARE_INFO_EXTERN(...) \
   using BuilderInfo = ::SST::ELI::BuilderInfoImpl<SST::ELI::ProvidesDefaultInfo,__VA_ARGS__,void>; \
@@ -307,8 +309,8 @@ constexpr unsigned SST_ELI_getTertiaryNumberFromVersion(SST_ELI_element_version_
 
 #define SST_ELI_DECLARE_DEFAULT_INFO_EXTERN() \
   using BuilderInfo = ::SST::ELI::BuilderInfoImpl<SST::ELI::ProvidesDefaultInfo,void>; \
-  SST_ELI_DECLARE_INFO_COMMON() \
-  static bool addInfo(const std::string& elemlib, const std::string& elem, BuilderInfo* info); 
+  static bool addInfo(const std::string& elemlib, const std::string& elem, BuilderInfo* info); \
+  SST_ELI_DECLARE_INFO_COMMON() 
 
 #define SST_ELI_DEFINE_INFO_EXTERN(base) \
   bool base::addInfo(const std::string& elemlib, const std::string& elem, BuilderInfo* info){ \


### PR DESCRIPTION
GCC 4.8.2 apparently fails doing template argument deduction for variadic templates. 

This removes the need for variadic templates in a couple places, getting 4.8.2 to work (hopefully)