### PR TITLE
sstInfo

### DIFF
--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -149,7 +149,7 @@ static void addELI(ElemLoader &loader, const std::string &lib, bool optional)
     } else if (!optional){
         fprintf(stderr, "**** WARNING - UNABLE TO PROCESS LIBRARY = %s\n", lib.c_str());
     } else {
-        fprintf(stdout, "**** %s not Found!\n", lib.c_str());
+        fprintf(stderr, "**** %s not Found!\n", lib.c_str());
     }
 
 }


### PR DESCRIPTION
Fixes an error with XML output. An error was being written to stdout, which interferes with xml output if sent to stdout.