### PR TITLE
Fixes issue where sst-info XML output had the wrong format

### DIFF
--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -457,7 +457,7 @@ void SSTLibraryInfo::outputXML(TiXmlElement* XMLLibraryElement)
     xmlComment(XMLLibraryElement, "Num %ss = %d", BaseType::ELI_baseName(), numObjects);
     int idx = 0;
     for (auto& pair : lib->getMap()){
-      TiXmlElement* XMLElement = new TiXmlElement("Component");
+      TiXmlElement* XMLElement = new TiXmlElement(BaseType::ELI_baseName());
       XMLElement->SetAttribute("Index", idx);
       pair.second->outputXML(XMLElement);
       XMLLibraryElement->LinkEndChild(XMLElement);


### PR DESCRIPTION
When generating an XML file with sst-info (e.g. `sst-info -xn`), all `BaseType`s where tagged as "Component" instead of the appropriate tag (Module, SubComponent).

This solution creates the tag calling `BaseType::ELI_baseName()`.



