### PR TITLE
Module APIs and SubComponent Fix

### DIFF
--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -47,7 +47,6 @@ BaseComponent::BaseComponent(ComponentId_t id) :
 
 BaseComponent::~BaseComponent()
 {
-
     // Need to cleanup my ComponentInfo and delete all my children.
 
     // If my_info is nullptr, then we are being deleted by our
@@ -60,6 +59,11 @@ BaseComponent::~BaseComponent()
     std::map<ComponentId_t,ComponentInfo>& subcomps = my_info->getSubComponents();
     for ( auto &ci : subcomps ) {
         // Delete the subcomponent
+
+        // Remove the parent info from the child so that it won't try
+        // to delete itself out of the map.  We'll clear the map
+        // after deleting everything.
+        ci.second.parent_info = nullptr;
         delete ci.second.component;
         ci.second.component = nullptr;
     }

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -324,6 +324,20 @@ public:
     Module* loadModuleWithComponent(std::string type, Component* comp, Params& params) __attribute__ ((deprecated("loadModuleWithComponent will be removed in SST version 10.0.  If the module needs access to the parent component, please use SubComponents instead of Modules.")));
 
 
+    /** Loads a module from an element Library
+     * @param type Fully Qualified library.moduleName
+     * @param params Parameters the module should use for configuration
+     * @return handle to new instance of module, or NULL on failure.
+     */
+    template <class T, class... ARGS>
+    T* loadModule(std::string type, Params& params, ARGS... args) {
+
+        // Check to see if this can be loaded with new API or if we have to fallback to old
+        return Factory::getFactory()->Create<T>(type, params, params, args...);
+    }
+
+    
+
     /** Loads a SubComponent from an element Library
      * @param type Fully Qualified library.moduleName
      * @param comp Pointer to component to pass to SuBaseComponent's constructor

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -195,7 +195,7 @@ public:
     inline ComponentId_t getID() const { return id; }
 
     inline const std::string& getName() const {
-        if ( name.empty() ) return parent_info->getName();
+        if ( name.empty() && parent_info ) return parent_info->getName();
         return name;
     }
 

--- a/src/sst/core/module.h
+++ b/src/sst/core/module.h
@@ -38,4 +38,20 @@ namespace SST {
   SST_ELI_REGISTER_DERIVED(SST::Module,cls,lib,name,ELI_FORWARD_AS_ONE(version),desc) \
   SST_ELI_INTERFACE_INFO(interface)
 
+
+// New way to register modules.  Must register an interface (API)
+// first, then you can register a module that implements it
+#define SST_ELI_REGISTER_MODULE_API(cls,...)              \
+    SST_ELI_DECLARE_NEW_BASE(SST::Module,::cls)           \
+    SST_ELI_NEW_BASE_CTOR(Params&,##__VA_ARGS__)
+
+#define SST_ELI_REGISTER_MODULE_DERIVED_API(cls,base,...) \
+    SST_ELI_DECLARE_NEW_BASE(::base,::cls)                          \
+    SST_ELI_NEW_BASE_CTOR(Params&,##__VA_ARGS__)
+
+#define SST_ELI_REGISTER_MODULE_DERIVED(cls,lib,name,version,desc,interface)   \
+    SST_ELI_REGISTER_DERIVED(::interface,cls,lib,name,ELI_FORWARD_AS_ONE(version),desc) \
+    SST_ELI_INTERFACE_INFO(#interface)
+
+
 #endif // SST_CORE_ACTION_H


### PR DESCRIPTION
Fixed a bug in SubComponent deletion that would occasionally cause segfaults.

Added the ability to define Module APIs and load them through a new templated function that allows passing parameters to the constructor.