### PR TITLE
Print useful debugging error messages on load failure: Issue #138

### DIFF
--- a/src/sst/core/elemLoader.h
+++ b/src/sst/core/elemLoader.h
@@ -32,10 +32,10 @@ public:
 
     /** Attempt to load a library
      * @param elemlib - The name of the Element Library to load
-     * @param showErrors - Print errors associated with attempting to find and load the library
+     * @param err_os - Where to print errors associated with attempting to find and load the library
      * @return Informational structure of the library, or NULL if it failed to load.
      */
-    void loadLibrary(const std::string &elemlib, bool showErrors);
+    void loadLibrary(const std::string &elemlib, std::ostream& err_os);
 
     /**
      * Returns a list of potential element libraries in the search path

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -17,6 +17,7 @@
 #include <set>
 #include <tuple>
 #include <stdio.h>
+#include <fstream>
 
 #include <sst/core/elemLoader.h>
 #include "sst/core/simulation.h"
@@ -207,7 +208,8 @@ Factory::CreateComponent(ComponentId_t id,
     std::tie(elemlib, elem) = parseLoadName(type);
 
     // ensure library is already loaded...
-    requireLibrary(elemlib);
+    std::stringstream sstr;
+    requireLibrary(elemlib, sstr);
 
     std::lock_guard<std::recursive_mutex> lock(factoryMutex);
     // Check to see if library is loaded into new
@@ -232,7 +234,8 @@ Factory::CreateComponent(ComponentId_t id,
       }
     }
     // If we make it to here, component not found
-    out.fatal(CALL_INFO, 1, "can't find requested component '%s'\n ", type.c_str());
+    out.fatal(CALL_INFO, 1, "can't find requested component '%s'\n%s\n",
+              type.c_str(), sstr.str().c_str());
     return NULL;
 }
 
@@ -246,7 +249,8 @@ Factory::DoesSubComponentSlotExist(const std::string& type, const std::string& s
     std::tie(elemlib, elem) = parseLoadName(compTypeToLoad);
 
     // ensure library is already loaded...
-    requireLibrary(elemlib);
+    std::stringstream error_os;
+    requireLibrary(elemlib, error_os);
 
     std::lock_guard<std::recursive_mutex> lock(factoryMutex);
 
@@ -274,7 +278,8 @@ Factory::DoesSubComponentSlotExist(const std::string& type, const std::string& s
     }
 
     // If we get to here, element doesn't exist
-    out.fatal(CALL_INFO, 1, "can't find requested component/subcomponent '%s'\n ", type.c_str());
+    out.fatal(CALL_INFO, 1, "can't find requested component/subcomponent '%s'\n%s\n",
+              type.c_str(), error_os.str().c_str());
     return false;
 }
 
@@ -290,7 +295,8 @@ Factory::DoesComponentInfoStatisticNameExist(const std::string& type, const std:
     std::tie(elemlib, elem) = parseLoadName(compTypeToLoad);
 
     // ensure library is already loaded...
-    requireLibrary(elemlib);
+    std::stringstream error_os;
+    requireLibrary(elemlib, error_os);
 
     std::lock_guard<std::recursive_mutex> lock(factoryMutex);
 
@@ -324,7 +330,8 @@ Factory::DoesComponentInfoStatisticNameExist(const std::string& type, const std:
     
 
     // If we get to here, element doesn't exist
-    out.fatal(CALL_INFO, 1, "can't find requested subcomponent '%s'\n ", type.c_str());
+    out.fatal(CALL_INFO, 1, "can't find requested subcomponent '%s'\n%s\n",
+              type.c_str(), error_os.str().c_str());
     return false;
 }
 
@@ -340,7 +347,8 @@ Factory::GetComponentInfoStatisticEnableLevel(const std::string& type, const std
     std::tie(elemlib, elem) = parseLoadName(compTypeToLoad);
 
     // ensure library is already loaded...
-    requireLibrary(elemlib);
+    std::stringstream error_os;
+    requireLibrary(elemlib, error_os);
 
     std::lock_guard<std::recursive_mutex> lock(factoryMutex);
 
@@ -373,7 +381,8 @@ Factory::GetComponentInfoStatisticEnableLevel(const std::string& type, const std
     }
 
     // If we get to here, element doesn't exist
-    out.fatal(CALL_INFO, 1, "can't find requested component '%s'\n ", type.c_str());
+    out.fatal(CALL_INFO, 1, "can't find requested component '%s'\n%s\n",
+              type.c_str(), error_os.str().c_str());
     return 0;
 }
 
@@ -389,8 +398,9 @@ Factory::GetComponentInfoStatisticUnits(const std::string& type, const std::stri
     std::tie(elemlib, elem) = parseLoadName(compTypeToLoad);
 
     // ensure library is already loaded...
+    std::stringstream error_os;
     if (loaded_libraries.find(elemlib) == loaded_libraries.end()) {
-        findLibrary(elemlib);
+        findLibrary(elemlib, error_os);
     }
 
     auto* compLib = ELI::InfoDatabase::getLibrary<Component>(elemlib);
@@ -407,7 +417,8 @@ Factory::GetComponentInfoStatisticUnits(const std::string& type, const std::stri
     }
 
     // If we get to here, element doesn't exist
-    out.fatal(CALL_INFO, 1, "can't find requested component '%s'\n ", type.c_str());
+    out.fatal(CALL_INFO, 1, "can't find requested component '%s'\n%s\n",
+              type.c_str(), error_os.str().c_str());
     return 0;
 }
 
@@ -423,7 +434,8 @@ Factory::CreateModule(std::string type, Params& params)
     std::string elemlib, elem;
     std::tie(elemlib, elem) = parseLoadName(type);
 
-    requireLibrary(elemlib);
+    std::stringstream error_os;
+    requireLibrary(elemlib, error_os);
     std::lock_guard<std::recursive_mutex> lock(factoryMutex);
 
     // Check to see if library is loaded into new
@@ -446,7 +458,8 @@ Factory::CreateModule(std::string type, Params& params)
     }
     
     // If we get to here, element doesn't exist
-    out.fatal(CALL_INFO, 1, "can't find requested module '%s'\n ", type.c_str());
+    out.fatal(CALL_INFO, 1, "can't find requested module '%s'\n%s\n",
+              type.c_str(), error_os.str().c_str());
     return NULL;
 }
 
@@ -457,7 +470,8 @@ Factory::CreateModuleWithComponent(std::string type, Component* comp, Params& pa
     std::tie(elemlib, elem) = parseLoadName(type);
 
     // ensure library is already loaded...
-    requireLibrary(elemlib);
+    std::stringstream error_os;
+    requireLibrary(elemlib, error_os);
 
     std::lock_guard<std::recursive_mutex> lock(factoryMutex);
 
@@ -481,7 +495,8 @@ Factory::CreateModuleWithComponent(std::string type, Component* comp, Params& pa
     }
 
     // If we get to here, element doesn't exist
-    out.fatal(CALL_INFO, 1, "can't find requested module '%s'\n ", type.c_str());
+    out.fatal(CALL_INFO, 1, "can't find requested module '%s'\n%s\n",
+              type.c_str(), error_os.str().c_str());
     return NULL;
 }
 
@@ -492,7 +507,8 @@ Factory::CreateSubComponent(std::string type, Component* comp, Params& params)
     std::tie(elemlib, elem) = parseLoadName(type);
 
     // ensure library is already loaded...
-    requireLibrary(elemlib);
+    std::stringstream error_os;
+    requireLibrary(elemlib, error_os);
 
     std::lock_guard<std::recursive_mutex> lock(factoryMutex);
     // Check to see if library is loaded into new
@@ -515,7 +531,8 @@ Factory::CreateSubComponent(std::string type, Component* comp, Params& params)
     }
 
     // If we get to here, element doesn't exist
-    out.fatal(CALL_INFO, 1, "can't find requested subcomponent '%s'\n ", type.c_str());
+    out.fatal(CALL_INFO, 1, "can't find requested subcomponent '%s'\n%s\n",
+              type.c_str(), error_os.str().c_str());
     return NULL;
 }
 
@@ -560,7 +577,8 @@ Factory::CreatePartitioner(std::string name, RankInfo total_ranks, RankInfo my_r
     std::tie(elemlib, elem) = parseLoadName(name);
 
     // ensure library is already loaded...
-    requireLibrary(elemlib);
+    std::stringstream error_os;
+    requireLibrary(elemlib, error_os);
 
     // Check to see if library is loaded into new
     // ElementLibraryDatabase
@@ -579,14 +597,16 @@ Factory::CreatePartitioner(std::string name, RankInfo total_ranks, RankInfo my_r
     }
 
     // If we get to here, element doesn't exist
-    out.fatal(CALL_INFO, 1, "Error: Unable to find requested partitioner '%s', check --help for information on partitioners.\n ", name.c_str());
+    out.fatal(CALL_INFO, 1,
+              "Error: Unable to find requested partitioner '%s', check --help for information on partitioners.\n%s\n",
+              name.c_str(), error_os.str().c_str());
     return NULL;
 }
 
 
 // genPythonModuleFunction
 SSTElementPythonModule*
-Factory::getPythonModule(std::string name)
+Factory::getPythonModule(const std::string& name)
 {
     std::string elemlib, elem;
     std::tie(elemlib, elem) = parseLoadName(name);
@@ -613,16 +633,28 @@ Factory::getPythonModule(std::string name)
 
 
 
-bool Factory::hasLibrary(std::string elemlib)
+bool Factory::hasLibrary(const std::string& elemlib, std::ostream& error_os)
 {
-    return findLibrary(elemlib, false);
+    return findLibrary(elemlib, error_os);
 }
 
 
-void Factory::requireLibrary(std::string &elemlib)
+void Factory::requireLibrary(const std::string& elemlib)
 {
     if ( elemlib == "sst" ) return;
-    findLibrary(elemlib, true);
+
+    //ignore error messages here
+    std::ofstream ofs("/dev/null", std::ofstream::out | std::ofstream::app);
+    requireLibrary(elemlib, ofs);
+}
+
+void Factory::requireLibrary(const std::string& elemlib, std::ostream& error_os)
+{
+    if ( elemlib == "sst" ) return;
+
+    //ignore error messages here
+    //std::ofstream ofs("/dev/null", std::ofstream::out | std::ofstream::app);
+    findLibrary(elemlib, error_os);
 }
 
 
@@ -646,13 +678,13 @@ void Factory::loadUnloadedLibraries(const std::set<std::string>& lib_names)
     
 
 bool
-Factory::findLibrary(std::string elemlib, bool showErrors)
+Factory::findLibrary(const std::string& elemlib, std::ostream& err_os)
 {
 
     std::lock_guard<std::recursive_mutex> lock(factoryMutex);
     if ( loaded_libraries.count(elemlib) == 1 ) return true;
 
-    return loadLibrary(elemlib, showErrors);
+    return loadLibrary(elemlib, err_os);
 }
 
 
@@ -675,16 +707,17 @@ Factory::parseLoadName(const std::string& wholename)
 }
 
 void
-Factory::notFound(const std::string &baseName, const std::string &type)
+Factory::notFound(const std::string &baseName, const std::string &type,
+                  const std::string& error_msg)
 {
-    out.fatal(CALL_INFO, 1, "can't find requested element library '%s' with element type '%s'\n ",
-            baseName.c_str(), type.c_str());
+    out.fatal(CALL_INFO, 1, "can't find requested element library '%s' with element type '%s'\n%s\n",
+            baseName.c_str(), type.c_str(), error_msg.c_str());
 }
 
 
-bool Factory::loadLibrary(std::string name, bool showErrors)
+bool Factory::loadLibrary(const std::string& name, std::ostream& err_os)
 {
-    loader->loadLibrary(name, showErrors);
+    loader->loadLibrary(name, err_os);
 
     if (!ELI::LoadedLibraries::isLoaded(name)) {
         return false;

--- a/src/sst/core/output.cc
+++ b/src/sst/core/output.cc
@@ -178,7 +178,9 @@ void Output::fatal(uint32_t line, const char* file, const char* func,
         openSSTTargetFile();
         
         // Check to make sure output location is not NONE
-        if (NONE != m_targetLoc) {
+        // Also make sure we are not redundantly printing to screen
+        // We have already printed to stderr
+        if (NONE != m_targetLoc && STDERR != m_targetLoc && STDOUT != m_targetLoc) {
             std::vfprintf(*m_targetOutputRef, newFmt.c_str(), arg2);
         }
 

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -139,7 +139,8 @@ static void addELI(ElemLoader &loader, const std::string &lib, bool optional)
     if ( g_configuration.debugEnabled() )
         fprintf (stdout, "Looking for library \"%s\"\n", lib.c_str());
 
-    loader.loadLibrary(lib, g_configuration.debugEnabled());
+    std::stringstream err_sstr;
+    loader.loadLibrary(lib, err_sstr);
 
     // Check to see if this library loaded into the new ELI
     // Database
@@ -148,8 +149,13 @@ static void addELI(ElemLoader &loader, const std::string &lib, bool optional)
         g_libInfoArray.emplace_back(lib);
     } else if (!optional){
         fprintf(stderr, "**** WARNING - UNABLE TO PROCESS LIBRARY = %s\n", lib.c_str());
+        if (g_configuration.debugEnabled()){
+          std::cerr << err_sstr.str() << std::endl;
+        }
     } else {
         fprintf(stderr, "**** %s not Found!\n", lib.c_str());
+        //regardless of debug - force error printing
+        std::cerr << err_sstr.str() << std::endl;
     }
 
 }


### PR DESCRIPTION
When components or modules fail to load due to some filesystem or linker reason, we do not print useful error messages currently.  We just print "load failed" and do not print the error messages from `dlopen`.  We do this because the dlopen routines can fail multiple times before succeeding and we don't want a bunch of verbose errors if we don't actually fail.

This change instead collects all error messages in an `ostream`. If the load eventually succeeds, we do not print error messages. In the event of a fatal error, however, all of the `ostream` output is printed to give useful debugging information.

We could potentially make this more fine-grained with a command-line option. I believe what is implemented should be our default behavior. 