### PR TITLE
don't require unused subcomp ctors: Issue #449

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -17,7 +17,7 @@ AM_CPPFLAGS =  \
 
 DIST_SUBDIRS = libltdl .
 SUBDIRS = libltdl .
-EXTRA_DIST = mainpage.dox
+EXTRA_DIST = mainpage.dox eli/README.md
 
 sstdir = $(includedir)/sst/core
 nobase_dist_sst_HEADERS = \

--- a/src/sst/core/eli/README.md
+++ b/src/sst/core/eli/README.md
@@ -1,0 +1,56 @@
+![SST](http://sst-simulator.org/img/sst-logo-small.png)
+
+# Element Library Concepts
+
+Here we introduce the classes necessary to understanding how SST element libraries work.
+The most difficult (and possibly most important) thing to understand are the C++ Concepts defining the interfaces between functions. To be used in a particular context, classes must define a minimal set of type aliases (typedefs) and functions.
+
+# Element Builders
+
+The element builders are used for making derived types of a base class based on string inputs.
+````
+Base* b = create<Base>(name, args...);
+````
+This eventually needs to call 
+````
+Derived* d = new Derived(args...);
+return d;
+````
+## Constructor Concept
+
+A constructor class represents a particular instance of a constructor, usually via a variadic template `Args...` that represent the list of arguments in the constructor. The constructor concept is meant to encapsulate any number of valid constructors rather than a single set of `Args...`.  A class meeting the constructor concept needs two things.
+* A template function `add` that adds the derived type to the Base's registry for all matching constructors.
+````
+template <class T> void add(){
+  ...
+  Base::addBuilder(...);
+}
+````
+* A template type alias `is_constructible` that says whether a give type `T` provides any of the valid constructors for a given `Base`, e.g.
+````
+template <class T>
+using is_constructible = std::is_constructible<T,Args>;
+````
+
+### Single Constructor
+The simplest class meeting the constructor concept is `SingleCtor` which represents a single valid constructor of `Args...`.
+
+### Constructor Lists
+A more complicated constructor is the `CtorList` that represents a list of possible valid constructors.
+This class should register builders matching at least one of the constructors in the list.
+
+### Extended Constructor
+The extended constructor is the most complicated version. This represents a second base class, i.e.
+a given class `Derived` might be created via either:
+````
+Base1* b1 = create<Base1>(name, args...);
+````
+or 
+````
+Base2* b2 = create<Base2>(name, args...);
+````
+where `Base2` itself inherits from `Base1`.
+The derived constructor for `Base2` must register a class `T` to itself and to the original `Base1`.
+The meaning of the type alias `is_constructible` applies only to the most derived base class.
+
+#### Copyright (c) 2009-2019, National Technology and Engineering Solutions of Sandia, LLC (NTESS)

--- a/src/sst/core/eli/elementbuilder.h
+++ b/src/sst/core/eli/elementbuilder.h
@@ -200,12 +200,36 @@ struct ElementsBuilder<Base, std::tuple<Args...>>
 
 };
 
+
+/**
+ @class ExtendedCtor
+ Implements a constructor for a derived base as usually happens with subcomponents, e.g.
+ class U extends API extends Subcomponent. You can construct U as either an API*
+ or a Subcomponent* depending on usage.
+*/
 template <class NewCtor, class OldCtor>
 struct ExtendedCtor
 {
-  template <class T> static bool add(){
+  template <class T>
+  using is_constructible = typename NewCtor::template is_constructible<T>;
+
+  /**
+    The derived Ctor can "block" the more abstract Ctor, meaning an object
+    should only be instantiated as the most derived type. enable_if here
+    checks if both the derived API and the parent API are still valid
+  */
+  template <class T>
+  static typename std::enable_if<OldCtor::template is_constructible<T>::value,bool>::type
+  add(){
       //if abstract, force an allocation to generate meaningful errors
     return NewCtor::template add<T>() && OldCtor::template add<T>();
+  }
+
+  template <class T>
+  static typename std::enable_if<!OldCtor::template is_constructible<T>::value,bool>::type
+  add(){
+      //if abstract, force an allocation to generate meaningful errors
+    return NewCtor::template add<T>();
   }
 
   template <class __NewCtor>
@@ -218,6 +242,9 @@ struct ExtendedCtor
 template <class Base, class... Args>
 struct SingleCtor
 {
+  template <class T>
+  using is_constructible = std::is_constructible<T,Args...>;
+
   template <class T> static bool add(){
     //if abstract, force an allocation to generate meaningful errors
     auto* fact = new DerivedBuilder<T,Base,Args...>;
@@ -231,10 +258,15 @@ struct SingleCtor
   using ExtendCtor = ExtendedCtor<NewCtor, SingleCtor<Base,Args...>>;
 };
 
-
 template <class Base, class Ctor, class... Ctors>
 struct CtorList : public CtorList<Base,Ctors...>
 {
+  template <class T>  //if T is constructible with Ctor arguments
+  using is_constructible = typename std::conditional<is_tuple_constructible<T,Ctor>::value,
+                 std::true_type, //yes, constructible
+                 typename CtorList<Base,Ctors...>::template is_constructible<T> //not constructible here but maybe later
+               >::type;
+
   template <class T, int NumValid=0, class U=T>
   static typename std::enable_if<std::is_abstract<U>::value || is_tuple_constructible<U,Ctor>::value, bool>::type
   add(){
@@ -264,6 +296,9 @@ template <> class NoValidConstructorsForDerivedType<0> {};
 
 template <class Base> struct CtorList<Base,void>
 {
+  template <class T>
+  using is_constructible = std::false_type;
+
   template <class T,int numValidCtors>
   static bool add(){
     return NoValidConstructorsForDerivedType<numValidCtors>::atLeastOneValidCtor;


### PR DESCRIPTION
Derived subcomponent APIs should not be required to implement the base Subcomponent constructor if they are only ever used with the derived API.