### PR TITLE
Added ability to suppress warnings about deprecated functions.

### DIFF
--- a/src/sst/core/warnmacros.h
+++ b/src/sst/core/warnmacros.h
@@ -44,6 +44,9 @@
 #define DISABLE_WARN_MISSING_OVERRIDE \
     DIAG_DISABLE(inconsistent-missing-override)
 
+#define DISABLE_WARN_DEPRECATED_DECLARATION \
+    DIAG_DISABLE(deprecated-declarations)
+
 
 #elif defined(__GNUC__)
 #define DIAG_COMPILER GCC
@@ -59,6 +62,9 @@
 #else
 #define DISABLE_WARN_MISSING_OVERRIDE
 #endif
+
+#define DISABLE_WARN_DEPRECATED_DECLARATION \
+    DIAG_DISABLE(deprecated-declarations)
 
 #else
 


### PR DESCRIPTION
This is needed in the case where use of deprecated APIS is
required to maintain backward compatibility until the next
major release.
