### PR TITLE
Reorder vars to get rid of compiler warnings

### DIFF
--- a/src/sst/core/interprocess/ipctunnel.h
+++ b/src/sst/core/interprocess/ipctunnel.h
@@ -260,9 +260,10 @@ protected:
 
 private:
     bool master;
-    int fd;
-    std::string filename;
     void *shmPtr;
+    int fd;
+    
+    std::string filename;
     uint8_t *nextAllocPtr;
     size_t shmSize;
     InternalSharedData *isd;


### PR DESCRIPTION
Reorder variables in IPCTunnel class to remove compiler warning around initialization order.

```
sst/sst-core/include/sst/core/interprocess/ipctunnel.h: In instantiation of 'SST::Core::Interprocess::IPCTunnel<ShareDataType, MsgType>::IPCTunnel(uint32_t, size_t, size_t, uint32_t) [with ShareDataType = SST::ArielComponent::ArielSharedData; MsgType = SST::ArielComponent::ArielCommand; uint32_t = unsigned int; size_t = long unsigned int]':
./../ariel/ariel_shmem.h:188:104:   required from here
sst/sst-core/include/sst/core/interprocess/ipctunnel.h:265:11: warning: 'SST::Core::Interprocess::IPCTunnel<SST::ArielComponent::ArielSharedData, SST::ArielComponent::ArielCommand>::shmPtr' will be initialized after [-Wreorder]
     void *shmPtr;
           ^
sst/sst-core/include/sst/core/interprocess/ipctunnel.h:263:9: warning:   'int SST::Core::Interprocess::IPCTunnel<SST::ArielComponent::ArielSharedData, SST::ArielComponent::ArielCommand>::fd' [-Wreorder]
     int fd;
         ^
In file included from ./../ariel/ariel_shmem.h:21:0,
                 from Gpgpusim_Event.h:27,
                 from Gpgpusim.h:15,
                 from Gpgpusim.cc:5:
sst/sst-core/include/sst/core/interprocess/ipctunnel.h:62:5: warning:   when initialized here [-Wreorder]
     IPCTunnel(uint32_t comp_id, size_t numBuffers, size_t bufferSize, uint32_t expectedChildren = 1) : master(true), shmPtr(NULL), fd(-1)
```
