### PR TITLE
Subcomp api update

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -27,6 +27,7 @@ nobase_dist_sst_HEADERS = \
 	clock.h \
 	baseComponent.h \
 	component.h \
+	componentExtension.h \
 	componentInfo.h \
 	config.h \
 	configGraph.h \

--- a/src/sst/core/activity.h
+++ b/src/sst/core/activity.h
@@ -188,12 +188,12 @@ public:
     class less_time {
     public:
         /** Compare pointers */
-        inline bool operator()(const Activity* lhs, const Activity* rhs) {
+        inline bool operator()(const Activity* lhs, const Activity* rhs) const {
             return lhs->delivery_time < rhs->delivery_time;
         }
 
         /** Compare references */
-        inline bool operator()(const Activity& lhs, const Activity& rhs) {
+        inline bool operator()(const Activity& lhs, const Activity& rhs) const {
             return lhs.delivery_time < rhs.delivery_time;
         }
     };

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -412,6 +412,15 @@ BaseComponent::getTrueComponent() const {
     return static_cast<Component* const>(info->component);
 }
 
+Component*
+BaseComponent::getTrueComponentPrivate() const {
+    // Walk up the parent tree until we hit the base Component.  We
+    // know we're the base Component when parent is NULL.
+    ComponentInfo* info = my_info;
+    while ( info->parent_info != NULL ) info = info->parent_info;
+    return static_cast<Component* const>(info->component);
+}
+
 /* New ELI style */
 SubComponent*
 BaseComponent::loadNamedSubComponent(std::string name) {
@@ -460,22 +469,22 @@ BaseComponent::loadNamedSubComponent(std::string name, int slot_num, Params& par
     sub_info->share_flags = ComponentInfo::SHARE_NONE;
     sub_info->parent_info = my_info;
     
-    // ComponentInfo *oldLoadingSubcomponent = getTrueComponent()->currentlyLoadingSubComponent;
+    // ComponentInfo *oldLoadingSubcomponent = getTrueComponentPrivate()->currentlyLoadingSubComponent;
     // // ComponentInfo *sub_info = &(infoItr->second);
-    // getTrueComponent()->currentlyLoadingSubComponent = sub_info;
+    // getTrueComponentPrivate()->currentlyLoadingSubComponent = sub_info;
 
-    ComponentId_t cid = getTrueComponent()->currentlyLoadingSubComponentID;
-    getTrueComponent()->currentlyLoadingSubComponentID = sub_info->id;
+    ComponentId_t cid = getTrueComponentPrivate()->currentlyLoadingSubComponentID;
+    getTrueComponentPrivate()->currentlyLoadingSubComponentID = sub_info->id;
         
     Params myParams;
     if ( sub_info->getParams() != NULL )
         myParams.insert(*sub_info->getParams());
     myParams.insert(params);
 
-    SubComponent* ret = Factory::getFactory()->CreateSubComponent(sub_info->getType(), getTrueComponent(), myParams);
+    SubComponent* ret = Factory::getFactory()->CreateSubComponent(sub_info->getType(), getTrueComponentPrivate(), myParams);
     sub_info->setComponent(ret);
 
-    getTrueComponent()->currentlyLoadingSubComponentID = cid;
+    getTrueComponentPrivate()->currentlyLoadingSubComponentID = cid;
     return ret;
 }
 

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -35,7 +35,11 @@ BaseComponent::BaseComponent(ComponentId_t id) :
     my_info(Simulation::getSimulation()->getComponentInfo(id)),
     currentlyLoadingSubComponent(NULL)
 {
-    my_info->component = this;
+    if ( my_info->component == nullptr ) {
+        // If it's already set, then this is a ComponentExtension and
+        // we shouldn't reset it.
+        my_info->component = this;
+    }
 }
 
 

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -68,9 +68,14 @@ BaseComponent::~BaseComponent()
         std::map<ComponentId_t,ComponentInfo>& parent_subcomps = my_info->parent_info->getSubComponents();
         size_t deleted = parent_subcomps.erase(my_info->id);
         if ( deleted != 1 ) {
-            // Should never happen, but issue warning just in case
-            Simulation::getSimulationOutput().
-                output("Warning:  BaseComponent destructor failed to remove ComponentInfo from parent.\n");
+            // This can't be checked while we still have backward
+            // compatibility to the old subcomponent API.  Making
+            // calls directly on a subcomponent/component makes the
+            // structure imperfect.
+
+            // // Should never happen, but issue warning just in case
+            // Simulation::getSimulationOutput().
+            //     output("Warning:  BaseComponent destructor failed to remove ComponentInfo from parent.\n");
         }
     }
 }

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -35,6 +35,7 @@ BaseComponent::BaseComponent(ComponentId_t id) :
     my_info(Simulation::getSimulation()->getComponentInfo(id)),
     currentlyLoadingSubComponent(NULL)
 {
+    my_info->component = this;
 }
 
 
@@ -453,7 +454,7 @@ BaseComponent::loadNamedSubComponent(std::string name, int slot_num, Params& par
         SST::Output outXX("SubComponentSlotWarning: ", 0, 0, Output::STDERR);
         outXX.output(CALL_INFO, "Warning: SubComponentSlot \"%s\" is undocumented.\n", name.c_str());
     }
-    
+
     ComponentInfo* sub_info = my_info->findSubComponent(name,slot_num);
     if ( sub_info == NULL ) return NULL;
     sub_info->share_flags = ComponentInfo::SHARE_NONE;

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -319,7 +319,7 @@ public:
      * @param params Parameters the module should use for configuration
      * @return handle to new instance of module, or NULL on failure.
      */
-    Module* loadModuleWithComponent(std::string type, Component* comp, Params& params) __attribute__ ((deprecated("loadModuleWithComponent will be removed in SST version 10.0.  If the module needs access to the parent component, please use SubComponents instead of Modules.")));;
+    Module* loadModuleWithComponent(std::string type, Component* comp, Params& params) __attribute__ ((deprecated("loadModuleWithComponent will be removed in SST version 10.0.  If the module needs access to the parent component, please use SubComponents instead of Modules.")));
 
 
     /** Loads a SubComponent from an element Library
@@ -574,26 +574,30 @@ public:
 
     // Create functions that support the legacy API
     template <typename T>
-    T* create(int slot_num, Params& params) const __attribute__ ((deprecated("This version of create will be removed in SST version 10.0.  Please switch to the new user defined API, which includes the share flags.")))
+    __attribute__ ((deprecated("This version of create will be removed in SST version 10.0.  Please switch to the new user defined API, which includes the share flags.")))
+    T* create(int slot_num, Params& params) const 
     {
         return private_create<T>(slot_num,params);
     }
 
     template <typename T>
-    void createAll(Params& params, std::vector<T*>& vec, bool insertNulls = true) const __attribute__ ((deprecated("This version of createAll will be removed in SST version 10.0.  Please switch to the new user defined API, which includes the share flags and optional constructor arguments.")))
+    __attribute__ ((deprecated("This version of createAll will be removed in SST version 10.0.  Please switch to the new user defined API, which includes the share flags and optional constructor arguments.")))
+    void createAll(Params& params, std::vector<T*>& vec, bool insertNulls = true) const 
     {
         return private_createAll<T>(params, vec, insertNulls);
     }
 
      template <typename T>
-    T* create(int slot_num) const __attribute__ ((deprecated("This version of create will be removed in SST version 10.0.  Please switch to the new user defined API, which includes the share flags and optional constructor arguments.")))
+     __attribute__ ((deprecated("This version of create will be removed in SST version 10.0.  Please switch to the new user defined API, which includes the share flags and optional constructor arguments.")))    T* create(int slot_num) const 
     {
         Params empty;
         return private_create<T>(slot_num, empty);
     }
 
     template <typename T>
-    void createAll(std::vector<T*>& vec, bool insertNulls = true) const __attribute__ ((deprecated("This version of createAll will be removed in SST version 10.0.  Please switch to the new user defined API, which includes the share flags and optional constructor arguments."))) {
+    __attribute__ ((deprecated("This version of createAll will be removed in SST version 10.0.  Please switch to the new user defined API, which includes the share flags and optional constructor arguments.")))
+    void createAll(std::vector<T*>& vec, bool insertNulls = true) const 
+    {
         Params empty;
         return private_createAll<T>(empty, vec, insertNulls);
     }

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -335,6 +335,7 @@ public:
     template <class T, class... ARGS>
     T* loadAnonymousSubComponent(std::string type, std::string slot_name, int slot_num, uint64_t share_flags, Params& params, ARGS... args) {
 
+        share_flags = share_flags & ComponentInfo::USER_FLAGS;
         ComponentId_t cid = my_info->addAnonymousSubComponent(my_info, type, slot_name, slot_num, share_flags);
         ComponentInfo* sub_info = my_info->findSubComponent(cid);
 
@@ -353,7 +354,7 @@ public:
     }
     
     template <class T, class... ARGS>
-    T* loadUserSubComponent(std::string slot_name, int share_flags, ARGS... args) {
+    T* loadUserSubComponent(std::string slot_name, uint64_t share_flags, ARGS... args) {
 
         // Get list of ComponentInfo objects and make sure that there is
         // only one SubComponent put into this slot
@@ -408,6 +409,9 @@ private:
     
     template <class T, class... ARGS>
     T* loadUserSubComponentByIndex(std::string slot_name, int slot_num, int share_flags, ARGS... args) {
+
+        share_flags = share_flags & ComponentInfo::USER_FLAGS;
+        
         // Check to see if the slot exists
         ComponentInfo* sub_info = my_info->findSubComponent(slot_name,slot_num);
         if ( sub_info == NULL ) return NULL;
@@ -606,12 +610,12 @@ public:
 
 
     template <class T, class... ARGS>
-    T* create(int slot_num, int share_flags, ARGS... args) const {
+    T* create(int slot_num, uint64_t share_flags, ARGS... args) const {
         return comp->loadUserSubComponentByIndex<T,ARGS...>(slot_name,slot_num, share_flags, args...);
     }
 
     template <typename T, class... ARGS>
-    void createAll(std::vector<T*>& vec, bool insertNulls, int share_flags, ARGS... args) const {
+    void createAll(std::vector<T*>& vec, bool insertNulls, uint64_t share_flags, ARGS... args) const {
         for ( int i = 0; i <= getMaxPopulatedSlotNumber(); ++i ) {
             T* sub = create<T>(i, share_flags, args...);
             if ( sub != NULL || insertNulls ) vec.push_back(sub);
@@ -619,7 +623,7 @@ public:
     }
 
     template <typename T, class... ARGS>
-    void createAll(std::vector<T*>& vec, int share_flags, ARGS... args) const {
+    void createAll(std::vector<T*>& vec, uint64_t share_flags, ARGS... args) const {
         createAll<T,ARGS...>(vec,true,share_flags,args...);
     }
 

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -383,11 +383,11 @@ public:
      * @param params Parameters the module should use for configuration
      * @return handle to new instance of SubComponent, or NULL on failure.
      */
-    SubComponent* loadSubComponent(std::string type, Component* comp, Params& params) __attribute__ ((deprecated("This version of loadSubComponent will be removed in SST version 10.0.  Please switch to new python defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
+    SubComponent* loadSubComponent(std::string type, Component* comp, Params& params) __attribute__ ((deprecated("This version of loadSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
 
     /* New ELI style */
-    SubComponent* loadNamedSubComponent(std::string name) __attribute__ ((deprecated("This version of loadNamedSubComponent will be removed in SST version 10.0.  Please switch to new python defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
-    SubComponent* loadNamedSubComponent(std::string name, Params& params) __attribute__ ((deprecated("This version of loadNamedSubComponent will be removed in SST version 10.0.  Please switch to new python defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
+    SubComponent* loadNamedSubComponent(std::string name) __attribute__ ((deprecated("This version of loadNamedSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
+    SubComponent* loadNamedSubComponent(std::string name, Params& params) __attribute__ ((deprecated("This version of loadNamedSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
 
 private:
 

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -53,7 +53,8 @@ class BaseComponent {
 
     friend class SubComponentSlotInfo;
     friend class SubComponent;
-
+    friend class ComponentInfo;
+    
 public:
 
     BaseComponent(ComponentId_t id);

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -630,7 +630,6 @@ private:
     template <typename T>
     T* private_create(int slot_num, Params& params) const
     {
-        TraceFunction trace(CALL_INFO_LONG);
         SubComponent* sub = protected_create(slot_num, params);
         if ( sub == NULL ) {
             // Nothing populated at this index, simply return NULL
@@ -650,7 +649,6 @@ private:
     template <typename T>
     void private_createAll(Params& params, std::vector<T*>& vec, bool insertNulls = true) const 
     {
-        TraceFunction trace(CALL_INFO_LONG);
         for ( int i = 0; i <= getMaxPopulatedSlotNumber(); ++i ) {
             T* sub = create<T>(i, params);
             if ( sub != NULL || insertNulls ) vec.push_back(sub);

--- a/src/sst/core/component.cc
+++ b/src/sst/core/component.cc
@@ -24,11 +24,10 @@ namespace SST {
 SST_ELI_DEFINE_INFO_EXTERN(Component)
 SST_ELI_DEFINE_CTOR_EXTERN(Component)
 
-Component::Component(ComponentId_t id) : BaseComponent(),
-    id(id)
+Component::Component(ComponentId_t id) : BaseComponent(id)
 {
-    my_info = sim->getComponentInfo(id);
-    currentlyLoadingSubComponent = my_info;
+    // my_info = sim->getComponentInfo(id);
+    // currentlyLoadingSubComponent = my_info;
 }
 
 
@@ -72,7 +71,7 @@ Component::primaryComponentOKToEndSim()
 
 bool Component::doesComponentInfoStatisticExist(const std::string &statisticName) const
 {
-    const std::string& type = my_info->getType();
+    const std::string& type = getType();
     return Factory::getFactory()->DoesComponentInfoStatisticNameExist(type, statisticName);
 }
 

--- a/src/sst/core/component.cc
+++ b/src/sst/core/component.cc
@@ -68,14 +68,6 @@ Component::primaryComponentOKToEndSim()
 }
 
 
-
-bool Component::doesComponentInfoStatisticExist(const std::string &statisticName) const
-{
-    const std::string& type = getType();
-    return Factory::getFactory()->DoesComponentInfoStatisticNameExist(type, statisticName);
-}
-
-
 } // namespace SST
 
 

--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -59,13 +59,13 @@ public:
 
         @sa Component::unregisterExit()
     */
-    bool registerExit();
+    bool registerExit() __attribute__ ((deprecated("registerExit is deprecated and will be removed in SST version 10.0.  Please use registerAsPrimaryComponent() and primaryComponentDoNotEndSim() instead.")));
 
     /** Indicate permission for the simulation to end. This function is
         the mirror of Component::registerExit(). It decrements the
         global counter, which, upon reaching zero, indicates that the
         simulation can terminate. @sa Component::registerExit() */
-    bool unregisterExit();
+    bool unregisterExit() __attribute__ ((deprecated("unregisterExit is deprecated and will be removed in SST version 10.0.  Please use primaryComponentOKToEndSim() instead.")));
 
     /** Register as a primary component, which allows the component to
         specify when it is and is not OK to end simulation.  The
@@ -124,7 +124,7 @@ protected:
 private:
 
     /** Unique ID */
-    ComponentId_t   id;
+    // ComponentId_t   id;
 
 };
 

--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -114,18 +114,6 @@ protected:
     friend class SubComponent;
     Component() {} // Unused, but previously available
 
-    Component* getTrueComponent() const final override { return const_cast<Component*>(this); }
-    BaseComponent* getStatisticOwner() const final override { return const_cast<Component*>(this); }
-
-
-    // Does the statisticName exist in the ElementInfoStatistic
-    virtual bool doesComponentInfoStatisticExist(const std::string &statisticName) const final override;
-
-private:
-
-    /** Unique ID */
-    // ComponentId_t   id;
-
 };
 
 } //namespace SST

--- a/src/sst/core/componentExtension.h
+++ b/src/sst/core/componentExtension.h
@@ -1,0 +1,43 @@
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+// 
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+// 
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+#ifndef SST_CORE_COMPONENTEXTENSION_H
+#define SST_CORE_COMPONENTEXTENSION_H
+
+#include <sst/core/warnmacros.h>
+#include <sst/core/baseComponent.h>
+
+namespace SST {
+
+/**
+   ComponentExtension is a class that can be loaded using
+   loadComponentExtension<T>(...).  All the calls to the BaseComponent
+   APIU will act like they are happening in the nearest SubConmponent
+   or Component parent.  Hierarchy will not be kept in the case were a
+   ComponentExtension is loaded into a ComponentExtension; they will
+   both act like they are in the parent.
+*/
+class ComponentExtension : public BaseComponent {
+
+public:
+
+    ComponentExtension(ComponentId_t id) :
+        BaseComponent(id)
+    {}
+
+	virtual ~ComponentExtension() {};
+
+};
+
+} //namespace SST
+
+#endif // SST_CORE_COMPONENTEXTENSION_H

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -21,49 +21,85 @@ namespace SST {
 
 ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name) :
     id(id),
+    parent_info(NULL),
     name(name),
     type(""),
     link_map(NULL),
     component(NULL),
     params(NULL),
+    defaultTimeBase(NULL),
     enabledStats(NULL),
-    coordinates(3, 0.0)
+    coordinates(3, 0.0),
+    subIDIndex(1),
+    slot_name(""),
+    slot_num(-1),
+    share_flags(0)    
 {
 }
 
 
-ComponentInfo::ComponentInfo(const std::string &type, const Params *params, const ComponentInfo *parent) :
-    id(parent->id),
-    name(parent->name),
+// ComponentInfo::ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const std::string &type, const Params *params, const ComponentInfo *parent) :
+//     id(parent->id),
+//     name(parent->name),
+//     type(type),
+//     link_map(parent->link_map),
+//     component(NULL),
+//     params(params),
+//     enabledStats(parent->enabledStats),
+//     coordinates(parent->coordinates),
+//     subIDIndex(1),
+//     slot_name(""),
+//     slot_num(-1),
+//     share_flags(0)
+// {
+// }
+
+
+// Constructor used for ComponentDefined SubComponents
+ComponentInfo::ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const std::string &type,
+                             const std::string& slot_name, int slot_num, uint64_t share_flags/*, const Params& params_in*/) :
+    id(id),
+    parent_info(parent_info),
+    name(""),
     type(type),
-    link_map(parent->link_map),
+    link_map(NULL),
     component(NULL),
-    params(params),
-    enabledStats(parent->enabledStats),
-    coordinates(parent->coordinates)
+    params(/*new Params()*/ NULL),
+    defaultTimeBase(NULL),
+    enabledStats(NULL),
+    coordinates(parent_info->coordinates),
+    subIDIndex(1),
+    slot_name(slot_name),
+    slot_num(slot_num),
+    share_flags(share_flags)
 {
+    /*params.insert(params_in.getParams());*/
 }
 
 
-ComponentInfo::ComponentInfo(ConfigComponent *ccomp, const std::string& name, LinkMap* link_map) :
+ComponentInfo::ComponentInfo(ConfigComponent *ccomp, const std::string& name, ComponentInfo* parent_info, LinkMap* link_map) :
     id(ccomp->id),
+    parent_info(parent_info),
     name(name),
-    slot_name(ccomp->name),
-    slot_num(ccomp->slot_num),
     type(ccomp->type),
     link_map(link_map),
     component(NULL),
     params(&ccomp->params),
+    defaultTimeBase(NULL),
     enabledStats(&ccomp->enabledStatistics),
-    coordinates(ccomp->coords)
+    coordinates(ccomp->coords),
+    subIDIndex(1),
+    slot_name(ccomp->name),
+    slot_num(ccomp->slot_num),
+    share_flags(0)
 {
+    // printf("ComponentInfo(ConfigComponent): id = %llx\n",ccomp->id);
 
     // See how many subcomponents are in each slot so we know how to name them
     std::map<std::string, int> counts;
     for ( auto &sc : ccomp->subComponents ) {
         counts[sc.name]++;
     }
-    
     
     for ( auto &sc : ccomp->subComponents ) {
         std::string sub_name(name);
@@ -76,52 +112,97 @@ ComponentInfo::ComponentInfo(ConfigComponent *ccomp, const std::string& name, Li
             sub_name += std::to_string(sc.slot_num);
             sub_name += "]";
         }
-        subComponents.emplace_back(ComponentInfo(&sc, sub_name, new LinkMap()));
-
+        subComponents.emplace_hint(subComponents.end(), std::piecewise_construct, std::make_tuple(sc.id), std::forward_as_tuple(&sc, sub_name, this, new LinkMap()));
     }   
 }
 
 ComponentInfo::ComponentInfo(ComponentInfo &&o) :
     id(o.id),
+    parent_info(o.parent_info),
     name(std::move(o.name)),
-    slot_name(o.slot_name),
-    slot_num(o.slot_num),
     type(std::move(o.type)),
     link_map(o.link_map),
-    component(o.component),
+    component(o.component), 
+    subComponents(std::move(o.subComponents)),
     params(o.params),
+    defaultTimeBase(o.defaultTimeBase),
     enabledStats(o.enabledStats),
-    coordinates(o.coordinates)
+    coordinates(o.coordinates),
+    subIDIndex(o.subIDIndex),
+    slot_name(o.slot_name),
+    slot_num(o.slot_num),
+    share_flags(o.share_flags)
 {
+    o.parent_info = NULL;
     o.link_map = NULL;
     o.component = NULL;
+    o.defaultTimeBase = NULL;
 }
 
 
 ComponentInfo::~ComponentInfo() {
     if ( link_map ) delete link_map;
-    if ( component ) delete component;
+    if ( component ) {
+        // For backward compatibility, don't delete component defined
+        // (anonymous) subcomponents since they weren't before.
+        if ( !isComponentDefined() ) {
+            delete component;
+        }
+    }
 }
 
-void ComponentInfo::finalizeLinkConfiguration() {
-    for ( auto & i : link_map->getLinkMap() ) {
-        i.second->finalizeConfiguration();
+LinkMap*
+ComponentInfo::getLinkMap() {
+    if ( link_map == NULL ) link_map = new LinkMap();
+    return link_map;
+}
+
+
+ComponentId_t
+ComponentInfo::addComponentDefinedSubComponent(ComponentInfo* parent_info, const std::string& type, const std::string& slot_name,
+                                               int slot_num, uint64_t share_flags)
+{
+    // First, get the next subIDIndex by working our way up to the
+    // actual component (parent pointer will be NULL).
+    ComponentInfo* real_comp = this;
+    while ( real_comp->parent_info != NULL) real_comp = real_comp->parent_info;
+
+    // Get the subIDIndex and increment it for next time
+    uint64_t sub_id = real_comp->subIDIndex++;
+
+    ComponentId_t cid = COMPDEFINED_SUBCOMPONENT_ID_CREATE(COMPONENT_ID_MASK(id), sub_id);
+    
+    subComponents.emplace_hint(subComponents.end(), std::piecewise_construct, std::make_tuple(cid), std::forward_as_tuple(cid, parent_info, type, slot_name, slot_num, share_flags));
+    
+    return cid;
+
+}
+
+
+void ComponentInfo::finalizeLinkConfiguration() const {
+    if ( NULL != link_map ) {
+        for ( auto & i : link_map->getLinkMap() ) {
+            i.second->finalizeConfiguration();
+        }
     }
     for ( auto &s : subComponents ) {
-        s.finalizeLinkConfiguration();
+        s.second.finalizeLinkConfiguration();
     }
 }
 
-void ComponentInfo::prepareForComplete() {
-    for ( auto & i : link_map->getLinkMap() ) {
-        i.second->prepareForComplete();
+void ComponentInfo::prepareForComplete() const {
+    if ( NULL != link_map ) {
+        for ( auto & i : link_map->getLinkMap() ) {
+            i.second->prepareForComplete();
+        }
     }
     for ( auto &s : subComponents ) {
-        s.prepareForComplete();
+        s.second.prepareForComplete();
     }
 }
 
-ComponentInfo* ComponentInfo::findSubComponent(ComponentId_t id)
+
+ComponentInfo* ComponentInfo::findSubComponent(ComponentId_t id) 
 {
     /* See if it is us */
     if ( id == this->id )
@@ -132,18 +213,18 @@ ComponentInfo* ComponentInfo::findSubComponent(ComponentId_t id)
         return NULL;
 
     for ( auto &s : subComponents ) {
-        ComponentInfo* found = s.findSubComponent(id);
+        ComponentInfo* found = s.second.findSubComponent(id);
         if ( found != NULL )
             return found;
     }
     return NULL;
 }
 
-ComponentInfo* ComponentInfo::findSubComponent(std::string slot, int slot_num)
+ComponentInfo* ComponentInfo::findSubComponent(std::string slot, int slot_num) 
 {
     // Non-recursive, only look in current component
     for ( auto &sc : subComponents ) {
-        if ( sc.slot_name == slot && sc.slot_num == slot_num ) return &sc;
+        if ( sc.second.slot_name == slot && sc.second.slot_num == slot_num ) return &sc.second;
     }
     return NULL;
 }
@@ -152,11 +233,13 @@ ComponentInfo* ComponentInfo::findSubComponent(std::string slot, int slot_num)
 std::vector<LinkId_t> ComponentInfo::getAllLinkIds() const
 {
     std::vector<LinkId_t> res;
-    for ( auto & l : link_map->getLinkMap() ) {
-        res.push_back(l.second->id);
+    if ( NULL != link_map ) {
+        for ( auto & l : link_map->getLinkMap() ) {
+            res.push_back(l.second->id);
+        }
     }
     for ( auto& sc : subComponents ) {
-        std::vector<LinkId_t> s = sc.getAllLinkIds();
+        std::vector<LinkId_t> s = sc.second.getAllLinkIds();
         res.insert(res.end(), s.begin(), s.end());
     }
     return res;

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -55,7 +55,7 @@ ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name) :
 // }
 
 
-// Constructor used for ComponentDefined SubComponents
+// Constructor used for Anonymous SubComponents
 ComponentInfo::ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const std::string &type,
                              const std::string& slot_name, int slot_num, uint64_t share_flags/*, const Params& params_in*/) :
     id(id),
@@ -145,7 +145,7 @@ ComponentInfo::~ComponentInfo() {
     if ( component ) {
         // For backward compatibility, don't delete component defined
         // (anonymous) subcomponents since they weren't before.
-        if ( !isComponentDefined() ) {
+        if ( !isAnonymous() ) {
             delete component;
         }
     }
@@ -159,8 +159,8 @@ ComponentInfo::getLinkMap() {
 
 
 ComponentId_t
-ComponentInfo::addComponentDefinedSubComponent(ComponentInfo* parent_info, const std::string& type, const std::string& slot_name,
-                                               int slot_num, uint64_t share_flags)
+ComponentInfo::addAnonymousSubComponent(ComponentInfo* parent_info, const std::string& type, const std::string& slot_name,
+                                        int slot_num, uint64_t share_flags)
 {
     // First, get the next subIDIndex by working our way up to the
     // actual component (parent pointer will be NULL).

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -145,7 +145,8 @@ ComponentInfo::~ComponentInfo() {
     if ( component ) {
         // For backward compatibility, don't delete component defined
         // (anonymous) subcomponents since they weren't before.
-        if ( !isAnonymous() ) {
+        if ( !isLegacySubComponent() ) {
+            component->my_info = nullptr;
             delete component;
         }
     }

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -40,17 +40,21 @@ public:
 
 
     // Share Flags for SubComponent loading
-    static const int SHARE_PORTS = 0x1;
-    static const int SHARE_STATS = 0x2;
-    static const int INSERT_STATS = 0x4;
+    static const uint64_t SHARE_PORTS = 0x1;
+    static const uint64_t SHARE_STATS = 0x2;
+    static const uint64_t INSERT_STATS = 0x4;
 
     // Temporary, only for backward compatibility with loadSubComponent
-    static const int IS_LEGACY_SUBCOMPONENT = 0x32;
+    static const uint64_t IS_LEGACY_SUBCOMPONENT = 0x32;
 
-    static const int SHARE_NONE = 0x0;
+    static const uint64_t SHARE_NONE = 0x0;
 
 private:
 
+    // Mask to make sure users are only setting the flags that are
+    // available to them
+    static const uint64_t USER_FLAGS = 0x7;
+    
     // Friend classes
     friend class Simulation;
     friend class BaseComponent;

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -45,7 +45,7 @@ public:
     static const int INSERT_STATS = 0x4;
 
     // Temporary, only for backward compatibility with loadSubComponent
-    static const int IS_ANONYMOUS_SUBCOMPONENT = 0x32;
+    static const int IS_LEGACY_SUBCOMPONENT = 0x32;
 
     static const int SHARE_NONE = 0x0;
 
@@ -83,7 +83,7 @@ private:
        Component/SubComponent in the python file.
 
        This field is not used for SubComponents loaded with
-       loadComponentDefinedSubComponent().
+       loadAnonymousSubComponent().
      */
     LinkMap* link_map;
 
@@ -101,7 +101,7 @@ private:
        Parameters defined in the python file for the (Sub)Component.  
 
        This field is used for only a short time while loading for
-       SubComponents loaded with loadComponentDefinedSubComponent().
+       SubComponents loaded with loadAnonymousSubComponent().
        For python defined SubComponents, this field is created during
        python execution.
     */
@@ -149,8 +149,8 @@ private:
         return (share_flags & INSERT_STATS) != 0;
     }
     
-    bool isAnonymousSubComponent() {
-        return (share_flags & IS_ANONYMOUS_SUBCOMPONENT) != 0;
+    bool isLegacySubComponent() {
+        return (share_flags & IS_LEGACY_SUBCOMPONENT) != 0;
     }
     
 
@@ -162,16 +162,16 @@ private:
     void finalizeLinkConfiguration() const;
     void prepareForComplete() const;
 
-    ComponentId_t addComponentDefinedSubComponent(ComponentInfo* parent_info, const std::string& type,
-                                                  const std::string& slot_name, int slot_num,
-                                                  uint64_t share_flags);
+    ComponentId_t addAnonymousSubComponent(ComponentInfo* parent_info, const std::string& type,
+                                           const std::string& slot_name, int slot_num,
+                                           uint64_t share_flags);
 
     
 public:
     /* Old ELI Style subcomponent constructor */
     ComponentInfo(const std::string &type, const Params *params, const ComponentInfo *parent_info);
 
-    /* ComponentDefined SubComponent */
+    /* Anonymous SubComponent */
     ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const std::string& type, const std::string& slot_name,
                   int slot_num, uint64_t share_flags/*, const Params& params_in*/);
     
@@ -180,11 +180,11 @@ public:
     ComponentInfo(ComponentInfo &&o);
     ~ComponentInfo();
 
-    bool isComponentDefined() {
+    bool isAnonymous() {
         return COMPDEFINED_SUBCOMPONENT_ID_MASK(id);
     }
 
-    bool isPythonDefined() {
+    bool isUser() {
         return !COMPDEFINED_SUBCOMPONENT_ID_MASK(id);
     }
     

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -16,6 +16,7 @@
 #include <sst/core/params.h>
 
 #include <unordered_set>
+#include <map>
 #include <string>
 #include <functional>
 
@@ -26,6 +27,7 @@ class BaseComponent;
 
 class ConfigComponent;
 class ComponentInfoMap;
+class TimeConverter;
 
 namespace Statistics {
 class StatisticInfo;
@@ -36,43 +38,162 @@ class ComponentInfo {
 public:
     typedef std::vector<Statistics::StatisticInfo>      statEnableList_t;        /*!< List of Enabled Statistics */
 
+
+    // Share Flags for SubComponent loading
+    static const int SHARE_PORTS = 0x1;
+    static const int SHARE_STATS = 0x2;
+    static const int INSERT_STATS = 0x4;
+
+    // Temporary, only for backward compatibility with loadSubComponent
+    static const int IS_ANONYMOUS_SUBCOMPONENT = 0x32;
+
+    static const int SHARE_NONE = 0x0;
+
 private:
+
+    // Friend classes
     friend class Simulation;
     friend class BaseComponent;
     friend class ComponentInfoMap;
+
+
+    /**
+       Component ID.
+
+       SubComponents share the lower bits (defined by macros in
+       sst_types.h) with their Component parent.  However, every
+       SubComponent has a unique ID.
+    */
     const ComponentId_t id;
+
+
+    ComponentInfo* parent_info;
+    /**
+       Name of the Component/SubComponent.
+     */
     const std::string name;
-    const std::string slot_name;
-    int slot_num;
+
+    /**
+       Type of the Component/SubComponent.
+     */
     const std::string type;
+
+    /**
+       LinkMap containing the links assigned to this
+       Component/SubComponent in the python file.
+
+       This field is not used for SubComponents loaded with
+       loadComponentDefinedSubComponent().
+     */
     LinkMap* link_map;
+
+    /**
+       Pointer to the Component created using this ComponentInfo.
+     */
     BaseComponent* component;
-    
-    std::vector<ComponentInfo> subComponents;
+
+    /**
+       SubComponents loaded into the Component/SubComponent.
+     */
+    std::map<ComponentId_t,ComponentInfo> subComponents;
+
+    /**
+       Parameters defined in the python file for the (Sub)Component.  
+
+       This field is used for only a short time while loading for
+       SubComponents loaded with loadComponentDefinedSubComponent().
+       For python defined SubComponents, this field is created during
+       python execution.
+    */
     const Params *params;
 
+    TimeConverter* defaultTimeBase;
+    
     statEnableList_t * enabledStats;
     std::vector<double> coordinates;
 
+    uint64_t subIDIndex;
+    
+
+    // Variables only used by SubComponents
+    
+    /**
+       Name of the slot this SubComponent was loaded into.  This field
+       is not used for Components.
+     */
+    const std::string slot_name;
+
+    /**
+       Index in the slot this SubComponent was loaded into.  This field
+       is not used for Components.
+     */
+    int slot_num;
+
+    /**
+       Sharing flags.
+
+       Determines whether various data is shared from parent to child.
+     */
+    uint64_t share_flags;
+
+
+    bool sharesPorts() {
+        return (share_flags & SHARE_PORTS) != 0;
+    }
+    
+    bool sharesStatistics() {
+        return (share_flags & SHARE_STATS) != 0;
+    }
+    
+    bool canInsertStatistics() {
+        return (share_flags & INSERT_STATS) != 0;
+    }
+    
+    bool isAnonymousSubComponent() {
+        return (share_flags & IS_ANONYMOUS_SUBCOMPONENT) != 0;
+    }
+    
+
     inline void setComponent(BaseComponent* comp) { component = comp; }
+    // inline void setParent(BaseComponent* comp) { parent = comp; }
 
     /* Lookup Key style constructor */
     ComponentInfo(ComponentId_t id, const std::string &name);
-    void finalizeLinkConfiguration();
-    void prepareForComplete();
+    void finalizeLinkConfiguration() const;
+    void prepareForComplete() const;
 
+    ComponentId_t addComponentDefinedSubComponent(ComponentInfo* parent_info, const std::string& type,
+                                                  const std::string& slot_name, int slot_num,
+                                                  uint64_t share_flags);
+
+    
 public:
     /* Old ELI Style subcomponent constructor */
-    ComponentInfo(const std::string &type, const Params *params, const ComponentInfo *parent);
+    ComponentInfo(const std::string &type, const Params *params, const ComponentInfo *parent_info);
 
+    /* ComponentDefined SubComponent */
+    ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const std::string& type, const std::string& slot_name,
+                  int slot_num, uint64_t share_flags/*, const Params& params_in*/);
+    
     /* New ELI Style */
-    ComponentInfo(ConfigComponent *ccomp, const std::string& name, LinkMap* link_map);
+    ComponentInfo(ConfigComponent *ccomp, const std::string& name, ComponentInfo* parent_info, LinkMap* link_map);
     ComponentInfo(ComponentInfo &&o);
     ~ComponentInfo();
 
+    bool isComponentDefined() {
+        return COMPDEFINED_SUBCOMPONENT_ID_MASK(id);
+    }
+
+    bool isPythonDefined() {
+        return !COMPDEFINED_SUBCOMPONENT_ID_MASK(id);
+    }
+    
     inline ComponentId_t getID() const { return id; }
 
-    inline const std::string& getName() const { return name; }
+    inline const std::string& getName() const {
+        if ( name.empty() ) return parent_info->getName();
+        return name;
+    }
 
     inline const std::string& getSlotName() const { return slot_name; }
 
@@ -82,12 +203,12 @@ public:
 
     inline BaseComponent* getComponent() const { return component; }
 
-    inline LinkMap* getLinkMap() const { return link_map; }
-
+    LinkMap* getLinkMap();
+    
     inline const Params* getParams() const { return params; }
 
     // inline std::map<std::string, ComponentInfo>& getSubComponents() { return subComponents; }
-    inline std::vector<ComponentInfo>& getSubComponents() { return subComponents; }
+    inline std::map<ComponentId_t,ComponentInfo>& getSubComponents() { return subComponents; }
 
     ComponentInfo* findSubComponent(std::string slot, int slot_num);
     ComponentInfo* findSubComponent(ComponentId_t id);
@@ -120,6 +241,7 @@ public:
             return lhs->id == rhs->id;
         }
     };
+
 };
 
 

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -85,9 +85,7 @@ std::pair<bool, std::string> ConfigStatGroup::verifyStatsAndComponents(const Con
         }
         for ( auto & statKV : statMap ) {
 
-            bool ok = SUBCOMPONENT_ID_MASK(comp->id) == 0 ?
-                Factory::getFactory()->DoesComponentInfoStatisticNameExist(comp->type, statKV.first) :
-                Factory::getFactory()->DoesSubComponentInfoStatisticNameExist(comp->type, statKV.first);
+            bool ok = Factory::getFactory()->DoesComponentInfoStatisticNameExist(comp->type, statKV.first);
 
             if ( !ok ) {
                 std::stringstream ss;
@@ -102,7 +100,7 @@ std::pair<bool, std::string> ConfigStatGroup::verifyStatsAndComponents(const Con
 
 
 void ConfigComponent::print(std::ostream &os) const {
-    os << "Component " << name << " (id = " << id << ")" << std::endl;
+    os << "Component " << name << " (id = " << std::hex << id << std::dec << ")" << std::endl;
     os << "  slot_num = " << slot_num << std::endl;
     os << "  type = " << type << std::endl;
     os << "  weight = " << weight << std::endl;

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -195,6 +195,7 @@ typedef SparseVectorMap<LinkId_t,ConfigLink> ConfigLinkMap_t;
 class ConfigComponent : public SST::Core::Serialization::serializable {
 public:
     ComponentId_t                 id;                /*!< Unique ID of this component */
+    ConfigComponent*              ulitmate_parent;   /*!< Ultimate parent of this component */
     std::string                   name;              /*!< Name of this component, or slot name for subcomp */
     int                           slot_num;          /*!< Slot number.  Only valid for subcomponents */
     std::string                   type;              /*!< Type of this component */
@@ -205,8 +206,9 @@ public:
     std::vector<Statistics::StatisticInfo> enabledStatistics; /*!< List of statistics to be enabled */
     std::vector<ConfigComponent>  subComponents; /*!< List of subcomponents */
     std::vector<double>           coords;
-
-		static constexpr ComponentId_t null_id = std::numeric_limits<ComponentId_t>::max();
+    uint16_t                      nextSubID;         /*!< Next subID to use for children */
+    
+    static constexpr ComponentId_t null_id = std::numeric_limits<ComponentId_t>::max();
 
     inline const ComponentId_t& key()const { return id; }
 

--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -37,11 +37,11 @@ class Module;
 class SubComponent;
 class BaseComponent;
 namespace Partition {
-    class SSTPartitioner;
+class SSTPartitioner;
 }
 namespace Statistics {
-  template <class T> class Statistic;
-  class StatisticBase;
+template <class T> class Statistic;
+class StatisticBase;
 }
 class RankInfo;
 class SSTElementPythonModule;
@@ -54,32 +54,32 @@ namespace ELI {
 
 template <class T>
 class DataBase {
- public:
-  static T* get(const std::string& elemlib, const std::string& elem){
-    if (!infos_) return nullptr;
+public:
+    static T* get(const std::string& elemlib, const std::string& elem){
+        if (!infos_) return nullptr;
 
-    auto libiter = infos_->find(elemlib);
-    if (libiter != infos_->end()){
-      auto& submap = libiter->second;
-      auto elemiter = submap.find(elem);
-      if (elemiter != submap.end()){
-        return elemiter->second;
-      }
-    }
-    return nullptr;
-  }
-
-  static void add(const std::string& elemlib, const std::string& elem, T* info){
-    if (!infos_){
-      infos_ = std::unique_ptr<std::map<std::string, std::map<std::string, T*>>>(
-                  new std::map<std::string, std::map<std::string, T*>>);
+        auto libiter = infos_->find(elemlib);
+        if (libiter != infos_->end()){
+            auto& submap = libiter->second;
+            auto elemiter = submap.find(elem);
+            if (elemiter != submap.end()){
+                return elemiter->second;
+            }
+        }
+        return nullptr;
     }
 
-    (*infos_)[elemlib][elem] = info;
-  }
+    static void add(const std::string& elemlib, const std::string& elem, T* info){
+        if (!infos_){
+            infos_ = std::unique_ptr<std::map<std::string, std::map<std::string, T*>>>(
+                new std::map<std::string, std::map<std::string, T*>>);
+        }
 
- private:
-  static std::unique_ptr<std::map<std::string, std::map<std::string, T*>>> infos_;
+        (*infos_)[elemlib][elem] = info;
+    }
+
+private:
+    static std::unique_ptr<std::map<std::string, std::map<std::string, T*>>> infos_;
 };
 template <class T> std::unique_ptr<std::map<std::string,std::map<std::string,T*>>> DataBase<T>::infos_;
 
@@ -87,157 +87,157 @@ template <class T> std::unique_ptr<std::map<std::string,std::map<std::string,T*>
 template <class Policy, class... Policies>
 class BuilderInfoImpl : public Policy, public BuilderInfoImpl<Policies...>
 {
-  using Parent=BuilderInfoImpl<Policies...>;
- public:
-  template <class... Args> BuilderInfoImpl(const std::string& elemlib,
-                                           const std::string& elem,
-                                           Args&&... args)
-    : Policy(args...), Parent(elemlib, elem, args...) //forward as l-values
-  {
-    DataBase<Policy>::add(elemlib,elem,this);
-  }
+    using Parent=BuilderInfoImpl<Policies...>;
+public:
+    template <class... Args> BuilderInfoImpl(const std::string& elemlib,
+                                             const std::string& elem,
+                                             Args&&... args)
+        : Policy(args...), Parent(elemlib, elem, args...) //forward as l-values
+        {
+            DataBase<Policy>::add(elemlib,elem,this);
+        }
 
-  template <class XMLNode> void outputXML(XMLNode* node){
-    Policy::outputXML(node);
-    Parent::outputXML(node);
-  }
+    template <class XMLNode> void outputXML(XMLNode* node){
+        Policy::outputXML(node);
+        Parent::outputXML(node);
+    }
 
-  void toString(std::ostream& os) const {
-    Parent::toString(os);
-    Policy::toString(os);
-  }
+    void toString(std::ostream& os) const {
+        Parent::toString(os);
+        Policy::toString(os);
+    }
 };
 
 template <> class BuilderInfoImpl<void> {
- protected:
-  template <class... Args> BuilderInfoImpl(Args&&... UNUSED(args))
-  {
-  }
+protected:
+    template <class... Args> BuilderInfoImpl(Args&&... UNUSED(args))
+        {
+        }
 
-  template <class XMLNode> void outputXML(XMLNode* UNUSED(node)){}
+    template <class XMLNode> void outputXML(XMLNode* UNUSED(node)){}
 
-  void toString(std::ostream& UNUSED(os)) const {}
+    void toString(std::ostream& UNUSED(os)) const {}
 
 };
 
 template <class Base, class T>
 struct InstantiateBuilderInfo {
-  static bool isLoaded() {
-    return loaded;
-  }
+    static bool isLoaded() {
+        return loaded;
+    }
 
-  static const bool loaded;
+    static const bool loaded;
 };
 
 template <class Base> class InfoLibrary
 {
- public:
-  using BaseInfo = typename Base::BuilderInfo;
+public:
+    using BaseInfo = typename Base::BuilderInfo;
 
-  InfoLibrary(const std::string& name) :
-    name_(name)
-  {
-  }
+    InfoLibrary(const std::string& name) :
+        name_(name)
+        {
+        }
 
-  BaseInfo* getInfo(const std::string& name) {
-    auto iter = infos_.find(name);
-    if (iter == infos_.end()){
-      return nullptr;
-    } else {
-      return iter->second;
+    BaseInfo* getInfo(const std::string& name) {
+        auto iter = infos_.find(name);
+        if (iter == infos_.end()){
+            return nullptr;
+        } else {
+            return iter->second;
+        }
     }
-  }
 
-  bool hasInfo(const std::string& name) const {
-    return infos_.find(name) != infos_.end();
-  }
+    bool hasInfo(const std::string& name) const {
+        return infos_.find(name) != infos_.end();
+    }
 
-  int numEntries() const {
-    return infos_.size();
-  }
+    int numEntries() const {
+        return infos_.size();
+    }
 
-  const std::map<std::string, BaseInfo*>& getMap() const {
-    return infos_;
-  }
+    const std::map<std::string, BaseInfo*>& getMap() const {
+        return infos_;
+    }
 
-  void readdInfo(const std::string& name, BaseInfo* info){
-    infos_[name] = info;
-  }
+    void readdInfo(const std::string& name, BaseInfo* info){
+        infos_[name] = info;
+    }
 
-  bool addInfo(const std::string& elem, BaseInfo* info){
-    readdInfo(elem, info);
-    //dlopen might thrash this later - add a loader to put it back in case
-    addLoader(name_, elem, info);
-    return true;
-  }
+    bool addInfo(const std::string& elem, BaseInfo* info){
+        readdInfo(elem, info);
+        //dlopen might thrash this later - add a loader to put it back in case
+        addLoader(name_, elem, info);
+        return true;
+    }
 
- private:
-  void addLoader(const std::string& lib, const std::string& name, BaseInfo* info);
+private:
+    void addLoader(const std::string& lib, const std::string& name, BaseInfo* info);
 
-  std::map<std::string, BaseInfo*> infos_;
+    std::map<std::string, BaseInfo*> infos_;
 
-  std::string name_;
+    std::string name_;
 };
 
 template <class Base>
 class InfoLibraryDatabase {
- public:
-  using Library=InfoLibrary<Base>;
-  using BaseInfo=typename Library::BaseInfo;
-  using Map=std::map<std::string,Library*>;
+public:
+    using Library=InfoLibrary<Base>;
+    using BaseInfo=typename Library::BaseInfo;
+    using Map=std::map<std::string,Library*>;
 
-  static Library* getLibrary(const std::string& name){
-    if (!libraries){
-      libraries = new Map;
+    static Library* getLibrary(const std::string& name){
+        if (!libraries){
+            libraries = new Map;
+        }
+        auto iter = libraries->find(name);
+        if (iter == libraries->end()){
+            auto* info = new Library(name);
+            (*libraries)[name] = info;
+            return info;
+        } else {
+            return iter->second;
+        }
     }
-    auto iter = libraries->find(name);
-    if (iter == libraries->end()){
-      auto* info = new Library(name);
-      (*libraries)[name] = info;
-      return info;
-    } else {
-      return iter->second;
-    }
-  }
 
- private:
-  // Database - needs to be a pointer for static init order
-  static Map* libraries;
+private:
+    // Database - needs to be a pointer for static init order
+    static Map* libraries;
 };
 
 template <class Base> typename InfoLibraryDatabase<Base>::Map*
-  InfoLibraryDatabase<Base>::libraries = nullptr;
+InfoLibraryDatabase<Base>::libraries = nullptr;
 
 template <class Base> void InfoLibrary<Base>::addLoader(const std::string& elemlib, const std::string& elem,
-                                                  BaseInfo* info){
-  LoadedLibraries::addLoader(elemlib, elem, [=]{
-      auto* lib = InfoLibraryDatabase<Base>::getLibrary(elemlib);
-      if (!lib->hasInfo(elem)){
-        lib->readdInfo(elem, info);
-      }
-  });
+                                                        BaseInfo* info){
+    LoadedLibraries::addLoader(elemlib, elem, [=]{
+                                                  auto* lib = InfoLibraryDatabase<Base>::getLibrary(elemlib);
+                                                  if (!lib->hasInfo(elem)){
+                                                      lib->readdInfo(elem, info);
+                                                  }
+                                              });
 }
 
 
 template <class Base> struct ElementsInfo
 {
-  static InfoLibrary<Base>* getLibrary(const std::string& name){
-    return InfoLibraryDatabase<Base>::getLibrary(name);
-  }
+    static InfoLibrary<Base>* getLibrary(const std::string& name){
+        return InfoLibraryDatabase<Base>::getLibrary(name);
+    }
 
-  template <class T> static bool add(){
-    return Base::template addDerivedInfo<T>(T::ELI_getLibrary(), T::ELI_getName());
-  }
+    template <class T> static bool add(){
+        return Base::template addDerivedInfo<T>(T::ELI_getLibrary(), T::ELI_getName());
+    }
 };
 template <class Base, class T> const bool InstantiateBuilderInfo<Base,T>::loaded
-  = ElementsInfo<Base>::template add<T>();
+= ElementsInfo<Base>::template add<T>();
 
 
 struct InfoDatabase {
-  template <class T>
-  static InfoLibrary<T>* getLibrary(const std::string& name){
-    return InfoLibraryDatabase<T>::getLibrary(name);
-  }
+    template <class T>
+    static InfoLibrary<T>* getLibrary(const std::string& name){
+        return InfoLibraryDatabase<T>::getLibrary(name);
+    }
 };
 
 } //namespace ELI

--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -274,16 +274,6 @@ constexpr unsigned SST_ELI_getTertiaryNumberFromVersion(SST_ELI_element_version_
   Macros used by elements to add element documentation
 **************************************************************************/
 
-#define SST_ELI_DECLARE_BASE(Base) \
-  using __LocalEliBase = Base; \
-  using InfoLibrary = ::SST::ELI::InfoLibrary<Base>; \
-  static const char* ELI_baseName(){ return #Base; }
-
-#define SST_ELI_DECLARE_INFO_COMMON() \
-  template <class __TT> static bool addDerivedInfo(const std::string& lib, const std::string& elem){ \
-    return addInfo(lib,elem,new BuilderInfo(lib,elem,(__TT*)nullptr)); \
-  }
-
 #define SST_ELI_DECLARE_INFO(...) \
   using BuilderInfo = ::SST::ELI::BuilderInfoImpl<__VA_ARGS__,SST::ELI::ProvidesDefaultInfo,void>; \
   template <class BuilderImpl> static bool addInfo(const std::string& elemlib, const std::string& elem, \
@@ -333,6 +323,7 @@ constexpr unsigned SST_ELI_getTertiaryNumberFromVersion(SST_ELI_element_version_
     return SST::ELI::InstantiateBuilder<base,cls>::isLoaded() \
       && SST::ELI::InstantiateBuilderInfo<base,cls>::isLoaded(); \
   }
+
 
 } //namespace SST
 

--- a/src/sst/core/eli/elibase.h
+++ b/src/sst/core/eli/elibase.h
@@ -129,4 +129,26 @@ class LoadedLibraries {
 
 #define ELI_FORWARD_AS_ONE(...) __VA_ARGS__
 
+#define SST_ELI_DECLARE_BASE(Base) \
+  using __LocalEliBase = Base; \
+  static const char* ELI_baseName(){ return #Base; }
+
+#define SST_ELI_DECLARE_INFO_COMMON()                          \
+  using InfoLibrary = ::SST::ELI::InfoLibrary<__LocalEliBase>; \
+  template <class __TT> static bool addDerivedInfo(const std::string& lib, const std::string& elem){ \
+    return addInfo(lib,elem,new BuilderInfo(lib,elem,(__TT*)nullptr)); \
+  }
+
+#define SST_ELI_DECLARE_NEW_BASE(OldBase,NewBase) \
+  using __LocalEliBase = NewBase; \
+  using __ParentEliBase = OldBase; \
+  SST_ELI_DECLARE_INFO_COMMON() \
+  static const char* ELI_baseName(){ return #NewBase; } \
+  template <class InfoImpl> static bool addInfo(const std::string& elemlib, const std::string& elem, \
+                                                InfoImpl* info){ \
+    return OldBase::addInfo(elemlib, elem, info) \
+      && ::SST::ELI::InfoDatabase::getLibrary<NewBase>(elemlib)->addInfo(elem,info); \
+  }
+
+
 #endif // SST_CORE_ELIBASE_H

--- a/src/sst/core/eli/elibase.h
+++ b/src/sst/core/eli/elibase.h
@@ -105,22 +105,22 @@ namespace ELI {
 template <class T> struct MethodDetect { using type=void; };
 
 class LoadedLibraries {
- public:
-  using InfoMap=std::map<std::string, std::function<void()>>;
-  using LibraryMap=std::map<std::string,InfoMap>;
+public:
+    using InfoMap=std::map<std::string, std::function<void()>>;
+    using LibraryMap=std::map<std::string,InfoMap>;
 
-  static bool isLoaded(const std::string& name);
+    static bool isLoaded(const std::string& name);
 
-  /**
-		@return A boolean indicated successfully added
+    /**
+       @return A boolean indicated successfully added
 	*/
-  static bool addLoader(const std::string& lib, const std::string& name,
-                        std::function<void()>&& loader);
+    static bool addLoader(const std::string& lib, const std::string& name,
+                          std::function<void()>&& loader);
 
-  static const LibraryMap& getLoaders();
+    static const LibraryMap& getLoaders();
 
- private:
-  static std::unique_ptr<LibraryMap> loaders_;
+private:
+    static std::unique_ptr<LibraryMap> loaders_;
 
 };
 

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -221,8 +221,6 @@ Factory::CreateComponent(ComponentId_t id,
         if (compLib){
           auto* fact = compLib->getBuilder(elem);
           if (fact){
-            // LinkMap *lm = Simulation::getSimulation()->getComponentLinkMap(id);
-            // lm->setAllowedPorts(&(compInfo->getPortnames()));
             loadingComponentType = type;
             params.pushAllowedKeys(compInfo->getParamNames());
             Component* ret = fact->create(id,params);
@@ -298,55 +296,32 @@ Factory::DoesComponentInfoStatisticNameExist(const std::string& type, const std:
 
     // Check to see if library is loaded into new
     // ElementLibraryDatabase
-    auto* lib = ELI::InfoDatabase::getLibrary<Component>(elemlib);
-    if (lib){
-      auto* info = lib->getInfo(elem);
-      if (info){
-        for (auto& item : info->getStatnames()) {
-            if (statisticName == item) {
-                return true;
+    auto* sublib = ELI::InfoDatabase::getLibrary<SubComponent>(elemlib);
+    if (sublib){
+        auto* info = sublib->getInfo(elem);
+        if (info){
+            for ( auto& item : info->getStatnames() ) {
+                if ( statisticName == item ) {
+                    return true;
+                }
             }
+            return false;
         }
-        return false;
-      }
     }
 
-    
-    // If we get to here, element doesn't exist
-    out.fatal(CALL_INFO, 1, "can't find requested component '%s'\n ", type.c_str());
-    return false;
-}
-
-bool 
-Factory::DoesSubComponentInfoStatisticNameExist(const std::string& type, const std::string& statisticName)
-{
-    std::string compTypeToLoad = type;
-    if (true == type.empty()) { 
-        compTypeToLoad = loadingComponentType;
-    }
-    
-    std::string elemlib, elem;
-    std::tie(elemlib, elem) = parseLoadName(compTypeToLoad);
-
-    // ensure library is already loaded...
-    requireLibrary(elemlib);
-
-    std::lock_guard<std::recursive_mutex> lock(factoryMutex);
-
-    // Check to see if library is loaded into new
-    // ElementLibraryDatabase
-    auto* lib = ELI::InfoDatabase::getLibrary<SubComponent>(elemlib);
-    if (lib){
-      auto* info = lib->getInfo(elem);
-      if (info){
-        for ( auto& item : info->getStatnames() ) {
-            if ( statisticName == item ) {
-                return true;
+    auto* complib = ELI::InfoDatabase::getLibrary<Component>(elemlib);
+    if (complib){
+        auto* info = complib->getInfo(elem);
+        if (info){
+            for ( auto& item : info->getStatnames() ) {
+                if ( statisticName == item ) {
+                    return true;
+                }
             }
+            return false;
         }
-        return false;
-      }
     }
+    
 
     // If we get to here, element doesn't exist
     out.fatal(CALL_INFO, 1, "can't find requested subcomponent '%s'\n ", type.c_str());

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -154,6 +154,48 @@ bool Factory::isPortNameValid(const std::string &type, const std::string port_na
     return false;
 }
 
+const Params::KeySet_t&
+Factory::getParamNames(const std::string &type)
+{
+    // This is only needed so we can return something in the error
+    // case.  It is never used.
+    static Params::KeySet_t empty_keyset;
+
+    std::string elemlib, elem;
+    std::tie(elemlib, elem) = parseLoadName(type);
+    // ensure library is already loaded...
+    if (loaded_libraries.find(elemlib) == loaded_libraries.end()) {
+        findLibrary(elemlib);
+    }
+    
+    // Check to see if library is loaded into new
+    // ElementLibraryDatabase
+    auto* lib = ELI::InfoDatabase::getLibrary<Component>(elemlib);
+    if (lib) {
+        auto* compInfo = lib->getInfo(elem);
+        if ( compInfo ) return compInfo->getParamNames();
+    }
+    else {
+        auto* lib = ELI::InfoDatabase::getLibrary<SubComponent>(elemlib);
+        if ( lib ) {
+            auto* compInfo = lib->getInfo(elem);
+            if ( compInfo ) return compInfo->getParamNames();
+        }
+        else {
+            auto* lib = ELI::InfoDatabase::getLibrary<Module>(elemlib);
+            if ( lib ) {
+                auto* compInfo = lib->getInfo(elem);
+                if ( compInfo ) return compInfo->getParamNames();
+            }
+        }
+    }
+    // If we made it to here we didn't find an element that has params
+    // with the given name
+    out.fatal(CALL_INFO, 1,"can't find requested element %s.\n ", type.c_str());
+    return empty_keyset;
+}
+
+
 
 Component*
 Factory::CreateComponent(ComponentId_t id, 
@@ -179,8 +221,8 @@ Factory::CreateComponent(ComponentId_t id,
         if (compLib){
           auto* fact = compLib->getBuilder(elem);
           if (fact){
-            LinkMap *lm = Simulation::getSimulation()->getComponentLinkMap(id);
-            lm->setAllowedPorts(&(compInfo->getPortnames()));
+            // LinkMap *lm = Simulation::getSimulation()->getComponentLinkMap(id);
+            // lm->setAllowedPorts(&(compInfo->getPortnames()));
             loadingComponentType = type;
             params.pushAllowedKeys(compInfo->getParamNames());
             Component* ret = fact->create(id,params);
@@ -213,24 +255,24 @@ Factory::DoesSubComponentSlotExist(const std::string& type, const std::string& s
     // Check to see if library is loaded into new ElementLibraryDatabase
     auto* compLib = ELI::InfoDatabase::getLibrary<Component>(elemlib);
     if (compLib){
-      auto* info = compLib->getInfo(elem);
-      if (info){
-        for (auto& item : info->getSubComponentSlots()){
-          if (item.name == slotName) return true;
+        auto* info = compLib->getInfo(elem);
+        if (info){
+            for (auto& item : info->getSubComponentSlots()){
+                if (item.name == slotName) return true;
+            }
+            return false;
         }
-      }
-      return false;
     }
 
     auto* subLib = ELI::InfoDatabase::getLibrary<SubComponent>(elemlib);
     if (subLib){
-      auto* info = subLib->getInfo(elem);
-      if (info){
-        for (auto& item : info->getSubComponentSlots()){
-          if (item.name == slotName) return true;
+        auto* info = subLib->getInfo(elem);
+        if (info){
+            for (auto& item : info->getSubComponentSlots()){
+                if (item.name == slotName) return true;
+            }
+            return false;
         }
-      }
-      return false;
     }
 
     // If we get to here, element doesn't exist
@@ -502,6 +544,28 @@ Factory::CreateSubComponent(std::string type, Component* comp, Params& params)
     return NULL;
 }
 
+
+bool
+Factory::doesSubComponentExist(std::string type)
+{
+    std::string elemlib, elem;
+    std::tie(elemlib, elem) = parseLoadName(type);
+
+    // ensure library is already loaded...
+    requireLibrary(elemlib);
+
+    std::lock_guard<std::recursive_mutex> lock(factoryMutex);
+    // Check to see if library is loaded into new
+    // ElementLibraryDatabase
+    auto* lib = ELI::InfoDatabase::getLibrary<SubComponent>(elemlib);
+    if (lib){
+      auto* info = lib->getInfo(elem);
+      if ( info ) return true;
+    }
+
+    // If we get to here, element doesn't exist
+    return false;
+}
 
 void
 Factory::RequireEvent(std::string eventname)

--- a/src/sst/core/factory.h
+++ b/src/sst/core/factory.h
@@ -51,6 +51,12 @@ public:
      */
     bool isPortNameValid(const std::string &type, const std::string port_name);
 
+    /** Get a list of allowed param keys for a given component type.
+     * @param type - Name of component in lib.name format
+     * @return True if this is a valid portname
+     */
+    const Params::KeySet_t& getParamNames(const std::string &type);
+
 
     /** Attempt to create a new Component instantiation
      * @param id - The unique ID of the component instantiation
@@ -86,6 +92,9 @@ public:
      */
     SubComponent* CreateSubComponent(std::string type, Component* comp, Params& params);
 
+
+    bool doesSubComponentExist(std::string type);
+    
     /** Return partitioner function
      * @param name - Fully qualified elementlibname.partitioner type name
      */

--- a/src/sst/core/factory.h
+++ b/src/sst/core/factory.h
@@ -109,30 +109,31 @@ public:
      */
     template <class Base, class... CtorArgs>
     Base* Create(const std::string& type, SST::Params& params, CtorArgs&&... args){
-      std::string elemlib, elem;
-      std::tie(elemlib, elem) = parseLoadName(type);
+        std::string elemlib, elem;
+        std::tie(elemlib, elem) = parseLoadName(type);
 
-      requireLibrary(elemlib);
-      std::lock_guard<std::recursive_mutex> lock(factoryMutex);
+        requireLibrary(elemlib);
+        std::lock_guard<std::recursive_mutex> lock(factoryMutex);
 
-      auto* lib = ELI::InfoDatabase::getLibrary<Base>(elemlib);
-      if (lib){
-        auto* info = lib->getInfo(elem);
-        if (info){
-          auto* builderLib = Base::getBuilderLibrary(elemlib);
-          if (builderLib){
-            auto* fact = builderLib->getBuilder(elem);
-            if (fact){
-              params.pushAllowedKeys(info->getParamNames());
-              Base* ret = fact->create(std::forward<CtorArgs>(args)...);
-              params.popAllowedKeys();
-              return ret;
+        auto* lib = ELI::InfoDatabase::getLibrary<Base>(elemlib);
+        if (lib){
+            auto map = lib->getMap();
+            auto* info = lib->getInfo(elem);
+            if (info){
+                auto* builderLib = Base::getBuilderLibrary(elemlib);
+                if (builderLib){
+                    auto* fact = builderLib->getBuilder(elem);
+                    if (fact){
+                        params.pushAllowedKeys(info->getParamNames());
+                        Base* ret = fact->create(std::forward<CtorArgs>(args)...);
+                        params.popAllowedKeys();
+                        return ret;
+                    }
+                }
             }
-          }
         }
-      }
-      notFound(Base::ELI_baseName(), type);
-      return nullptr;
+        notFound(Base::ELI_baseName(), type);
+        return nullptr;
     }
 
     /** Instantiate a new Statistic
@@ -196,7 +197,7 @@ public:
      * @param statisticName - The name of the statistic 
      * @return True if the statistic is defined in the component's ElementInfoStatistic
      */
-    bool DoesSubComponentInfoStatisticNameExist(const std::string& type, const std::string& statisticName);
+    // bool DoesSubComponentInfoStatisticNameExist(const std::string& type, const std::string& statisticName);
 
     /** Get the enable level of a statistic defined in the component's ElementInfoStatistic
      * @param componentname - The name of the component

--- a/src/sst/core/interfaces/simpleMem.h
+++ b/src/sst/core/interfaces/simpleMem.h
@@ -42,7 +42,7 @@ class SimpleMem : public SubComponent {
 public:
     class HandlerBase;
 
-    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleMem,HandlerBase*)
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleMem,TimeConverter*,HandlerBase*)
     /** All Addresses can be 64-bit */
     typedef uint64_t Addr;
 

--- a/src/sst/core/interfaces/simpleMem.h
+++ b/src/sst/core/interfaces/simpleMem.h
@@ -32,13 +32,15 @@ class Event;
 
 namespace Interfaces {
 
+class HandlerBase;
+
 /**
  * Simplified, generic interface to Memory models
  */
 class SimpleMem : public SubComponent {
 
 public:
-    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleMem)
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleMem,HandlerBase*)
     /** All Addresses can be 64-bit */
     typedef uint64_t Addr;
 

--- a/src/sst/core/interfaces/simpleMem.h
+++ b/src/sst/core/interfaces/simpleMem.h
@@ -32,14 +32,16 @@ class Event;
 
 namespace Interfaces {
 
-class HandlerBase;
 
 /**
  * Simplified, generic interface to Memory models
  */
 class SimpleMem : public SubComponent {
 
+    
 public:
+    class HandlerBase;
+
     SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleMem,HandlerBase*)
     /** All Addresses can be 64-bit */
     typedef uint64_t Addr;

--- a/src/sst/core/interfaces/simpleMem.h
+++ b/src/sst/core/interfaces/simpleMem.h
@@ -38,6 +38,7 @@ namespace Interfaces {
 class SimpleMem : public SubComponent {
 
 public:
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleMem)
     /** All Addresses can be 64-bit */
     typedef uint64_t Addr;
 
@@ -308,6 +309,11 @@ public:
     /** Constructor, designed to be used via 'loadSubComponent'. */
     SimpleMem(SST::Component *comp, Params &UNUSED(params)) :
         SubComponent(comp)
+        { }
+
+    /** Constructor, designed to be used via 'loadUserSubComponent and loadAnonymousSubComponent'. */
+    SimpleMem(SST::ComponentId_t id, Params &UNUSED(params)) :
+        SubComponent(id)
         { }
 
     /** Second half of building the interface.

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -39,6 +39,9 @@ namespace Interfaces {
 class SimpleNetwork : public SubComponent {
 
 public:
+
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork,int)
+    
     /** All Addresses can be 64-bit */
     typedef int64_t nid_t;
 
@@ -56,6 +59,7 @@ public:
         size_t size_in_bits;  /*!< Size of packet in bits */
         bool   head;          /*!< True if this is the head of a stream */
         bool   tail;          /*!< True if this is the tail of a steram */
+        bool   allow_adaptive; /*!< Indicates whether adaptive routing is allowed or not. */
         
     private:
         Event* payload;       /*!< Payload of the request */
@@ -105,14 +109,14 @@ public:
 
         /** Constructor */
         Request() :
-            dest(0), src(0), size_in_bits(0), head(false), tail(false), payload(NULL),
-            trace(NONE), traceID(0)
+            dest(0), src(0), size_in_bits(0), head(false), tail(false), allow_adaptive(true),
+            payload(NULL), trace(NONE), traceID(0)
         {}
 
         Request(nid_t dest, nid_t src, size_t size_in_bits,
                 bool head, bool tail, Event* payload = NULL) :
-            dest(dest), src(src), size_in_bits(size_in_bits), head(head), tail(tail), payload(payload),
-            trace(NONE), traceID(0)
+            dest(dest), src(src), size_in_bits(size_in_bits), head(head), tail(tail), allow_adaptive(true),
+            payload(payload), trace(NONE), traceID(0)
         {
         }
 
@@ -144,6 +148,7 @@ public:
             ser & payload;
             ser & trace;
             ser & traceID;
+            ser & allow_adaptive;
         }
         
     protected:
@@ -246,6 +251,11 @@ public:
     /** Constructor, designed to be used via 'loadSubComponent'. */
     SimpleNetwork(SST::Component *comp) :
         SubComponent(comp)
+    { }
+
+    /** Constructor, designed to be used via 'loadUserSubComponent or loadAnonymousSubComponent'. */
+    SimpleNetwork(SST::ComponentId_t id) :
+        SubComponent(id)
     { }
 
     /** Second half of building the interface.

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -38,7 +38,8 @@ Link::Link(LinkId_t id) :
     defaultTimeBase( NULL ),
     latency(1),
     type(HANDLER),
-    id(id)
+    id(id),
+    configured(false)
 {
     recvQueue = uninitQueue;
     untimedQueue = NULL;
@@ -50,7 +51,8 @@ Link::Link() :
     defaultTimeBase( NULL ),
     latency(1),
     type(HANDLER),
-    id(-1)
+    id(-1),
+    configured(false)
 {
     recvQueue = uninitQueue;
     untimedQueue = NULL;

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -132,6 +132,15 @@ public:
         return recvUntimedData();
     }
 
+
+    void setAsConfigured() {
+        configured = true;
+    }
+
+    bool isConfigured() {
+        return configured;
+    }
+
 #ifdef __SST_DEBUG_EVENT_TRACKING__
     void setSendingComponentInfo(const std::string& comp_in, const std::string& type_in, const std::string& port_in) {
         comp = comp_in;
@@ -191,7 +200,8 @@ private:
     
     Type_t type;
     LinkId_t id;
-
+    bool configured;
+    
 #ifdef __SST_DEBUG_EVENT_TRACKING__
     std::string comp;
     std::string ctype;

--- a/src/sst/core/linkMap.h
+++ b/src/sst/core/linkMap.h
@@ -29,7 +29,7 @@ class LinkMap {
 
 private:
     std::map<std::string,Link*> linkMap;
-    const std::vector<std::string> * allowedPorts;
+    // const std::vector<std::string> * allowedPorts;
     std::vector<std::string> selfPorts;
 
     // bool checkPort(const char *def, const char *offered) const
@@ -119,7 +119,7 @@ private:
     // }
 
 public:
-    LinkMap() : allowedPorts(NULL) {}
+    LinkMap() /*: allowedPorts(NULL)*/ {}
     ~LinkMap() {
         // Delete all the links in the map
         for ( std::map<std::string,Link*>::iterator it = linkMap.begin(); it != linkMap.end(); ++it ) {
@@ -128,13 +128,15 @@ public:
         linkMap.clear();
     }
 
-    /**
-     * Set the list of allowed port names from the ElementInfoPort
-     */
-    void setAllowedPorts(const std::vector<std::string> *p)
-    {
-        allowedPorts = p;
-    }
+    // /**
+    //  * Set the list of allowed port names from the ElementInfoPort
+    //  */
+    // void setAllowedPorts(const std::vector<std::string> *p)
+    // {
+    //     allowedPorts = p;
+    // }
+
+
 
     /**
      * Add a port name to the list of allowed ports.
@@ -161,6 +163,10 @@ public:
         linkMap.insert(std::pair<std::string,Link*>(name,link));
     }
 
+    void removeLink(std::string name) {
+        linkMap.erase(name);
+    }
+    
     /** Returns a Link pointer for a given name */
     Link* getLink(std::string name) {
 //         if ( !checkPort(name) ) {

--- a/src/sst/core/output.h
+++ b/src/sst/core/output.h
@@ -495,6 +495,8 @@ public:
     static Output& getDefaultObject() { return m_defaultObject; }
 
 private:
+
+    friend class TraceFunction;
     // Support Methods
     void setTargetOutput(output_location_t location);
     void openSSTTargetFile() const;
@@ -578,19 +580,32 @@ private:
 
 // Class to easily trace function enter and exit
 class TraceFunction {
+
+    static int trace_level;
+    static std::vector<char> indent_array;
+    
 public:
-    TraceFunction(uint32_t line, const char* file, const char* func);
+    TraceFunction(uint32_t line, const char* file, const char* func, bool print_sim_info = true);
     ~TraceFunction();
 
-    Output& getOutput() {return output;}
+    Output& getOutput() {return output_obj;}
+
+    /** Output the message with formatting as specified by the format parameter.
+        @param format Format string.  All valid formats for printf are available.
+        @param ... Arguments for format.
+     */
+    void output(const char* format, ...) const
+        __attribute__ ((format (printf, 2, 3)));
+
     
 private:
-    Output output;
+    Output output_obj;
     uint32_t line;
     std::string file;
     std::string function;
-    uint32_t rank;
-    uint32_t thread;
+    // uint32_t rank;
+    // uint32_t thread;
+    int indent_length;
 };
 
 

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -300,7 +300,7 @@ int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTi
     {
         ConfigComponent* ccomp = &(*iter);
         if ( ccomp->rank == myRank ) {
-            compInfoMap.insert(new ComponentInfo(ccomp, ccomp->name, new LinkMap()));
+            compInfoMap.insert(new ComponentInfo(ccomp, ccomp->name, NULL, new LinkMap()));
         }
     }
 

--- a/src/sst/core/sst_types.h
+++ b/src/sst/core/sst_types.h
@@ -25,13 +25,15 @@ typedef uint64_t  SimTime_t;
 typedef double          Time_t;
 
 #define MAX_SIMTIME_T 0xFFFFFFFFFFFFFFFFl
-/* Subcomponent IDs are in the high-12 bits of the Component ID */
+/* Subcomponent IDs are in the high-16 bits of the Component ID */
 #define UNSET_COMPONENT_ID 0xFFFFFFFFFFFFFFFFULL
 #define COMPONENT_ID_BITS 48
 #define COMPONENT_ID_MASK(x) ((x) & 0x0000FFFFFFFFFFFFULL)
 #define SUBCOMPONENT_ID_BITS 16
 #define SUBCOMPONENT_ID_MASK(x) ((x) >> COMPONENT_ID_BITS)
 #define SUBCOMPONENT_ID_CREATE(compId, sCompId) ((((uint64_t)sCompId) << COMPONENT_ID_BITS) | compId)
+#define COMPDEFINED_SUBCOMPONENT_ID_CREATE(compId, sCompId) ((((uint64_t)sCompId) << COMPONENT_ID_BITS) | compId | 0x8000000000000000ULL)
+#define COMPDEFINED_SUBCOMPONENT_ID_MASK(x) ((x) >> 63)
 
 typedef double watts;
 typedef double joules;

--- a/src/sst/core/statapi/statengine.cc
+++ b/src/sst/core/statapi/statengine.cc
@@ -91,6 +91,7 @@ bool StatisticProcessingEngine::registerStatisticCore(StatisticBase* stat)
     if ( stat->isNullStatistic() )
         return true;
 
+
     if ( 0 == m_statLoadLevel ) {
         m_output.verbose(CALL_INFO, 1, 0,
                 " Warning: Statistic Load Level = 0 (all statistics disabled); statistic %s is disabled...\n",

--- a/src/sst/core/subcomponent.cc
+++ b/src/sst/core/subcomponent.cc
@@ -18,6 +18,17 @@ namespace SST {
 SST_ELI_DEFINE_INFO_EXTERN(SubComponent)
 SST_ELI_DEFINE_CTOR_EXTERN(SubComponent)
 
+SubComponent::SubComponent(Component* parent) :
+    BaseComponent(parent->getCurrentlyLoadingSubComponentID()),
+    parent(parent)
+{}
+
+SubComponent::SubComponent(ComponentId_t id) :
+    BaseComponent(id),
+    parent(getTrueComponent())
+{}
+
+
 SubComponent*
 SubComponent::loadSubComponent(std::string type, Params& params)
 {

--- a/src/sst/core/subcomponent.cc
+++ b/src/sst/core/subcomponent.cc
@@ -18,10 +18,5 @@ namespace SST {
 SST_ELI_DEFINE_INFO_EXTERN(SubComponent)
 SST_ELI_DEFINE_CTOR_EXTERN(SubComponent)
 
-bool
-SubComponent::doesComponentInfoStatisticExist(const std::string &statisticName) const
-{
-    return Factory::getFactory()->DoesSubComponentInfoStatisticNameExist(getType(), statisticName);
-}
 
 } // namespace SST

--- a/src/sst/core/subcomponent.cc
+++ b/src/sst/core/subcomponent.cc
@@ -18,5 +18,10 @@ namespace SST {
 SST_ELI_DEFINE_INFO_EXTERN(SubComponent)
 SST_ELI_DEFINE_CTOR_EXTERN(SubComponent)
 
+SubComponent*
+SubComponent::loadSubComponent(std::string type, Params& params)
+{
+    return BaseComponent::loadSubComponent(type, getTrueComponent(), params);
+}
 
 } // namespace SST

--- a/src/sst/core/subcomponent.cc
+++ b/src/sst/core/subcomponent.cc
@@ -21,7 +21,7 @@ SST_ELI_DEFINE_CTOR_EXTERN(SubComponent)
 bool
 SubComponent::doesComponentInfoStatisticExist(const std::string &statisticName) const
 {
-    return Factory::getFactory()->DoesSubComponentInfoStatisticNameExist(my_info->getType(), statisticName);
+    return Factory::getFactory()->DoesSubComponentInfoStatisticNameExist(getType(), statisticName);
 }
 
 } // namespace SST

--- a/src/sst/core/subcomponent.cc
+++ b/src/sst/core/subcomponent.cc
@@ -25,14 +25,14 @@ SubComponent::SubComponent(Component* parent) :
 
 SubComponent::SubComponent(ComponentId_t id) :
     BaseComponent(id),
-    parent(getTrueComponent())
+    parent(getTrueComponentPrivate())
 {}
 
 
 SubComponent*
 SubComponent::loadSubComponent(std::string type, Params& params)
 {
-    return BaseComponent::loadSubComponent(type, getTrueComponent(), params);
+    return BaseComponent::loadSubComponent(type, getTrueComponentPrivate(), params);
 }
 
 } // namespace SST

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -40,7 +40,7 @@ public:
       ELI::ProvidesStats,
       ELI::ProvidesInterface)
 
-	SubComponent(Component* parent) :
+	SubComponent(Component* parent) __attribute__ ((deprecated("This version of SubComponent constructor will be removed in SST version 10.0.  Please switch to new API which uses SubComponent(ComponentId_t)."))) :
         BaseComponent(parent->getCurrentlyLoadingSubComponentID()),
         parent(parent)
      {}

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -40,15 +40,8 @@ public:
       ELI::ProvidesStats,
       ELI::ProvidesInterface)
 
-	SubComponent(Component* parent) :
-        BaseComponent(parent->getCurrentlyLoadingSubComponentID()),
-        parent(parent)
-     {}
-
-	SubComponent(ComponentId_t id) :
-        BaseComponent(id),
-        parent(getTrueComponent())
-    {}
+	SubComponent(Component* parent);
+	SubComponent(ComponentId_t id);
 
 	virtual ~SubComponent() {};
 
@@ -63,17 +56,13 @@ public:
     virtual void finish( ) override { }
 
 protected:
-    Component* const parent __attribute__ ((deprecated("The parent data member will be removed in SST version 10.0.  With the sbcomponent structure, direct access to your parent is not allowed.")));
+    Component* const parent __attribute__ ((deprecated("The parent data member will be removed in SST version 10.0.  With the new subcomponent structure, direct access to your parent is not allowed.")));
 
     /* Deprecate?   Old ELI style*/
     SubComponent* loadSubComponent(std::string type, Params& params) __attribute__ ((deprecated("This version of loadSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
 
 
 private:
-    /** Component's type, set by the factory when the object is created.
-        It is identical to the configuration string used to create the
-        component. I.e. the XML "<component id="aFoo"><foo>..." would
-        set component::type to "foo" */
     friend class Component;
 
 };

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -40,7 +40,7 @@ public:
       ELI::ProvidesStats,
       ELI::ProvidesInterface)
 
-	SubComponent(Component* parent) __attribute__ ((deprecated("This version of SubComponent constructor will be removed in SST version 10.0.  Please switch to new API which uses SubComponent(ComponentId_t)."))) :
+	SubComponent(Component* parent) :
         BaseComponent(parent->getCurrentlyLoadingSubComponentID()),
         parent(parent)
      {}
@@ -63,13 +63,10 @@ public:
     virtual void finish( ) override { }
 
 protected:
-    Component* const parent;
+    Component* const parent __attribute__ ((deprecated("The parent data member will be removed in SST version 10.0.  With the sbcomponent structure, direct access to your parent is not allowed.")));
 
     /* Deprecate?   Old ELI style*/
-    SubComponent* loadSubComponent(std::string type, Params& params) {
-        // return parent->loadSubComponent(type, parent, params);
-        return BaseComponent::loadSubComponent(type, getTrueComponent(), params);
-    }
+    SubComponent* loadSubComponent(std::string type, Params& params) __attribute__ ((deprecated("This version of loadSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
 
 
 private:
@@ -88,11 +85,11 @@ private:
     SST_ELI_NEW_BASE_CTOR(ComponentId_t,Params&,##__VA_ARGS__)
 
 #define SST_ELI_REGISTER_SUBCOMPONENT(cls,lib,name,version,desc,interface)   \
-  SST_ELI_REGISTER_DERIVED(SST::SubComponent,cls,lib,name,ELI_FORWARD_AS_ONE(version),desc) \
-  SST_ELI_INTERFACE_INFO(interface)
+    SST_ELI_REGISTER_DERIVED(SST::SubComponent,cls,lib,name,ELI_FORWARD_AS_ONE(version),desc) \
+    SST_ELI_INTERFACE_INFO(interface)
 
 #define SST_ELI_REGISTER_SUBCOMPONENT_DERIVED(cls,lib,name,version,desc,interface)   \
     SST_ELI_REGISTER_DERIVED(::interface,cls,lib,name,ELI_FORWARD_AS_ONE(version),desc) \
-  SST_ELI_INTERFACE_INFO(#interface)
+    SST_ELI_INTERFACE_INFO(#interface)
 
 #endif // SST_CORE_SUBCOMPONENT_H

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -69,13 +69,22 @@ private:
 
 } //namespace SST
 
-#define SST_ELI_REGISTER_SUBCOMPONENT_API(cls,...) \
-    SST_ELI_DECLARE_NEW_BASE(SST::SubComponent,::cls)           \
-    SST_ELI_NEW_BASE_CTOR(ComponentId_t,Params&,##__VA_ARGS__)
 
+// Legacy version of subcomponent registration
 #define SST_ELI_REGISTER_SUBCOMPONENT(cls,lib,name,version,desc,interface)   \
     SST_ELI_REGISTER_DERIVED(SST::SubComponent,cls,lib,name,ELI_FORWARD_AS_ONE(version),desc) \
     SST_ELI_INTERFACE_INFO(interface)
+
+// New way to register subcomponents.  Must register an interface
+// (API) first, then you can register a subcomponent that implements
+// it
+#define SST_ELI_REGISTER_SUBCOMPONENT_API(cls,...)              \
+    SST_ELI_DECLARE_NEW_BASE(SST::SubComponent,::cls)           \
+    SST_ELI_NEW_BASE_CTOR(ComponentId_t,Params&,##__VA_ARGS__)
+
+#define SST_ELI_REGISTER_SUBCOMPONENT_DERIVED_API(cls,base,...) \
+    SST_ELI_DECLARE_NEW_BASE(::base,::cls)                          \
+    SST_ELI_NEW_BASE_CTOR(ComponentId_t,Params&,##__VA_ARGS__)
 
 #define SST_ELI_REGISTER_SUBCOMPONENT_DERIVED(cls,lib,name,version,desc,interface)   \
     SST_ELI_REGISTER_DERIVED(::interface,cls,lib,name,ELI_FORWARD_AS_ONE(version),desc) \

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -40,9 +40,16 @@ public:
       ELI::ProvidesStats,
       ELI::ProvidesInterface)
 
-	SubComponent(Component* parent) : BaseComponent(), parent(parent) {
-        my_info = parent->currentlyLoadingSubComponent;
-    };
+	SubComponent(Component* parent) :
+        BaseComponent(parent->getCurrentlyLoadingSubComponentID()),
+        parent(parent)
+        {}
+
+	SubComponent(ComponentId_t id) :
+        BaseComponent(id),
+        parent(getTrueComponent())
+        {}
+
 	virtual ~SubComponent() {};
 
     /** Used during the init phase.  The method will be called each phase of initialization.
@@ -68,10 +75,11 @@ protected:
 
     /* Deprecate?   Old ELI style*/
     SubComponent* loadSubComponent(std::string type, Params& params) {
-        return parent->loadSubComponent(type, parent, params);
+        // return parent->loadSubComponent(type, parent, params);
+        return BaseComponent::loadSubComponent(type, getTrueComponent(), params);
     }
 
-    // Does the statisticName exist in the ElementInfoStatistic
+    // // Does the statisticName exist in the ElementInfoStatistic
     virtual bool doesComponentInfoStatisticExist(const std::string &statisticName) const final override;
 
 private:

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -43,12 +43,12 @@ public:
 	SubComponent(Component* parent) :
         BaseComponent(parent->getCurrentlyLoadingSubComponentID()),
         parent(parent)
-        {}
+     {}
 
 	SubComponent(ComponentId_t id) :
         BaseComponent(id),
         parent(getTrueComponent())
-        {}
+    {}
 
 	virtual ~SubComponent() {};
 
@@ -65,22 +65,12 @@ public:
 protected:
     Component* const parent;
 
-    Component* getTrueComponent() const final override { return parent; }
-    BaseComponent* getStatisticOwner() const final override {
-        /* If our ID == parent ID, then we're a legacy subcomponent that doesn't own stats. */
-        if ( this->getId() == parent->getId() )
-            return parent;
-        return const_cast<SubComponent*>(this);
-    }
-
     /* Deprecate?   Old ELI style*/
     SubComponent* loadSubComponent(std::string type, Params& params) {
         // return parent->loadSubComponent(type, parent, params);
         return BaseComponent::loadSubComponent(type, getTrueComponent(), params);
     }
 
-    // // Does the statisticName exist in the ElementInfoStatistic
-    virtual bool doesComponentInfoStatisticExist(const std::string &statisticName) const final override;
 
 private:
     /** Component's type, set by the factory when the object is created.
@@ -93,8 +83,16 @@ private:
 
 } //namespace SST
 
+#define SST_ELI_REGISTER_SUBCOMPONENT_API(cls,...) \
+    SST_ELI_DECLARE_NEW_BASE(SST::SubComponent,::cls)           \
+    SST_ELI_NEW_BASE_CTOR(ComponentId_t,Params&,##__VA_ARGS__)
+
 #define SST_ELI_REGISTER_SUBCOMPONENT(cls,lib,name,version,desc,interface)   \
   SST_ELI_REGISTER_DERIVED(SST::SubComponent,cls,lib,name,ELI_FORWARD_AS_ONE(version),desc) \
   SST_ELI_INTERFACE_INFO(interface)
+
+#define SST_ELI_REGISTER_SUBCOMPONENT_DERIVED(cls,lib,name,version,desc,interface)   \
+    SST_ELI_REGISTER_DERIVED(::interface,cls,lib,name,ELI_FORWARD_AS_ONE(version),desc) \
+  SST_ELI_INTERFACE_INFO(#interface)
 
 #endif // SST_CORE_SUBCOMPONENT_H


### PR DESCRIPTION
Update to the SubComponent API.

- Introduces loadUserSubComponent and loadAnonymousSubComponent and deprecates loadSubComponent and loadNamedSubComponent.

- The ELI now requires you to register SubComponent APIs using SST_ELI_REGISTER_SUBCOMPONENT_ELI.
