### PR TITLE
Subcomp update

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -162,6 +162,7 @@ sst_core_sources = \
 	clock.cc \
 	baseComponent.cc \
 	component.cc \
+	componentExtension.cc \
 	componentInfo.cc \
 	config.cc \
 	configGraph.cc \

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -34,7 +34,8 @@ BaseComponent::BaseComponent(ComponentId_t id) :
     sim(Simulation::getSimulation()),
     loadedWithLegacyAPI(false),
     my_info(Simulation::getSimulation()->getComponentInfo(id)),
-    currentlyLoadingSubComponent(NULL)
+    currentlyLoadingSubComponent(NULL),
+    isExtension(false)
 {
     if ( my_info->component == nullptr ) {
         // If it's already set, then this is a ComponentExtension and
@@ -53,6 +54,7 @@ BaseComponent::~BaseComponent()
     // ComponentInfo object.  This happens at the end of execution
     // when the simulation destructor fires.
     if ( !my_info ) return;
+    if ( isExtension ) return;
 
     // Start by deleting children    
     std::map<ComponentId_t,ComponentInfo>& subcomps = my_info->getSubComponents();

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -54,6 +54,7 @@ class BaseComponent {
     friend class SubComponentSlotInfo;
     friend class SubComponent;
     friend class ComponentInfo;
+    friend class ComponentExtension;
     
 public:
 
@@ -580,7 +581,8 @@ private:
     ComponentInfo* my_info;
     ComponentInfo* currentlyLoadingSubComponent;
     ComponentId_t currentlyLoadingSubComponentID;
-
+    bool isExtension;
+    
     void addSelfLink(std::string name);
     Link* getLinkFromParentSharedPort(const std::string& port);
 
@@ -777,7 +779,7 @@ public:
     void createAllSparse(std::vector<std::pair<int,T*> >& vec, uint64_t share_flags, ARGS... args) const {
         for ( int i = 0; i <= getMaxPopulatedSlotNumber(); ++i ) {
             T* sub = create<T>(i, share_flags, args...);
-            vec.push_back(i,sub);
+            if ( sub != nullptr ) vec.push_back(i,sub);
         }
     }
 
@@ -801,7 +803,7 @@ public:
     void createAllSparse(std::vector<T*>& vec, uint64_t share_flags, ARGS... args) const {
         for ( int i = 0; i <= getMaxPopulatedSlotNumber(); ++i ) {
             T* sub = create<T>(i, share_flags, args...);
-            vec.push_back(sub);
+            if ( sub != nullptr ) vec.push_back(sub);
         }
     }
 

--- a/src/sst/core/componentExtension.cc
+++ b/src/sst/core/componentExtension.cc
@@ -1,0 +1,24 @@
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+// 
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+// 
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include <sst_config.h>
+#include <sst/core/componentExtension.h>
+
+namespace SST {
+
+ComponentExtension::ComponentExtension(ComponentId_t id) :
+    BaseComponent(id)
+{
+    isExtension = true;
+}
+
+
+} // namespace SST

--- a/src/sst/core/componentExtension.h
+++ b/src/sst/core/componentExtension.h
@@ -30,9 +30,7 @@ class ComponentExtension : public BaseComponent {
 
 public:
 
-    ComponentExtension(ComponentId_t id) :
-        BaseComponent(id)
-    {}
+    ComponentExtension(ComponentId_t id);
 
 	virtual ~ComponentExtension() {};
 

--- a/src/sst/core/eli/categoryInfo.h
+++ b/src/sst/core/eli/categoryInfo.h
@@ -29,7 +29,7 @@ class ProvidesCategory {
   }
 
   void toString(std::ostream& UNUSED(os)) const {
-    os << "CATEGORY: " << categoryName(cat_) << "\n";
+    os << "      CATEGORY: " << categoryName(cat_) << "\n";
   }
 
   template <class XMLNode> void outputXML(XMLNode* UNUSED(node)){

--- a/src/sst/core/eli/interfaceInfo.h
+++ b/src/sst/core/eli/interfaceInfo.h
@@ -11,7 +11,7 @@ class ProvidesInterface {
   }
 
   void toString(std::ostream& os) const {
-    os << "Interface: " << iface_ << "\n";
+    os << "      Interface: " << iface_ << "\n";
   }
 
   template <class XMLNode> void outputXML(XMLNode* node) const {

--- a/src/sst/core/factory.h
+++ b/src/sst/core/factory.h
@@ -100,6 +100,36 @@ public:
      */
     Partition::SSTPartitioner* CreatePartitioner(std::string name, RankInfo total_ranks, RankInfo my_rank, int verbosity);
 
+
+    /**
+       Check to see if a given element type is loadable with a particular API
+       @param name - Name of element to check in lib.name format
+       @return True if loadable as the API specified as the template parameter
+     */
+    template <class Base>
+    bool isSubComponentLoadableUsingAPI(std::string type) {
+        std::string elemlib, elem;
+        std::tie(elemlib, elem) = parseLoadName(type);
+
+        requireLibrary(elemlib);
+        std::lock_guard<std::recursive_mutex> lock(factoryMutex);
+
+        auto* lib = ELI::InfoDatabase::getLibrary<Base>(elemlib);
+        if (lib){
+            auto map = lib->getMap();
+            auto* info = lib->getInfo(elem);
+            if (info){
+                auto* builderLib = Base::getBuilderLibrary(elemlib);
+                if (builderLib){
+                    auto* fact = builderLib->getBuilder(elem);
+                    if (fact){
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
     
     /**
      * General function for a given base class

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -165,8 +165,14 @@ public:
     class NetworkInspector : public SubComponent {
 
     public:
+        SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork::NetworkInspector,std::string)
+
         NetworkInspector(Component* parent) :
             SubComponent(parent)
+        {}
+
+        NetworkInspector(ComponentId_t id) :
+            SubComponent(id)
         {}
 
         virtual ~NetworkInspector() {}

--- a/src/sst/core/subcomponent.cc
+++ b/src/sst/core/subcomponent.cc
@@ -21,7 +21,9 @@ SST_ELI_DEFINE_CTOR_EXTERN(SubComponent)
 SubComponent::SubComponent(Component* parent) :
     BaseComponent(parent->getCurrentlyLoadingSubComponentID()),
     parent(parent)
-{}
+{
+    loadedWithLegacyAPI = true;
+}
 
 SubComponent::SubComponent(ComponentId_t id) :
     BaseComponent(id),


### PR DESCRIPTION
Disambiguated some of the templated APIs for SubComponent loading and added backward compatibility into the new load*SubComponent calls.  The calls will now try to load using the new API, but will fallback to the old, if needed.  Also added a new call to check if it loaded with the new or old API.