### PR TITLE
Fix SST_EXPORT_CFLAGS and SST_EXPORT_CXXFLAGS regex

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,8 +167,8 @@ AC_DEFINE_UNQUOTED([SST_INSTALL_PREFIX], ["$prefix"], [Defines the location SST 
 AC_CACHE_SAVE
 
 dnl Remove flags like -g, -O, and -W, that are not needed by other elements
-SST_EXPORT_CXXFLAGS=`echo "$CXXFLAGS" | sed -E -e 's/ *-(g|O.|W@<:@^\s@:>@+)//g'`
-SST_EXPORT_CFLAGS=`echo "$CFLAGS" | sed -E -e 's/ *-(g|O.|W@<:@^\s@:>@+)//g'`
+SST_EXPORT_CXXFLAGS=`echo "$CXXFLAGS" | sed -E -e 's/ *-(g|O.|W@<:@^@<:@:space:@:>@@:>@+)//g'`
+SST_EXPORT_CFLAGS=`echo "$CFLAGS" | sed -E -e 's/ *-(g|O.|W@<:@^@<:@:space:@:>@@:>@+)//g'`
 AC_SUBST(SST_EXPORT_CXXFLAGS)
 AC_SUBST(SST_EXPORT_CFLAGS)
 


### PR DESCRIPTION
The \s character class does not work in all versions of sed (even
with -E). Use [:space:] instead.