### PR TITLE
General code cleanup.

### DIFF
--- a/src/sst/core/action.h
+++ b/src/sst/core/action.h
@@ -13,12 +13,12 @@
 #ifndef SST_CORE_ACTION_H
 #define SST_CORE_ACTION_H
 
-#include <sst/core/serialization/serializer.h>
+#include "sst/core/serialization/serializer.h"
 
 #include <cinttypes>
 
-#include <sst/core/activity.h>
-#include <sst/core/output.h>
+#include "sst/core/activity.h"
+#include "sst/core/output.h"
 
 
 

--- a/src/sst/core/activity.h
+++ b/src/sst/core/activity.h
@@ -13,21 +13,19 @@
 #ifndef SST_CORE_ACTIVITY_H
 #define SST_CORE_ACTIVITY_H
 
-#include <sst/core/sst_types.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/warnmacros.h"
 
-#include <sst/core/serialization/serializable.h>
+#include "sst/core/serialization/serializable.h"
 
-#include <sst/core/output.h>
-#include <sst/core/mempool.h>
+#include "sst/core/output.h"
+#include "sst/core/mempool.h"
 
 #include <unordered_map>
 #include <cinttypes>
 #include <cstring>
 
 #include <errno.h>
-
-// #include <sst/core/serialization/serializable.h>
 
 // Default Priority Settings
 #define STOPACTIONPRIORITY     01
@@ -240,7 +238,7 @@ public:
          * 2) Alloc item from pool
          * 3) Append PoolID to item, increment pointer
          */
-        Core::MemPool *pool = NULL;
+        Core::MemPool *pool = nullptr;
         size_t nPools = memPools.size();
         std::thread::id tid = std::this_thread::get_id();
         for ( size_t i = 0 ; i < nPools ; i++ ) {
@@ -250,7 +248,7 @@ public:
                 break;
             }
         }
-        if ( NULL == pool ) {
+        if ( nullptr == pool ) {
             /* Still can't find it, alloc a new one */
             pool = new Core::MemPool(size+sizeof(PoolData_t));
 
@@ -261,7 +259,7 @@ public:
         PoolData_t *ptr = (PoolData_t*)pool->malloc();
         if ( !ptr ) {
             fprintf(stderr, "Memory Pool failed to allocate a new object.  Error: %s\n", strerror(errno));
-            return NULL;
+            return nullptr;
         }
         *ptr = pool;
         return (void*)(ptr+1);
@@ -273,24 +271,24 @@ public:
     {
         /* 1) Decrement pointer
          * 2) Determine Pool Pointer
-         * 2b) Set Pointer field to NULL to allow tracking
+         * 2b) Set Pointer field to nullptr to allow tracking
          * 3) Return to pool
          */
         PoolData_t *ptr8 = ((PoolData_t*)ptr) - 1;
         Core::MemPool* pool = *ptr8;
-        *ptr8 = NULL;
+        *ptr8 = nullptr;
 
         pool->free(ptr8);
     }
     void operator delete(void* ptr, std::size_t UNUSED(sz)){
         /* 1) Decrement pointer
          * 2) Determine Pool Pointer
-         * 2b) Set Pointer field to NULL to allow tracking
+         * 2b) Set Pointer field to nullptr to allow tracking
          * 3) Return to pool
          */
         PoolData_t *ptr8 = ((PoolData_t*)ptr) - 1;
         Core::MemPool* pool = *ptr8;
-        *ptr8 = NULL;
+        *ptr8 = nullptr;
 
         pool->free(ptr8);
     };
@@ -313,7 +311,7 @@ public:
             for ( auto iter = arenas.begin(); iter != arenas.end(); ++iter ) {
                 for ( size_t j = 0; j < nelem; j++ ) {
                     PoolData_t* ptr = (PoolData_t*)((*iter) + (elemSize*j));
-                    if ( *ptr != NULL ) {
+                    if ( *ptr != nullptr ) {
                         Activity* act = (Activity*)(ptr + 1);
                         if ( act->delivery_time <= before ) {
                             act->print(header, out);

--- a/src/sst/core/activityQueue.h
+++ b/src/sst/core/activityQueue.h
@@ -13,7 +13,7 @@
 #ifndef SST_CORE_ACTIVITYQUEUE_H
 #define SST_CORE_ACTIVITYQUEUE_H
 
-#include <sst/core/activity.h>
+#include "sst/core/activity.h"
 
 namespace SST {
 

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -9,23 +9,24 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
-#include <sst/core/warnmacros.h>
+#include "sst_config.h"
+#include "sst/core/baseComponent.h"
+
+#include "sst/core/warnmacros.h"
 
 #include <string>
 
-#include <sst/core/baseComponent.h>
-#include <sst/core/component.h>
-#include <sst/core/subcomponent.h>
-#include <sst/core/unitAlgebra.h>
-#include <sst/core/factory.h>
-#include <sst/core/link.h>
-#include <sst/core/linkMap.h>
-#include <sst/core/simulation.h>
-#include <sst/core/timeConverter.h>
-#include <sst/core/timeLord.h>
-#include <sst/core/unitAlgebra.h>
-#include <sst/core/sharedRegion.h>
+#include "sst/core/component.h"
+#include "sst/core/subcomponent.h"
+#include "sst/core/unitAlgebra.h"
+#include "sst/core/factory.h"
+#include "sst/core/link.h"
+#include "sst/core/linkMap.h"
+#include "sst/core/simulation.h"
+#include "sst/core/timeConverter.h"
+#include "sst/core/timeLord.h"
+#include "sst/core/unitAlgebra.h"
+#include "sst/core/sharedRegion.h"
 
 namespace SST {
 
@@ -34,7 +35,7 @@ BaseComponent::BaseComponent(ComponentId_t id) :
     sim(Simulation::getSimulation()),
     loadedWithLegacyAPI(false),
     my_info(Simulation::getSimulation()->getComponentInfo(id)),
-    currentlyLoadingSubComponent(NULL),
+    currentlyLoadingSubComponent(nullptr),
     isExtension(false)
 {
     if ( my_info->component == nullptr ) {
@@ -94,10 +95,10 @@ BaseComponent::~BaseComponent()
 void
 BaseComponent::setDefaultTimeBaseForParentLinks(TimeConverter* tc) {
     LinkMap* myLinks = my_info->getLinkMap();
-    if (NULL != myLinks) {
+    if (nullptr != myLinks) {
         for ( std::pair<std::string,Link*> p : myLinks->getLinkMap() ) {
-            // if ( NULL == p.second->getDefaultTimeBase() ) {
-            if ( NULL == p.second->getDefaultTimeBase() && p.second->isConfigured() ) {
+            // if ( nullptr == p.second->getDefaultTimeBase() ) {
+            if ( nullptr == p.second->getDefaultTimeBase() && p.second->isConfigured() ) {
                 p.second->setDefaultTimeBase(tc);
             }
         }
@@ -112,10 +113,10 @@ BaseComponent::setDefaultTimeBaseForParentLinks(TimeConverter* tc) {
 void
 BaseComponent::setDefaultTimeBaseForChildLinks(TimeConverter* tc) {
     LinkMap* myLinks = my_info->getLinkMap();
-    if (NULL != myLinks) {
+    if (nullptr != myLinks) {
         for ( std::pair<std::string,Link*> p : myLinks->getLinkMap() ) {
-            // if ( NULL == p.second->getDefaultTimeBase() ) {
-            if ( NULL == p.second->getDefaultTimeBase() && p.second->isConfigured() ) {
+            // if ( nullptr == p.second->getDefaultTimeBase() ) {
+            if ( nullptr == p.second->getDefaultTimeBase() && p.second->isConfigured() ) {
                 p.second->setDefaultTimeBase(tc);
             }
         }
@@ -135,10 +136,10 @@ BaseComponent::setDefaultTimeBaseForChildLinks(TimeConverter* tc) {
 void
 BaseComponent::setDefaultTimeBaseForLinks(TimeConverter* tc) {
     LinkMap* myLinks = my_info->getLinkMap();
-    if (NULL != myLinks) {
+    if (nullptr != myLinks) {
         for ( std::pair<std::string,Link*> p : myLinks->getLinkMap() ) {
-            // if ( NULL == p.second->getDefaultTimeBase() ) {
-            if ( NULL == p.second->getDefaultTimeBase() && p.second->isConfigured() ) {
+            // if ( nullptr == p.second->getDefaultTimeBase() ) {
+            if ( nullptr == p.second->getDefaultTimeBase() && p.second->isConfigured() ) {
                 p.second->setDefaultTimeBase(tc);
             }
         }
@@ -170,7 +171,7 @@ BaseComponent::pushValidParams(Params& params, const std::string& type)
 }
 
 
-TimeConverter* BaseComponent::registerClock( std::string freq, Clock::HandlerBase* handler, bool regAll) {
+TimeConverter* BaseComponent::registerClock( const std::string& freq, Clock::HandlerBase* handler, bool regAll) {
     TimeConverter* tc = getSimulation()->registerClock(freq, handler, CLOCKPRIORITY);
 
     // if regAll is true set tc as the default for the component and
@@ -206,7 +207,7 @@ void BaseComponent::unregisterClock(TimeConverter *tc, Clock::HandlerBase* handl
     getSimulation()->unregisterClock(tc, handler, CLOCKPRIORITY);
 }
 
-TimeConverter* BaseComponent::registerOneShot( std::string timeDelay, OneShot::HandlerBase* handler) {
+TimeConverter* BaseComponent::registerOneShot( const std::string& timeDelay, OneShot::HandlerBase* handler) {
     return getSimulation()->registerOneShot(timeDelay, handler, ONESHOTPRIORITY);
 }
 
@@ -214,7 +215,7 @@ TimeConverter* BaseComponent::registerOneShot( const UnitAlgebra& timeDelay, One
     return getSimulation()->registerOneShot(timeDelay, handler, ONESHOTPRIORITY);
 }
 
-TimeConverter* BaseComponent::registerTimeBase( std::string base, bool regAll) {
+TimeConverter* BaseComponent::registerTimeBase( const std::string& base, bool regAll) {
     TimeConverter* tc = getSimulation()->getTimeLord()->getTimeConverter(base);
 
     // if regAll is true set tc as the default for the component and
@@ -240,9 +241,9 @@ BaseComponent::getTimeConverter( const UnitAlgebra& base )
 
 
 bool
-BaseComponent::isPortConnected(const std::string &name) const
+BaseComponent::isPortConnected(const std::string& name) const
 {
-    return (my_info->getLinkMap()->getLink(name) != NULL);
+    return (my_info->getLinkMap()->getLink(name) != nullptr);
 }
 
 
@@ -259,9 +260,9 @@ BaseComponent::getLinkFromParentSharedPort(const std::string& port)
     // See if the link is found, and if not see if my parent shared
     // their ports with me
     
-    if ( NULL != myLinks ) {
+    if ( nullptr != myLinks ) {
         Link* tmp = myLinks->getLink(port);
-        if ( NULL != tmp ) {
+        if ( nullptr != tmp ) {
             // Found the link in my linkmap
 
             // Check to see if it has been configured.  If not, remove
@@ -281,56 +282,56 @@ BaseComponent::getLinkFromParentSharedPort(const std::string& port)
         return my_info->parent_info->component->getLinkFromParentSharedPort(port);
     }
     else {
-        return NULL;
+        return nullptr;
     }    
 }
 
 
 Link*
-BaseComponent::configureLink(std::string name, TimeConverter* time_base, Event::HandlerBase* handler)
+BaseComponent::configureLink(const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler)
 {
     LinkMap* myLinks = my_info->getLinkMap();
 
-    Link* tmp = NULL;
+    Link* tmp = nullptr;
     
     // If I have a linkmap, check to see if a link was connected to
     // port "name"
-    if ( NULL != myLinks ) {
+    if ( nullptr != myLinks ) {
         tmp = myLinks->getLink(name);
     }
-    // If tmp is NULL, then I didn't have the port connected, check
+    // If tmp is nullptr, then I didn't have the port connected, check
     // with parents if sharing is turned on
-    if ( NULL == tmp ) {
+    if ( nullptr == tmp ) {
         if ( my_info->sharesPorts() ) {
             tmp = my_info->parent_info->component->getLinkFromParentSharedPort(name);
             // If I got a link from my parent, I need to put it in my
             // link map
-            if ( NULL != tmp ) {
-                if ( NULL == myLinks ) {
+            if ( nullptr != tmp ) {
+                if ( nullptr == myLinks ) {
                     myLinks = new LinkMap();
                     my_info->link_map = myLinks;
                 }
                 myLinks->insertLink(name,tmp);
-                // Need to set the link's defaultTimeBase to NULL,
+                // Need to set the link's defaultTimeBase to nullptr,
                 // except in the case of this being an Anonymously
                 // loadeed SubComponent, then for backward
                 // compatibility, we leave it as is.
                 if ( !my_info->isLegacySubComponent() ) {
-                    tmp->setDefaultTimeBase(NULL);
+                    tmp->setDefaultTimeBase(nullptr);
                 }
             }
         }
     }
 
     // If I got a link, configure it
-    if ( NULL != tmp ) {
+    if ( nullptr != tmp ) {
         
         // If no functor, this is a polling link
-        if ( handler == NULL ) {
+        if ( handler == nullptr ) {
             tmp->setPolling();
         }
         tmp->setFunctor(handler);
-        if ( NULL != time_base ) tmp->setDefaultTimeBase(time_base);
+        if ( nullptr != time_base ) tmp->setDefaultTimeBase(time_base);
         else tmp->setDefaultTimeBase(my_info->defaultTimeBase);
         tmp->setAsConfigured();
 #ifdef __SST_DEBUG_EVENT_TRACKING__
@@ -341,23 +342,23 @@ BaseComponent::configureLink(std::string name, TimeConverter* time_base, Event::
 }
 
 Link*
-BaseComponent::configureLink(std::string name, std::string time_base, Event::HandlerBase* handler)
+BaseComponent::configureLink(const std::string& name, const std::string& time_base, Event::HandlerBase* handler)
 {
     return configureLink(name,getSimulation()->getTimeLord()->getTimeConverter(time_base),handler);
 }
 
 Link*
-BaseComponent::configureLink(std::string name, Event::HandlerBase* handler)
+BaseComponent::configureLink(const std::string& name, Event::HandlerBase* handler)
 {
-    return configureLink(name,NULL,handler);
+    return configureLink(name,nullptr,handler);
 }
 
 void
-BaseComponent::addSelfLink(std::string name)
+BaseComponent::addSelfLink(const std::string& name)
 {
     LinkMap* myLinks = my_info->getLinkMap();
     myLinks->addSelfPort(name);
-    if ( myLinks->getLink(name) != NULL ) {
+    if ( myLinks->getLink(name) != nullptr ) {
         printf("Attempting to add self link with duplicate name: %s\n",name.c_str());
         abort();
     }
@@ -370,21 +371,21 @@ BaseComponent::addSelfLink(std::string name)
 }
 
 Link*
-BaseComponent::configureSelfLink( std::string name, TimeConverter* time_base, Event::HandlerBase* handler)
+BaseComponent::configureSelfLink( const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler)
 {
     addSelfLink(name);
     return configureLink(name,time_base,handler);
 }
 
 Link*
-BaseComponent::configureSelfLink( std::string name, std::string time_base, Event::HandlerBase* handler)
+BaseComponent::configureSelfLink( const std::string& name,  const std::string& time_base, Event::HandlerBase* handler)
 {
     addSelfLink(name);
     return configureLink(name,time_base,handler);
 }
 
 Link*
-BaseComponent::configureSelfLink( std::string name, Event::HandlerBase* handler)
+BaseComponent::configureSelfLink( const std::string& name, Event::HandlerBase* handler)
 {
     addSelfLink(name);
     return configureLink(name,handler);
@@ -394,7 +395,7 @@ SimTime_t BaseComponent::getCurrentSimTime(TimeConverter *tc) const {
     return tc->convertFromCoreTime(getSimulation()->getCurrentSimCycle());
 }
 
-SimTime_t BaseComponent::getCurrentSimTime(std::string base) {
+SimTime_t BaseComponent::getCurrentSimTime(const std::string& base) {
     return getCurrentSimTime(getSimulation()->getTimeLord()->getTimeConverter(base));
 
 }
@@ -411,7 +412,7 @@ SimTime_t BaseComponent::getCurrentSimTimeMilli() const {
     return getCurrentSimTime(getSimulation()->getTimeLord()->getMilli());
 }
 
-bool BaseComponent::doesComponentInfoStatisticExist(const std::string &statisticName) const
+bool BaseComponent::doesComponentInfoStatisticExist(const std::string& statisticName) const
 {
     const std::string& type = my_info->getType();
     return Factory::getFactory()->DoesComponentInfoStatisticNameExist(type, statisticName);
@@ -419,20 +420,20 @@ bool BaseComponent::doesComponentInfoStatisticExist(const std::string &statistic
 
 
 Module*
-BaseComponent::loadModule(std::string type, Params& params)
+BaseComponent::loadModule(const std::string& type, Params& params)
 {
     return Factory::getFactory()->CreateModule(type,params);
 }
 
 Module*
-BaseComponent::loadModuleWithComponent(std::string type, Component* comp, Params& params)
+BaseComponent::loadModuleWithComponent(const std::string& type, Component* comp, Params& params)
 {
     return Factory::getFactory()->CreateModuleWithComponent(type,comp,params);
 }
 
 /* Old ELI style */
 SubComponent*
-BaseComponent::loadSubComponent(std::string type, Component* comp, Params& params)
+BaseComponent::loadSubComponent(const std::string& type, Component* comp, Params& params)
 {
     // /* Old Style SubComponents end up with their parent's Id, name, etc. */
     // ComponentInfo *sub_info = new ComponentInfo(type, &params, my_info);
@@ -463,30 +464,30 @@ BaseComponent::loadLegacySubComponentPrivate(ComponentId_t cid, const std::strin
 Component*
 BaseComponent::getTrueComponent() const {
     // Walk up the parent tree until we hit the base Component.  We
-    // know we're the base Component when parent is NULL.
+    // know we're the base Component when parent is nullptr.
     ComponentInfo* info = my_info;
-    while ( info->parent_info != NULL ) info = info->parent_info;
+    while ( info->parent_info != nullptr ) info = info->parent_info;
     return static_cast<Component* const>(info->component);
 }
 
 Component*
 BaseComponent::getTrueComponentPrivate() const {
     // Walk up the parent tree until we hit the base Component.  We
-    // know we're the base Component when parent is NULL.
+    // know we're the base Component when parent is nullptr.
     ComponentInfo* info = my_info;
-    while ( info->parent_info != NULL ) info = info->parent_info;
+    while ( info->parent_info != nullptr ) info = info->parent_info;
     return static_cast<Component* const>(info->component);
 }
 
 /* New ELI style */
 SubComponent*
-BaseComponent::loadNamedSubComponent(std::string name) {
+BaseComponent::loadNamedSubComponent(const std::string& name) {
     Params empty;
     return loadNamedSubComponent(name, empty);
 }
 
 SubComponent*
-BaseComponent::loadNamedSubComponent(std::string name, Params& params) {
+BaseComponent::loadNamedSubComponent(const std::string& name, Params& params) {
     // Get list of ComponentInfo objects and make sure that there is
     // only one SubComponent put into this slot
     const std::map<ComponentId_t,ComponentInfo>& subcomps = my_info->getSubComponents();
@@ -507,14 +508,14 @@ BaseComponent::loadNamedSubComponent(std::string name, Params& params) {
 }
 
 SubComponent*
-BaseComponent::loadNamedSubComponent(std::string name, int slot_num) {
+BaseComponent::loadNamedSubComponent(const std::string& name, int slot_num) {
     Params empty;
     return loadNamedSubComponent(name, slot_num, empty);
 }
 
 // Private
 SubComponent*
-BaseComponent::loadNamedSubComponent(std::string name, int slot_num, Params& params)
+BaseComponent::loadNamedSubComponent(const std::string& name, int slot_num, Params& params)
 {
     if ( !Factory::getFactory()->DoesSubComponentSlotExist(my_info->type, name) ) {
         SST::Output outXX("SubComponentSlotWarning: ", 0, 0, Output::STDERR);
@@ -522,7 +523,7 @@ BaseComponent::loadNamedSubComponent(std::string name, int slot_num, Params& par
     }
 
     ComponentInfo* sub_info = my_info->findSubComponent(name,slot_num);
-    if ( sub_info == NULL ) return NULL;
+    if ( sub_info == nullptr ) return nullptr;
     sub_info->share_flags = ComponentInfo::SHARE_NONE;
     sub_info->parent_info = my_info;
     
@@ -534,7 +535,7 @@ BaseComponent::loadNamedSubComponent(std::string name, int slot_num, Params& par
     getTrueComponentPrivate()->currentlyLoadingSubComponentID = sub_info->id;
         
     Params myParams;
-    if ( sub_info->getParams() != NULL )
+    if ( sub_info->getParams() != nullptr )
         myParams.insert(*sub_info->getParams());
     myParams.insert(params);
 
@@ -552,7 +553,7 @@ BaseComponent::loadNamedSubComponentLegacyPrivate(ComponentInfo* sub_info, Param
     getTrueComponentPrivate()->currentlyLoadingSubComponentID = sub_info->id;
     
     Params myParams;
-    if ( sub_info->getParams() != NULL )
+    if ( sub_info->getParams() != nullptr )
         myParams.insert(*sub_info->getParams());
     myParams.insert(params);
     
@@ -564,12 +565,12 @@ BaseComponent::loadNamedSubComponentLegacyPrivate(ComponentInfo* sub_info, Param
 }
 
 SubComponentSlotInfo*
-BaseComponent::getSubComponentSlotInfo(std::string name, bool fatalOnEmptyIndex) {
+BaseComponent::getSubComponentSlotInfo(const std::string& name, bool fatalOnEmptyIndex) {
     SubComponentSlotInfo* info = new SubComponentSlotInfo(this, name);
     if ( info->getMaxPopulatedSlotNumber() < 0 ) {
         // Nothing registered on this slot
         delete info;
-        return NULL;
+        return nullptr;
     }
     if ( !info->isAllPopulated() && fatalOnEmptyIndex ) {
         Simulation::getSimulationOutput().
@@ -581,19 +582,19 @@ BaseComponent::getSubComponentSlotInfo(std::string name, bool fatalOnEmptyIndex)
 }
 
 bool
-BaseComponent::doesSubComponentExist(std::string type)
+BaseComponent::doesSubComponentExist(const std::string& type)
 {
     return Factory::getFactory()->doesSubComponentExist(type);
 }
 
-SharedRegion* BaseComponent::getLocalSharedRegion(const std::string &key, size_t size)
+SharedRegion* BaseComponent::getLocalSharedRegion(const std::string& key, size_t size)
 {
     SharedRegionManager *mgr = Simulation::getSharedRegionManager();
     return mgr->getLocalSharedRegion(key, size);
 }
 
 
-SharedRegion* BaseComponent::getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger)
+SharedRegion* BaseComponent::getGlobalSharedRegion(const std::string& key, size_t size, SharedRegionMerger *merger)
 {
     SharedRegionManager *mgr = Simulation::getSharedRegionManager();
     return mgr->getGlobalSharedRegion(key, size, merger);
@@ -601,7 +602,7 @@ SharedRegion* BaseComponent::getGlobalSharedRegion(const std::string &key, size_
 
 
 
-uint8_t BaseComponent::getComponentInfoStatisticEnableLevel(const std::string &statisticName) const
+uint8_t BaseComponent::getComponentInfoStatisticEnableLevel(const std::string& statisticName) const
 {
     return Factory::getFactory()->GetComponentInfoStatisticEnableLevel(my_info->type, statisticName);
 }
@@ -621,7 +622,7 @@ BaseComponent::registerStatisticCore(SST::Params& params, const std::string& sta
     UnitAlgebra                     collectionRate;
     std::string                     statRateParam;
     std::string                     statTypeParam;
-    StatisticBase*                   statistic = NULL;
+    StatisticBase*                   statistic = nullptr;
 
 
     // First check to see if this is an "inserted" statistic that has
@@ -635,7 +636,7 @@ BaseComponent::registerStatisticCore(SST::Params& params, const std::string& sta
         // if so return the cached copy
         StatisticBase* prevStat = StatisticProcessingEngine::getInstance()->isStatisticRegisteredWithEngine(
             curr_info->parent_info->getName(), curr_info->parent_info->getID(), statName, statSubId, fieldType);
-        if (NULL != prevStat) {
+        if (nullptr != prevStat) {
             // Dynamic cast the base stat to the expected type
             return prevStat;
         }
@@ -730,7 +731,7 @@ BaseComponent::registerStatisticCore(SST::Params& params, const std::string& sta
         // Instantiate the Statistic here defined by the type here
         //statistic = engine->createStatistic<T>(owner, statTypeParam, statName, statSubId, statParams);
         statistic = create(statTypeParam, curr_info->component, statName, statSubId, statParams);
-        if (NULL == statistic) {
+        if (nullptr == statistic) {
             out.fatal(CALL_INFO, 1, "ERROR: Unable to instantiate Statistic %s; exiting...\n", fullStatName.c_str());
         }
 
@@ -755,14 +756,14 @@ BaseComponent::registerStatisticCore(SST::Params& params, const std::string& sta
 
     if (false == statGood ) {
         // Delete the original statistic (if created), and return a NULL statistic instead
-        if (NULL != statistic) {
+        if (nullptr != statistic) {
             delete statistic;
         }
 
         // Instantiate the Statistic here defined by the type here
         statTypeParam = "sst.NullStatistic";
         statistic = create(statTypeParam, curr_info->component, statName, statSubId, statParams);
-        if (NULL == statistic) {
+        if (nullptr == statistic) {
             statGood = false;
             out.fatal(CALL_INFO, 1, "ERROR: Unable to instantiate Null Statistic %s; exiting...\n", fullStatName.c_str());
         }

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -12,20 +12,20 @@
 #ifndef SST_CORE_BASECOMPONENT_H
 #define SST_CORE_BASECOMPONENT_H
 
-#include <sst/core/sst_types.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/warnmacros.h"
 
 #include <map>
 #include <string>
 
-#include <sst/core/statapi/statengine.h>
-#include <sst/core/statapi/statbase.h>
-#include <sst/core/event.h>
-#include <sst/core/clock.h>
-#include <sst/core/oneshot.h>
-#include <sst/core/componentInfo.h>
-#include <sst/core/simulation.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/statapi/statengine.h"
+#include "sst/core/statapi/statbase.h"
+#include "sst/core/event.h"
+#include "sst/core/clock.h"
+#include "sst/core/oneshot.h"
+#include "sst/core/componentInfo.h"
+#include "sst/core/simulation.h"
+#include "sst/core/eli/elementinfo.h"
 
 using namespace SST::Statistics;
 
@@ -106,51 +106,51 @@ public:
     virtual void printStatus(Output &UNUSED(out)) { return; }
 
     /** Determine if a port name is connected to any links */
-    bool isPortConnected(const std::string &name) const;
+    bool isPortConnected(const std::string& name) const;
 
     /** Configure a Link
      * @param name - Port Name on which the link to configure is attached.
-     * @param time_base - Time Base of the link.  If NULL is passed in, then it
+     * @param time_base - Time Base of the link.  If nullptr is passed in, then it
      * will use the Component defaultTimeBase
      * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
+     * @return A pointer to the configured link, or nullptr if an error occured.
      */
-    Link* configureLink( std::string name, TimeConverter* time_base, Event::HandlerBase* handler = NULL);
+    Link* configureLink( const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler = nullptr);
     /** Configure a Link
      * @param name - Port Name on which the link to configure is attached.
      * @param time_base - Time Base of the link as a string
      * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
+     * @return A pointer to the configured link, or nullptr if an error occured.
      */
-    Link* configureLink( std::string name, std::string time_base, Event::HandlerBase* handler = NULL);
+    Link* configureLink( const std::string& name, const std::string& time_base, Event::HandlerBase* handler = nullptr);
     /** Configure a Link
      * @param name - Port Name on which the link to configure is attached.
      * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
+     * @return A pointer to the configured link, or nullptr if an error occured.
      */
-    Link* configureLink( std::string name, Event::HandlerBase* handler = NULL);
+    Link* configureLink( const std::string& name, Event::HandlerBase* handler = nullptr);
 
     /** Configure a SelfLink  (Loopback link)
      * @param name - Name of the self-link port
-     * @param time_base - Time Base of the link.  If NULL is passed in, then it
+     * @param time_base - Time Base of the link.  If nullptr is passed in, then it
      * will use the Component defaultTimeBase
      * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
+     * @return A pointer to the configured link, or nullptr if an error occured.
      */
-    Link* configureSelfLink( std::string name, TimeConverter* time_base, Event::HandlerBase* handler = NULL);
+    Link* configureSelfLink( const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler = nullptr);
     /** Configure a SelfLink  (Loopback link)
      * @param name - Name of the self-link port
      * @param time_base - Time Base of the link
      * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
+     * @return A pointer to the configured link, or nullptr if an error occured.
      */
-    Link* configureSelfLink( std::string name, std::string time_base, Event::HandlerBase* handler = NULL);
+    Link* configureSelfLink( const std::string& name, const std::string& time_base, Event::HandlerBase* handler = nullptr);
     /** Configure a SelfLink  (Loopback link)
      * @param name - Name of the self-link port
      * @param handler - Optional Handler to be called when an Event is received
-     * @return A pointer to the configured link, or NULL if an error occured.
+     * @return A pointer to the configured link, or nullptr if an error occured.
      */
-    Link* configureSelfLink( std::string name, Event::HandlerBase* handler = NULL);
+    Link* configureSelfLink( const std::string& name, Event::HandlerBase* handler = nullptr);
 
     /** Registers a clock for this component.
         @param freq Frequency for the clock in SI units
@@ -159,7 +159,7 @@ public:
         @param regAll Should this clock period be used as the default
         time base for all of the links connected to this component
     */
-    TimeConverter* registerClock( std::string freq, Clock::HandlerBase* handler,
+    TimeConverter* registerClock( const std::string& freq, Clock::HandlerBase* handler,
                                   bool regAll = true);
     TimeConverter* registerClock( const UnitAlgebra& freq, Clock::HandlerBase* handler,
                                   bool regAll = true);
@@ -180,7 +180,7 @@ public:
         @param handler Pointer to OneShot::HandlerBase which is to be invoked
         at the specified interval
     */
-    TimeConverter* registerOneShot( std::string timeDelay, OneShot::HandlerBase* handler);
+    TimeConverter* registerOneShot( const std::string& timeDelay, OneShot::HandlerBase* handler);
     TimeConverter* registerOneShot( const UnitAlgebra& timeDelay, OneShot::HandlerBase* handler);
 
     /** Registers a default time base for the component and optionally
@@ -191,7 +191,7 @@ public:
         @param regAll Should this clock period be used as the default
         time base for all of the links connected to this component
     */
-    TimeConverter* registerTimeBase( std::string base, bool regAll = true);
+    TimeConverter* registerTimeBase( const std::string& base, bool regAll = true);
 
     TimeConverter* getTimeConverter( const std::string& base );
     TimeConverter* getTimeConverter( const UnitAlgebra& base );
@@ -206,7 +206,7 @@ public:
     }
     /** return the time since the simulation began in timebase specified
         @param base Timebase frequency in SI Units */
-    SimTime_t getCurrentSimTime(std::string base);
+    SimTime_t getCurrentSimTime(const std::string& base);
 
     /** Utility function to return the time since the simulation began in nanoseconds */
     SimTime_t getCurrentSimTimeNano() const;
@@ -311,26 +311,26 @@ public:
     /** Loads a module from an element Library
      * @param type Fully Qualified library.moduleName
      * @param params Parameters the module should use for configuration
-     * @return handle to new instance of module, or NULL on failure.
+     * @return handle to new instance of module, or nullptr on failure.
      */
-    Module* loadModule(std::string type, Params& params);
+    Module* loadModule(const std::string& type, Params& params);
 
     /** Loads a module from an element Library
      * @param type Fully Qualified library.moduleName
      * @param comp Pointer to component to pass to Module's constructor
      * @param params Parameters the module should use for configuration
-     * @return handle to new instance of module, or NULL on failure.
+     * @return handle to new instance of module, or nullptr on failure.
      */
-    Module* loadModuleWithComponent(std::string type, Component* comp, Params& params) __attribute__ ((deprecated("loadModuleWithComponent will be removed in SST version 10.0.  If the module needs access to the parent component, please use SubComponents instead of Modules.")));
+    Module* loadModuleWithComponent(const std::string& type, Component* comp, Params& params) __attribute__ ((deprecated("loadModuleWithComponent will be removed in SST version 10.0.  If the module needs access to the parent component, please use SubComponents instead of Modules.")));
 
 
     /** Loads a module from an element Library
      * @param type Fully Qualified library.moduleName
      * @param params Parameters the module should use for configuration
-     * @return handle to new instance of module, or NULL on failure.
+     * @return handle to new instance of module, or nullptr on failure.
      */
     template <class T, class... ARGS>
-    T* loadModule(std::string type, Params& params, ARGS... args) {
+    T* loadModule(const std::string& type, Params& params, ARGS... args) {
 
         // Check to see if this can be loaded with new API or if we have to fallback to old
         return Factory::getFactory()->Create<T>(type, params, params, args...);
@@ -342,13 +342,13 @@ public:
      * @param type Fully Qualified library.moduleName
      * @param comp Pointer to component to pass to SuBaseComponent's constructor
      * @param params Parameters the module should use for configuration
-     * @return handle to new instance of SubComponent, or NULL on failure.
+     * @return handle to new instance of SubComponent, or nullptr on failure.
      */
-    SubComponent* loadSubComponent(std::string type, Component* comp, Params& params) __attribute__ ((deprecated("This version of loadSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
+    SubComponent* loadSubComponent(const std::string& type, Component* comp, Params& params) __attribute__ ((deprecated("This version of loadSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
 
     /* New ELI style */
-    SubComponent* loadNamedSubComponent(std::string name) __attribute__ ((deprecated("This version of loadNamedSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
-    SubComponent* loadNamedSubComponent(std::string name, Params& params) __attribute__ ((deprecated("This version of loadNamedSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
+    SubComponent* loadNamedSubComponent(const std::string& name) __attribute__ ((deprecated("This version of loadNamedSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
+    SubComponent* loadNamedSubComponent(const std::string& name, Params& params) __attribute__ ((deprecated("This version of loadNamedSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
 
     
 protected:
@@ -369,7 +369,7 @@ protected:
        @return True if loadable as the API specified as the template parameter
      */
     template <class T>
-    bool isSubComponentLoadableUsingAPI(std::string type) {
+    bool isSubComponentLoadableUsingAPI(const std::string& type) {
         return Factory::getFactory()->isSubComponentLoadableUsingAPI<T>(type);
     }
     
@@ -390,14 +390,14 @@ protected:
        unsuccessful.
     */
     template <class T, class... ARGS>
-    T* loadAnonymousSubComponent(std::string type, std::string slot_name, int slot_num, uint64_t share_flags, Params& params, ARGS... args) {
+    T* loadAnonymousSubComponent(const std::string& type, const std::string& slot_name, int slot_num, uint64_t share_flags, Params& params, ARGS... args) {
 
         share_flags = share_flags & ComponentInfo::USER_FLAGS;
         ComponentId_t cid = my_info->addAnonymousSubComponent(my_info, type, slot_name, slot_num, share_flags);
         ComponentInfo* sub_info = my_info->findSubComponent(cid);
 
         //This shouldn't happen since we just put it in, but just in case
-        if ( sub_info == NULL ) return NULL;
+        if ( sub_info == nullptr ) return nullptr;
 
         // Check to see if this can be loaded with new API or if we have to fallback to old
         if ( isSubComponentLoadableUsingAPI<T>(type) ) {
@@ -423,7 +423,7 @@ protected:
        unsuccessful.
     */
     template <class T>
-    T* loadUserSubComponent(std::string slot_name) {
+    T* loadUserSubComponent(const std::string& slot_name) {
         return loadUserSubComponent<T>(slot_name, ComponentInfo::SHARE_NONE);
     }
     
@@ -441,7 +441,7 @@ protected:
        unsuccessful.
     */
     template <class T, class... ARGS>
-    T* loadUserSubComponent(std::string slot_name, uint64_t share_flags, ARGS... args) {
+    T* loadUserSubComponent(const std::string& slot_name, uint64_t share_flags, ARGS... args) {
 
         // Get list of ComponentInfo objects and make sure that there is
         // only one SubComponent put into this slot
@@ -467,8 +467,8 @@ protected:
     
 private:
 
-    SubComponent* loadNamedSubComponent(std::string name, int slot_num);
-    SubComponent* loadNamedSubComponent(std::string name, int slot_num, Params& params);
+    SubComponent* loadNamedSubComponent(const std::string& name, int slot_num);
+    SubComponent* loadNamedSubComponent(const std::string& name, int slot_num, Params& params);
 
     SubComponent* loadNamedSubComponentLegacyPrivate(ComponentInfo* sub_info, Params& params);
 
@@ -486,19 +486,19 @@ private:
     void pushValidParams(Params& params, const std::string& type);
     
     template <class T, class... ARGS>
-    T* loadUserSubComponentByIndex(std::string slot_name, int slot_num, int share_flags, ARGS... args) {
+    T* loadUserSubComponentByIndex(const std::string& slot_name, int slot_num, int share_flags, ARGS... args) {
 
         share_flags = share_flags & ComponentInfo::USER_FLAGS;
         
         // Check to see if the slot exists
         ComponentInfo* sub_info = my_info->findSubComponent(slot_name,slot_num);
-        if ( sub_info == NULL ) return NULL;
+        if ( sub_info == nullptr ) return nullptr;
         sub_info->share_flags = share_flags;
         sub_info->parent_info = my_info;
         
         // Check to see if this is documented, and if so, try to load it through the ElementBuilder
         Params myParams;
-        if ( sub_info->getParams() != NULL ) {
+        if ( sub_info->getParams() != nullptr ) {
             myParams.insert(*sub_info->getParams());
         }
 
@@ -519,7 +519,7 @@ private:
 
 
 public:
-    SubComponentSlotInfo* getSubComponentSlotInfo(std::string name, bool fatalOnEmptyIndex = false);
+    SubComponentSlotInfo* getSubComponentSlotInfo(const std::string& name, bool fatalOnEmptyIndex = false);
 
     /** Retrieve the X,Y,Z coordinates of this component */
     const std::vector<double>& getCoordinates() const {
@@ -546,22 +546,22 @@ protected:
         return my_info->defaultTimeBase;
     }
 
-    bool doesSubComponentExist(std::string type);
+    bool doesSubComponentExist(const std::string& type);
 
 
     /** Find a lookup table */
-    SharedRegion* getLocalSharedRegion(const std::string &key, size_t size);
-    SharedRegion* getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger = NULL);
+    SharedRegion* getLocalSharedRegion(const std::string& key, size_t size);
+    SharedRegion* getGlobalSharedRegion(const std::string& key, size_t size, SharedRegionMerger *merger = nullptr);
 
     /* Get the Simulation */
     Simulation* getSimulation() const { return sim; }
 
     // Does the statisticName exist in the ElementInfoStatistic
-    virtual bool doesComponentInfoStatisticExist(const std::string &statisticName) const;
+    virtual bool doesComponentInfoStatisticExist(const std::string& statisticName) const;
     // Return the EnableLevel for the statisticName from the ElementInfoStatistic
-    uint8_t getComponentInfoStatisticEnableLevel(const std::string &statisticName) const;
+    uint8_t getComponentInfoStatisticEnableLevel(const std::string& statisticName) const;
     // Return the Units for the statisticName from the ElementInfoStatistic
-    // std::string getComponentInfoStatisticUnits(const std::string &statisticName) const;
+    // std::string getComponentInfoStatisticUnits(const std::string& statisticName) const;
 
     
     Component* getTrueComponent() const __attribute__ ((deprecated("getTrueParent will be removed in SST version 10.0.  With the new subcomponent structure, direct access to your parent component is not allowed.")));
@@ -597,7 +597,7 @@ private:
     ComponentId_t currentlyLoadingSubComponentID;
     bool isExtension;
     
-    void addSelfLink(std::string name);
+    void addSelfLink(const std::string& name);
     Link* getLinkFromParentSharedPort(const std::string& port);
 
     using CreateFxn = std::function<StatisticBase*(const std::string&,
@@ -626,7 +626,7 @@ class SubComponentSlotInfo {
 protected:
     
     SubComponent* protected_create(int slot_num, Params& params) const {
-        if ( slot_num > max_slot_index ) return NULL;
+        if ( slot_num > max_slot_index ) return nullptr;
 
         return comp->loadNamedSubComponent(slot_name, slot_num, params);
     }    
@@ -638,7 +638,7 @@ public:
     ~SubComponentSlotInfo() {}
     
 
-    SubComponentSlotInfo(BaseComponent* comp, std::string slot_name) :
+    SubComponentSlotInfo(BaseComponent* comp, const std::string& slot_name) :
         comp(comp),
         slot_name(slot_name)
     {
@@ -661,13 +661,13 @@ public:
 
     bool isPopulated(int slot_num) const {
         if ( slot_num > max_slot_index ) return false;
-        if ( comp->my_info->findSubComponent(slot_name,slot_num) == NULL ) return false;
+        if ( comp->my_info->findSubComponent(slot_name,slot_num) == nullptr ) return false;
         return true;
     }
 
     bool isAllPopulated() const {
         for ( int i = 0; i < max_slot_index; ++i ) {
-            if ( comp->my_info->findSubComponent(slot_name,i) == NULL ) return false;
+            if ( comp->my_info->findSubComponent(slot_name,i) == nullptr ) return false;
         }
         return true;
     }
@@ -829,12 +829,12 @@ private:
     T* private_create(int slot_num, Params& params) const
     {
         SubComponent* sub = protected_create(slot_num, params);
-        if ( sub == NULL ) {
-            // Nothing populated at this index, simply return NULL
-            return NULL;
+        if ( sub == nullptr ) {
+            // Nothing populated at this index, simply return nullptr
+            return nullptr;
         }
         T* cast_sub = dynamic_cast<T*>(sub);
-        if ( cast_sub == NULL ) {
+        if ( cast_sub == nullptr ) {
             // SubComponent not castable to the correct class,
             // fatal
             Simulation::getSimulationOutput().fatal(CALL_INFO,1,"Attempt to load SubComponent into slot "
@@ -849,7 +849,7 @@ private:
     {
         for ( int i = 0; i <= getMaxPopulatedSlotNumber(); ++i ) {
             T* sub = create<T>(i, params);
-            if ( sub != NULL || insertNulls ) vec.push_back(sub);
+            if ( sub != nullptr || insertNulls ) vec.push_back(sub);
         }
     }
 

--- a/src/sst/core/bootshared.cc
+++ b/src/sst/core/bootshared.cc
@@ -11,14 +11,14 @@
 
 
 #include "sst_config.h"
+#include "bootshared.h"
 
 #include <climits>
 #include <map>
 #include <cstring>
 #include <string>
 
-#include "bootshared.h"
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 #include "sst/core/env/envquery.h"
 
 void update_env_var(const char* name, const int UNUSED(verbose), char* UNUSED(argv[]), const int UNUSED(argc)) {
@@ -31,7 +31,7 @@ void update_env_var(const char* name, const int UNUSED(verbose), char* UNUSED(ar
 		new_ld_path_copy[i] = '\0';
 	}
 
-	if(NULL != current_ld_path) {
+	if(nullptr != current_ld_path) {
 		sprintf(new_ld_path, "%s", current_ld_path);
 	}
 	std::vector<std::string> configFiles;
@@ -65,7 +65,7 @@ void update_env_var(const char* name, const int UNUSED(verbose), char* UNUSED(ar
 	// Set the SST_ROOT information
 #ifdef SST_INSTALL_PREFIX
 	// If SST_ROOT not previous set, then we will provide our own
-	if(NULL == getenv("SST_ROOT")) {
+	if(nullptr == getenv("SST_ROOT")) {
 		setenv("SST_ROOT", SST_INSTALL_PREFIX, 1);
 	}
 #endif
@@ -87,7 +87,7 @@ void boot_sst_executable(const char* binary, const int verbose, char* argv[], co
 
 	if(verbose) {
 		char** check_env = environ;
-		while(NULL != check_env && NULL != check_env[0]) {
+		while(nullptr != check_env && nullptr != check_env[0]) {
 			printf("SST Environment Variable: %s\n", check_env[0]);
 			check_env++;
 		}

--- a/src/sst/core/bootsst.cc
+++ b/src/sst/core/bootsst.cc
@@ -10,8 +10,8 @@
 // distribution.
 
 
-#include <sst_config.h>
-#include <sst/core/bootshared.h>
+#include "sst_config.h"
+#include "sst/core/bootshared.h"
 
 #include <cstdlib>
 
@@ -34,13 +34,13 @@ int main(int argc, char* argv[]) {
 		const char* check_print_env   = std::getenv("SST_PRINT_ENV");
 		const char* check_display_env = std::getenv("SST_DISPLAY_ENV");
 
-		if( NULL != check_display_env ) {
+		if( nullptr != check_display_env ) {
 			if(strcmp("1", check_display_env) == 0) {
 				print_env = 1;
 			}
 		}
 
-		if( NULL != check_print_env ) {
+		if( nullptr != check_print_env ) {
 			if(strcmp("1", check_print_env) == 0) {
 				print_env = 1;
 			}
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
 	if(1 == print_env) {
 		int next_index = 0;
 
-		while( NULL != environ[next_index] ) {
+		while( nullptr != environ[next_index] ) {
 			const char* next_env = environ[next_index];
 			printf("%s\n", next_env);
 

--- a/src/sst/core/bootsstinfo.cc
+++ b/src/sst/core/bootsstinfo.cc
@@ -9,8 +9,8 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
-#include <sst/core/bootshared.h>
+#include "sst_config.h"
+#include "sst/core/bootshared.h"
 
 int main(int argc, char* argv[]) {
 	int config_env = 1;

--- a/src/sst/core/cfgoutput/dotConfigOutput.cc
+++ b/src/sst/core/cfgoutput/dotConfigOutput.cc
@@ -10,10 +10,11 @@
 // distribution.
 //
 
-#include <sst_config.h>
-#include <sst/core/configGraphOutput.h>
-#include <sst/core/config.h>
+#include "sst_config.h"
 #include "dotConfigOutput.h"
+
+#include "sst/core/configGraphOutput.h"
+#include "sst/core/config.h"
 
 using namespace SST::Core;
 
@@ -24,7 +25,7 @@ DotConfigGraphOutput::DotConfigGraphOutput(const char* path) :
 
 void DotConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph) {
 
-	if ( NULL == outputFile ) {
+	if ( nullptr == outputFile ) {
 		throw ConfigGraphOutputException("Output file is not open for writing");
 	}
 

--- a/src/sst/core/cfgoutput/dotConfigOutput.h
+++ b/src/sst/core/cfgoutput/dotConfigOutput.h
@@ -13,8 +13,8 @@
 #ifndef _H_SST_CORE_CONFIG_OUTPUT_DOT
 #define _H_SST_CORE_CONFIG_OUTPUT_DOT
 
-#include <sst/core/configGraph.h>
-#include <sst/core/configGraphOutput.h>
+#include "sst/core/configGraph.h"
+#include "sst/core/configGraphOutput.h"
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.cc
@@ -10,14 +10,14 @@
 // distribution.
 //
 
-#include <sst_config.h>
+#include "sst_config.h"
+#include "sst/core/cfgoutput/jsonConfigOutput.h"
 
-#include <sst/core/warnmacros.h>
-#include <sst/core/config.h>
-#include <sst/core/configGraph.h>
-#include <sst/core/configGraphOutput.h>
-#include <sst/core/params.h>
-#include <sst/core/cfgoutput/jsonConfigOutput.h>
+#include "sst/core/warnmacros.h"
+#include "sst/core/config.h"
+#include "sst/core/configGraph.h"
+#include "sst/core/configGraphOutput.h"
+#include "sst/core/params.h"
 
 #include <map>
 
@@ -31,7 +31,7 @@ JSONConfigGraphOutput::JSONConfigGraphOutput(const char* path) :
 void JSONConfigGraphOutput::generate(const Config* UNUSED(cfg), ConfigGraph* graph) {
 
 	int num = 0;
-	if(NULL == outputFile) {
+	if(nullptr == outputFile) {
 		throw ConfigGraphOutputException("Output file is not open for writing");
 	}
 
@@ -58,7 +58,7 @@ void JSONConfigGraphOutput::generate(const Config* UNUSED(cfg), ConfigGraph* gra
 }
 
 
-void JSONConfigGraphOutput::generateJSON(const std::string indent, const ConfigComponent& comp, const ConfigLinkMap_t& linkMap) const {
+void JSONConfigGraphOutput::generateJSON(const std::string& indent, const ConfigComponent& comp, const ConfigLinkMap_t& linkMap) const {
 	
 	int num = 0;
 	std::string temp = indent + "\"name\" : \"" + comp.name + "\",\n" + indent + "\"type\" : \"" + comp.type + "\",\n";

--- a/src/sst/core/cfgoutput/jsonConfigOutput.h
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.h
@@ -13,8 +13,8 @@
 #ifndef _SST_CORE_CONFIG_OUTPUT_JSON
 #define _SST_CORE_CONFIG_OUTPUT_JSON
 
-#include <sst/core/configGraph.h>
-#include <sst/core/configGraphOutput.h>
+#include "sst/core/configGraph.h"
+#include "sst/core/configGraphOutput.h"
 
 namespace SST {
 namespace Core {
@@ -26,7 +26,7 @@ public:
 	virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 
 protected:
-	void generateJSON(const std::string indent, const ConfigComponent& comp, const ConfigLinkMap_t& linkMap) const;
+	void generateJSON(const std::string& indent, const ConfigComponent& comp, const ConfigLinkMap_t& linkMap) const;
   void generateJSON(const ConfigLink& link, const ConfigComponentMap_t& compMap) const;
 };
 

--- a/src/sst/core/cfgoutput/pythonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.cc
@@ -10,18 +10,18 @@
 // distribution.
 //
 
-#include <sst_config.h>
-
+#include "sst_config.h"
 #include "pythonConfigOutput.h"
-#include <sst/core/simulation.h>
-#include <sst/core/config.h>
-#include <sst/core/timeLord.h>
-#include <sst/core/timeConverter.h>
+
+#include "sst/core/simulation.h"
+#include "sst/core/config.h"
+#include "sst/core/timeLord.h"
+#include "sst/core/timeConverter.h"
 
 using namespace SST::Core;
 
 PythonConfigGraphOutput::PythonConfigGraphOutput(const char* path) :
-	ConfigGraphOutput(path), graph(NULL) {
+	ConfigGraphOutput(path), graph(nullptr) {
 
 }
 
@@ -210,7 +210,7 @@ void PythonConfigGraphOutput::generateStatGroup(const ConfigGraph* graph, const 
 void PythonConfigGraphOutput::generate(const Config* cfg,
 	ConfigGraph* graph) {
 
-	if(NULL == outputFile) {
+	if(nullptr == outputFile) {
 		throw ConfigGraphOutputException("Input file is not open for output writing");
 	}
 
@@ -261,11 +261,11 @@ void PythonConfigGraphOutput::generate(const Config* cfg,
 
 	fprintf(outputFile, "# End of generated output.\n\n");
 
-    this->graph = NULL;
+    this->graph = nullptr;
     linkMap.clear();
 }
 
-bool PythonConfigGraphOutput::isMultiLine(const std::string check) const {
+bool PythonConfigGraphOutput::isMultiLine(const std::string& check) const {
 	bool isMultiLine = false;
 
 	for(size_t i = 0; i < check.size(); i++) {
@@ -292,11 +292,11 @@ bool PythonConfigGraphOutput::isMultiLine(const char* check) const {
 	return isMultiLine;
 }
 
-char* PythonConfigGraphOutput::makePythonSafeWithPrefix(const std::string name,
-	const std::string prefix) const {
+char* PythonConfigGraphOutput::makePythonSafeWithPrefix(const std::string& name,
+	const std::string& prefix) const {
 
 	const auto nameLength = name.size();
-	char* buffer = NULL;
+	char* buffer = nullptr;
 
 	if( nameLength > 0 && isdigit(name.at(0)) ) {
 		if( name.size() > prefix.size() ) {
@@ -367,7 +367,7 @@ bool PythonConfigGraphOutput::strncmp(const char* a, const char* b,
 	return matched;
 };
 
-char* PythonConfigGraphOutput::makeEscapeSafe(const std::string input) const {
+char* PythonConfigGraphOutput::makeEscapeSafe(const std::string& input) const {
 
 	std::string escapedInput = "";
 	auto inputLength = input.size();

--- a/src/sst/core/cfgoutput/pythonConfigOutput.h
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.h
@@ -13,8 +13,8 @@
 #ifndef _H_SST_CORE_CONFIG_OUTPUT_PYTHON
 #define _H_SST_CORE_CONFIG_OUTPUT_PYTHON
 
-#include <sst/core/configGraph.h>
-#include <sst/core/configGraphOutput.h>
+#include "sst/core/configGraph.h"
+#include "sst/core/configGraphOutput.h"
 #include <map>
 
 namespace SST {
@@ -37,12 +37,12 @@ protected:
 
     const std::string& getLinkObject(LinkId_t id);
 
-    char* makePythonSafeWithPrefix(const std::string name, const std::string prefix) const;
+    char* makePythonSafeWithPrefix(const std::string& name, const std::string& prefix) const;
     void makeBufferPythonSafe(char* buffer) const;
-    char* makeEscapeSafe(const std::string input) const;
+    char* makeEscapeSafe(const std::string& input) const;
     bool strncmp(const char* a, const char* b, const size_t n) const;
     bool isMultiLine(const char* check) const;
-    bool isMultiLine(const std::string check) const;
+    bool isMultiLine(const std::string& check) const;
 
 private:
     ConfigGraph *graph;

--- a/src/sst/core/cfgoutput/xmlConfigOutput.cc
+++ b/src/sst/core/cfgoutput/xmlConfigOutput.cc
@@ -10,9 +10,10 @@
 // distribution.
 //
 
-#include <sst_config.h>
-#include <sst/core/warnmacros.h>
-#include <sst/core/configGraphOutput.h>
+#include "sst_config.h"
+#include "sst/core/configGraphOutput.h"
+
+#include "sst/core/warnmacros.h"
 #include "xmlConfigOutput.h"
 
 using namespace SST::Core;
@@ -25,7 +26,7 @@ XMLConfigGraphOutput::XMLConfigGraphOutput(const char* path) :
 void XMLConfigGraphOutput::generate(const Config* UNUSED(cfg),
                 ConfigGraph* graph) {
 
-	if(NULL == outputFile) {
+	if(nullptr == outputFile) {
 		throw ConfigGraphOutputException("Output file is not open for writing");
 	}
 
@@ -48,7 +49,7 @@ void XMLConfigGraphOutput::generate(const Config* UNUSED(cfg),
 	fprintf(outputFile, "</component>\n");
 }
 
-void XMLConfigGraphOutput::generateXML(const std::string indent, const ConfigComponent& comp,
+void XMLConfigGraphOutput::generateXML(const std::string& indent, const ConfigComponent& comp,
                 const ConfigLinkMap_t& UNUSED(linkMap)) const {
 
 	fprintf(outputFile, "%s<component id=\"system.%s\" name=\"%s\" type=\"%s\">\n",
@@ -68,7 +69,7 @@ void XMLConfigGraphOutput::generateXML(const std::string indent, const ConfigCom
 	fprintf(outputFile, "%s</component>\n", indent.c_str());
 }
 
-void XMLConfigGraphOutput::generateXML(const std::string indent, const ConfigLink& link,
+void XMLConfigGraphOutput::generateXML(const std::string& indent, const ConfigLink& link,
 	const ConfigComponentMap_t& compMap) const {
 
 	const ConfigComponent* link_left  = &compMap[link.component[0]];

--- a/src/sst/core/cfgoutput/xmlConfigOutput.h
+++ b/src/sst/core/cfgoutput/xmlConfigOutput.h
@@ -13,8 +13,8 @@
 #ifndef _SST_CORE_CONFIG_OUTPUT_XML
 #define _SST_CORE_CONFIG_OUTPUT_XML
 
-#include <sst/core/configGraph.h>
-#include <sst/core/configGraphOutput.h>
+#include "sst/core/configGraph.h"
+#include "sst/core/configGraphOutput.h"
 
 namespace SST {
 namespace Core {
@@ -25,9 +25,9 @@ public:
 	virtual void generate(const Config* cfg,
                 ConfigGraph* graph) override;
 protected:
-        void generateXML(const std::string indent, const ConfigComponent& comp,
+        void generateXML(const std::string& indent, const ConfigComponent& comp,
 		const ConfigLinkMap_t& linkMap) const;
-        void generateXML(const std::string indent, const ConfigLink& link,
+        void generateXML(const std::string& indent, const ConfigLink& link,
 		const ConfigComponentMap_t& compMap) const;
 };
 

--- a/src/sst/core/clock.cc
+++ b/src/sst/core/clock.cc
@@ -12,7 +12,6 @@
 #include "sst_config.h"
 #include "sst/core/clock.h"
 
-//#include "sst/core/event.h"
 #include "sst/core/simulation.h"
 #include "sst/core/timeConverter.h"
     

--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -13,13 +13,10 @@
 #ifndef SST_CORE_CLOCK_H
 #define SST_CORE_CLOCK_H
 
-//#include <deque>
-//#include <list>
 #include <vector>
 #include <cinttypes>
 
-#include <sst/core/action.h>
-//#include <sst/core/clockHandler.h>
+#include "sst/core/action.h"
 
 #define _CLE_DBG( fmt, args...)__DBG( DBG_CLOCK, Clock, fmt, ## args )
 

--- a/src/sst/core/component.cc
+++ b/src/sst/core/component.cc
@@ -9,13 +9,12 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
-#include <string>
+#include "sst_config.h"
+#include "sst/core/component.h"
 
-#include <sst/core/component.h>
-#include <sst/core/exit.h>
-#include <sst/core/simulation.h>
-#include <sst/core/factory.h>
+#include "sst/core/exit.h"
+#include "sst/core/simulation.h"
+#include "sst/core/factory.h"
 
 using namespace SST::Statistics;
 

--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -12,13 +12,12 @@
 #ifndef SST_CORE_COMPONENT_H
 #define SST_CORE_COMPONENT_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 #include <map>
-#include <string>
 
-#include <sst/core/baseComponent.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/baseComponent.h"
+#include "sst/core/eli/elementinfo.h"
 
 using namespace SST::Statistics;
 

--- a/src/sst/core/componentExtension.cc
+++ b/src/sst/core/componentExtension.cc
@@ -9,8 +9,8 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
-#include <sst/core/componentExtension.h>
+#include "sst_config.h"
+#include "sst/core/componentExtension.h"
 
 namespace SST {
 

--- a/src/sst/core/componentExtension.h
+++ b/src/sst/core/componentExtension.h
@@ -13,8 +13,8 @@
 #ifndef SST_CORE_COMPONENTEXTENSION_H
 #define SST_CORE_COMPONENTEXTENSION_H
 
-#include <sst/core/warnmacros.h>
-#include <sst/core/baseComponent.h>
+#include "sst/core/warnmacros.h"
+#include "sst/core/baseComponent.h"
 
 namespace SST {
 

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -13,22 +13,22 @@
 #include "sst_config.h"
 // #include "sst/core/serialization.h"
 
-#include <sst/core/componentInfo.h>
-#include <sst/core/configGraph.h>
-#include <sst/core/linkMap.h>
+#include "sst/core/componentInfo.h"
+#include "sst/core/configGraph.h"
+#include "sst/core/linkMap.h"
 
 namespace SST {
 
-ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name) :
+ComponentInfo::ComponentInfo(ComponentId_t id, const std::string& name) :
     id(id),
-    parent_info(NULL),
+    parent_info(nullptr),
     name(name),
     type(""),
-    link_map(NULL),
-    component(NULL),
-    params(NULL),
-    defaultTimeBase(NULL),
-    enabledStats(NULL),
+    link_map(nullptr),
+    component(nullptr),
+    params(nullptr),
+    defaultTimeBase(nullptr),
+    enabledStats(nullptr),
     coordinates(3, 0.0),
     subIDIndex(1),
     slot_name(""),
@@ -38,12 +38,12 @@ ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name) :
 }
 
 
-// ComponentInfo::ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const std::string &type, const Params *params, const ComponentInfo *parent) :
+// ComponentInfo::ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const std::string& type, const Params *params, const ComponentInfo *parent) :
 //     id(parent->id),
 //     name(parent->name),
 //     type(type),
 //     link_map(parent->link_map),
-//     component(NULL),
+//     component(nullptr),
 //     params(params),
 //     enabledStats(parent->enabledStats),
 //     coordinates(parent->coordinates),
@@ -56,17 +56,17 @@ ComponentInfo::ComponentInfo(ComponentId_t id, const std::string &name) :
 
 
 // Constructor used for Anonymous SubComponents
-ComponentInfo::ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const std::string &type,
+ComponentInfo::ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const std::string& type,
                              const std::string& slot_name, int slot_num, uint64_t share_flags/*, const Params& params_in*/) :
     id(id),
     parent_info(parent_info),
     name(""),
     type(type),
-    link_map(NULL),
-    component(NULL),
-    params(/*new Params()*/ NULL),
-    defaultTimeBase(NULL),
-    enabledStats(NULL),
+    link_map(nullptr),
+    component(nullptr),
+    params(/*new Params()*/ nullptr),
+    defaultTimeBase(nullptr),
+    enabledStats(nullptr),
     coordinates(parent_info->coordinates),
     subIDIndex(1),
     slot_name(slot_name),
@@ -83,9 +83,9 @@ ComponentInfo::ComponentInfo(ConfigComponent *ccomp, const std::string& name, Co
     name(name),
     type(ccomp->type),
     link_map(link_map),
-    component(NULL),
+    component(nullptr),
     params(&ccomp->params),
-    defaultTimeBase(NULL),
+    defaultTimeBase(nullptr),
     enabledStats(&ccomp->enabledStatistics),
     coordinates(ccomp->coords),
     subIDIndex(1),
@@ -133,10 +133,10 @@ ComponentInfo::ComponentInfo(ComponentInfo &&o) :
     slot_num(o.slot_num),
     share_flags(o.share_flags)
 {
-    o.parent_info = NULL;
-    o.link_map = NULL;
-    o.component = NULL;
-    o.defaultTimeBase = NULL;
+    o.parent_info = nullptr;
+    o.link_map = nullptr;
+    o.component = nullptr;
+    o.defaultTimeBase = nullptr;
 }
 
 
@@ -154,7 +154,7 @@ ComponentInfo::~ComponentInfo() {
 
 LinkMap*
 ComponentInfo::getLinkMap() {
-    if ( link_map == NULL ) link_map = new LinkMap();
+    if ( link_map == nullptr ) link_map = new LinkMap();
     return link_map;
 }
 
@@ -164,9 +164,9 @@ ComponentInfo::addAnonymousSubComponent(ComponentInfo* parent_info, const std::s
                                         int slot_num, uint64_t share_flags)
 {
     // First, get the next subIDIndex by working our way up to the
-    // actual component (parent pointer will be NULL).
+    // actual component (parent pointer will be nullptr).
     ComponentInfo* real_comp = this;
-    while ( real_comp->parent_info != NULL) real_comp = real_comp->parent_info;
+    while ( real_comp->parent_info != nullptr) real_comp = real_comp->parent_info;
 
     // Get the subIDIndex and increment it for next time
     uint64_t sub_id = real_comp->subIDIndex++;
@@ -181,7 +181,7 @@ ComponentInfo::addAnonymousSubComponent(ComponentInfo* parent_info, const std::s
 
 
 void ComponentInfo::finalizeLinkConfiguration() const {
-    if ( NULL != link_map ) {
+    if ( nullptr != link_map ) {
         for ( auto & i : link_map->getLinkMap() ) {
             i.second->finalizeConfiguration();
         }
@@ -192,7 +192,7 @@ void ComponentInfo::finalizeLinkConfiguration() const {
 }
 
 void ComponentInfo::prepareForComplete() const {
-    if ( NULL != link_map ) {
+    if ( nullptr != link_map ) {
         for ( auto & i : link_map->getLinkMap() ) {
             i.second->prepareForComplete();
         }
@@ -211,30 +211,30 @@ ComponentInfo* ComponentInfo::findSubComponent(ComponentId_t id)
 
     /* Check to make sure we're part of the same component */
     if ( COMPONENT_ID_MASK(id) != COMPONENT_ID_MASK(this->id) )
-        return NULL;
+        return nullptr;
 
     for ( auto &s : subComponents ) {
         ComponentInfo* found = s.second.findSubComponent(id);
-        if ( found != NULL )
+        if ( found != nullptr )
             return found;
     }
-    return NULL;
+    return nullptr;
 }
 
-ComponentInfo* ComponentInfo::findSubComponent(std::string slot, int slot_num) 
+ComponentInfo* ComponentInfo::findSubComponent(const std::string& slot, int slot_num) 
 {
     // Non-recursive, only look in current component
     for ( auto &sc : subComponents ) {
         if ( sc.second.slot_name == slot && sc.second.slot_num == slot_num ) return &sc.second;
     }
-    return NULL;
+    return nullptr;
 }
 
 
 std::vector<LinkId_t> ComponentInfo::getAllLinkIds() const
 {
     std::vector<LinkId_t> res;
-    if ( NULL != link_map ) {
+    if ( nullptr != link_map ) {
         for ( auto & l : link_map->getLinkMap() ) {
             res.push_back(l.second->id);
         }

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -12,8 +12,8 @@
 #ifndef SST_CORE_COMPONENTINFO_H
 #define SST_CORE_COMPONENTINFO_H
 
-#include <sst/core/sst_types.h>
-#include <sst/core/params.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/params.h"
 
 #include <unordered_set>
 #include <map>
@@ -162,7 +162,7 @@ private:
     // inline void setParent(BaseComponent* comp) { parent = comp; }
 
     /* Lookup Key style constructor */
-    ComponentInfo(ComponentId_t id, const std::string &name);
+    ComponentInfo(ComponentId_t id, const std::string& name);
     void finalizeLinkConfiguration() const;
     void prepareForComplete() const;
 
@@ -173,7 +173,7 @@ private:
     
 public:
     /* Old ELI Style subcomponent constructor */
-    ComponentInfo(const std::string &type, const Params *params, const ComponentInfo *parent_info);
+    ComponentInfo(const std::string& type, const Params *params, const ComponentInfo *parent_info);
 
     /* Anonymous SubComponent */
     ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const std::string& type, const std::string& slot_name,
@@ -214,7 +214,7 @@ public:
     // inline std::map<std::string, ComponentInfo>& getSubComponents() { return subComponents; }
     inline std::map<ComponentId_t,ComponentInfo>& getSubComponents() { return subComponents; }
 
-    ComponentInfo* findSubComponent(std::string slot, int slot_num);
+    ComponentInfo* findSubComponent(const std::string& slot, int slot_num);
     ComponentInfo* findSubComponent(ComponentId_t id);
     std::vector<LinkId_t> getAllLinkIds() const;
 
@@ -273,7 +273,7 @@ public:
     ComponentInfo* getByID(const ComponentId_t key) const {
         ComponentInfo infoKey(COMPONENT_ID_MASK(key), "");
         auto value = dataByID.find(&infoKey);
-        if ( value == dataByID.end() ) return NULL;
+        if ( value == dataByID.end() ) return nullptr;
         if ( SUBCOMPONENT_ID_MASK(key) != 0 ) {
             // Looking for a subcomponent
             return (*value)->findSubComponent(key);

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -10,7 +10,7 @@
 // distribution.
 
 
-#include <sst_config.h>
+#include "sst_config.h"
 #include "sst/core/config.h"
 #include "sst/core/part/sstpart.h"
 
@@ -26,7 +26,7 @@
 #include <iostream>
 #include <cstdlib>
 
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 #ifdef SST_CONFIG_HAVE_MPI
 DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
@@ -63,7 +63,7 @@ Config::Config(RankInfo rankInfo)
     getcwd(wd_buf, PATH_MAX);
 
     output_directory = "";
-    if( NULL != wd_buf ) {
+    if( nullptr != wd_buf ) {
 	output_directory.append(wd_buf);
         free(wd_buf);
     }
@@ -99,14 +99,14 @@ struct sstLongOpts_s {
 
 
 #define DEF_FLAGOPTVAL(longName, shortName, text, func, valFunc) \
-    {{longName, no_argument, 0, shortName}, NULL, text, func, valFunc}
+    {{longName, no_argument, 0, shortName}, nullptr, text, func, valFunc}
 
 #define DEF_FLAGOPT(longName, shortName, text, func) \
-    DEF_FLAGOPTVAL(longName, shortName, text, func, NULL)
+    DEF_FLAGOPTVAL(longName, shortName, text, func, nullptr)
 
 
 #define DEF_ARGOPT_SHORT(longName, shortName, argName, text, func) \
-    {{longName, required_argument, 0, shortName}, argName, text, NULL, func}
+    {{longName, required_argument, 0, shortName}, argName, text, nullptr, func}
 
 #define DEF_ARGOPT(longName, argName, text, func) \
     DEF_ARGOPT_SHORT(longName, 0, argName, text, func)
@@ -146,7 +146,7 @@ static const struct sstLongOpts_s sstOptions[] = {
 #endif
     DEF_ARGOPT("model-options",     "STR",          "provide options to the python configuration script", &Config::setModelOptions),
     DEF_ARGOPT_SHORT("num_threads", 'n',   "NUM",   "number of parallel threads to use per rank", &Config::setNumThreads),
-    {{NULL, 0, 0, 0}, NULL, NULL, NULL, NULL}
+    {{nullptr, 0, 0, 0}, nullptr, nullptr, nullptr, nullptr}
 };
 static const size_t nLongOpts = (sizeof(sstOptions) / sizeof(sstLongOpts_s)) -1;
 
@@ -196,7 +196,7 @@ bool Config::usage() {
 
 
         const char *text = sstOptions[i].desc;
-        while ( text != NULL  && *text != '\0' ) {
+        while ( text != nullptr  && *text != '\0' ) {
             /* Advance to offset */
             while ( npos < desc_start ) npos += fprintf(stderr, " ");
 
@@ -224,7 +224,7 @@ Config::parseCmdLine(int argc, char* argv[]) {
     for ( size_t i = 0 ; i < nLongOpts ; i++ ) {
         sst_long_options[i] = sstOptions[i].opt;
     }
-    sst_long_options[nLongOpts] = {NULL, 0 ,0, 0};
+    sst_long_options[nLongOpts] = {nullptr, 0 ,0, 0};
 
     run_name = argv[0];
 
@@ -241,7 +241,7 @@ Config::parseCmdLine(int argc, char* argv[]) {
         switch (c) {
         case 0:
             /* Long option, no short option */
-            if ( optarg == NULL ) {
+            if ( optarg == nullptr ) {
                 ok = (this->*sstOptions[option_index].flagFunc)();
             } else {
                 ok = (this->*sstOptions[option_index].argFunc)(optarg);
@@ -322,11 +322,11 @@ Config::parseCmdLine(int argc, char* argv[]) {
 }
 
 
-bool Config::setConfigEntryFromModel(const string &entryName, const string &value)
+bool Config::setConfigEntryFromModel(const string& entryName, const string& value)
 {
     for ( size_t i = 0 ; i < nLongOpts ; i++ ) {
         if ( !entryName.compare(sstOptions[i].opt.name) ) {
-            if ( NULL != sstOptions[i].argFunc ) {
+            if ( nullptr != sstOptions[i].argFunc ) {
                 return (this->*sstOptions[i].argFunc)(value);
             } else {
                 return (this->*sstOptions[i].flagFunc)();
@@ -351,10 +351,10 @@ bool Config::printVersion() {
 }
 
 
-bool Config::setConfigFile(const std::string &arg) {
+bool Config::setConfigFile(const std::string& arg) {
     struct stat sb;
-    char *fqpath = realpath(arg.c_str(), NULL);
-    if ( NULL == fqpath ) {
+    char *fqpath = realpath(arg.c_str(), nullptr);
+    if ( nullptr == fqpath ) {
         fprintf(stderr, "Failed to canonicalize path [%s]:  %s\n", arg.c_str(), strerror(errno));
         return false;
     }
@@ -378,15 +378,15 @@ bool Config::setConfigFile(const std::string &arg) {
 }
 
 
-bool Config::setDebugFile(const std::string &arg) { debugFile = arg; return true; }
+bool Config::setDebugFile(const std::string& arg) { debugFile = arg; return true; }
 
 /* TODO: Error checking */
-bool Config::setLibPath(const std::string &arg) { libpath = arg; return true; }
+bool Config::setLibPath(const std::string& arg) { libpath = arg; return true; }
 /* TODO: Error checking */
-bool Config::addLibPath(const std::string &arg) { libpath += std::string(":") + arg; return true; }
+bool Config::addLibPath(const std::string& arg) { libpath += std::string(":") + arg; return true; }
 
 
-bool Config::setRunMode(const std::string &arg) {
+bool Config::setRunMode(const std::string& arg) {
     if( ! arg.compare( "init" ) ) runMode =  Simulation::INIT;
     else if( ! arg.compare( "run" ) )  runMode =  Simulation::RUN;
     else if( ! arg.compare( "both" ) ) runMode =  Simulation::BOTH;
@@ -397,9 +397,9 @@ bool Config::setRunMode(const std::string &arg) {
 
 
 /* TODO: Error checking */
-bool Config::setStopAt(const std::string &arg) { stopAtCycle = arg;  return true; }
+bool Config::setStopAt(const std::string& arg) { stopAtCycle = arg;  return true; }
 /* TODO: Error checking */
-bool Config::setStopAfter(const std::string &arg) {
+bool Config::setStopAfter(const std::string& arg) {
     errno = 0;
 
     static const char *templates[] = {
@@ -418,7 +418,7 @@ bool Config::setStopAfter(const std::string &arg) {
         memset(&res, '\0', sizeof(res));
         p = strptime(arg.c_str(), templates[i], &res);
         fprintf(stderr, "**** [%s]  p = %p ; *p = '%c', %u:%u:%u\n", templates[i], p, (p) ? *p : '\0', res.tm_hour, res.tm_min, res.tm_sec);
-        if ( p != NULL && *p == '\0' ) {
+        if ( p != nullptr && *p == '\0' ) {
             stopAfterSec = res.tm_sec;
             stopAfterSec += res.tm_min * 60;
             stopAfterSec += res.tm_hour * 60 * 60;
@@ -435,12 +435,12 @@ bool Config::setStopAfter(const std::string &arg) {
     return false;
 }
 /* TODO: Error checking */
-bool Config::setHeartbeat(const std::string &arg) { heartbeatPeriod = arg;  return true; }
+bool Config::setHeartbeat(const std::string& arg) { heartbeatPeriod = arg;  return true; }
 /* TODO: Error checking */
-bool Config::setTimebase(const std::string &arg) { timeBase = arg;  return true; }
+bool Config::setTimebase(const std::string& arg) { timeBase = arg;  return true; }
 
 /* TODO: Error checking */
-bool Config::setPartitioner(const std::string &arg) {
+bool Config::setPartitioner(const std::string& arg) {
     partitioner = arg;
     if ( partitioner.find('.') == partitioner.npos ) {
         partitioner = "sst." + partitioner;
@@ -448,23 +448,23 @@ bool Config::setPartitioner(const std::string &arg) {
     return true;
 }
 
-bool Config::setTimeVortex(const std::string &arg) {
+bool Config::setTimeVortex(const std::string& arg) {
     timeVortex = arg;
     return true;
 }
 
-bool Config::setOutputDir(const std::string &arg) { output_directory = arg ;  return true; }
-bool Config::setWriteConfig(const std::string &arg) { output_config_graph = arg;  return true; }
-bool Config::setWriteDot(const std::string &arg) { output_dot = arg; return true; }
-bool Config::setWriteXML(const std::string &arg){ output_xml = arg; return true; }
-bool Config::setWriteJSON(const std::string &arg) { output_json = arg; return true; }
-bool Config::setWritePartition(const std::string &arg) { dump_component_graph_file = arg; return true; }
-bool Config::setOutputPrefix(const std::string &arg) { output_core_prefix = arg; return true; }
+bool Config::setOutputDir(const std::string& arg) { output_directory = arg ;  return true; }
+bool Config::setWriteConfig(const std::string& arg) { output_config_graph = arg;  return true; }
+bool Config::setWriteDot(const std::string& arg) { output_dot = arg; return true; }
+bool Config::setWriteXML(const std::string& arg){ output_xml = arg; return true; }
+bool Config::setWriteJSON(const std::string& arg) { output_json = arg; return true; }
+bool Config::setWritePartition(const std::string& arg) { dump_component_graph_file = arg; return true; }
+bool Config::setOutputPrefix(const std::string& arg) { output_core_prefix = arg; return true; }
 #ifdef USE_MEMPOOL
-bool Config::setWriteUndeleted(const std::string &arg) { event_dump_file = arg; return true; }
+bool Config::setWriteUndeleted(const std::string& arg) { event_dump_file = arg; return true; }
 #endif
 
-bool Config::setModelOptions(const std::string &arg) {
+bool Config::setModelOptions(const std::string& arg) {
     if ( model_options.empty() )
         model_options = arg;
     else
@@ -473,9 +473,9 @@ bool Config::setModelOptions(const std::string &arg) {
 }
 
 
-bool Config::setVerbosity(const std::string &arg) {
+bool Config::setVerbosity(const std::string& arg) {
     errno = E_OK;
-    unsigned long val = strtoul(arg.c_str(), NULL, 0);
+    unsigned long val = strtoul(arg.c_str(), nullptr, 0);
     if ( errno == E_OK ) {
         verbose = val;
         return true;
@@ -485,9 +485,9 @@ bool Config::setVerbosity(const std::string &arg) {
 }
 
 
-bool Config::setNumThreads(const std::string &arg) {
+bool Config::setNumThreads(const std::string& arg) {
     errno = E_OK;
-    unsigned long nthr = strtoul(arg.c_str(), NULL, 0);
+    unsigned long nthr = strtoul(arg.c_str(), nullptr, 0);
     if ( errno == E_OK ) {
         world_size.thread = nthr;
         return true;
@@ -546,7 +546,7 @@ std::string Config::getLibPath(void) const {
     // Clean up and delete the configuration we just loaded up
     delete envConfig;
 
-    if(NULL != envpath) {
+    if(nullptr != envpath) {
         fullLibPath.clear();
         fullLibPath.append(envpath);
     }

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -146,7 +146,7 @@ static const struct sstLongOpts_s sstOptions[] = {
 #endif
     DEF_ARGOPT("model-options",     "STR",          "provide options to the python configuration script", &Config::setModelOptions),
     DEF_ARGOPT_SHORT("num_threads", 'n',   "NUM",   "number of parallel threads to use per rank", &Config::setNumThreads),
-    {{nullptr, 0, 0, 0}, nullptr, nullptr, nullptr, nullptr}
+    {{nullptr, 0, nullptr, 0}, nullptr, nullptr, nullptr, nullptr}
 };
 static const size_t nLongOpts = (sizeof(sstOptions) / sizeof(sstLongOpts_s)) -1;
 
@@ -168,7 +168,7 @@ bool Config::usage() {
 
     if ( getenv("COLUMNS") ) {
         errno = E_OK;
-        uint32_t x = strtoul(getenv("COLUMNS"), 0, 0);
+        uint32_t x = strtoul(getenv("COLUMNS"), nullptr, 0);
         if ( errno == E_OK ) MAX_WIDTH = x;
     }
 
@@ -224,7 +224,7 @@ Config::parseCmdLine(int argc, char* argv[]) {
     for ( size_t i = 0 ; i < nLongOpts ; i++ ) {
         sst_long_options[i] = sstOptions[i].opt;
     }
-    sst_long_options[nLongOpts] = {nullptr, 0 ,0, 0};
+    sst_long_options[nLongOpts] = {nullptr, 0 ,nullptr, 0};
 
     run_name = argv[0];
 

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -12,13 +12,13 @@
 #ifndef SST_CORE_CONFIG_H
 #define SST_CORE_CONFIG_H
 
-#include <sst/core/sst_types.h>
-#include <sst/core/simulation.h>
-#include <sst/core/rankInfo.h>
-#include <sst/core/env/envquery.h>
-#include <sst/core/env/envconfig.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/simulation.h"
+#include "sst/core/rankInfo.h"
+#include "sst/core/env/envquery.h"
+#include "sst/core/env/envconfig.h"
 
-#include <sst/core/serialization/serializable.h>
+#include "sst/core/serialization/serializable.h"
 
 #include <string>
 
@@ -42,17 +42,13 @@ public:
     /** Parse command-line arguments to update configuration values */
     int parseCmdLine( int argc, char* argv[] );
     /** Set a configuration string to update configuration values */
-    bool setConfigEntryFromModel( const std::string &entryName, const std::string &value );
+    bool setConfigEntryFromModel( const std::string& entryName, const std::string& value );
     /** Return the current Verbosity level */
     uint32_t getVerboseLevel();
 
     /** Print the SST core timing information */
     bool printTimingInfo();
 
-    /** Set the cycle at which to stop the simulation */
-    void setStopAt(std::string stopAtStr);
-    /** Sets the default timebase of the simulation */
-    void setTimeBase(std::string timeBase);
     /** Print the current configuration to stdout */
     void Print();
 
@@ -87,40 +83,40 @@ public:
 
 
     typedef bool (Config::*flagFunction)(void);
-    typedef bool (Config::*argFunction)(const std::string &arg);
+    typedef bool (Config::*argFunction)(const std::string& arg);
 
     bool usage();
     bool printVersion();
     bool incrVerbose()          { verbose++; return true;}
-    bool setVerbosity(const std::string &arg);
+    bool setVerbosity(const std::string& arg);
     bool disableSigHandlers()   { enable_sig_handling = false; return true;}
     bool disableEnvConfig()     { no_env_config = true; return true;}
     bool enablePrintTiming()    { print_timing = true; return true;}
     bool enablePrintEnv()       { print_env = true; return true; }
 
-    bool setConfigFile(const std::string &arg);
-    bool setDebugFile(const std::string &arg);
-    bool setLibPath(const std::string &arg);
-    bool addLibPath(const std::string &arg);
-    bool setRunMode(const std::string &arg);
-    bool setStopAt(const std::string &arg);
-    bool setStopAfter(const std::string &arg);
-    bool setHeartbeat(const std::string &arg);
-    bool setTimebase(const std::string &arg);
-    bool setPartitioner(const std::string &arg);
-    bool setTimeVortex(const std::string &arg);
-    bool setOutputDir(const std::string &arg);
-    bool setWriteConfig(const std::string &arg);
-    bool setWriteDot(const std::string &arg);
-    bool setWriteXML(const std::string &arg);
-    bool setWriteJSON(const std::string &arg);
-    bool setWritePartition(const std::string &arg);
-    bool setOutputPrefix(const std::string &arg);
+    bool setConfigFile(const std::string& arg);
+    bool setDebugFile(const std::string& arg);
+    bool setLibPath(const std::string& arg);
+    bool addLibPath(const std::string& arg);
+    bool setRunMode(const std::string& arg);
+    bool setStopAt(const std::string& arg);
+    bool setStopAfter(const std::string& arg);
+    bool setHeartbeat(const std::string& arg);
+    bool setTimebase(const std::string& arg);
+    bool setPartitioner(const std::string& arg);
+    bool setTimeVortex(const std::string& arg);
+    bool setOutputDir(const std::string& arg);
+    bool setWriteConfig(const std::string& arg);
+    bool setWriteDot(const std::string& arg);
+    bool setWriteXML(const std::string& arg);
+    bool setWriteJSON(const std::string& arg);
+    bool setWritePartition(const std::string& arg);
+    bool setOutputPrefix(const std::string& arg);
 #ifdef USE_MEMPOOL
-    bool setWriteUndeleted(const std::string &arg);
+    bool setWriteUndeleted(const std::string& arg);
 #endif
-    bool setModelOptions(const std::string &arg);
-    bool setNumThreads(const std::string &arg);
+    bool setModelOptions(const std::string& arg);
+    bool setNumThreads(const std::string& arg);
 
 
     Simulation::Mode_t getRunMode() { return runMode; }
@@ -191,7 +187,7 @@ private:
     int rank;
 	int numRanks;
 
-    bool isFileNameOnly(const std::string name) {
+    bool isFileNameOnly(const std::string& name) {
 	bool nameOnly = true;
 
 	for( size_t i = 0; i < name.size(); ++i ) {

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -10,17 +10,17 @@
 // distribution.
 
 
-#include <sst_config.h>
-#include <sst/core/configGraph.h>
+#include "sst_config.h"
+#include "sst/core/configGraph.h"
 
 #include <fstream>
 #include <algorithm>
 
-#include <sst/core/component.h>
-#include <sst/core/config.h>
-#include <sst/core/timeLord.h>
-#include <sst/core/simulation.h>
-#include <sst/core/factory.h>
+#include "sst/core/component.h"
+#include "sst/core/config.h"
+#include "sst/core/timeLord.h"
+#include "sst/core/simulation.h"
+#include "sst/core/factory.h"
 
 #include <string.h>
 
@@ -45,7 +45,7 @@ bool ConfigStatGroup::addComponent(ComponentId_t id)
 }
 
 
-bool ConfigStatGroup::addStatistic(const std::string &name, Params &p)
+bool ConfigStatGroup::addStatistic(const std::string& name, Params &p)
 {
     statMap[name] = p;
     if ( outputFrequency.getRoundedValue() == 0 ) {
@@ -63,7 +63,7 @@ bool ConfigStatGroup::setOutput(size_t id)
 }
 
 
-bool ConfigStatGroup::setFrequency(const std::string &freq)
+bool ConfigStatGroup::setFrequency(const std::string& freq)
 {
     UnitAlgebra uaFreq(freq);
     if ( uaFreq.hasUnits("s") || uaFreq.hasUnits("hz") ) {
@@ -191,14 +191,14 @@ void ConfigComponent::setCoordinates(const std::vector<double> &c)
 }
 
 
-void ConfigComponent::addParameter(const std::string &key, const std::string &value, bool overwrite)
+void ConfigComponent::addParameter(const std::string& key, const std::string& value, bool overwrite)
 {
     bool bk = params.enableVerify(false);
     params.insert(key, value, overwrite);
     params.enableVerify(bk);
 }
 
-void ConfigComponent::enableStatistic(const std::string &statisticName, bool recursively)
+void ConfigComponent::enableStatistic(const std::string& statisticName, bool recursively)
 {
     // NOTE: For every statistic in the enabledStatistics List, there must be
     //       a corresponding params entry in enabledStatParams list.  The two
@@ -241,7 +241,7 @@ void ConfigComponent::enableStatistic(const std::string &statisticName, bool rec
 }
 
 
-void ConfigComponent::addStatisticParameter(const std::string &statisticName, const std::string &param, const std::string &value, bool recursively)
+void ConfigComponent::addStatisticParameter(const std::string& statisticName, const std::string& param, const std::string& value, bool recursively)
 {
     // NOTE: For every statistic in the enabledStatistics List, there must be
     //       a corresponding params entry in enabledStatParams list.  The two
@@ -264,7 +264,7 @@ void ConfigComponent::addStatisticParameter(const std::string &statisticName, co
 }
 
 
-void ConfigComponent::setStatisticParameters(const std::string &statisticName, const Params &params, bool recursively)
+void ConfigComponent::setStatisticParameters(const std::string& statisticName, const Params &params, bool recursively)
 {
     if ( recursively ) {
         for ( auto &sc : subComponents ) {
@@ -283,12 +283,12 @@ void ConfigComponent::setStatisticParameters(const std::string &statisticName, c
 
 
 
-ConfigComponent* ConfigComponent::addSubComponent(ComponentId_t sid, const std::string &name, const std::string &type, int slot_num)
+ConfigComponent* ConfigComponent::addSubComponent(ComponentId_t sid, const std::string& name, const std::string& type, int slot_num)
 {
     /* Check for existing subComponent with this name */
     for ( auto &i : subComponents ) {
         if ( i.name == name && i.slot_num == slot_num )
-            return NULL;
+            return nullptr;
     }
 
     subComponents.emplace_back(
@@ -308,11 +308,11 @@ const ConfigComponent* ConfigComponent::findSubComponent(ComponentId_t sid) cons
 
     for ( auto &s : subComponents ) {
         const ConfigComponent* res = s.findSubComponent(sid);
-        if ( res != NULL )
+        if ( res != nullptr )
             return res;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 
@@ -475,14 +475,14 @@ ConfigGraph::checkForStructuralErrors()
 
 
 ComponentId_t
-ConfigGraph::addComponent(ComponentId_t id, std::string name, std::string type, float weight, RankInfo rank)
+ConfigGraph::addComponent(ComponentId_t id, const std::string& name, const std::string& type, float weight, RankInfo rank)
 {
 	comps.push_back(ConfigComponent(id, name, type, weight, rank));
     return id;
 }
 
 ComponentId_t
-ConfigGraph::addComponent(ComponentId_t id, std::string name, std::string type)
+ConfigGraph::addComponent(ComponentId_t id, const std::string& name, const std::string& type)
 {
 	comps.push_back(ConfigComponent(id, name, type, 1.0f, RankInfo()));
     return id;
@@ -492,7 +492,7 @@ ConfigGraph::addComponent(ComponentId_t id, std::string name, std::string type)
 
 
 void
-ConfigGraph::setStatisticOutput(const std::string &name)
+ConfigGraph::setStatisticOutput(const std::string& name)
 {
     statOutputs[0].type = name;
 }
@@ -518,7 +518,7 @@ ConfigGraph::setStatisticLoadLevel(uint8_t loadLevel)
 
 
 void
-ConfigGraph::enableStatisticForComponentName(string ComponentName, string statisticName)
+ConfigGraph::enableStatisticForComponentName(const std::string& ComponentName, const std::string& statisticName)
 {
     bool found;
 
@@ -551,7 +551,7 @@ size_t for_each_subcomp_if(ConfigComponent &c, PredicateFunc p, UnaryFunc f) {
 
 
 void
-ConfigGraph::enableStatisticForComponentType(string ComponentType, string statisticName)
+ConfigGraph::enableStatisticForComponentType(const std::string& ComponentType, const std::string& statisticName)
 {
     if ( ComponentType == STATALLFLAG ) {
         for ( auto &c : comps ) {
@@ -569,7 +569,7 @@ ConfigGraph::enableStatisticForComponentType(string ComponentType, string statis
 }
 
 void
-ConfigGraph::addStatisticParameterForComponentName(const std::string &ComponentName, const std::string &statisticName, const std::string &param, const std::string &value)
+ConfigGraph::addStatisticParameterForComponentName(const std::string& ComponentName, const std::string& statisticName, const std::string& param, const std::string& value)
 {
     bool found;
 
@@ -584,7 +584,7 @@ ConfigGraph::addStatisticParameterForComponentName(const std::string &ComponentN
 }
 
 void
-ConfigGraph::addStatisticParameterForComponentType(const std::string &ComponentType, const std::string &statisticName, const std::string &param, const std::string &value)
+ConfigGraph::addStatisticParameterForComponentType(const std::string& ComponentType, const std::string& statisticName, const std::string& param, const std::string& value)
 {
     if ( ComponentType == STATALLFLAG ) {
         for ( auto &c : comps ) {
@@ -602,7 +602,7 @@ ConfigGraph::addStatisticParameterForComponentType(const std::string &ComponentT
 }
 
 void
-ConfigGraph::addLink(ComponentId_t comp_id, string link_name, string port, string latency_str, bool no_cut)
+ConfigGraph::addLink(ComponentId_t comp_id, const std::string& link_name, const std::string& port, const std::string& latency_str, bool no_cut)
 {
 	if ( link_names.find(link_name) == link_names.end() ) {
         LinkId_t id = links.size();
@@ -631,7 +631,7 @@ ConfigGraph::addLink(ComponentId_t comp_id, string link_name, string port, strin
 }
 
 void
-ConfigGraph::setLinkNoCut(string link_name)
+ConfigGraph::setLinkNoCut(const std::string& link_name)
 {
     // If link doesn't exist, return
     if ( link_names.find(link_name) == link_names.end() ) return;

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -21,16 +21,14 @@
 #include <set>
 #include <climits>
 
-#include <sst/core/sparseVectorMap.h>
-#include <sst/core/params.h>
-#include <sst/core/statapi/statbase.h>
-#include <sst/core/statapi/statoutput.h>
-#include <sst/core/rankInfo.h>
-#include <sst/core/unitAlgebra.h>
+#include "sst/core/sparseVectorMap.h"
+#include "sst/core/params.h"
+#include "sst/core/statapi/statbase.h"
+#include "sst/core/statapi/statoutput.h"
+#include "sst/core/rankInfo.h"
+#include "sst/core/unitAlgebra.h"
 
-#include <sst/core/serialization/serializable.h>
-
-// #include "sst/core/simulation.h"
+#include "sst/core/serialization/serializable.h"
 
 using namespace SST::Statistics;
 
@@ -109,7 +107,7 @@ private:
         component[1] = ULONG_MAX;
     }
 
-    ConfigLink(LinkId_t id, const std::string &n) :
+    ConfigLink(LinkId_t id, const std::string& n) :
         id(id),
         no_cut(false)
     {
@@ -136,14 +134,14 @@ public:
     size_t outputID;
     UnitAlgebra outputFrequency;
 
-    ConfigStatGroup(const std::string &name) : name(name), outputID(0) { }
+    ConfigStatGroup(const std::string& name) : name(name), outputID(0) { }
     ConfigStatGroup() {} /* Do not use */
 
 
     bool addComponent(ComponentId_t id);
-    bool addStatistic(const std::string &name, Params &p);
+    bool addStatistic(const std::string& name, Params &p);
     bool setOutput(size_t id);
-    bool setFrequency(const std::string &freq);
+    bool setFrequency(const std::string& freq);
 
     /**
      * Checks to make sure that all components in the group support all
@@ -173,10 +171,10 @@ public:
     std::string type;
     Params params;
 
-    ConfigStatOutput(const std::string &type) : type(type) { }
+    ConfigStatOutput(const std::string& type) : type(type) { }
     ConfigStatOutput() { }
 
-    void addParameter(const std::string &key, const std::string &val) {
+    void addParameter(const std::string& key, const std::string& val) {
         params.insert(key, val);
     }
 
@@ -224,13 +222,13 @@ public:
     void setRank(RankInfo r);
     void setWeight(double w);
     void setCoordinates(const std::vector<double> &c);
-    void addParameter(const std::string &key, const std::string &value, bool overwrite);
-    ConfigComponent* addSubComponent(ComponentId_t, const std::string &name, const std::string &type, int slot);
+    void addParameter(const std::string& key, const std::string& value, bool overwrite);
+    ConfigComponent* addSubComponent(ComponentId_t, const std::string& name, const std::string& type, int slot);
     ConfigComponent* findSubComponent(ComponentId_t);
     const ConfigComponent* findSubComponent(ComponentId_t) const;
-    void enableStatistic(const std::string &statisticName, bool recursively = false);
-    void addStatisticParameter(const std::string &statisticName, const std::string &param, const std::string &value, bool recursively = false);
-    void setStatisticParameters(const std::string &statisticName, const Params &params, bool recursively = false);
+    void enableStatistic(const std::string& statisticName, bool recursively = false);
+    void addStatisticParameter(const std::string& statisticName, const std::string& param, const std::string& value, bool recursively = false);
+    void setStatisticParameters(const std::string& statisticName, const Params &params, bool recursively = false);
 
     std::vector<LinkId_t> allLinks() const;
 
@@ -254,7 +252,7 @@ private:
 
     friend class ConfigGraph;
     /** Create a new Component */
-    ConfigComponent(ComponentId_t id, std::string name, std::string type, float weight, RankInfo rank) :
+    ConfigComponent(ComponentId_t id, const std::string& name, const std::string& type, float weight, RankInfo rank) :
         id(id),
         name(name),
         type(type),
@@ -264,7 +262,7 @@ private:
         coords.resize(3, 0.0);
     }
 
-    ConfigComponent(ComponentId_t id, std::string name, int slot_num, std::string type, float weight, RankInfo rank) :
+    ConfigComponent(ComponentId_t id, const std::string& name, int slot_num, const std::string& type, float weight, RankInfo rank) :
         id(id),
         name(name),
         slot_num(slot_num),
@@ -325,16 +323,16 @@ public:
 
     // API for programmatic initialization
     /** Create a new component with weight and rank */
-    ComponentId_t addComponent(ComponentId_t id, std::string name, std::string type, float weight, RankInfo rank);
+    ComponentId_t addComponent(ComponentId_t id, const std::string& name, const std::string& type, float weight, RankInfo rank);
     /** Create a new component */
-    ComponentId_t addComponent(ComponentId_t id, std::string name, std::string type);
+    ComponentId_t addComponent(ComponentId_t id, const std::string& name, const std::string& type);
 
 
     /** Set the statistic output module */
-    void setStatisticOutput(const std::string &name);
+    void setStatisticOutput(const std::string& name);
 
     /** Add parameter to the statistic output module */
-    void addStatisticOutputParameter(const std::string &param, const std::string &value);
+    void addStatisticOutputParameter(const std::string& param, const std::string& value);
 
     /** Set a set of parameter to the statistic output module */
     void setStatisticOutputParams(const Params& p);
@@ -343,22 +341,22 @@ public:
     void setStatisticLoadLevel(uint8_t loadLevel);
 
     /** Enable a Statistics assigned to a component */
-    void enableStatisticForComponentName(std::string ComponentName, std::string statisticName);
-    void enableStatisticForComponentType(std::string ComponentType, std::string statisticName);
+    void enableStatisticForComponentName(const std::string& ComponentName, const std::string& statisticName);
+    void enableStatisticForComponentType(const std::string& ComponentType, const std::string& statisticName);
 
     /** Add Parameters for a Statistic */
-    void addStatisticParameterForComponentName(const std::string &ComponentName, const std::string &statisticName, const std::string &param, const std::string &value);
-    void addStatisticParameterForComponentType(const std::string &ComponentType, const std::string &statisticName, const std::string &param, const std::string &value);
+    void addStatisticParameterForComponentName(const std::string& ComponentName, const std::string& statisticName, const std::string& param, const std::string& value);
+    void addStatisticParameterForComponentType(const std::string& ComponentType, const std::string& statisticName, const std::string& param, const std::string& value);
 
     std::vector<ConfigStatOutput>& getStatOutputs() {return statOutputs;}
     const ConfigStatOutput& getStatOutput(size_t index = 0) const {return statOutputs[index];}
     long getStatLoadLevel() const {return statLoadLevel;}
 
     /** Add a Link to a Component on a given Port */
-    void addLink(ComponentId_t comp_id, std::string link_name, std::string port, std::string latency_str, bool no_cut = false);
+    void addLink(ComponentId_t comp_id, const std::string& link_name, const std::string& port, const std::string& latency_str, bool no_cut = false);
 
     /** Set a Link to be no-cut */
-    void setLinkNoCut(std::string link_name);
+    void setLinkNoCut(const std::string& link_name);
 
     /** Perform any post-creation cleanup processes */
     void postCreationCleanup();
@@ -373,7 +371,7 @@ public:
     }
 
     const std::map<std::string, ConfigStatGroup>& getStatGroups() const { return statGroups; }
-    ConfigStatGroup* getStatGroup(const std::string &name) {
+    ConfigStatGroup* getStatGroup(const std::string& name) {
         auto found = statGroups.find(name);
         if ( found == statGroups.end() ) {
             bool ok;

--- a/src/sst/core/configGraphOutput.h
+++ b/src/sst/core/configGraphOutput.h
@@ -15,7 +15,6 @@
 #include <configGraph.h>
 
 #include <exception>
-#include <cstring>
 #include <cstdio>
 
 namespace SST {

--- a/src/sst/core/cputimer.cc
+++ b/src/sst/core/cputimer.cc
@@ -15,7 +15,7 @@
 
 double sst_get_cpu_time() {
 	struct timeval the_time;
-	gettimeofday(&the_time, 0);
+	gettimeofday(&the_time, nullptr);
 
 	return ((double) the_time.tv_sec) + (((double) the_time.tv_usec) * 1.0e-6);
 }

--- a/src/sst/core/cputimer.cc
+++ b/src/sst/core/cputimer.cc
@@ -10,7 +10,7 @@
 // distribution.
 
 
-#include <sst_config.h>
+#include "sst_config.h"
 #include "cputimer.h"
 
 double sst_get_cpu_time() {

--- a/src/sst/core/decimal_fixedpoint.h
+++ b/src/sst/core/decimal_fixedpoint.h
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <type_traits>
 
-#include <sst/core/from_string.h>
+#include "sst/core/from_string.h"
 
 namespace SST {
 /**
@@ -87,7 +87,8 @@ private:
        the c++ double precision strings.  For example 1.234, -1.234,
        0.234, 1.234e14, 1.234e14, etc.
      */
-    void from_string(std::string init) {
+    void from_string(const std::string& init_str) {
+        std::string init(init_str);
         negative = false;
         for ( int i = 0; i < whole_words + fraction_words; ++i ) {
             data[i] = 0;
@@ -211,7 +212,7 @@ public:
        the c++ double precision strings.  For example 1.234, -1.234,
        0.234, 1.234e14, 1.234e14, etc.
      */
-    decimal_fixedpoint(std::string init) {
+    decimal_fixedpoint(const std::string& init) {
         from_string(init);
     }
 
@@ -310,7 +311,7 @@ public:
     /**
        Equal operator for string.
      */
-    decimal_fixedpoint& operator=(std::string v) {
+    decimal_fixedpoint& operator=(const std::string& v) {
         from_string(v);
         return *this;
     }

--- a/src/sst/core/decimal_fixedpoint.h
+++ b/src/sst/core/decimal_fixedpoint.h
@@ -223,7 +223,7 @@ public:
        @param init Initialization value.
      */
     template <class T>
-    decimal_fixedpoint(T init, typename std::enable_if<std::is_unsigned<T>::value >::type* = 0) {
+    decimal_fixedpoint(T init, typename std::enable_if<std::is_unsigned<T>::value >::type* = nullptr) {
         from_uint64(init);
     }
 
@@ -235,7 +235,7 @@ public:
      */
     template <class T>
     decimal_fixedpoint(T init, typename std::enable_if<std::is_signed<T>::value &&
-                       std::is_integral<T>::value >::type* = 0) {
+                       std::is_integral<T>::value >::type* = nullptr) {
         if ( init < 0 ) {
             from_uint64(-init);
             negative = true;
@@ -251,7 +251,7 @@ public:
        @param init Initialization value.
      */
     template <class T>
-    decimal_fixedpoint(const T init, typename std::enable_if<std::is_floating_point<T>::value >::type* = 0) {
+    decimal_fixedpoint(const T init, typename std::enable_if<std::is_floating_point<T>::value >::type* = nullptr) {
         from_double(init);
     }
 

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -13,12 +13,13 @@
 #include "sst_config.h"
 
 #include "elemLoader.h"
+
 #include "sst/core/eli/elementinfo.h"
 #include "sst/core/component.h"
 #include "sst/core/subcomponent.h"
-#include <sst/core/part/sstpart.h>
-#include <sst/core/sstpart.h>
-#include <sst/core/model/element_python.h>
+#include "sst/core/part/sstpart.h"
+#include "sst/core/sstpart.h"
+#include "sst/core/model/element_python.h"
 
 #include <ltdl.h>
 #include <vector>
@@ -66,7 +67,7 @@ struct LoaderData {
 };
 
 
-ElemLoader::ElemLoader(const std::string &searchPaths) :
+ElemLoader::ElemLoader(const std::string& searchPaths) :
     searchPaths(searchPaths)
 {
     loaderData = new LoaderData;
@@ -124,14 +125,14 @@ ElemLoader::~ElemLoader()
 }
 
 
-static std::vector<std::string> splitPath(const std::string & searchPaths)
+static std::vector<std::string> splitPath(const std::string& searchPaths)
 {
     std::vector<std::string> paths;
     char * pathCopy = new char [searchPaths.length() + 1];
     std::strcpy(pathCopy, searchPaths.c_str());
-    char *brkb = NULL;
-    char *p = NULL;
-    for ( p = strtok_r(pathCopy, ":", &brkb); p ; p = strtok_r(NULL, ":", &brkb) ) {
+    char *brkb = nullptr;
+    char *p = nullptr;
+    for ( p = strtok_r(pathCopy, ":", &brkb); p ; p = strtok_r(nullptr, ":", &brkb) ) {
         paths.push_back(p);
     }
 
@@ -162,7 +163,7 @@ static void followError(const std::string& libname, const std::string& elemlib, 
     // didn't succeed in the stat, we'll get a file not found error
     // from dlopen, which is a useful error message for the user.
     handle = dlopen(fullpath.c_str(), RTLD_NOW|RTLD_GLOBAL);
-    if (NULL == handle) {
+    if (nullptr == handle) {
         std::vector<char> err_str(1e6); //make darn sure we fit the str
         sprintf(err_str.data(),
           "Opening and resolving references for element library %s failed:\n" "\t%s\n",
@@ -172,12 +173,12 @@ static void followError(const std::string& libname, const std::string& elemlib, 
 }
 
 void
-ElemLoader::loadLibrary(const std::string &elemlib, std::ostream& err_os)
+ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
 {
     std::string libname = "lib" + elemlib;
     lt_dlhandle lt_handle;
     lt_handle = lt_dlopenadvise(libname.c_str(), loaderData->advise_handle);
-    if (NULL == lt_handle) {
+    if (nullptr == lt_handle) {
       // The preopen module runs last and if the
         // component was found earlier, but has a missing symbol or
         // the like, we just get an amorphous "file not found" error,

--- a/src/sst/core/elemLoader.h
+++ b/src/sst/core/elemLoader.h
@@ -27,15 +27,15 @@ class ElemLoader {
     std::string searchPaths;
 public:
     /** Create a new ElementLoader with a given searchpath of directories */
-    ElemLoader(const std::string &searchPaths);
+    ElemLoader(const std::string& searchPaths);
     ~ElemLoader();
 
     /** Attempt to load a library
      * @param elemlib - The name of the Element Library to load
      * @param err_os - Where to print errors associated with attempting to find and load the library
-     * @return Informational structure of the library, or NULL if it failed to load.
+     * @return Informational structure of the library, or nullptr if it failed to load.
      */
-    void loadLibrary(const std::string &elemlib, std::ostream& err_os);
+    void loadLibrary(const std::string& elemlib, std::ostream& err_os);
 
     /**
      * Returns a list of potential element libraries in the search path

--- a/src/sst/core/elementinfo.h
+++ b/src/sst/core/elementinfo.h
@@ -14,6 +14,6 @@
 
 #warning "This file has been moved, however, in most situations you will no longer need to include it as it is now included in other SST core header files used for creating elements.  If you still need to include it independently, it has been moved to sst/core/eli/elementinfo.h.  This temporary file will be removed in SST 10."
 
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/eli/elementinfo.h"
 
 #endif

--- a/src/sst/core/eli/categoryInfo.h
+++ b/src/sst/core/eli/categoryInfo.h
@@ -1,3 +1,14 @@
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
 #ifndef SST_CORE_CATEGORY_INFO_H
 #define SST_CORE_CATEGORY_INFO_H
 

--- a/src/sst/core/eli/defaultInfo.h
+++ b/src/sst/core/eli/defaultInfo.h
@@ -1,3 +1,14 @@
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
 #ifndef SST_CORE_DEFAULTINFO_H
 #define SST_CORE_DEFAULTINFO_H
 

--- a/src/sst/core/eli/elementbuilder.h
+++ b/src/sst/core/eli/elementbuilder.h
@@ -1,8 +1,18 @@
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
 #ifndef SST_CORE_FACTORY_INFO_H
 #define SST_CORE_FACTORY_INFO_H
 
-#include <sst/core/eli/elibase.h>
+#include "sst/core/eli/elibase.h"
 #include <type_traits>
 
 namespace SST {
@@ -30,7 +40,7 @@ class BuilderLibrary
   {
   }
 
-  BaseBuilder* getBuilder(const std::string &name) {
+  BaseBuilder* getBuilder(const std::string& name) {
     auto iter = factories_.find(name);
     if (iter == factories_.end()){
       return nullptr;
@@ -116,7 +126,7 @@ struct BuilderLoader : public LibraryLoader {
 };
 
 template <class Base, class... CtorArgs>
-bool BuilderLibrary<Base,CtorArgs...>::addLoader(const std::string &elemlib, const std::string &elem,
+bool BuilderLibrary<Base,CtorArgs...>::addLoader(const std::string& elemlib, const std::string& elem,
                                                  BaseBuilder *fact){
   auto loader = new BuilderLoader<Base,BaseBuilder,CtorArgs...>(elemlib, elem, fact);
   return ELI::LoadedLibraries::addLoader(elemlib, elem, loader);

--- a/src/sst/core/eli/elementinfo.cc
+++ b/src/sst/core/eli/elementinfo.cc
@@ -12,9 +12,6 @@
 
 #include "sst_config.h"
 #include "sst/core/eli/elementinfo.h"
-#include <sst/core/statapi/statbase.h>
-
-#include <sstream>
 
 namespace SST {
 
@@ -52,8 +49,8 @@ ProvidesParams::toString(std::ostream& os) const
     for (const ElementInfoParam& item : getValidParams() ) {
       os << "            PARAMETER " << index
          << " = " << item.name
-         << " (" << (item.description == NULL ? "<empty>" : item.description) << ")"
-         << " [" << (item.defaultValue == NULL ? "<required>" : item.defaultValue) << "]\n";
+         << " (" << (item.description == nullptr ? "<empty>" : item.description) << ")"
+         << " [" << (item.defaultValue == nullptr ? "<required>" : item.defaultValue) << "]\n";
       index++;
     }
 }
@@ -66,7 +63,7 @@ ProvidesPorts::toString(std::ostream& os) const
     for ( auto& item : getValidPorts() ) {
       os << "            PORT " << index
          << " = " << item.name
-         << " (" << (item.description == NULL ? "<empty>" : item.description) << ")\n";
+         << " (" << (item.description == nullptr ? "<empty>" : item.description) << ")\n";
       ++index;
     }
 }
@@ -79,8 +76,8 @@ ProvidesSubComponentSlots::toString(std::ostream& os) const
     for ( auto& item : getSubComponentSlots() ) {
       os << "            SUB COMPONENT SLOT " << index
          << " = " << item.name
-         << " (" << (item.description == NULL ? "<empty>" : item.description) << ")"
-         << " [" << (item.superclass == NULL ? "<none>" : item.superclass) << "]\n";
+         << " (" << (item.description == nullptr ? "<empty>" : item.description) << ")"
+         << " [" << (item.superclass == nullptr ? "<none>" : item.superclass) << "]\n";
       ++index;
     }
 }
@@ -93,8 +90,8 @@ ProvidesStats::toString(std::ostream& os) const
     for ( auto& item : getValidStats() ) {
       os << "            STATISTIC " << index
          << " = " << item.name
-         << " [" << (item.description == NULL ? "<empty>" : item.description) << "]"
-         << " (" << (item.units == NULL ? "<empty>" : item.units) << ")"
+         << " [" << (item.description == nullptr ? "<empty>" : item.description) << "]"
+         << " (" << (item.units == nullptr ? "<empty>" : item.units) << ")"
          << " Enable level = " << (int16_t)item.enableLevel << "\n";
         ++index;
     }

--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -12,24 +12,23 @@
 #ifndef SST_CORE_ELEMENTINFO_H
 #define SST_CORE_ELEMENTINFO_H
 
-#include <sst/core/sst_types.h>
-#include <sst/core/warnmacros.h>
-#include <sst/core/params.h>
-#include <sst/core/statapi/statfieldinfo.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/warnmacros.h"
+#include "sst/core/params.h"
 
-#include <sst/core/eli/paramsInfo.h>
-#include <sst/core/eli/statsInfo.h>
-#include <sst/core/eli/defaultInfo.h>
-#include <sst/core/eli/portsInfo.h>
-#include <sst/core/eli/subcompSlotInfo.h>
-#include <sst/core/eli/interfaceInfo.h>
-#include <sst/core/eli/categoryInfo.h>
-#include <sst/core/eli/elementbuilder.h>
+#include "sst/core/eli/paramsInfo.h"
+#include "sst/core/eli/statsInfo.h"
+#include "sst/core/eli/defaultInfo.h"
+#include "sst/core/eli/portsInfo.h"
+#include "sst/core/eli/subcompSlotInfo.h"
+#include "sst/core/eli/interfaceInfo.h"
+#include "sst/core/eli/categoryInfo.h"
+#include "sst/core/eli/elementbuilder.h"
 
 #include <string>
 #include <vector>
 
-#include <sst/core/eli/elibase.h>
+#include "sst/core/eli/elibase.h"
 
 namespace SST {
 class Component;

--- a/src/sst/core/eli/elibase.cc
+++ b/src/sst/core/eli/elibase.cc
@@ -11,11 +11,8 @@
 
 
 #include "sst_config.h"
-#include "sst/core/eli/elibase.h"
-#include "sst/core/eli/elementinfo.h"
-#include <sst/core/statapi/statbase.h>
 
-#include <sstream>
+#include "sst/core/eli/elibase.h"
 
 namespace SST {
 
@@ -29,7 +26,7 @@ std::unique_ptr<LoadedLibraries::LibraryMap> LoadedLibraries::loaders_{};
 static const std::vector<int> SST_ELI_COMPILED_VERSION = {0, 9, 0};
 
 bool
-LoadedLibraries::addLoader(const std::string &lib, const std::string &name,
+LoadedLibraries::addLoader(const std::string& lib, const std::string& name,
                            LibraryLoader* loader)
 {
   if (!loaders_){

--- a/src/sst/core/eli/elibase.h
+++ b/src/sst/core/eli/elibase.h
@@ -12,7 +12,7 @@
 #ifndef SST_CORE_ELIBASE_H
 #define SST_CORE_ELIBASE_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 #include <functional>
 #include <string>
@@ -46,7 +46,7 @@ struct ElementInfoStatistic {
 struct ElementInfoParam {
     const char *name;			/*!< Name of the parameter */
     const char *description;	/*!< Brief description of the parameter (ie, what it controls) */
-    const char *defaultValue;	/*!< Default value (if any) NULL == required parameter with no default, "" == optional parameter, blank default, "foo" == default value */
+    const char *defaultValue;	/*!< Default value (if any) nullptr == required parameter with no default, "" == optional parameter, blank default, "foo" == default value */
 };
 
 /** Describes Ports that the Component can use
@@ -68,9 +68,9 @@ struct ElementInfoPort2 {
 private:
     std::vector<std::string> createVector(const char** events) {
         std::vector<std::string> vec;
-        if ( events == NULL ) return vec;
+        if ( events == nullptr ) return vec;
         const char** ev = events;
-        while ( NULL != *ev ) {
+        while ( nullptr != *ev ) {
             vec.push_back(*ev);
             ev++;
         }

--- a/src/sst/core/eli/interfaceInfo.h
+++ b/src/sst/core/eli/interfaceInfo.h
@@ -1,3 +1,14 @@
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
 #ifndef SST_CORE_INTERFACE_INFO_H
 #define SST_CORE_INTERFACE_INFO_H
 

--- a/src/sst/core/eli/paramsInfo.h
+++ b/src/sst/core/eli/paramsInfo.h
@@ -1,10 +1,21 @@
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
 #ifndef SST_CORE_PARAMS_INFO_H
 #define SST_CORE_PARAMS_INFO_H
 
 #include <vector>
 #include <string>
-#include <sst/core/params.h>
-#include <sst/core/eli/elibase.h>
+#include "sst/core/params.h"
+#include "sst/core/eli/elibase.h"
 
 namespace SST {
 namespace ELI {

--- a/src/sst/core/eli/portsInfo.h
+++ b/src/sst/core/eli/portsInfo.h
@@ -1,10 +1,21 @@
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
 #ifndef SST_CORE_PORTS_INFO_H
 #define SST_CORE_PORTS_INFO_H
 
 #include <vector>
 #include <string>
 
-#include <sst/core/eli/elibase.h>
+#include "sst/core/eli/elibase.h"
 
 namespace SST {
 namespace ELI {

--- a/src/sst/core/eli/statsInfo.h
+++ b/src/sst/core/eli/statsInfo.h
@@ -1,9 +1,20 @@
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
 #ifndef SST_CORE_STATS_INFO_H
 #define SST_CORE_STATS_INFO_H
 
 #include <vector>
 #include <string>
-#include <sst/core/eli/elibase.h>
+#include "sst/core/eli/elibase.h"
 
 namespace SST {
 namespace ELI {

--- a/src/sst/core/eli/subcompSlotInfo.h
+++ b/src/sst/core/eli/subcompSlotInfo.h
@@ -1,10 +1,21 @@
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
 #ifndef SST_CORE_SUBCOMPSLOTINFO_H
 #define SST_CORE_SUBCOMPSLOTINFO_H
 
 #include <string>
 #include <vector>
 
-#include <sst/core/eli/elibase.h>
+#include "sst/core/eli/elibase.h"
 
 namespace SST {
 namespace ELI {

--- a/src/sst/core/elibase.h
+++ b/src/sst/core/elibase.h
@@ -14,6 +14,6 @@
 
 #warning "This file has been moved, however, in most situations you will no longer need to include it as it is now included in other SST core header files used for creating elements.  If you still need to include it independently, it has been moved to sst/core/eli/elibase.h.  This temporary file will be reomved in SST 10."
 
-#include <sst/core/eli/elibase.h>
+#include "sst/core/eli/elibase.h"
 
 #endif

--- a/src/sst/core/env/envconfig.cc
+++ b/src/sst/core/env/envconfig.cc
@@ -39,12 +39,12 @@ std::set<std::string> SST::Core::Environment::EnvironmentConfigGroup::getKeys() 
 	return retKeys;
 }
 
-std::string SST::Core::Environment::EnvironmentConfigGroup::getValue(std::string key) {
+std::string SST::Core::Environment::EnvironmentConfigGroup::getValue(const std::string& key) {
 	return (params.find(key) == params.end()) ?
 		"" : params[key];
 }
 
-void SST::Core::Environment::EnvironmentConfigGroup::setValue(std::string key, std::string value) {
+void SST::Core::Environment::EnvironmentConfigGroup::setValue(const std::string& key, const std::string& value) {
 	auto paramsItr = params.find(key);
 
 	if(paramsItr != params.end()) {
@@ -91,8 +91,8 @@ SST::Core::Environment::EnvironmentConfiguration::~EnvironmentConfiguration() {
 	}
 }
 
-SST::Core::Environment::EnvironmentConfigGroup* SST::Core::Environment::EnvironmentConfiguration::createGroup(std::string groupName) {
-	EnvironmentConfigGroup* newGroup = NULL;
+SST::Core::Environment::EnvironmentConfigGroup* SST::Core::Environment::EnvironmentConfiguration::createGroup(const std::string& groupName) {
+	EnvironmentConfigGroup* newGroup = nullptr;
 
 	if(groups.find(groupName) == groups.end()) {
 		newGroup = new EnvironmentConfigGroup(groupName);
@@ -104,7 +104,7 @@ SST::Core::Environment::EnvironmentConfigGroup* SST::Core::Environment::Environm
 	return newGroup;
 }
 
-void SST::Core::Environment::EnvironmentConfiguration::removeGroup(std::string groupName) {
+void SST::Core::Environment::EnvironmentConfiguration::removeGroup(const std::string& groupName) {
 	auto theGroup = groups.find(groupName);
 
 	if(theGroup != groups.end()) {
@@ -122,7 +122,7 @@ std::set<std::string> SST::Core::Environment::EnvironmentConfiguration::getGroup
 	return groupNames;
 }
 
-SST::Core::Environment::EnvironmentConfigGroup* SST::Core::Environment::EnvironmentConfiguration::getGroupByName(std::string groupName) {
+SST::Core::Environment::EnvironmentConfigGroup* SST::Core::Environment::EnvironmentConfiguration::getGroupByName(const std::string& groupName) {
 	return createGroup(groupName);
 }
 
@@ -132,10 +132,10 @@ void SST::Core::Environment::EnvironmentConfiguration::print() {
 	}
 }
 
-void SST::Core::Environment::EnvironmentConfiguration::writeTo(std::string filePath) {
+void SST::Core::Environment::EnvironmentConfiguration::writeTo(const std::string& filePath) {
 	FILE* output = fopen(filePath.c_str(), "w+");
 
-	if(NULL == output) {
+	if(nullptr == output) {
 		fprintf(stderr, "Unable to open file: %s\n", filePath.c_str());
 		exit(-1);
 	}

--- a/src/sst/core/env/envconfig.h
+++ b/src/sst/core/env/envconfig.h
@@ -61,11 +61,11 @@ SST releases.
 class EnvironmentConfigGroup {
 
 public:
-	EnvironmentConfigGroup(std::string name) : groupName(name) {}
+	EnvironmentConfigGroup(const std::string& name) : groupName(name) {}
 	std::string getName() const;
 	std::set<std::string> getKeys() const;
-	std::string getValue(std::string key);
-	void setValue(std::string key, std::string value);
+	std::string getValue(const std::string& key);
+	void setValue(const std::string& key, const std::string& value);
 	void print();
 	void writeTo(FILE* outFile);
 
@@ -110,12 +110,12 @@ public:
 	EnvironmentConfiguration();
 	~EnvironmentConfiguration();
 
-	EnvironmentConfigGroup* createGroup(std::string groupName);
-	void removeGroup(std::string groupName);
+	EnvironmentConfigGroup* createGroup(const std::string& groupName);
+	void removeGroup(const std::string& groupName);
 	std::set<std::string> getGroupNames();
-	EnvironmentConfigGroup* getGroupByName(std::string groupName);
+	EnvironmentConfigGroup* getGroupByName(const std::string& groupName);
 	void print();
-	void writeTo(std::string filePath);
+	void writeTo(const std::string& filePath);
 	void writeTo(FILE* outFile);
 
 private:

--- a/src/sst/core/env/envquery.cc
+++ b/src/sst/core/env/envquery.cc
@@ -9,7 +9,8 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
+#include "envquery.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -18,8 +19,7 @@
 #include <string>
 #include <sys/file.h>
 
-#include <sst/core/warnmacros.h>
-#include "envquery.h"
+#include "sst/core/warnmacros.h"
 #include "envconfig.h"
 
 void SST::Core::Environment::configReadLine(FILE* theFile, char* lineBuffer) {
@@ -112,7 +112,7 @@ void SST::Core::Environment::populateEnvironmentConfig(const std::string& path, 
 	const char* configFilePath = path.c_str();
 	FILE* configFile = fopen(configFilePath, "r");
 
-	if(NULL == configFile) {
+	if(nullptr == configFile) {
 		if(errorOnNotOpen) {
 			std::cerr << "SST: Unable to open configuration file \'" <<
 				path << "\'" << std::endl;
@@ -144,7 +144,7 @@ SST::Core::Environment::EnvironmentConfiguration*
 	char* homeConfigPath = (char*) malloc( sizeof(char) * PATH_MAX );
 	char* userHome = getenv("HOME");
 
-	if(NULL == userHome) {
+	if(nullptr == userHome) {
 		sprintf(homeConfigPath, "~/.sst/sstsimulator.conf");
 	} else {
 		sprintf(homeConfigPath, "%s/.sst/sstsimulator.conf", userHome);
@@ -161,19 +161,19 @@ SST::Core::Environment::EnvironmentConfiguration*
 
 	// If this isn't specified by the environment, we will default to UNIX ":" to be
 	// safe.
-	if( NULL == envConfigPathSep ) {
+	if( nullptr == envConfigPathSep ) {
 		envConfigPathSep = ":";
 	}
 
-	if( NULL != envConfigPaths ) {
+	if( nullptr != envConfigPaths ) {
 		char* envConfigPathBuffer = (char*) malloc( sizeof(char) * (strlen(envConfigPaths) + 1) );
 		strcpy(envConfigPathBuffer, envConfigPaths);
 
 		char* nextToken = strtok(envConfigPathBuffer, envConfigPathSep);
 
-		while( NULL != nextToken ) {
+		while( nullptr != nextToken ) {
 			populateEnvironmentConfig(nextToken, envConfig, true);
-			nextToken = strtok(NULL, envConfigPathSep);
+			nextToken = strtok(nullptr, envConfigPathSep);
 		}
 
 		free(envConfigPathBuffer);

--- a/src/sst/core/env/envquery.h
+++ b/src/sst/core/env/envquery.h
@@ -12,9 +12,9 @@
 #ifndef _H_SST_CORE_ENV_QUERY_H
 #define _H_SST_CORE_ENV_QUERY_H
 
-#include <sst_config.h>
+#include "sst_config.h"
 
-#include <sst/core/env/envconfig.h>
+#include "sst/core/env/envconfig.h"
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/sst/core/event.cc
+++ b/src/sst/core/event.cc
@@ -34,7 +34,7 @@ Event* Event::clone() {
     Simulation::getSimulation()->getSimulationOutput().
         fatal(CALL_INFO,1,"Called clone() on an Event that doesn't"
               " implement it.");            
-    return NULL;  // Never reached, but gets rid of compiler warning
+    return nullptr;  // Never reached, but gets rid of compiler warning
 }
 
 Event::id_type Event::generateUniqueId()
@@ -45,7 +45,7 @@ Event::id_type Event::generateUniqueId()
 
 void NullEvent::execute(void)
 {
-    delivery_link->deliverEvent(NULL);
+    delivery_link->deliverEvent(nullptr);
     delete this;
 }
 

--- a/src/sst/core/event.h
+++ b/src/sst/core/event.h
@@ -12,13 +12,13 @@
 #ifndef SST_CORE_CORE_EVENT_H
 #define SST_CORE_CORE_EVENT_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 #include <atomic>
 #include <string>
 #include <cinttypes>
 
-#include <sst/core/activity.h>
+#include "sst/core/activity.h"
 
 namespace SST {
 
@@ -69,7 +69,7 @@ public:
 
     /** For use by SST Core only */
     inline void setRemoteEvent() {
-        delivery_link = NULL;
+        delivery_link = nullptr;
     }
 
     /** Gets the link id associated with this event.  For use by SST Core only */

--- a/src/sst/core/exit.cc
+++ b/src/sst/core/exit.cc
@@ -13,7 +13,7 @@
 #include "sst_config.h"
 #include "sst/core/exit.h"
 
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 #ifdef SST_CONFIG_HAVE_MPI
 DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>

--- a/src/sst/core/exit.h
+++ b/src/sst/core/exit.h
@@ -12,12 +12,12 @@
 #ifndef SST_CORE_CORE_EXIT_H
 #define SST_CORE_CORE_EXIT_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 #include <unordered_set>
 #include <cinttypes>
 
-#include <sst/core/action.h>
+#include "sst/core/action.h"
 
 namespace SST{
 

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -11,7 +11,7 @@
 
 
 #include "sst_config.h"
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 #include "sst/core/factory.h"
 
 #include <set>
@@ -19,38 +19,38 @@
 #include <stdio.h>
 #include <fstream>
 
-#include <sst/core/elemLoader.h>
+#include "sst/core/elemLoader.h"
 #include "sst/core/simulation.h"
 #include "sst/core/component.h"
 #include "sst/core/subcomponent.h"
 #include "sst/core/part/sstpart.h"
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/eli/elementinfo.h"
 #include "sst/core/params.h"
 #include "sst/core/linkMap.h"
-#include <sst/core/model/element_python.h>
+#include "sst/core/model/element_python.h"
 
 // Statistic Output Objects
-#include <sst/core/statapi/statoutputconsole.h>
-#include <sst/core/statapi/statoutputtxt.h>
-#include <sst/core/statapi/statoutputcsv.h>
-#include <sst/core/statapi/statoutputjson.h>
+#include "sst/core/statapi/statoutputconsole.h"
+#include "sst/core/statapi/statoutputtxt.h"
+#include "sst/core/statapi/statoutputcsv.h"
+#include "sst/core/statapi/statoutputjson.h"
 #ifdef HAVE_HDF5
-#include <sst/core/statapi/statoutputhdf5.h>
+#include "sst/core/statapi/statoutputhdf5.h"
 #endif
-#include <sst/core/statapi/statbase.h>
-#include <sst/core/statapi/stataccumulator.h>
-#include <sst/core/statapi/stathistogram.h>
-#include <sst/core/statapi/statnull.h>
-#include <sst/core/statapi/statuniquecount.h>
+#include "sst/core/statapi/statbase.h"
+#include "sst/core/statapi/stataccumulator.h"
+#include "sst/core/statapi/stathistogram.h"
+#include "sst/core/statapi/statnull.h"
+#include "sst/core/statapi/statuniquecount.h"
 
 using namespace SST::Statistics;
 
 namespace SST {
 
-Factory* Factory::instance = NULL;
+Factory* Factory::instance = nullptr;
 
 
-Factory::Factory(std::string searchPaths) :
+Factory::Factory(const std::string& searchPaths) :
     searchPaths(searchPaths),
     out(Output::getDefaultObject())
 {
@@ -68,7 +68,7 @@ Factory::~Factory()
 
 
 
-static bool checkPort(const std::string &def, const std::string &offered)
+static bool checkPort(const std::string& def, const std::string& offered)
 {
     const char * x = def.c_str();
     const char * y = offered.c_str();
@@ -95,11 +95,11 @@ static bool checkPort(const std::string &def, const std::string &offered)
         x++;
         y++;
     } while ( *x && *y );
-    if ( *x != *y ) return false; // aka, both NULL
+    if ( *x != *y ) return false; // aka, both nullptr
     return true;
 }
 
-bool Factory::isPortNameValid(const std::string &type, const std::string port_name)
+bool Factory::isPortNameValid(const std::string& type, const std::string& port_name)
 {
     std::string elemlib, elem;
     std::tie(elemlib, elem) = parseLoadName(type);
@@ -108,7 +108,7 @@ bool Factory::isPortNameValid(const std::string &type, const std::string port_na
         findLibrary(elemlib);
     }
 
-    const std::vector<std::string> *portNames = NULL;
+    const std::vector<std::string> *portNames = nullptr;
 
     // Check to see if library is loaded into new
     // ElementLibraryDatabase
@@ -138,7 +138,7 @@ bool Factory::isPortNameValid(const std::string &type, const std::string port_na
     
     std::string tmp = elemlib + "." + elem;
 
-    if (portNames == NULL) {
+    if (portNames == nullptr) {
       err << "Valid Components: ";
       for (auto& pair : lib->getMap()){
         err << pair.first << "\n";
@@ -156,7 +156,7 @@ bool Factory::isPortNameValid(const std::string &type, const std::string port_na
 }
 
 const Params::KeySet_t&
-Factory::getParamNames(const std::string &type)
+Factory::getParamNames(const std::string& type)
 {
     // This is only needed so we can return something in the error
     // case.  It is never used.
@@ -200,7 +200,7 @@ Factory::getParamNames(const std::string &type)
 
 Component*
 Factory::CreateComponent(ComponentId_t id, 
-                         std::string &type, 
+                         const std::string& type, 
                          Params& params)
 {
     std::string elemlib, elem;
@@ -236,7 +236,7 @@ Factory::CreateComponent(ComponentId_t id,
     // If we make it to here, component not found
     out.fatal(CALL_INFO, 1, "can't find requested component '%s'\n%s\n",
               type.c_str(), sstr.str().c_str());
-    return NULL;
+    return nullptr;
 }
 
 
@@ -424,7 +424,7 @@ Factory::GetComponentInfoStatisticUnits(const std::string& type, const std::stri
 
 
 Module*
-Factory::CreateModule(std::string type, Params& params)
+Factory::CreateModule(const std::string& type, Params& params)
 {
     if("" == type) {
         Simulation::getSimulation()->getSimulationOutput().fatal(CALL_INFO,
@@ -460,11 +460,11 @@ Factory::CreateModule(std::string type, Params& params)
     // If we get to here, element doesn't exist
     out.fatal(CALL_INFO, 1, "can't find requested module '%s'\n%s\n",
               type.c_str(), error_os.str().c_str());
-    return NULL;
+    return nullptr;
 }
 
 Module*
-Factory::CreateModuleWithComponent(std::string type, Component* comp, Params& params)
+Factory::CreateModuleWithComponent(const std::string& type, Component* comp, Params& params)
 {
     std::string elemlib, elem;
     std::tie(elemlib, elem) = parseLoadName(type);
@@ -497,11 +497,11 @@ Factory::CreateModuleWithComponent(std::string type, Component* comp, Params& pa
     // If we get to here, element doesn't exist
     out.fatal(CALL_INFO, 1, "can't find requested module '%s'\n%s\n",
               type.c_str(), error_os.str().c_str());
-    return NULL;
+    return nullptr;
 }
 
 SubComponent*
-Factory::CreateSubComponent(std::string type, Component* comp, Params& params)
+Factory::CreateSubComponent(const std::string& type, Component* comp, Params& params)
 {
     std::string elemlib, elem;
     std::tie(elemlib, elem) = parseLoadName(type);
@@ -533,12 +533,12 @@ Factory::CreateSubComponent(std::string type, Component* comp, Params& params)
     // If we get to here, element doesn't exist
     out.fatal(CALL_INFO, 1, "can't find requested subcomponent '%s'\n%s\n",
               type.c_str(), error_os.str().c_str());
-    return NULL;
+    return nullptr;
 }
 
 
 bool
-Factory::doesSubComponentExist(std::string type)
+Factory::doesSubComponentExist(const std::string& type)
 {
     std::string elemlib, elem;
     std::tie(elemlib, elem) = parseLoadName(type);
@@ -560,7 +560,7 @@ Factory::doesSubComponentExist(std::string type)
 }
 
 void
-Factory::RequireEvent(std::string eventname)
+Factory::RequireEvent(const std::string& eventname)
 {
     std::string elemlib, elem;
     std::tie(elemlib, elem) = parseLoadName(eventname);
@@ -571,7 +571,7 @@ Factory::RequireEvent(std::string eventname)
 }
 
 Partition::SSTPartitioner*
-Factory::CreatePartitioner(std::string name, RankInfo total_ranks, RankInfo my_rank, int verbosity)
+Factory::CreatePartitioner(const std::string& name, RankInfo total_ranks, RankInfo my_rank, int verbosity)
 {
     std::string elemlib, elem;
     std::tie(elemlib, elem) = parseLoadName(name);
@@ -600,7 +600,7 @@ Factory::CreatePartitioner(std::string name, RankInfo total_ranks, RankInfo my_r
     out.fatal(CALL_INFO, 1,
               "Error: Unable to find requested partitioner '%s', check --help for information on partitioners.\n%s\n",
               name.c_str(), error_os.str().c_str());
-    return NULL;
+    return nullptr;
 }
 
 
@@ -628,7 +628,7 @@ Factory::getPythonModule(const std::string& name)
       }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 
@@ -707,7 +707,7 @@ Factory::parseLoadName(const std::string& wholename)
 }
 
 void
-Factory::notFound(const std::string &baseName, const std::string &type,
+Factory::notFound(const std::string& baseName, const std::string& type,
                   const std::string& error_msg)
 {
     out.fatal(CALL_INFO, 1, "can't find requested element library '%s' with element type '%s'\n%s\n",

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -413,13 +413,13 @@ Factory::GetComponentInfoStatisticUnits(const std::string& type, const std::stri
             }
         }
       }
-      return 0;
+      return nullptr;
     }
 
     // If we get to here, element doesn't exist
     out.fatal(CALL_INFO, 1, "can't find requested component '%s'\n%s\n",
               type.c_str(), error_os.str().c_str());
-    return 0;
+    return nullptr;
 }
 
 

--- a/src/sst/core/factory.h
+++ b/src/sst/core/factory.h
@@ -12,13 +12,13 @@
 #ifndef _SST_CORE_FACTORY_H
 #define _SST_CORE_FACTORY_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 #include <stdio.h>
 #include <mutex>
 
-#include <sst/core/params.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/params.h"
+#include "sst/core/eli/elementinfo.h"
 
 /* Forward declare for Friendship */
 extern int main(int argc, char **argv);
@@ -49,13 +49,13 @@ public:
      * @param type - Name of component in lib.name format
      * @return True if this is a valid portname
      */
-    bool isPortNameValid(const std::string &type, const std::string port_name);
+    bool isPortNameValid(const std::string& type, const std::string& port_name);
 
     /** Get a list of allowed param keys for a given component type.
      * @param type - Name of component in lib.name format
      * @return True if this is a valid portname
      */
-    const Params::KeySet_t& getParamNames(const std::string &type);
+    const Params::KeySet_t& getParamNames(const std::string& type);
 
 
     /** Attempt to create a new Component instantiation
@@ -64,41 +64,41 @@ public:
      * @param params - The params to pass to the component's constructor
      * @return Newly created component
      */
-    Component* CreateComponent(ComponentId_t id, std::string &componentname,
+    Component* CreateComponent(ComponentId_t id, const std::string& componentname,
                                Params& params);
 
     /** Ensure that an element library containing the required event is loaded
      * @param eventname - The fully qualified elementlibname.eventname type
      */
-    void RequireEvent(std::string eventname);
+    void RequireEvent(const std::string& eventname);
 
     /** Instantiate a new Module
      * @param type - Fully qualified elementlibname.modulename type
      * @param params - Parameters to pass to the Module's constructor
      */
-    Module* CreateModule(std::string type, Params& params);
+    Module* CreateModule(const std::string& type, Params& params);
 
     /** Instantiate a new Module
      * @param type - Fully qualified elementlibname.modulename type
      * @param comp - Component instance to pass to the Module's constructor
      * @param params - Parameters to pass to the Module's constructor
      */
-    Module* CreateModuleWithComponent(std::string type, Component* comp, Params& params);
+    Module* CreateModuleWithComponent(const std::string& type, Component* comp, Params& params);
 
     /** Instantiate a new Module
      * @param type - Fully qualified elementlibname.modulename type
      * @param comp - Component instance to pass to the SubComponent's constructor
      * @param params - Parameters to pass to the SubComponent's constructor
      */
-    SubComponent* CreateSubComponent(std::string type, Component* comp, Params& params);
+    SubComponent* CreateSubComponent(const std::string& type, Component* comp, Params& params);
 
 
-    bool doesSubComponentExist(std::string type);
+    bool doesSubComponentExist(const std::string& type);
     
     /** Return partitioner function
      * @param name - Fully qualified elementlibname.partitioner type name
      */
-    Partition::SSTPartitioner* CreatePartitioner(std::string name, RankInfo total_ranks, RankInfo my_rank, int verbosity);
+    Partition::SSTPartitioner* CreatePartitioner(const std::string& name, RankInfo total_ranks, RankInfo my_rank, int verbosity);
 
 
     /**
@@ -176,7 +176,7 @@ public:
      * @param fieldType - Type of data stored in statistic
      */
     template <class T, class... Args>
-    Statistics::Statistic<T>* CreateStatistic(std::string type,
+    Statistics::Statistic<T>* CreateStatistic(const std::string& type,
                                    BaseComponent* comp, const std::string& statName,
                                    const std::string& stat, Params& params,
                                    Args... args){
@@ -196,7 +196,7 @@ public:
       // If we make it to here, component not found
       out.fatal(CALL_INFO, -1,"can't find requested statistic %s.\n%s\n",
                 type.c_str(), sstr.str().c_str());
-      return NULL;
+      return nullptr;
     }
 
 
@@ -212,12 +212,12 @@ public:
      * @return whether the library was found
      */
     bool hasLibrary(const std::string& elemlib, std::ostream& err_os);
-    void requireLibrary(const std::string &elemlib, std::ostream& err_os);
+    void requireLibrary(const std::string& elemlib, std::ostream& err_os);
     /**
      * @brief requireLibrary Throws away error messages
      * @param elemlib
      */
-    void requireLibrary(const std::string &elemlib);
+    void requireLibrary(const std::string& elemlib);
 
     void getLoadedLibraryNames(std::set<std::string>& lib_names);
     void loadUnloadedLibraries(const std::set<std::string>& lib_names);
@@ -264,7 +264,7 @@ private:
                   const std::string& errorMsg);
 
 
-    Factory(std::string searchPaths);
+    Factory(const std::string& searchPaths);
     ~Factory();
 
     Factory();                      // Don't Implement

--- a/src/sst/core/from_string.h
+++ b/src/sst/core/from_string.h
@@ -25,16 +25,16 @@ typename std::enable_if<std::is_integral<T>::value, T >::type
 {
     if ( std::is_signed<T>::value ) {
         if ( std::is_same<int,T>::value ) {
-            return std::stoi(input,0,0);
+            return std::stoi(input,nullptr,0);
         }
         else if ( std::is_same<long,T>::value ) {
-            return std::stol(input,0,0);
+            return std::stol(input,nullptr,0);
         }
         else if ( std::is_same<long long, T>::value ) {
-            return std::stoll(input,0,0);
+            return std::stoll(input,nullptr,0);
         }
         else {  // Smaller than 32-bit
-            return static_cast<T>(std::stol(input,0,0));
+            return static_cast<T>(std::stol(input,nullptr,0));
         }
     }
     else {
@@ -52,13 +52,13 @@ typename std::enable_if<std::is_integral<T>::value, T >::type
             }
         }
         else if ( std::is_same<unsigned long, T>::value ) {
-            return std::stoul(input,0,0);
+            return std::stoul(input,nullptr,0);
         }
         else if ( std::is_same<unsigned long long, T>::value ) {
-            return std::stoull(input,0,0);
+            return std::stoull(input,nullptr,0);
         }
         else {  // Smaller than 32-bit
-            return static_cast<T>(std::stoul(input,0,0));
+            return static_cast<T>(std::stoul(input,nullptr,0));
         }
     }
 }

--- a/src/sst/core/heartbeat.cc
+++ b/src/sst/core/heartbeat.cc
@@ -17,7 +17,7 @@
 #include "sst/core/simulation.h"
 #include "sst/core/timeConverter.h"
 
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 #ifdef SST_CONFIG_HAVE_MPI
 DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>

--- a/src/sst/core/heartbeat.h
+++ b/src/sst/core/heartbeat.h
@@ -12,13 +12,13 @@
 #ifndef SST_CORE_CORE_HEARTBEAT_H
 #define SST_CORE_CORE_HEARTBEAT_H
 
-#include <sst/core/sst_types.h>
-#include <sst/core/output.h>
-#include <sst/core/config.h>
-#include <sst/core/cputimer.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/output.h"
+#include "sst/core/config.h"
+#include "sst/core/cputimer.h"
 
 #include <set>
-#include <sst/core/action.h>
+#include "sst/core/action.h"
 
 namespace SST {
 

--- a/src/sst/core/impl/partitioners/linpart.cc
+++ b/src/sst/core/impl/partitioners/linpart.cc
@@ -9,13 +9,13 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
-#include <sst/core/impl/partitioners/linpart.h>
+#include "sst_config.h"
+#include "sst/core/impl/partitioners/linpart.h"
 
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 
-#include <sst/core/output.h>
-#include <sst/core/configGraph.h>
+#include "sst/core/output.h"
+#include "sst/core/configGraph.h"
 
 using namespace std;
 using namespace SST::IMPL::Partition;

--- a/src/sst/core/impl/partitioners/linpart.h
+++ b/src/sst/core/impl/partitioners/linpart.h
@@ -13,8 +13,8 @@
 #ifndef SST_CORE_IMPL_PARTITONERS_LINPART_H
 #define SST_CORE_IMPL_PARTITONERS_LINPART_H
 
-#include <sst/core/sstpart.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/sstpart.h"
+#include "sst/core/eli/elementinfo.h"
 
 namespace SST {
 

--- a/src/sst/core/impl/partitioners/rrobin.cc
+++ b/src/sst/core/impl/partitioners/rrobin.cc
@@ -9,12 +9,10 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
 #include "sst/core/impl/partitioners/rrobin.h"
 
-#include <sst/core/warnmacros.h>
-
-#include <string>
+#include "sst/core/warnmacros.h"
 
 #include "sst/core/configGraph.h"
 

--- a/src/sst/core/impl/partitioners/rrobin.h
+++ b/src/sst/core/impl/partitioners/rrobin.h
@@ -11,8 +11,8 @@
 #ifndef SST_CORE_IMPL_PARTITONERS_RROBIN_H
 #define SST_CORE_IMPL_PARTITONERS_RROBIN_H
 
-#include <sst/core/sstpart.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/sstpart.h"
+#include "sst/core/eli/elementinfo.h"
 
 namespace SST {
 namespace IMPL {

--- a/src/sst/core/impl/partitioners/selfpart.cc
+++ b/src/sst/core/impl/partitioners/selfpart.cc
@@ -9,5 +9,5 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
-#include <sst/core/impl/partitioners/selfpart.h>
+#include "sst_config.h"
+#include "sst/core/impl/partitioners/selfpart.h"

--- a/src/sst/core/impl/partitioners/selfpart.h
+++ b/src/sst/core/impl/partitioners/selfpart.h
@@ -13,9 +13,9 @@
 #ifndef SST_CORE_IMPL_PARTITONERS_SELF_H
 #define SST_CORE_IMPL_PARTITONERS_SELF_H
 
-#include <sst/core/sstpart.h>
+#include "sst/core/sstpart.h"
 
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/eli/elementinfo.h"
 
 namespace SST {
 namespace IMPL {

--- a/src/sst/core/impl/partitioners/simplepart.cc
+++ b/src/sst/core/impl/partitioners/simplepart.cc
@@ -9,12 +9,11 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
 #include "sst/core/impl/partitioners/simplepart.h"
 
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 
-#include <string>
 #include <vector>
 #include <map>
 #include <stdlib.h>
@@ -228,7 +227,6 @@ SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo UNUSED(my_ra
 					setB[indexB++] = theComponent;
 				}
 
-				// vector<string> component_links = (*compItr).links;
 				LinkIdMap_t component_links = (*compItr).links;
 
                 PartitionLinkMap_t& linkMap = graph->getLinkMap();

--- a/src/sst/core/impl/partitioners/simplepart.h
+++ b/src/sst/core/impl/partitioners/simplepart.h
@@ -13,11 +13,11 @@
 
 #include <map>
 
-#include <sst/core/sst_types.h>
-#include <sst/core/sstpart.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/sstpart.h"
 
-#include <sst/core/eli/elementinfo.h>
-#include <sst/core/configGraph.h>
+#include "sst/core/eli/elementinfo.h"
+#include "sst/core/configGraph.h"
 
 namespace SST {
 namespace IMPL {

--- a/src/sst/core/impl/partitioners/singlepart.cc
+++ b/src/sst/core/impl/partitioners/singlepart.cc
@@ -9,13 +9,13 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
 
-#include <sst/core/impl/partitioners/singlepart.h>
+#include "sst/core/impl/partitioners/singlepart.h"
 
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 
-#include <sst/core/configGraph.h>
+#include "sst/core/configGraph.h"
 
 using namespace std;
 

--- a/src/sst/core/impl/partitioners/singlepart.h
+++ b/src/sst/core/impl/partitioners/singlepart.h
@@ -13,8 +13,8 @@
 #ifndef SST_CORE_IMPL_PARTITONERS_SINGLEPART_H
 #define SST_CORE_IMPL_PARTITONERS_SINGLEPART_H
 
-#include <sst/core/sstpart.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/sstpart.h"
+#include "sst/core/eli/elementinfo.h"
 
 namespace SST {
 namespace IMPL {

--- a/src/sst/core/impl/partitioners/zoltpart.cc
+++ b/src/sst/core/impl/partitioners/zoltpart.cc
@@ -9,11 +9,11 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
-#include <sst/core/impl/partitioners/zoltpart.h>
+#include "sst_config.h"
+#include "sst/core/impl/partitioners/zoltpart.h"
 
-#include <sst/core/warnmacros.h>
-#include <sst/core/configGraph.h>
+#include "sst/core/warnmacros.h"
+#include "sst/core/configGraph.h"
 
 #ifdef HAVE_ZOLTAN
 
@@ -228,7 +228,7 @@ void SSTZoltanPartition::performPartition(PartitionGraph* graph) {
 
 
 	if(0 == rank.rank) {
-		assert(NULL != graph);
+		assert(nullptr != graph);
 	}
 	assert(rankcount.rank > 0);
 	

--- a/src/sst/core/impl/partitioners/zoltpart.h
+++ b/src/sst/core/impl/partitioners/zoltpart.h
@@ -16,9 +16,9 @@
 
 #ifdef HAVE_ZOLTAN
 
-#include <sst/core/sstpart.h>
-#include <sst/core/output.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/sstpart.h"
+#include "sst/core/output.h"
+#include "sst/core/eli/elementinfo.h"
 
 // SST and ZOLTANÕs configurations are conflicting on the SST_CONFIG_HAVE_MPI definition.  
 // So temporarily shut down SSTÕs SST_CONFIG_HAVE_MPI, then allow ZOLTANÕs SST_CONFIG_HAVE_MPI to 

--- a/src/sst/core/impl/timevortex/timeVortexPQ.cc
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.cc
@@ -12,12 +12,12 @@
 
 #include "sst_config.h"
 
-#include <sst/core/impl/timevortex/timeVortexPQ.h>
+#include "sst/core/impl/timevortex/timeVortexPQ.h"
 
-#include <sst/core/output.h>
+#include "sst/core/output.h"
 
-#include <sst/core/clock.h>
-#include <sst/core/simulation.h>
+#include "sst/core/clock.h"
+#include "sst/core/simulation.h"
 
 namespace SST {
 namespace IMPL {
@@ -61,7 +61,7 @@ void TimeVortexPQ::insert(Activity* activity)
 
 Activity* TimeVortexPQ::pop()
 {
-    if ( data.empty() ) return NULL;
+    if ( data.empty() ) return nullptr;
     Activity* ret_val = data.top();
     data.pop();
     current_depth--;

--- a/src/sst/core/impl/timevortex/timeVortexPQ.h
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.h
@@ -16,8 +16,8 @@
 #include <queue>
 #include <vector>
 
-#include <sst/core/timeVortex.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/timeVortex.h"
+#include "sst/core/eli/elementinfo.h"
 
 namespace SST {
 

--- a/src/sst/core/initQueue.cc
+++ b/src/sst/core/initQueue.cc
@@ -12,7 +12,7 @@
 
 #include "sst_config.h"
 
-#include <sst/core/initQueue.h>
+#include "sst/core/initQueue.h"
 
 namespace SST {
 
@@ -43,7 +43,7 @@ namespace SST {
     
     Activity* InitQueue::pop()
     {
-	if ( data.size() == 0 ) return NULL;
+	if ( data.size() == 0 ) return nullptr;
 	Activity* ret_val = data.front();
 	data.pop_front();
 	return ret_val;
@@ -51,7 +51,7 @@ namespace SST {
 
     Activity* InitQueue::front()
     {
-	if ( data.size() == 0 ) return NULL;
+	if ( data.size() == 0 ) return nullptr;
 	return data.front();
     }
 

--- a/src/sst/core/initQueue.h
+++ b/src/sst/core/initQueue.h
@@ -14,7 +14,7 @@
 
 #include <deque>
 
-#include <sst/core/activityQueue.h>
+#include "sst/core/activityQueue.h"
 
 namespace SST {
 

--- a/src/sst/core/interfaces/TestEvent.h
+++ b/src/sst/core/interfaces/TestEvent.h
@@ -10,10 +10,10 @@
 // distribution.
 
 
-#ifndef INTERFACES_TEST_EVENT_H
-#define INTERFACES_TEST_EVENT_H
+#ifndef SST_CORE_INTERFACES_TEST_EVENT_H
+#define SST_CORE_INTERFACES_TEST_EVENT_H
 
-#include <sst/core/event.h>
+#include "sst/core/event.h"
 
 namespace SST{
 namespace Interfaces {

--- a/src/sst/core/interfaces/simpleMem.cc
+++ b/src/sst/core/interfaces/simpleMem.cc
@@ -10,7 +10,7 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 //
-#include <sst_config.h>
+#include "sst_config.h"
 #include "sst/core/interfaces/simpleMem.h"
 
 std::atomic<uint64_t> SST::Interfaces::SimpleMem::Request::main_id(0);

--- a/src/sst/core/interfaces/simpleMem.h
+++ b/src/sst/core/interfaces/simpleMem.h
@@ -11,19 +11,19 @@
 // distribution.
 //
 
-#ifndef CORE_INTERFACES_SIMPLEMEM_H_
-#define CORE_INTERFACES_SIMPLEMEM_H_
+#ifndef SST_CORE_INTERFACES_SIMPLEMEM_H_
+#define SST_CORE_INTERFACES_SIMPLEMEM_H_
 
 #include <string>
 #include <utility>
 #include <map>
 #include <atomic>
 
-#include <sst/core/sst_types.h>
-#include <sst/core/warnmacros.h>
-#include <sst/core/subcomponent.h>
-#include <sst/core/params.h>
-#include <sst/core/link.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/warnmacros.h"
+#include "sst/core/subcomponent.h"
+#include "sst/core/params.h"
+#include "sst/core/link.h"
 
 namespace SST {
 
@@ -324,7 +324,7 @@ public:
      * Initialize with link name name, and handler, if any
      * @return true if the link was able to be configured.
      */
-    virtual bool initialize(const std::string &linkName, HandlerBase *handler = NULL) = 0;
+    virtual bool initialize(const std::string& linkName, HandlerBase *handler = nullptr) = 0;
 
     /**
      * Sends a memory-based request during the init() phase
@@ -360,7 +360,7 @@ public:
      * Use this method for polling-based applications.
      * Register a handler for push-based notification of responses.
      *
-     * @return NULL if nothing is available.
+     * @return nullptr if nothing is available.
      * @return Pointer to a Request response (that should be deleted)
      */
     virtual Request* recvResponse(void) = 0;

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -11,18 +11,18 @@
 // distribution.
 //
 
-#ifndef CORE_INTERFACES_SIMPLENETWORK_H_
-#define CORE_INTERFACES_SIMPLENETWORK_H_
+#ifndef SST_CORE_INTERFACES_SIMPLENETWORK_H_
+#define SST_CORE_INTERFACES_SIMPLENETWORK_H_
 
 #include <string>
 #include <unordered_map>
 
-#include <sst/core/sst_types.h>
-#include <sst/core/warnmacros.h>
-#include <sst/core/subcomponent.h>
-#include <sst/core/params.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/warnmacros.h"
+#include "sst/core/subcomponent.h"
+#include "sst/core/params.h"
 
-#include <sst/core/serialization/serializable.h>
+#include "sst/core/serialization/serializable.h"
 
 namespace SST {
 
@@ -76,19 +76,19 @@ public:
         
         /**
            Returns the payload for the request.  This will also set
-           the payload to NULL, so the call will only return valid
+           the payload to nullptr, so the call will only return valid
            data one time after each givePayload call.
            @return Event that was set as payload of the request.
         */
         inline Event* takePayload() {
             Event* ret = payload;
-            payload = NULL;
+            payload = nullptr;
             return ret;
         }
 
         /**
            Returns the payload for the request for inspection.  This
-           call does not set the payload to NULL, so deleting the
+           call does not set the payload to nullptr, so deleting the
            request will also delete the payload.  If the request is
            going to be deleted, use takePayload instead.
            @return Event that was set as payload of the request.
@@ -110,11 +110,11 @@ public:
         /** Constructor */
         Request() :
             dest(0), src(0), size_in_bits(0), head(false), tail(false), allow_adaptive(true),
-            payload(NULL), trace(NONE), traceID(0)
+            payload(nullptr), trace(NONE), traceID(0)
         {}
 
         Request(nid_t dest, nid_t src, size_t size_in_bits,
-                bool head, bool tail, Event* payload = NULL) :
+                bool head, bool tail, Event* payload = nullptr) :
             dest(dest), src(src), size_in_bits(size_in_bits), head(head), tail(tail), allow_adaptive(true),
             payload(payload), trace(NONE), traceID(0)
         {
@@ -122,14 +122,14 @@ public:
 
         virtual ~Request()
         {
-            if ( payload != NULL ) delete payload;
+            if ( payload != nullptr ) delete payload;
         }
         
         inline Request* clone() {
             Request* req = new Request(*this);
             // Copy constructor only makes a shallow copy, need to
             // clone the event.
-            if ( payload != NULL ) req->payload = payload->clone();
+            if ( payload != nullptr ) req->payload = payload->clone();
             return req;
         }
         
@@ -273,7 +273,7 @@ public:
         @param out_buf_size - Size of output buffers (to router)
      * @return true if the link was able to be configured.
      */
-    virtual bool initialize(const std::string &portName, const UnitAlgebra& link_bw,
+    virtual bool initialize(const std::string& portName, const UnitAlgebra& link_bw,
                             int vns, const UnitAlgebra& in_buf_size,
                             const UnitAlgebra& out_buf_size) = 0;
 
@@ -338,7 +338,7 @@ public:
      * Register a handler for push-based notification of responses.
      *
      * @param vn Virtual network to receive on
-     * @return NULL if nothing is available.
+     * @return nullptr if nothing is available.
      * @return Pointer to a Request response (that should be deleted)
      */
     virtual Request* recv(int vn) = 0;

--- a/src/sst/core/interfaces/stringEvent.h
+++ b/src/sst/core/interfaces/stringEvent.h
@@ -9,12 +9,12 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#ifndef INTERFACES_STRINGEVENT_H
-#define INTERFACES_STRINGEVENT_H
+#ifndef SST_CORE_INTERFACES_STRINGEVENT_H
+#define SST_CORE_INTERFACES_STRINGEVENT_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
-#include <sst/core/event.h>
+#include "sst/core/event.h"
 
 namespace SST {
 namespace Interfaces {
@@ -29,7 +29,7 @@ public:
     /** Create a new StringEvent
      * @param str - The String contents of this event
      */
-	StringEvent(const std::string &str) :
+	StringEvent(const std::string& str) :
 		SST::Event(), str(str)
 	{ }
 
@@ -37,14 +37,14 @@ public:
 	StringEvent(const StringEvent &me) : SST::Event()
 	{
 		str = me.str;
-		setDeliveryLink(me.getLinkId(), NULL);
+		setDeliveryLink(me.getLinkId(), nullptr);
 	}
 
     /** Copies an existing StringEvent */
 	StringEvent(const StringEvent *me) : SST::Event()
 	{
 		str = me->str;
-		setDeliveryLink(me->getLinkId(), NULL);
+		setDeliveryLink(me->getLinkId(), nullptr);
 	}
 
     /** Returns the contents of this Event */

--- a/src/sst/core/interprocess/ipctunnel.cc
+++ b/src/sst/core/interprocess/ipctunnel.cc
@@ -9,7 +9,7 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
 
 #include <inttypes.h>
 

--- a/src/sst/core/interprocess/ipctunnel.h
+++ b/src/sst/core/interprocess/ipctunnel.h
@@ -23,7 +23,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <sst/core/interprocess/circularBuffer.h>
+#include "sst/core/interprocess/circularBuffer.h"
 
 namespace SST {
 namespace Core {
@@ -59,7 +59,7 @@ public:
      * @param numBuffers Number of buffers for which we should tunnel
      * @param bufferSize How large each core's buffer should be
      */
-    IPCTunnel(uint32_t comp_id, size_t numBuffers, size_t bufferSize, uint32_t expectedChildren = 1) : master(true), shmPtr(NULL), fd(-1)
+    IPCTunnel(uint32_t comp_id, size_t numBuffers, size_t bufferSize, uint32_t expectedChildren = 1) : master(true), shmPtr(nullptr), fd(-1)
     {
         char key[256];
         memset(key, '\0', sizeof(key));
@@ -90,7 +90,7 @@ public:
             exit(1);
         }
 
-        shmPtr = mmap(NULL, shmSize, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+        shmPtr = mmap(nullptr, shmSize, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
         if ( shmPtr == MAP_FAILED ) {
             // Not using Output because IPC means Output might not be available
             fprintf(stderr, "mmap failed: %s\n", strerror(errno));
@@ -114,7 +114,7 @@ public:
         /* Construct the circular buffers */
         const size_t cbSize = sizeof(MsgType) * bufferSize;
         for ( size_t c = 0 ; c < isd->numBuffers ; c++ ) {
-            CircBuff_t* cPtr = NULL;
+            CircBuff_t* cPtr = nullptr;
 
             auto resResult = reserveSpace<CircBuff_t>(cbSize);
             isd->offsets[1+c] = resResult.first;
@@ -129,7 +129,7 @@ public:
      * Access an existing Tunnel
      * @param region_name Name of the shared-memory region to access
      */
-    IPCTunnel(const std::string &region_name) : master(false), shmPtr(NULL), fd(-1)
+    IPCTunnel(const std::string& region_name) : master(false), shmPtr(nullptr), fd(-1)
     {
         fd = shm_open(region_name.c_str(), O_RDWR, S_IRUSR|S_IWUSR);
         filename = region_name;
@@ -141,7 +141,7 @@ public:
             exit(1);
         }
 
-        shmPtr = mmap(NULL, sizeof(InternalSharedData), PROT_READ, MAP_SHARED, fd, 0);
+        shmPtr = mmap(nullptr, sizeof(InternalSharedData), PROT_READ, MAP_SHARED, fd, 0);
         if ( shmPtr == MAP_FAILED ) {
             // Not using Output because IPC means Output might not be available
             fprintf(stderr, "mmap 0 failed: %s\n", strerror(errno));
@@ -152,7 +152,7 @@ public:
         shmSize = isd->shmSegSize;
         munmap(shmPtr, sizeof(InternalSharedData));
 
-        shmPtr = mmap(NULL, shmSize, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+        shmPtr = mmap(nullptr, shmSize, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
         if ( shmPtr == MAP_FAILED ) {
             // Not using Output because IPC means Output might not be available
             fprintf(stderr, "mmap 1 failed: %s\n", strerror(errno));
@@ -192,7 +192,7 @@ public:
         }
         if ( shmPtr ) {
             munmap(shmPtr, shmSize);
-            shmPtr = NULL;
+            shmPtr = nullptr;
             shmSize = 0;
         }
         if ( fd >= 0 ) {
@@ -233,7 +233,7 @@ private:
     {
         size_t space = sizeof(T) + extraSpace;
         if ( ((nextAllocPtr + space) - (uint8_t*)shmPtr) > shmSize )
-            return std::make_pair<size_t, T*>(0, NULL);
+            return std::make_pair<size_t, T*>(0, nullptr);
         T* ptr = (T*)nextAllocPtr;
         nextAllocPtr += space;
         new (ptr) T();  // Call constructor if need be

--- a/src/sst/core/iouse.cc
+++ b/src/sst/core/iouse.cc
@@ -15,7 +15,7 @@
 #include "sst/core/iouse.h"
 
 #include <sys/resource.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 #ifdef SST_CONFIG_HAVE_MPI
 DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -11,51 +11,51 @@
 
 
 #include "sst_config.h"
-#include <sst/core/link.h>
+#include "sst/core/link.h"
 
 #include <utility>
 
-#include <sst/core/event.h>
-#include <sst/core/initQueue.h>
-#include <sst/core/pollingLinkQueue.h>
-#include <sst/core/simulation.h>
-#include <sst/core/timeConverter.h>
-#include <sst/core/timeLord.h>
-#include <sst/core/timeVortex.h>
-//#include <sst/core/syncQueue.h>
-#include <sst/core/uninitializedQueue.h>
-#include <sst/core/unitAlgebra.h>
+#include "sst/core/event.h"
+#include "sst/core/initQueue.h"
+#include "sst/core/pollingLinkQueue.h"
+#include "sst/core/simulation.h"
+#include "sst/core/timeConverter.h"
+#include "sst/core/timeLord.h"
+#include "sst/core/timeVortex.h"
+//#include "sst/core/syncQueue.h"
+#include "sst/core/uninitializedQueue.h"
+#include "sst/core/unitAlgebra.h"
 
 namespace SST { 
 
-// ActivityQueue* Link::uninitQueue = NULL;
+// ActivityQueue* Link::uninitQueue = nullptr;
 ActivityQueue* Link::uninitQueue = new UninitializedQueue("ERROR: Trying to send or recv from link during initialization.  Send and Recv cannot be called before setup.");
 ActivityQueue* Link::afterInitQueue = new UninitializedQueue("ERROR: Trying to call sendUntimedData/sendInitData or recvUntimedData/recvInitData during the run phase.");
 ActivityQueue* Link::afterRunQueue = new UninitializedQueue("ERROR: Trying to call send or recv during complete phase.");
     
 Link::Link(LinkId_t id) :
-    rFunctor( NULL ),
-    defaultTimeBase( NULL ),
+    rFunctor( nullptr ),
+    defaultTimeBase( nullptr ),
     latency(1),
     type(HANDLER),
     id(id),
     configured(false)
 {
     recvQueue = uninitQueue;
-    untimedQueue = NULL;
+    untimedQueue = nullptr;
     configuredQueue = Simulation::getSimulation()->getTimeVortex();
 }
 
 Link::Link() :
-    rFunctor( NULL ),
-    defaultTimeBase( NULL ),
+    rFunctor( nullptr ),
+    defaultTimeBase( nullptr ),
     latency(1),
     type(HANDLER),
     id(-1),
     configured(false)
 {
     recvQueue = uninitQueue;
-    untimedQueue = NULL;
+    untimedQueue = nullptr;
     configuredQueue = Simulation::getSimulation()->getTimeVortex();
 }
 
@@ -63,16 +63,16 @@ Link::~Link() {
     if ( type == POLL && recvQueue != uninitQueue && recvQueue != afterInitQueue && recvQueue != afterRunQueue ) {
         delete recvQueue;
     }
-    if ( rFunctor != NULL ) delete rFunctor;
+    if ( rFunctor != nullptr ) delete rFunctor;
 }
 
 void Link::finalizeConfiguration() {
     recvQueue = configuredQueue;
     configuredQueue = untimedQueue;
-    if ( untimedQueue != NULL ) {
-        if ( dynamic_cast<InitQueue*>(untimedQueue) != NULL) {
+    if ( untimedQueue != nullptr ) {
+        if ( dynamic_cast<InitQueue*>(untimedQueue) != nullptr) {
             delete untimedQueue;
-            configuredQueue = NULL;
+            configuredQueue = nullptr;
         }
     }
     untimedQueue = afterInitQueue;
@@ -96,7 +96,7 @@ void Link::setLatency(Cycle_t lat) {
     latency = lat;
 }
     
-void Link::addRecvLatency(int cycles, std::string timebase) {
+void Link::addRecvLatency(int cycles, const std::string& timebase) {
     SimTime_t tb = Simulation::getSimulation()->getTimeLord()->getSimCycles(timebase,"addOutputLatency");
     pair_link->latency += (cycles * tb);
 }
@@ -106,14 +106,14 @@ void Link::addRecvLatency(SimTime_t cycles, TimeConverter* timebase) {
 }
     
 void Link::send( SimTime_t delay, TimeConverter* tc, Event* event ) {  
-    if ( tc == NULL ) {
-        Simulation::getSimulation()->getSimulationOutput().fatal(CALL_INFO, 1, "Cannot send an event on Link with NULL TimeConverter\n");
+    if ( tc == nullptr ) {
+        Simulation::getSimulation()->getSimulationOutput().fatal(CALL_INFO, 1, "Cannot send an event on Link with nullptr TimeConverter\n");
     }
     
     Cycle_t cycle = Simulation::getSimulation()->getCurrentSimCycle() +
         tc->convertToCoreTime(delay) + latency;
     
-    if ( event == NULL ) {
+    if ( event == nullptr ) {
         event = new NullEvent();
     }
     event->setDeliveryTime(cycle);
@@ -137,7 +137,7 @@ Event* Link::recv()
         
     }
     
-    Event* event = NULL;
+    Event* event = nullptr;
     Simulation *simulation = Simulation::getSimulation();
 
     if ( !recvQueue->empty() ) {
@@ -152,7 +152,7 @@ Event* Link::recv()
 
 void Link::sendUntimedData(Event* data)
 {
-    if ( pair_link->untimedQueue == NULL ) {
+    if ( pair_link->untimedQueue == nullptr ) {
         pair_link->untimedQueue = new InitQueue();
     }
     Simulation::getSimulation()->untimed_msg_count++;
@@ -168,7 +168,7 @@ void Link::sendUntimedData(Event* data)
 
 void Link::sendUntimedData_sync(Event* data)
 {
-    if ( pair_link->untimedQueue == NULL ) {
+    if ( pair_link->untimedQueue == nullptr ) {
         pair_link->untimedQueue = new InitQueue();
     }
     // data->setDeliveryLink(id,pair_link);
@@ -178,9 +178,9 @@ void Link::sendUntimedData_sync(Event* data)
 
 Event* Link::recvUntimedData()
 {
-    if ( untimedQueue == NULL ) return NULL;
+    if ( untimedQueue == nullptr ) return nullptr;
 
-    Event* event = NULL;
+    Event* event = nullptr;
     if ( !untimedQueue->empty() ) {
 	Activity* activity = untimedQueue->front();
 	if ( activity->getDeliveryTime() <= Simulation::getSimulation()->untimed_phase ) {

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -12,10 +12,9 @@
 #ifndef SST_CORE_LINK_H
 #define SST_CORE_LINK_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
-#include <sst/core/event.h>
-// #include <sst/core/eventFunctor.h>
+#include "sst/core/event.h"
 
 namespace SST { 
 
@@ -54,7 +53,7 @@ public:
      * @param cycles Number of Cycles to be added
      * @param timebase Base Units of cycles
      */
-    void addRecvLatency(int cycles, std::string timebase);
+    void addRecvLatency(int cycles, const std::string& timebase);
     /** Set additional Latency to be added on to events coming in on this link.
      * @param cycles Number of Cycles to be added
      * @param timebase Base Units of cycles
@@ -99,7 +98,7 @@ public:
 
     /** Retrieve a pending event from the Link. For links which do not
       have a set event handler, they can be polled with this function.
-      Returns NULL if there is no pending event.
+      Returns nullptr if there is no pending event.
     */
     Event* recv();
 

--- a/src/sst/core/linkMap.h
+++ b/src/sst/core/linkMap.h
@@ -12,13 +12,13 @@
 #ifndef SST_CORE_LINKMAP_H
 #define SST_CORE_LINKMAP_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 #include <string>
 #include <map>
 
-#include <sst/core/component.h>
-#include <sst/core/link.h>
+#include "sst/core/component.h"
+#include "sst/core/link.h"
 
 namespace SST {
 
@@ -59,11 +59,11 @@ private:
     //         x++;
     //         y++;
     //     } while ( *x && *y );
-    //     if ( *x != *y ) return false; // aka, both NULL
+    //     if ( *x != *y ) return false; // aka, both nullptr
     //     return true;
     // }
 
-    // bool checkPort(const std::string &name) const
+    // bool checkPort(const std::string& name) const
     // {
     //     // First check to see if this is a self port
     //     for ( std::vector<std::string>::const_iterator i = selfPorts.begin() ; i != selfPorts.end() ; ++i ) {
@@ -78,7 +78,7 @@ private:
     //     Component::isValidPortForComponent(
     //     const char *x = name.c_str();
     //     bool found = false;
-    //     if ( NULL != allowedPorts ) {
+    //     if ( nullptr != allowedPorts ) {
     //         for ( std::vector<std::string>::const_iterator i = allowedPorts->begin() ; i != allowedPorts->end() ; ++i ) {
     //             /* Compare name with stored name, which may have wildcards */
     //             if ( checkPort(i->c_str(), x) ) {
@@ -90,11 +90,11 @@ private:
     //     return found;
     // }
 
-    // bool checkPort(const std::string &name) const
+    // bool checkPort(const std::string& name) const
     // {
     //     const char *x = name.c_str();
     //     bool found = false;
-    //     if ( NULL != allowedPorts ) {
+    //     if ( nullptr != allowedPorts ) {
     //         for ( std::vector<std::string>::const_iterator i = allowedPorts->begin() ; i != allowedPorts->end() ; ++i ) {
     //             /* Compare name with stored name, which may have wildcards */
     //             if ( checkPort(i->c_str(), x) ) {
@@ -119,7 +119,7 @@ private:
     // }
 
 public:
-    LinkMap() /*: allowedPorts(NULL)*/ {}
+    LinkMap() /*: allowedPorts(nullptr)*/ {}
     ~LinkMap() {
         // Delete all the links in the map
         for ( std::map<std::string,Link*>::iterator it = linkMap.begin(); it != linkMap.end(); ++it ) {
@@ -142,7 +142,7 @@ public:
      * Add a port name to the list of allowed ports.
      * Used by SelfLinks, as these are undocumented.
      */
-    void addSelfPort(std::string& name)
+    void addSelfPort(const std::string& name)
     {
         selfPorts.push_back(name);
     }
@@ -159,23 +159,23 @@ public:
     }
     
     /** Inserts a new pair of name and link into the map */
-    void insertLink(std::string name, Link* link) {
+    void insertLink(const std::string& name, Link* link) {
         linkMap.insert(std::pair<std::string,Link*>(name,link));
     }
 
-    void removeLink(std::string name) {
+    void removeLink(const std::string& name) {
         linkMap.erase(name);
     }
     
     /** Returns a Link pointer for a given name */
-    Link* getLink(std::string name) {
+    Link* getLink(const std::string& name) {
 //         if ( !checkPort(name) ) {
 // #ifdef USE_PARAM_WARNINGS
 //             std::cerr << "Warning:  Using undocumented port '" << name << "'." << std::endl;
 // #endif
 //         }
         std::map<std::string,Link*>::iterator it = linkMap.find(name);
-        if ( it == linkMap.end() ) return NULL;
+        if ( it == linkMap.end() ) return nullptr;
         else return it->second;
     }
 

--- a/src/sst/core/linkPair.h
+++ b/src/sst/core/linkPair.h
@@ -12,9 +12,9 @@
 #ifndef SST_CORE_LINKPAIR_H
 #define SST_CORE_LINKPAIR_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
-#include <sst/core/link.h>
+#include "sst/core/link.h"
 
 namespace SST {
 

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -10,8 +10,8 @@
 // distribution.
 
 
-#include <sst_config.h>
-#include <sst/core/warnmacros.h>
+#include "sst_config.h"
+#include "sst/core/warnmacros.h"
 
 DISABLE_WARN_DEPRECATED_REGISTER
 #include <Python.h>
@@ -30,37 +30,37 @@ REENABLE_WARNING
 #include <signal.h>
 #include <time.h>
 
-#include <sst/core/activity.h>
-#include <sst/core/config.h>
-#include <sst/core/configGraph.h>
-#include <sst/core/factory.h>
-#include <sst/core/rankInfo.h>
-#include <sst/core/threadsafe.h>
-#include <sst/core/simulation.h>
-#include <sst/core/timeLord.h>
-#include <sst/core/timeVortex.h>
-#include <sst/core/part/sstpart.h>
-#include <sst/core/statapi/statengine.h>
+#include "sst/core/activity.h"
+#include "sst/core/config.h"
+#include "sst/core/configGraph.h"
+#include "sst/core/factory.h"
+#include "sst/core/rankInfo.h"
+#include "sst/core/threadsafe.h"
+#include "sst/core/simulation.h"
+#include "sst/core/timeLord.h"
+#include "sst/core/timeVortex.h"
+#include "sst/core/part/sstpart.h"
+#include "sst/core/statapi/statengine.h"
 
-#include <sst/core/cputimer.h>
+#include "sst/core/cputimer.h"
 
-#include <sst/core/model/sstmodel.h>
-#include <sst/core/model/pymodel.h>
-#include <sst/core/memuse.h>
-#include <sst/core/iouse.h>
+#include "sst/core/model/sstmodel.h"
+#include "sst/core/model/pymodel.h"
+#include "sst/core/memuse.h"
+#include "sst/core/iouse.h"
 
 #include <sys/resource.h>
 
-#include <sst/core/objectComms.h>
+#include "sst/core/objectComms.h"
 
 // Configuration Graph Generation Options
-#include <sst/core/configGraphOutput.h>
-#include <sst/core/cfgoutput/pythonConfigOutput.h>
-#include <sst/core/cfgoutput/dotConfigOutput.h>
-#include <sst/core/cfgoutput/xmlConfigOutput.h>
-#include <sst/core/cfgoutput/jsonConfigOutput.h>
+#include "sst/core/configGraphOutput.h"
+#include "sst/core/cfgoutput/pythonConfigOutput.h"
+#include "sst/core/cfgoutput/dotConfigOutput.h"
+#include "sst/core/cfgoutput/xmlConfigOutput.h"
+#include "sst/core/cfgoutput/jsonConfigOutput.h"
 
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/eli/elementinfo.h"
 
 using namespace SST::Core;
 using namespace SST::Partition;
@@ -107,7 +107,7 @@ static void setupSignals(uint32_t threadRank)
         /* Other threads don't want to receive the signal */
         sigset_t maskset;
         sigfillset(&maskset);
-        pthread_sigmask(SIG_BLOCK, &maskset, NULL);
+        pthread_sigmask(SIG_BLOCK, &maskset, nullptr);
     }
 }
 
@@ -421,7 +421,7 @@ main(int argc, char *argv[])
     const uint64_t pre_graph_create_rss = maxGlobalMemSize();
 
     ////// Start ConfigGraph Creation //////
-    ConfigGraph* graph = NULL;
+    ConfigGraph* graph = nullptr;
 
     double start_graph_gen = sst_get_cpu_time();
     graph = new ConfigGraph();
@@ -452,7 +452,7 @@ main(int argc, char *argv[])
 
     // Delete the model generator
     delete modelGen;
-    modelGen = NULL;
+    modelGen = nullptr;
 
     double end_graph_gen = sst_get_cpu_time();
 

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -268,7 +268,7 @@ static void start_simulation(uint32_t tid, SimThreadInfo_t &info, Core::ThreadSa
         if ( info.config->verbose && 0 == tid ) {
             g_output.verbose(CALL_INFO, 1, 0, "# Starting main event loop\n");
 
-            time_t the_time = time(0);
+            time_t the_time = time(nullptr);
             struct tm* now = localtime( &the_time );
 
             g_output.verbose(CALL_INFO, 1, 0, "# Start time: %04u/%02u/%02u at: %02u:%02u:%02u\n",
@@ -381,7 +381,7 @@ main(int argc, char *argv[])
     }
     world_size.thread = cfg.getNumThreads();
 
-    SSTModelDescription* modelGen = 0;
+    SSTModelDescription* modelGen = nullptr;
 
     if ( cfg.configFile != "NONE" ) {
         string file_ext = "";

--- a/src/sst/core/mempool.h
+++ b/src/sst/core/mempool.h
@@ -17,7 +17,6 @@
 
 #include <cstddef>
 #include <cstdlib>
-#include <cstring>
 #include <cinttypes>
 #include <cstdint>
 #include <sys/mman.h>
@@ -44,7 +43,7 @@ class MemPool
 
         inline void* try_remove() {
             std::lock_guard<LOCK_t> lock(mtx);
-            if ( list.empty() ) return NULL;
+            if ( list.empty() ) return nullptr;
             void *p = list.back();
             list.pop_back();
             return p;
@@ -80,7 +79,7 @@ public:
         void *ret = freeList.try_remove();
         while ( !ret ) {
             bool ok = allocPool();
-            if ( !ok ) return NULL;
+            if ( !ok ) return nullptr;
 #if ( defined( __amd64 ) || defined( __amd64__ ) || \
         defined( __x86_64 ) || defined( __x86_64__ ) )
             _mm_pause();

--- a/src/sst/core/mempool.h
+++ b/src/sst/core/mempool.h
@@ -136,7 +136,7 @@ private:
             return true;
         }
 
-        uint8_t *newPool = (uint8_t*)mmap(0, arenaSize, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANON, -1, 0);
+        uint8_t *newPool = (uint8_t*)mmap(nullptr, arenaSize, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANON, -1, 0);
         if ( MAP_FAILED == newPool ) {
             allocating.store(0, std::memory_order_release);
             return false;

--- a/src/sst/core/memuse.cc
+++ b/src/sst/core/memuse.cc
@@ -11,9 +11,10 @@
 
 
 #include "sst_config.h"
-
 #include "sst/core/memuse.h"
-#include <sst/core/warnmacros.h>
+
+#include "sst/core/warnmacros.h"
+
 #include <sys/resource.h>
 
 #ifdef SST_CONFIG_HAVE_MPI

--- a/src/sst/core/model/element_python.cc
+++ b/src/sst/core/model/element_python.cc
@@ -13,16 +13,14 @@
 
 #include "sst_config.h"
 
-// Python header files
-#include <sst/core/warnmacros.h>
+#include "sst/core/model/element_python.h"
 
+// Python header files
 DISABLE_WARN_DEPRECATED_REGISTER
 #include <Python.h>
 REENABLE_WARNING
 #include <traceback.h>
 #include <frameobject.h>
-
-#include "sst/core/model/element_python.h"
 
 #include "sst/core/output.h"
 #include "sst/core/simulation.h"
@@ -42,9 +40,9 @@ void abortOnPyErr(uint32_t line, const char* file, const char* func,
 
     // Get the exception name
     char* exc_name = PyExceptionClass_Name(exc);
-    if (exc_name != NULL) {
+    if (exc_name != nullptr) {
         char *dot = strrchr(exc_name, '.');
-        if (dot != NULL)
+        if (dot != nullptr)
             exc_name = dot+1;
     }
 
@@ -62,7 +60,7 @@ void abortOnPyErr(uint32_t line, const char* file, const char* func,
     
     // Need to format the backtrace
     PyTracebackObject* ptb = (PyTracebackObject*)tb;
-    while ( ptb != NULL ) {
+    while ( ptb != nullptr ) {
         // Filename
         stream << "File \"" << PyString_AsString(ptb->tb_frame->f_code->co_filename) << "\", ";
         // Line number
@@ -84,7 +82,7 @@ void abortOnPyErr(uint32_t line, const char* file, const char* func,
 
 
 SSTElementPythonModuleCode* 
-SSTElementPythonModuleCode::addSubModule(const std::string& module_name, char* code, std::string filename)
+SSTElementPythonModuleCode::addSubModule(const std::string& module_name, char* code, const std::string& filename)
 {
     auto ret = new SSTElementPythonModuleCode(this,module_name,code,filename);
     sub_modules.push_back(ret);
@@ -98,13 +96,13 @@ SSTElementPythonModuleCode::load(void* parent_module)
     PyObject* pm = (PyObject*)parent_module;
 
     PyObject *compiled_code = Py_CompileString(code, filename.c_str(), Py_file_input);
-    if ( compiled_code == NULL) abortOnPyErr(CALL_INFO,1,"SSTElementPythonModule: Error running Py_CompileString on %s.  Details follow:\n", filename.c_str());
+    if ( compiled_code == nullptr) abortOnPyErr(CALL_INFO,1,"SSTElementPythonModule: Error running Py_CompileString on %s.  Details follow:\n", filename.c_str());
 
     PyObject *module = PyImport_ExecCodeModule(const_cast<char*>(getFullModuleName().c_str()), compiled_code);
-    if ( module == NULL) abortOnPyErr(CALL_INFO,1,"SSTElementPythonModule: Error running PyImport_ExecCodeModule on %s.  Details follow:\n",filename.c_str());
+    if ( module == nullptr) abortOnPyErr(CALL_INFO,1,"SSTElementPythonModule: Error running PyImport_ExecCodeModule on %s.  Details follow:\n",filename.c_str());
 
     // All but the top level module need to add themselves to the top level module
-    if ( parent != NULL) PyModule_AddObject(pm, getFullModuleName().c_str(), module);
+    if ( parent != nullptr) PyModule_AddObject(pm, getFullModuleName().c_str(), module);
     else pm = module;
     
     for ( auto item : sub_modules ) {
@@ -118,17 +116,17 @@ SSTElementPythonModuleCode::load(void* parent_module)
 std::string
 SSTElementPythonModuleCode::getFullModuleName()
 {
-    if ( parent == NULL ) return module_name;
+    if ( parent == nullptr ) return module_name;
     return parent->getFullModuleName() + "." + module_name;
 }
 
 
 
 
-SSTElementPythonModule::SSTElementPythonModule(std::string library) :
+SSTElementPythonModule::SSTElementPythonModule(const std::string& library) :
     library(library),
-    primary_module(NULL),
-    primary_code_module(NULL)
+    primary_module(nullptr),
+    primary_code_module(nullptr)
 {
     pylibrary = "py" + library;
     sstlibrary = "sst." + library;
@@ -137,7 +135,7 @@ SSTElementPythonModule::SSTElementPythonModule(std::string library) :
 void
 SSTElementPythonModule::addPrimaryModule(char* file)
 {
-    if ( primary_module == NULL ) {
+    if ( primary_module == nullptr ) {
         primary_module = file;
     }
     else {
@@ -146,7 +144,7 @@ SSTElementPythonModule::addPrimaryModule(char* file)
 }
 
 void
-SSTElementPythonModule::addSubModule(std::string name, char* file)
+SSTElementPythonModule::addSubModule(const std::string& name, char* file)
 {
     sub_modules.push_back(std::make_pair(name,file));
 }
@@ -156,26 +154,26 @@ void*
 SSTElementPythonModule::load()
 {
     // Need to see if we're using the new hierarchy based method or the old
-    if ( primary_code_module != NULL ) return primary_code_module->load(NULL);
+    if ( primary_code_module != nullptr ) return primary_code_module->load(nullptr);
 
-    if ( primary_module == NULL ) {
+    if ( primary_module == nullptr ) {
         Simulation::getSimulationOutput().fatal(CALL_INFO,1,"SSTElementPythonModule: Primary module not set.  Use addPrimaryModule().\n");
     }
     PyObject *code = Py_CompileString(primary_module, pylibrary.c_str(), Py_file_input);
-    if ( code == NULL) abortOnPyErr(CALL_INFO,1,"SSTElementPythonModule: Error running Py_CompileString on %s.  Details follow:\n",const_cast<char*>(pylibrary.c_str()));
+    if ( code == nullptr) abortOnPyErr(CALL_INFO,1,"SSTElementPythonModule: Error running Py_CompileString on %s.  Details follow:\n",const_cast<char*>(pylibrary.c_str()));
 
     PyObject *module = PyImport_ExecCodeModule(const_cast<char*>(sstlibrary.c_str()), code);
-    if ( module == NULL) abortOnPyErr(CALL_INFO,1,"SSTElementPythonModule: Error running PyImport_ExecCodeModule on %s.  Details follow:\n",const_cast<char*>(sstlibrary.c_str()));
+    if ( module == nullptr) abortOnPyErr(CALL_INFO,1,"SSTElementPythonModule: Error running PyImport_ExecCodeModule on %s.  Details follow:\n",const_cast<char*>(sstlibrary.c_str()));
 
     for ( auto item : sub_modules ) {
         std::string pylib = pylibrary + "-" + item.first;
         std::string sstlib = sstlibrary + "." + item.first;
 
         PyObject* subcode = Py_CompileString(item.second, pylib.c_str(), Py_file_input);
-        if ( subcode == NULL) abortOnPyErr(CALL_INFO,1,"SSTElementPythonModule: Error running Py_CompileString on %s.  Details follow:\n",const_cast<char*>(pylib.c_str()));
+        if ( subcode == nullptr) abortOnPyErr(CALL_INFO,1,"SSTElementPythonModule: Error running Py_CompileString on %s.  Details follow:\n",const_cast<char*>(pylib.c_str()));
 
         PyObject* submodule = PyImport_ExecCodeModule(const_cast<char*>(sstlib.c_str()), subcode);
-        if ( submodule == NULL) abortOnPyErr(CALL_INFO,1,"SSTElementPythonModule: Error running PyImport_ExecCodeModule on %s.  Details follow:\n",const_cast<char*>(sstlib.c_str()));
+        if ( submodule == nullptr) abortOnPyErr(CALL_INFO,1,"SSTElementPythonModule: Error running PyImport_ExecCodeModule on %s.  Details follow:\n",const_cast<char*>(sstlib.c_str()));
         PyModule_AddObject(module, item.first.c_str(), submodule);
     }
     
@@ -185,10 +183,10 @@ SSTElementPythonModule::load()
 
 // New functions
 SSTElementPythonModuleCode*
-SSTElementPythonModule::createPrimaryModule(char* code, std::string filename)
+SSTElementPythonModule::createPrimaryModule(char* code, const std::string& filename)
 {
-    if ( primary_module == NULL ) {
-        primary_code_module = new SSTElementPythonModuleCode(NULL, sstlibrary, code, filename);
+    if ( primary_module == nullptr ) {
+        primary_code_module = new SSTElementPythonModuleCode(nullptr, sstlibrary, code, filename);
     }
     else {
         Simulation::getSimulationOutput().fatal(CALL_INFO,1,"SSTElementPythonModule::createPrimaryModule: Attempt to create second primary module.\n");

--- a/src/sst/core/model/element_python.h
+++ b/src/sst/core/model/element_python.h
@@ -15,7 +15,7 @@
 
 #include <vector>
 #include <string>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/eli/elementinfo.h"
 
 namespace SST {
 
@@ -29,7 +29,7 @@ class SSTElementPythonModuleCode {
 
 private:
     //! Pointer to parent module.
-    /** Parent module.  This will be NULL if this is the primary module (i.e. sst.*) */
+    /** Parent module.  This will be nullptr if this is the primary module (i.e. sst.*) */
     SSTElementPythonModuleCode* parent;
 
     //! Simple name of the module.
@@ -62,7 +62,7 @@ private:
      *  \param filename filname used when reporting errors
      *  \sa parent, module_name, code, filename
      */
-    SSTElementPythonModuleCode(SSTElementPythonModuleCode* parent, const std::string& module_name, char* code = NULL, std::string filename = "") :
+    SSTElementPythonModuleCode(SSTElementPythonModuleCode* parent, const std::string& module_name, char* code = nullptr, std::string filename = "") :
         parent(parent),
         module_name(module_name),
         code(code),
@@ -105,7 +105,7 @@ public:
     /// \param filename filname used when reporting errors
     ///
     /// 
-    SSTElementPythonModuleCode* addSubModule(const std::string& module_name, char* code = NULL, std::string filename = "");
+    SSTElementPythonModuleCode* addSubModule(const std::string& module_name, char* code = nullptr, const std::string& filename = "");
 
     //! Get the full name of the module
     /**
@@ -151,14 +151,14 @@ public:
      * of.  Primary module name will be sst.library and submodules
      * under this can also be created.
      */ 
-    SSTElementPythonModule(std::string library);
+    SSTElementPythonModule(const std::string& library);
 
     
     __attribute__ ((deprecated("Support for addPrimaryModule will be removed in version 9.0.  Please use createPrimaryModule().")))
     void addPrimaryModule(char* file);
 
     __attribute__ ((deprecated("Support for addPrimaryModule will be removed in version 9.0.  Please use createPrimaryModule() to get an SSTElementPythonModuleCode object then use it's addSubModule() method.")))
-    void addSubModule(std::string name, char* file);
+    void addSubModule(const std::string& name, char* file);
 
     virtual void* load();
 
@@ -171,7 +171,7 @@ public:
     /// \param filename filname used when reporting errors
     ///
     ///     
-    SSTElementPythonModuleCode* createPrimaryModule(char* code = NULL, std::string filename = "");
+    SSTElementPythonModuleCode* createPrimaryModule(char* code = nullptr, const std::string& filename = "");
 
 };
 

--- a/src/sst/core/model/pymodel.cc
+++ b/src/sst/core/model/pymodel.cc
@@ -41,7 +41,7 @@ DISABLE_WARN_STRICT_ALIASING
 
 using namespace SST::Core;
 
-SST::Core::SSTPythonModelDefinition *gModel = NULL;
+SST::Core::SSTPythonModelDefinition *gModel = nullptr;
 
 extern "C" {
 
@@ -70,58 +70,58 @@ static PyObject* mlLoadModule(PyObject *self, PyObject *args);
 static PyMethodDef mlMethods[] = {
     {   "find_module", mlFindModule, METH_VARARGS, "Finds an SST Element Module"},
     {   "load_module", mlLoadModule, METH_VARARGS, "Loads an SST Element Module"},
-    {   NULL, NULL, 0, NULL }
+    {   nullptr, nullptr, 0, nullptr }
 };
 
 
 static PyTypeObject ModuleLoaderType = {
-    PyObject_HEAD_INIT(NULL)
+    PyObject_HEAD_INIT(nullptr)
     0,                         /* ob_size */
-    "ModuleLoader",        /* tp_name */
+    "ModuleLoader",            /* tp_name */
     sizeof(ModuleLoaderPy_t),  /* tp_basicsize */
     0,                         /* tp_itemsize */
-    0,                         /* tp_dealloc */
-    0,                         /* tp_print */
-    0,                         /* tp_getattr */
-    0,                         /* tp_setattr */
-    0,                         /* tp_compare */
-    0,                         /* tp_repr */
-    0,                         /* tp_as_number */
-    0,                         /* tp_as_sequence */
-    0,                         /* tp_as_mapping */
-    0,                         /* tp_hash */
-    0,                         /* tp_call */
-    0,                         /* tp_str */
-    0,                         /* tp_getattro */
-    0,                         /* tp_setattro */
-    0,                         /* tp_as_buffer */
+    nullptr,                   /* tp_dealloc */
+    nullptr,                   /* tp_print */
+    nullptr,                   /* tp_getattr */
+    nullptr,                   /* tp_setattr */
+    nullptr,                   /* tp_compare */
+    nullptr,                   /* tp_repr */
+    nullptr,                   /* tp_as_number */
+    nullptr,                   /* tp_as_sequence */
+    nullptr,                   /* tp_as_mapping */
+    nullptr,                   /* tp_hash */
+    nullptr,                   /* tp_call */
+    nullptr,                   /* tp_str */
+    nullptr,                   /* tp_getattro */
+    nullptr,                   /* tp_setattro */
+    nullptr,                   /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,        /* tp_flags */
     "SST Module Loader",       /* tp_doc */
-    0,                         /* tp_traverse */
-    0,                         /* tp_clear */
-    0,                         /* tp_richcompare */
+    nullptr,                   /* tp_traverse */
+    nullptr,                   /* tp_clear */
+    nullptr,                   /* tp_richcompare */
     0,                         /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
+    nullptr,                   /* tp_iter */
+    nullptr,                   /* tp_iternext */
     mlMethods,                 /* tp_methods */
-    0,                         /* tp_members */
-    0,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
+    nullptr,                   /* tp_members */
+    nullptr,                   /* tp_getset */
+    nullptr,                   /* tp_base */
+    nullptr,                   /* tp_dict */
+    nullptr,                   /* tp_descr_get */
+    nullptr,                   /* tp_descr_set */
     0,                         /* tp_dictoffset */
-    0,                         /* tp_init */
-    0,                         /* tp_alloc */
-    0,                         /* tp_new */
-    0,                         /* tp_free */
-    0,                         /* tp_is_gc */
-    0,                         /* tp_bases */
-    0,                         /* tp_mro */
-    0,                         /* tp_cache */
-    0,                         /* tp_subclasses */
-    0,                         /* tp_weaklist */
-    0,                         /* tp_del */
+    nullptr,                   /* tp_init */
+    nullptr,                   /* tp_alloc */
+    nullptr,                   /* tp_new */
+    nullptr,                   /* tp_free */
+    nullptr,                   /* tp_is_gc */
+    nullptr,                   /* tp_bases */
+    nullptr,                   /* tp_mro */
+    nullptr,                   /* tp_cache */
+    nullptr,                   /* tp_subclasses */
+    nullptr,                   /* tp_weaklist */
+    nullptr,                   /* tp_del */
     0,                         /* tp_version_tag */
 };
 
@@ -136,7 +136,7 @@ static PyObject* mlFindModule(PyObject *self, PyObject *args)
     char *name;
     PyObject *path;
     if ( !PyArg_ParseTuple(args, "s|O", &name, &path) )
-        return NULL;
+        return nullptr;
 
     //reset any previous load errors, they apparently didn't matter
     loadErrors = "";
@@ -167,18 +167,18 @@ static PyObject* mlFindModule(PyObject *self, PyObject *args)
 }
 
 static PyMethodDef emptyModMethods[] = {
-    {NULL, NULL, 0, NULL }
+    {nullptr, nullptr, 0, nullptr }
 };
 
 static PyObject* mlLoadModule(PyObject *UNUSED(self), PyObject *args)
 {
     char *name;
     if ( !PyArg_ParseTuple(args, "s", &name) )
-        return NULL;
+        return nullptr;
 
     if ( strncmp(name, "sst.", 4) ) {
         // We know how to handle only sst.<module>
-        return NULL; // ERROR!
+        return nullptr; // ERROR!
     }
 
     char *modName = name+4; // sst.<modName>
@@ -186,7 +186,7 @@ static PyObject* mlLoadModule(PyObject *UNUSED(self), PyObject *args)
     //fprintf(stderr, "Loading SST module '%s' (from %s)\n", modName, name);
     // genPythonModuleFunction func = Factory::getFactory()->getPythonModule(modName);
     SSTElementPythonModule* pymod = Factory::getFactory()->getPythonModule(modName);
-    PyObject* mod = NULL;
+    PyObject* mod = nullptr;
     if ( !pymod ) {
         mod = Py_InitModule(name, emptyModMethods);
     } else {
@@ -230,7 +230,7 @@ static PyObject* setProgramOption(PyObject* UNUSED(self), PyObject* args)
         else
             Py_RETURN_FALSE;
     } else {
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -238,7 +238,7 @@ static PyObject* setProgramOption(PyObject* UNUSED(self), PyObject* args)
 static PyObject* setProgramOptions(PyObject* UNUSED(self), PyObject* args)
 {
     if ( !PyDict_Check(args) ) {
-        return NULL;
+        return nullptr;
     }
     Py_ssize_t pos = 0;
     PyObject *key, *val;
@@ -283,14 +283,14 @@ static PyObject* getProgramOptions(PyObject*UNUSED(self), PyObject *UNUSED(args)
 
 static PyObject* pushNamePrefix(PyObject* UNUSED(self), PyObject* arg)
 {
-    char *name = NULL;
+    char *name = nullptr;
     PyErr_Clear();
     name = PyString_AsString(arg);
 
-    if ( name != NULL ) {
+    if ( name != nullptr ) {
         gModel->pushNamePrefix(name);
     } else {
-        return NULL;
+        return nullptr;
     }
     return PyInt_FromLong(0);
 }
@@ -306,7 +306,7 @@ static PyObject* popNamePrefix(PyObject* UNUSED(self), PyObject* UNUSED(args))
 static PyObject* exitsst(PyObject* UNUSED(self), PyObject* UNUSED(args))
 {
     exit(-1);
-    return NULL;
+    return nullptr;
 }
 
 static PyObject* getSSTMPIWorldSize(PyObject* UNUSED(self), PyObject* UNUSED(args)) {
@@ -336,7 +336,7 @@ static PyObject* setStatisticOutput(PyObject* UNUSED(self), PyObject* args)
 {
     char*      statOutputName;
     int        argOK = 0;
-    PyObject*  outputParamDict = NULL;
+    PyObject*  outputParamDict = nullptr;
 
     PyErr_Clear();
 
@@ -351,7 +351,7 @@ static PyObject* setStatisticOutput(PyObject* UNUSED(self), PyObject* args)
             gModel->addStatisticOutputParameter(p.first, p.second);
         }
     } else {
-        return NULL;
+        return nullptr;
     }
     return PyInt_FromLong(0);
 }
@@ -369,7 +369,7 @@ static PyObject* setStatisticOutputOption(PyObject* UNUSED(self), PyObject* args
     if (argOK) {
         gModel->addStatisticOutputParameter(param, value);
     } else {
-        return NULL;
+        return nullptr;
     }
     return PyInt_FromLong(0);
 }
@@ -380,7 +380,7 @@ static PyObject* setStatisticOutputOptions(PyObject* UNUSED(self), PyObject* arg
     PyErr_Clear();
 
     if ( !PyDict_Check(args) ) {
-        return NULL;
+        return nullptr;
     }
 
     // Generate and Add the Statistic Output Parameters
@@ -410,7 +410,7 @@ static PyObject* setStatisticLoadLevel(PyObject* UNUSED(self), PyObject* arg)
 static PyObject* enableAllStatisticsForAllComponents(PyObject* UNUSED(self), PyObject* args)
 {
     int           argOK = 0;
-    PyObject*     statParamDict = NULL;
+    PyObject*     statParamDict = nullptr;
 
     PyErr_Clear();
 
@@ -426,7 +426,7 @@ static PyObject* enableAllStatisticsForAllComponents(PyObject* UNUSED(self), PyO
         }
     } else {
         // ParseTuple Failed, return NULL for error
-        return NULL;
+        return nullptr;
     }
 
     return PyInt_FromLong(0);
@@ -436,8 +436,8 @@ static PyObject* enableAllStatisticsForAllComponents(PyObject* UNUSED(self), PyO
 static PyObject* enableAllStatisticsForComponentName(PyObject *UNUSED(self), PyObject *args)
 {
     int           argOK = 0;
-    char*         compName = NULL;
-    PyObject*     statParamDict = NULL;
+    char*         compName = nullptr;
+    PyObject*     statParamDict = nullptr;
 
     PyErr_Clear();
 
@@ -454,7 +454,7 @@ static PyObject* enableAllStatisticsForComponentName(PyObject *UNUSED(self), PyO
 
     } else {
         // ParseTuple Failed, return NULL for error
-        return NULL;
+        return nullptr;
     }
     return PyInt_FromLong(0);
 }
@@ -463,8 +463,8 @@ static PyObject* enableAllStatisticsForComponentName(PyObject *UNUSED(self), PyO
 static PyObject* enableAllStatisticsForComponentType(PyObject *UNUSED(self), PyObject *args)
 {
     int           argOK = 0;
-    char*         compType = NULL;
-    PyObject*     statParamDict = NULL;
+    char*         compType = nullptr;
+    PyObject*     statParamDict = nullptr;
 
     PyErr_Clear();
 
@@ -480,7 +480,7 @@ static PyObject* enableAllStatisticsForComponentType(PyObject *UNUSED(self), PyO
         }
     } else {
         // ParseTuple Failed, return NULL for error
-        return NULL;
+        return nullptr;
     }
     return PyInt_FromLong(0);
 }
@@ -489,9 +489,9 @@ static PyObject* enableAllStatisticsForComponentType(PyObject *UNUSED(self), PyO
 static PyObject* enableStatisticForComponentName(PyObject *UNUSED(self), PyObject *args)
 {
     int           argOK = 0;
-    char*         compName = NULL;
-    char*         statName = NULL;
-    PyObject*     statParamDict = NULL;
+    char*         compName = nullptr;
+    char*         statName = nullptr;
+    PyObject*     statParamDict = nullptr;
 
     PyErr_Clear();
 
@@ -507,7 +507,7 @@ static PyObject* enableStatisticForComponentName(PyObject *UNUSED(self), PyObjec
         }
     } else {
         // ParseTuple Failed, return NULL for error
-        return NULL;
+        return nullptr;
     }
     return PyInt_FromLong(0);
 }
@@ -516,9 +516,9 @@ static PyObject* enableStatisticForComponentName(PyObject *UNUSED(self), PyObjec
 static PyObject* enableStatisticForComponentType(PyObject *UNUSED(self), PyObject *args)
 {
     int           argOK = 0;
-    char*         compType = NULL;
-    char*         statName = NULL;
-    PyObject*     statParamDict = NULL;
+    char*         compType = nullptr;
+    char*         statName = nullptr;
+    PyObject*     statParamDict = nullptr;
 
     PyErr_Clear();
 
@@ -534,7 +534,7 @@ static PyObject* enableStatisticForComponentType(PyObject *UNUSED(self), PyObjec
         }
     } else {
         // ParseTuple Failed, return NULL for error
-        return NULL;
+        return nullptr;
     }
     return PyInt_FromLong(0);
 }
@@ -598,7 +598,7 @@ static PyMethodDef sstModuleMethods[] = {
     {   "findComponentByName",
         findComponentByName, METH_O,
         "Looks up to find a previously created component, based off of its name.  Returns None if none are to be found."},
-    {   NULL, NULL, 0, NULL }
+    {   nullptr, nullptr, 0, nullptr }
 };
 
 }  /* extern C */
@@ -683,7 +683,7 @@ void SSTPythonModelDefinition::initModel(const std::string& script_file, int ver
 }
 
 SSTPythonModelDefinition::SSTPythonModelDefinition(const std::string& script_file, int verbosity, Config* configObj) :
-	SSTModelDescription(), scriptName(script_file), config(configObj), namePrefix(NULL), namePrefixLen(0)
+	SSTModelDescription(), scriptName(script_file), config(configObj), namePrefix(nullptr), namePrefixLen(0)
 {
 	std::vector<std::string> argv_vector;
 	argv_vector.push_back("sstsim.x");
@@ -757,9 +757,9 @@ SSTPythonModelDefinition::SSTPythonModelDefinition(const std::string& script_fil
 
 SSTPythonModelDefinition::~SSTPythonModelDefinition() {
     delete output;
-    gModel = NULL;
+    gModel = nullptr;
 
-    if ( NULL != namePrefix ) free(namePrefix);
+    if ( nullptr != namePrefix ) free(namePrefix);
 }
 
 
@@ -774,7 +774,7 @@ ConfigGraph* SSTPythonModelDefinition::createConfigGraph()
     }
     int createReturn = PyRun_AnyFileEx(fp, scriptName.c_str(), 1);
 
-    if(NULL != PyErr_Occurred()) {
+    if(nullptr != PyErr_Occurred()) {
         // Print the Python error and then let SST exit as a fatal-stop.
         PyErr_Print();
         output->fatal(CALL_INFO, 1,
@@ -789,7 +789,7 @@ ConfigGraph* SSTPythonModelDefinition::createConfigGraph()
 
     output->verbose(CALL_INFO, 1, 0, "Construction of config graph with Python is complete.\n");
 
-    if(NULL != PyErr_Occurred()) {
+    if(nullptr != PyErr_Occurred()) {
         PyErr_Print();
         output->fatal(CALL_INFO, 1, "Error occured handling the creation of the component graph in Python.\n");
     }
@@ -800,7 +800,7 @@ ConfigGraph* SSTPythonModelDefinition::createConfigGraph()
 
 void SSTPythonModelDefinition::pushNamePrefix(const char *name)
 {
-    if ( NULL == namePrefix ) {
+    if ( nullptr == namePrefix ) {
         namePrefix = (char*)calloc(128, 1);
         namePrefixLen = 128;
     }
@@ -851,22 +851,22 @@ char* SSTPythonModelDefinition::addNamePrefix(const char *name) const
 /* Utilities */
 std::map<std::string,std::string> SST::Core::generateStatisticParameters(PyObject* statParamDict)
 {
-    PyObject*     pykey = NULL;
-    PyObject*     pyval = NULL;
+    PyObject*     pykey = nullptr;
+    PyObject*     pyval = nullptr;
     Py_ssize_t    pos = 0;
 
     std::map<std::string,std::string> p;
 
     // If the user did not include a dict for the parameters
     // the variable statParamDict will be NULL.
-    if (NULL != statParamDict) {
+    if (nullptr != statParamDict) {
         // Make sure it really is a Dict
         if (true == PyDict_Check(statParamDict)) {
 
             // Extract the Key and Value for each parameter and put them into the vectors 
             while ( PyDict_Next(statParamDict, &pos, &pykey, &pyval) ) {
-                PyObject* pyparam = PyObject_CallMethod(pykey, (char*)"__str__", NULL);
-                PyObject* pyvalue = PyObject_CallMethod(pyval, (char*)"__str__", NULL);
+                PyObject* pyparam = PyObject_CallMethod(pykey, (char*)"__str__", nullptr);
+                PyObject* pyvalue = PyObject_CallMethod(pyval, (char*)"__str__", nullptr);
 
                 p[PyString_AsString(pyparam)] = PyString_AsString(pyvalue);
 

--- a/src/sst/core/model/pymodel.cc
+++ b/src/sst/core/model/pymodel.cc
@@ -12,7 +12,7 @@
 // distribution.
 
 #include "sst_config.h"
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 
 DISABLE_WARN_DEPRECATED_REGISTER
 #include <Python.h>
@@ -25,19 +25,18 @@ REENABLE_WARNING
 #endif
 
 #include <string.h>
-#include <sstream>
 
-#include <sst/core/sst_types.h>
-#include <sst/core/model/pymodel.h>
-#include <sst/core/model/pymodel_comp.h>
-#include <sst/core/model/pymodel_link.h>
-#include <sst/core/model/pymodel_statgroup.h>
-#include <sst/core/model/element_python.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/model/pymodel.h"
+#include "sst/core/model/pymodel_comp.h"
+#include "sst/core/model/pymodel_link.h"
+#include "sst/core/model/pymodel_statgroup.h"
+#include "sst/core/model/element_python.h"
 
-#include <sst/core/simulation.h>
-#include <sst/core/factory.h>
-#include <sst/core/component.h>
-#include <sst/core/configGraph.h>
+#include "sst/core/simulation.h"
+#include "sst/core/factory.h"
+#include "sst/core/component.h"
+#include "sst/core/configGraph.h"
 DISABLE_WARN_STRICT_ALIASING
 
 using namespace SST::Core;
@@ -605,7 +604,7 @@ static PyMethodDef sstModuleMethods[] = {
 }  /* extern C */
 
 
-void SSTPythonModelDefinition::initModel(const std::string script_file, int verbosity, Config* UNUSED(config), int argc, char** argv)
+void SSTPythonModelDefinition::initModel(const std::string& script_file, int verbosity, Config* UNUSED(config), int argc, char** argv)
 {
     output = new Output("SSTPythonModel ", verbosity, 0, SST::Output::STDOUT);
 
@@ -683,7 +682,7 @@ void SSTPythonModelDefinition::initModel(const std::string script_file, int verb
 
 }
 
-SSTPythonModelDefinition::SSTPythonModelDefinition(const std::string script_file, int verbosity, Config* configObj) :
+SSTPythonModelDefinition::SSTPythonModelDefinition(const std::string& script_file, int verbosity, Config* configObj) :
 	SSTModelDescription(), scriptName(script_file), config(configObj), namePrefix(NULL), namePrefixLen(0)
 {
 	std::vector<std::string> argv_vector;
@@ -749,7 +748,7 @@ SSTPythonModelDefinition::SSTPythonModelDefinition(const std::string script_file
 	free(argv);
 }
 
-SSTPythonModelDefinition::SSTPythonModelDefinition(const std::string script_file, int verbosity,
+SSTPythonModelDefinition::SSTPythonModelDefinition(const std::string& script_file, int verbosity,
     Config* configObj, int argc, char **argv) :
     SSTModelDescription(), scriptName(script_file), config(configObj)
 {

--- a/src/sst/core/model/pymodel.h
+++ b/src/sst/core/model/pymodel.h
@@ -21,14 +21,13 @@
 
 #include <map>
 #include <string>
-#include <sstream>
 #include <vector>
 
-#include <sst/core/model/sstmodel.h>
-#include <sst/core/config.h>
-#include <sst/core/rankInfo.h>
-#include <sst/core/output.h>
-#include <sst/core/configGraph.h>
+#include "sst/core/model/sstmodel.h"
+#include "sst/core/config.h"
+#include "sst/core/rankInfo.h"
+#include "sst/core/output.h"
+#include "sst/core/configGraph.h"
 
 using namespace SST;
 
@@ -38,14 +37,14 @@ namespace Core {
 class SSTPythonModelDefinition : public SSTModelDescription {
 
 	public:
-		SSTPythonModelDefinition(const std::string script_file, int verbosity, Config* config, int argc, char **argv);
-		SSTPythonModelDefinition(const std::string script_file, int verbosity, Config* config);
+		SSTPythonModelDefinition(const std::string& script_file, int verbosity, Config* config, int argc, char **argv);
+		SSTPythonModelDefinition(const std::string& script_file, int verbosity, Config* config);
 		virtual ~SSTPythonModelDefinition();
 
 		ConfigGraph* createConfigGraph() override;
 
 	protected:
-		void initModel(const std::string script_file, int verbosity, Config* config, int argc, char** argv);
+		void initModel(const std::string& script_file, int verbosity, Config* config, int argc, char** argv);
 		std::string scriptName;
 		Output* output;
 		Config* config;
@@ -81,14 +80,14 @@ class SSTPythonModelDefinition : public SSTModelDescription {
         char* addNamePrefix(const char *name) const;
 
         void setStatisticOutput(const char* Name) { graph->setStatisticOutput(Name); }
-        void addStatisticOutputParameter(const std::string &param, const std::string &value) { graph->addStatisticOutputParameter(param, value); }
+        void addStatisticOutputParameter(const std::string& param, const std::string& value) { graph->addStatisticOutputParameter(param, value); }
         void setStatisticLoadLevel(uint8_t loadLevel) { graph->setStatisticLoadLevel(loadLevel); }
 
-        void enableStatisticForComponentName(const std::string &compname, const std::string &statname) const { graph->enableStatisticForComponentName(compname, statname); }
-        void enableStatisticForComponentType(const std::string &comptype, const std::string &statname) const  { graph->enableStatisticForComponentType(comptype, statname); }
+        void enableStatisticForComponentName(const std::string& compname, const std::string& statname) const { graph->enableStatisticForComponentName(compname, statname); }
+        void enableStatisticForComponentType(const std::string& comptype, const std::string& statname) const  { graph->enableStatisticForComponentType(comptype, statname); }
 
-        void addStatisticParameterForComponentName(const std::string &compname, const std::string &statname, const std::string &param, const std::string &value) { graph->addStatisticParameterForComponentName(compname, statname, param, value); }
-        void addStatisticParameterForComponentType(const std::string &comptype, const std::string &statname, const std::string &param, const std::string &value) { graph->addStatisticParameterForComponentType(comptype, statname, param, value); }
+        void addStatisticParameterForComponentName(const std::string& compname, const std::string& statname, const std::string& param, const std::string& value) { graph->addStatisticParameterForComponentName(compname, statname, param, value); }
+        void addStatisticParameterForComponentType(const std::string& comptype, const std::string& statname, const std::string& param, const std::string& value) { graph->addStatisticParameterForComponentType(comptype, statname, param, value); }
 };
 
 std::map<std::string,std::string> generateStatisticParameters(PyObject* statParamDict);

--- a/src/sst/core/model/pymodel_comp.cc
+++ b/src/sst/core/model/pymodel_comp.cc
@@ -43,7 +43,7 @@ ConfigComponent* ComponentHolder::getSubComp(const std::string& name, int slot_n
         if ( sc.name == name && sc.slot_num == slot_num)
             return &sc;
     }
-    return NULL;
+    return nullptr;
 }
 
 ComponentId_t ComponentHolder::getID()
@@ -137,15 +137,15 @@ static void compDealloc(ComponentPy_t *self)
 
 static PyObject* compAddParam(PyObject *self, PyObject *args)
 {
-    char *param = NULL;
-    PyObject *value = NULL;
+    char *param = nullptr;
+    PyObject *value = nullptr;
     if ( !PyArg_ParseTuple(args, "sO", &param, &value) )
-        return NULL;
+        return nullptr;
 
     ConfigComponent *c = getComp(self);
-    if ( NULL == c ) return NULL;
+    if ( nullptr == c ) return nullptr;
 
-    PyObject *vstr = PyObject_CallMethod(value, (char*)"__str__", NULL);
+    PyObject *vstr = PyObject_CallMethod(value, (char*)"__str__", nullptr);
     c->addParameter(param, PyString_AsString(vstr), true);
     Py_XDECREF(vstr);
 
@@ -156,10 +156,10 @@ static PyObject* compAddParam(PyObject *self, PyObject *args)
 static PyObject* compAddParams(PyObject *self, PyObject *args)
 {
     ConfigComponent *c = getComp(self);
-    if ( NULL == c ) return NULL;
+    if ( nullptr == c ) return nullptr;
 
     if ( !PyDict_Check(args) ) {
-        return NULL;
+        return nullptr;
     }
 
     Py_ssize_t pos = 0;
@@ -167,8 +167,8 @@ static PyObject* compAddParams(PyObject *self, PyObject *args)
     long count = 0;
 
     while ( PyDict_Next(args, &pos, &key, &val) ) {
-        PyObject *kstr = PyObject_CallMethod(key, (char*)"__str__", NULL);
-        PyObject *vstr = PyObject_CallMethod(val, (char*)"__str__", NULL);
+        PyObject *kstr = PyObject_CallMethod(key, (char*)"__str__", nullptr);
+        PyObject *vstr = PyObject_CallMethod(val, (char*)"__str__", nullptr);
         c->addParameter(PyString_AsString(kstr), PyString_AsString(vstr), true);
         Py_XDECREF(kstr);
         Py_XDECREF(vstr);
@@ -181,7 +181,7 @@ static PyObject* compAddParams(PyObject *self, PyObject *args)
 static PyObject* compSetRank(PyObject *self, PyObject *args)
 {
     ConfigComponent *c = getComp(self);
-    if ( NULL == c ) return NULL;
+    if ( nullptr == c ) return nullptr;
 
     PyErr_Clear();
 
@@ -189,7 +189,7 @@ static PyObject* compSetRank(PyObject *self, PyObject *args)
     unsigned long thread = (unsigned long)0;
 
     if ( !PyArg_ParseTuple(args, "k|k", &rank, &thread) ) {
-        return NULL;
+        return nullptr;
     }
 
     c->setRank(RankInfo(rank, thread));
@@ -201,7 +201,7 @@ static PyObject* compSetRank(PyObject *self, PyObject *args)
 static PyObject* compSetWeight(PyObject *self, PyObject *arg)
 {
     ConfigComponent *c = getComp(self);
-    if ( NULL == c ) return NULL;
+    if ( nullptr == c ) return nullptr;
 
     PyErr_Clear();
     double weight = PyFloat_AsDouble(arg);
@@ -221,16 +221,16 @@ static PyObject* compAddLink(PyObject *self, PyObject *args)
     ConfigComponent *c = getComp(self);
     ComponentId_t id = c->id;
 
-    PyObject *plink = NULL;
-    char *port = NULL, *lat = NULL;
+    PyObject *plink = nullptr;
+    char *port = nullptr, *lat = nullptr;
 
 
     if ( !PyArg_ParseTuple(args, "O!s|s", &PyModel_LinkType, &plink, &port, &lat) ) {
-        return NULL;
+        return nullptr;
     }
     LinkPy_t* link = (LinkPy_t*)plink;
-    if ( NULL == lat ) lat = link->latency;
-    if ( NULL == lat ) return NULL;
+    if ( nullptr == lat ) lat = link->latency;
+    if ( nullptr == lat ) return nullptr;
 
 
 	gModel->getOutput()->verbose(CALL_INFO, 4, 0, "Connecting component %" PRIu64 " to Link %s (lat: %s)\n", id, link->name, lat);
@@ -252,18 +252,18 @@ static int compCompare(PyObject *obj0, PyObject *obj1) {
 
 static PyObject* compSetSubComponent(PyObject *self, PyObject *args)
 {
-    char *name = NULL, *type = NULL;
+    char *name = nullptr, *type = nullptr;
     int slot = 0;
     
     if ( !PyArg_ParseTuple(args, "ss|i", &name, &type, &slot) )
-        return NULL;
+        return nullptr;
 
     ConfigComponent *c = getComp(self);
-    if ( NULL == c ) return NULL;
+    if ( nullptr == c ) return nullptr;
 
     PyComponent *baseComp = ((ComponentPy_t*)self)->obj->getBaseObj();
     ComponentId_t subC_id = SUBCOMPONENT_ID_CREATE(baseComp->id, ++(baseComp->subCompId));
-    if ( NULL != c->addSubComponent(subC_id, name, type, slot) ) {
+    if ( nullptr != c->addSubComponent(subC_id, name, type, slot) ) {
         PyObject *argList = Py_BuildValue("Ossi", self, name, type, slot);
         PyObject *subObj = PyObject_CallObject((PyObject*)&PyModel_SubComponentType, argList);
         Py_DECREF(argList);
@@ -273,14 +273,14 @@ static PyObject* compSetSubComponent(PyObject *self, PyObject *args)
     char errMsg[1024] = {0};
     snprintf(errMsg, sizeof(errMsg)-1, "Failed to create subcomponent %s on %s.  Already attached a subcomponent at that slot name and number?\n", name, c->name.c_str());
     PyErr_SetString(PyExc_RuntimeError, errMsg);
-    return NULL;
+    return nullptr;
 }
 
 static PyObject* compSetCoords(PyObject *self, PyObject *args)
 {
     std::vector<double> coords(3, 0.0);
     if ( !PyArg_ParseTuple(args, "d|dd", &coords[0], &coords[1], &coords[2]) ) {
-        PyObject* list = NULL;
+        PyObject* list = nullptr;
         if ( PyArg_ParseTuple(args, "O!", &PyList_Type, &list) && PyList_Size(list) > 0 ) {
             coords.clear();
             for ( Py_ssize_t i = 0 ; i < PyList_Size(list) ; i++ ) {
@@ -296,12 +296,12 @@ static PyObject* compSetCoords(PyObject *self, PyObject *args)
         } else {
 error:
             PyErr_SetString(PyExc_TypeError, "compSetCoords() expects arguments of 1-3 doubles, or a list/tuple of doubles");
-            return NULL;
+            return nullptr;
         }
     }
 
     ConfigComponent *c = getComp(self);
-    if ( NULL == c ) return NULL;
+    if ( nullptr == c ) return nullptr;
     c->setCoordinates(coords);
 
     return PyInt_FromLong(0);
@@ -310,7 +310,7 @@ error:
 static PyObject* compEnableAllStatistics(PyObject *self, PyObject *args)
 {
     int           argOK = 0;
-    PyObject*     statParamDict = NULL;
+    PyObject*     statParamDict = nullptr;
     ConfigComponent *c = getComp(self);
 
     PyErr_Clear();
@@ -328,7 +328,7 @@ static PyObject* compEnableAllStatistics(PyObject *self, PyObject *args)
 
     } else {
         // ParseTuple Failed, return NULL for error
-        return NULL;
+        return nullptr;
     }
     return PyInt_FromLong(0);
 }
@@ -337,8 +337,8 @@ static PyObject* compEnableAllStatistics(PyObject *self, PyObject *args)
 static PyObject* compEnableStatistics(PyObject *self, PyObject *args)
 {
     int           argOK = 0;
-    PyObject*     statList = NULL;
-    PyObject*     statParamDict = NULL;
+    PyObject*     statList = nullptr;
+    PyObject*     statParamDict = nullptr;
     Py_ssize_t    numStats = 0;
     ConfigComponent *c = getComp(self);
 
@@ -353,7 +353,7 @@ static PyObject* compEnableStatistics(PyObject *self, PyObject *args)
 
         // Make sure we have a list
         if ( !PyList_Check(statList) ) {
-            return NULL;
+            return nullptr;
         }
 
         // Get the Number of Stats in the list, and enable them separately,
@@ -361,7 +361,7 @@ static PyObject* compEnableStatistics(PyObject *self, PyObject *args)
         numStats = PyList_Size(statList);
         for (uint32_t x = 0; x < numStats; x++) {
             PyObject* pylistitem = PyList_GetItem(statList, x);
-            PyObject* pyname = PyObject_CallMethod(pylistitem, (char*)"__str__", NULL);
+            PyObject* pyname = PyObject_CallMethod(pylistitem, (char*)"__str__", nullptr);
 
             c->enableStatistic(PyString_AsString(pyname));
 
@@ -374,7 +374,7 @@ static PyObject* compEnableStatistics(PyObject *self, PyObject *args)
         }
     } else {
         // ParseTuple Failed, return NULL for error
-        return NULL;
+        return nullptr;
     }
     return PyInt_FromLong(0);
 }
@@ -411,58 +411,58 @@ static PyMethodDef componentMethods[] = {
     {   "setCoordinates",
         compSetCoords, METH_VARARGS,
         "Set (X,Y,Z) coordinates of this component, for use with visualization"},
-    {   NULL, NULL, 0, NULL }
+    {   nullptr, nullptr, 0, nullptr }
 };
 
 
 PyTypeObject PyModel_ComponentType = {
-    PyObject_HEAD_INIT(NULL)
+    PyObject_HEAD_INIT(nullptr)
     0,                         /* ob_size */
     "sst.Component",           /* tp_name */
     sizeof(ComponentPy_t),     /* tp_basicsize */
     0,                         /* tp_itemsize */
     (destructor)compDealloc,   /* tp_dealloc */
-    0,                         /* tp_print */
-    0,                         /* tp_getattr */
-    0,                         /* tp_setattr */
+    nullptr,                         /* tp_print */
+    nullptr,                         /* tp_getattr */
+    nullptr,                         /* tp_setattr */
     compCompare,               /* tp_compare */
-    0,                         /* tp_repr */
-    0,                         /* tp_as_number */
-    0,                         /* tp_as_sequence */
-    0,                         /* tp_as_mapping */
-    0,                         /* tp_hash */
-    0,                         /* tp_call */
-    0,                         /* tp_str */
-    0,                         /* tp_getattro */
-    0,                         /* tp_setattro */
-    0,                         /* tp_as_buffer */
+    nullptr,                         /* tp_repr */
+    nullptr,                         /* tp_as_number */
+    nullptr,                         /* tp_as_sequence */
+    nullptr,                         /* tp_as_mapping */
+    nullptr,                         /* tp_hash */
+    nullptr,                         /* tp_call */
+    nullptr,                         /* tp_str */
+    nullptr,                         /* tp_getattro */
+    nullptr,                         /* tp_setattro */
+    nullptr,                         /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,        /* tp_flags */
     "SST Component",           /* tp_doc */
-    0,                         /* tp_traverse */
-    0,                         /* tp_clear */
-    0,                         /* tp_richcompare */
+    nullptr,                         /* tp_traverse */
+    nullptr,                         /* tp_clear */
+    nullptr,                         /* tp_richcompare */
     0,                         /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
+    nullptr,                         /* tp_iter */
+    nullptr,                         /* tp_iternext */
     componentMethods,          /* tp_methods */
-    0,                         /* tp_members */
-    0,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
+    nullptr,                         /* tp_members */
+    nullptr,                         /* tp_getset */
+    nullptr,                         /* tp_base */
+    nullptr,                         /* tp_dict */
+    nullptr,                         /* tp_descr_get */
+    nullptr,                         /* tp_descr_set */
     0,                         /* tp_dictoffset */
     (initproc)compInit,        /* tp_init */
-    0,                         /* tp_alloc */
-    0,                         /* tp_new */
-    0,                         /* tp_free */
-    0,                         /* tp_is_gc */
-    0,                         /* tp_bases */
-    0,                         /* tp_mro */
-    0,                         /* tp_cache */
-    0,                         /* tp_subclasses */
-    0,                         /* tp_weaklist */
-    0,                         /* tp_del */
+    nullptr,                         /* tp_alloc */
+    nullptr,                         /* tp_new */
+    nullptr,                         /* tp_free */
+    nullptr,                         /* tp_is_gc */
+    nullptr,                         /* tp_bases */
+    nullptr,                         /* tp_mro */
+    nullptr,                         /* tp_cache */
+    nullptr,                         /* tp_subclasses */
+    nullptr,                         /* tp_weaklist */
+    nullptr,                         /* tp_del */
     0,                         /* tp_version_tag */
 };
 
@@ -528,58 +528,58 @@ static PyMethodDef subComponentMethods[] = {
     {   "setCoordinates",
         compSetCoords, METH_VARARGS,
         "Set (X,Y,Z) coordinates of this component, for use with visualization"},
-    {   NULL, NULL, 0, NULL }
+    {   nullptr, nullptr, 0, nullptr }
 };
 
 
 PyTypeObject PyModel_SubComponentType = {
-    PyObject_HEAD_INIT(NULL)
+    PyObject_HEAD_INIT(nullptr)
     0,                         /* ob_size */
     "sst.SubComponent",        /* tp_name */
     sizeof(ComponentPy_t),     /* tp_basicsize */
     0,                         /* tp_itemsize */
     (destructor)subCompDealloc,/* tp_dealloc */
-    0,                         /* tp_print */
-    0,                         /* tp_getattr */
-    0,                         /* tp_setattr */
+    nullptr,                         /* tp_print */
+    nullptr,                         /* tp_getattr */
+    nullptr,                         /* tp_setattr */
     compCompare,               /* tp_compare */
-    0,                         /* tp_repr */
-    0,                         /* tp_as_number */
-    0,                         /* tp_as_sequence */
-    0,                         /* tp_as_mapping */
-    0,                         /* tp_hash */
-    0,                         /* tp_call */
-    0,                         /* tp_str */
-    0,                         /* tp_getattro */
-    0,                         /* tp_setattro */
-    0,                         /* tp_as_buffer */
+    nullptr,                         /* tp_repr */
+    nullptr,                         /* tp_as_number */
+    nullptr,                         /* tp_as_sequence */
+    nullptr,                         /* tp_as_mapping */
+    nullptr,                         /* tp_hash */
+    nullptr,                         /* tp_call */
+    nullptr,                         /* tp_str */
+    nullptr,                         /* tp_getattro */
+    nullptr,                         /* tp_setattro */
+    nullptr,                         /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,        /* tp_flags */
     "SST SubComponent",        /* tp_doc */
-    0,                         /* tp_traverse */
-    0,                         /* tp_clear */
-    0,                         /* tp_richcompare */
+    nullptr,                         /* tp_traverse */
+    nullptr,                         /* tp_clear */
+    nullptr,                         /* tp_richcompare */
     0,                         /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
+    nullptr,                         /* tp_iter */
+    nullptr,                         /* tp_iternext */
     subComponentMethods,       /* tp_methods */
-    0,                         /* tp_members */
-    0,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
+    nullptr,                         /* tp_members */
+    nullptr,                         /* tp_getset */
+    nullptr,                         /* tp_base */
+    nullptr,                         /* tp_dict */
+    nullptr,                         /* tp_descr_get */
+    nullptr,                         /* tp_descr_set */
     0,                         /* tp_dictoffset */
     (initproc)subCompInit,     /* tp_init */
-    0,                         /* tp_alloc */
-    0,                         /* tp_new */
-    0,                         /* tp_free */
-    0,                         /* tp_is_gc */
-    0,                         /* tp_bases */
-    0,                         /* tp_mro */
-    0,                         /* tp_cache */
-    0,                         /* tp_subclasses */
-    0,                         /* tp_weaklist */
-    0,                         /* tp_del */
+    nullptr,                         /* tp_alloc */
+    nullptr,                         /* tp_new */
+    nullptr,                         /* tp_free */
+    nullptr,                         /* tp_is_gc */
+    nullptr,                         /* tp_bases */
+    nullptr,                         /* tp_mro */
+    nullptr,                         /* tp_cache */
+    nullptr,                         /* tp_subclasses */
+    nullptr,                         /* tp_weaklist */
+    nullptr,                         /* tp_del */
     0,                         /* tp_version_tag */
 };
 

--- a/src/sst/core/model/pymodel_comp.cc
+++ b/src/sst/core/model/pymodel_comp.cc
@@ -12,25 +12,23 @@
 // distribution.
 
 #include "sst_config.h"
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 
 DISABLE_WARN_DEPRECATED_REGISTER
 #include <Python.h>
 REENABLE_WARNING
 
-
 #include <string.h>
-#include <sstream>
 
-#include <sst/core/model/pymodel.h>
-#include <sst/core/model/pymodel_comp.h>
-#include <sst/core/model/pymodel_link.h>
+#include "sst/core/model/pymodel.h"
+#include "sst/core/model/pymodel_comp.h"
+#include "sst/core/model/pymodel_link.h"
 
-#include <sst/core/sst_types.h>
-#include <sst/core/simulation.h>
-#include <sst/core/component.h>
-#include <sst/core/subcomponent.h>
-#include <sst/core/configGraph.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/simulation.h"
+#include "sst/core/component.h"
+#include "sst/core/subcomponent.h"
+#include "sst/core/configGraph.h"
 
 using namespace SST::Core;
 extern SST::Core::SSTPythonModelDefinition *gModel;
@@ -39,7 +37,7 @@ extern SST::Core::SSTPythonModelDefinition *gModel;
 extern "C" {
 
 
-ConfigComponent* ComponentHolder::getSubComp(const std::string &name, int slot_num)
+ConfigComponent* ComponentHolder::getSubComp(const std::string& name, int slot_num)
 {
     for ( auto &sc : getComp()->subComponents ) {
         if ( sc.name == name && sc.slot_num == slot_num)

--- a/src/sst/core/model/pymodel_comp.h
+++ b/src/sst/core/model/pymodel_comp.h
@@ -14,7 +14,7 @@
 #ifndef SST_CORE_MODEL_PYMODEL_COMP_H
 #define SST_CORE_MODEL_PYMODEL_COMP_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 extern "C" {
 
@@ -25,14 +25,14 @@ struct PyComponent;
 struct ComponentHolder {
     ComponentPy_t *pobj;
 	char *name;
-    ComponentHolder(ComponentPy_t *pobj) : pobj(pobj), name(NULL) { }
+    ComponentHolder(ComponentPy_t *pobj) : pobj(pobj), name(nullptr) { }
     virtual ~ComponentHolder() { free(name); }
     virtual ConfigComponent* getComp() = 0;
     virtual PyComponent* getBaseObj() = 0;
     virtual int compare(ComponentHolder *other) = 0;
     virtual const char* getName() const = 0;
     ComponentId_t getID();
-    ConfigComponent* getSubComp(const std::string &name, int slot_num);
+    ConfigComponent* getSubComp(const std::string& name, int slot_num);
 };
 
 struct PyComponent : ComponentHolder {
@@ -72,7 +72,7 @@ extern PyTypeObject PyModel_SubComponentType;
 
 static inline ConfigComponent* getComp(PyObject *pobj) {
     ConfigComponent *c = ((ComponentPy_t*)pobj)->obj->getComp();
-    if ( c == NULL ) {
+    if ( c == nullptr ) {
         PyErr_SetString(PyExc_RuntimeError, "Failed to find ConfigComponent");
     }
     return c;

--- a/src/sst/core/model/pymodel_link.cc
+++ b/src/sst/core/model/pymodel_link.cc
@@ -12,23 +12,22 @@
 // distribution.
 
 #include "sst_config.h"
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 
 DISABLE_WARN_DEPRECATED_REGISTER
 #include <Python.h>
 REENABLE_WARNING
 
 #include <string.h>
-#include <sstream>
 
-#include <sst/core/model/pymodel.h>
-#include <sst/core/model/pymodel_comp.h>
-#include <sst/core/model/pymodel_link.h>
+#include "sst/core/model/pymodel.h"
+#include "sst/core/model/pymodel_comp.h"
+#include "sst/core/model/pymodel_link.h"
 
-#include <sst/core/sst_types.h>
-#include <sst/core/simulation.h>
-#include <sst/core/component.h>
-#include <sst/core/configGraph.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/simulation.h"
+#include "sst/core/component.h"
+#include "sst/core/configGraph.h"
 
 using namespace SST::Core;
 extern SST::Core::SSTPythonModelDefinition *gModel;

--- a/src/sst/core/model/pymodel_link.cc
+++ b/src/sst/core/model/pymodel_link.cc
@@ -37,12 +37,12 @@ extern "C" {
 
 static int linkInit(LinkPy_t *self, PyObject *args, PyObject *UNUSED(kwds))
 {
-    char *name = NULL, *lat = NULL;
+    char *name = nullptr, *lat = nullptr;
     if ( !PyArg_ParseTuple(args, "s|s", &name, &lat) ) return -1;
 
     self->name = gModel->addNamePrefix(name);
     self->no_cut = false;
-    self->latency = lat ? strdup(lat) : NULL;
+    self->latency = lat ? strdup(lat) : nullptr;
 	gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Creating Link %s\n", self->name);
 
     return 0;
@@ -62,12 +62,12 @@ static PyObject* linkConnect(PyObject* self, PyObject *args)
     if ( !PyArg_ParseTuple(args, "O!O!",
                 &PyTuple_Type, &t0,
                 &PyTuple_Type, &t1) ) {
-        return NULL;
+        return nullptr;
     }
 
     PyObject *c0, *c1;
     char *port0, *port1;
-    char *lat0 = NULL, *lat1 = NULL;
+    char *lat0 = nullptr, *lat1 = nullptr;
 
     LinkPy_t *link = (LinkPy_t*)self;
 
@@ -76,10 +76,10 @@ static PyObject* linkConnect(PyObject* self, PyObject *args)
         PyErr_Clear();
         if ( !PyArg_ParseTuple(t0, "O!s|s",
                     &PyModel_SubComponentType, &c0, &port0, &lat0) ) {
-            return NULL;
+            return nullptr;
         }
     }
-    if ( NULL == lat0 )
+    if ( nullptr == lat0 )
         lat0 = link->latency;
 
     if ( !PyArg_ParseTuple(t1, "O!s|s",
@@ -87,15 +87,15 @@ static PyObject* linkConnect(PyObject* self, PyObject *args)
         PyErr_Clear();
         if ( !PyArg_ParseTuple(t1, "O!s|s",
                     &PyModel_SubComponentType, &c1, &port1, &lat1) ) {
-            return NULL;
+            return nullptr;
         }
     }
-    if ( NULL == lat1 )
+    if ( nullptr == lat1 )
         lat1 = link->latency;
 
-    if ( NULL == lat0 || NULL == lat1 ) {
+    if ( nullptr == lat0 || nullptr == lat1 ) {
         gModel->getOutput()->fatal(CALL_INFO, 1, "No Latency specified for link %s\n", link->name);
-        return NULL;
+        return nullptr;
     }
 
     ComponentId_t id0, id1;
@@ -131,58 +131,58 @@ static PyMethodDef linkMethods[] = {
     {   "setNoCut",
         linkSetNoCut, METH_NOARGS,
         "Specifies that this link should not be partitioned across"},
-    {   NULL, NULL, 0, NULL }
+    {   nullptr, nullptr, 0, nullptr }
 };
 
 
 PyTypeObject PyModel_LinkType = {
-    PyObject_HEAD_INIT(NULL)
+    PyObject_HEAD_INIT(nullptr)
     0,                         /* ob_size */
     "sst.Link",                /* tp_name */
     sizeof(LinkPy_t),          /* tp_basicsize */
     0,                         /* tp_itemsize */
     (destructor)linkDealloc,   /* tp_dealloc */
-    0,                         /* tp_print */
-    0,                         /* tp_getattr */
-    0,                         /* tp_setattr */
-    0,                         /* tp_compare */
-    0,                         /* tp_repr */
-    0,                         /* tp_as_number */
-    0,                         /* tp_as_sequence */
-    0,                         /* tp_as_mapping */
-    0,                         /* tp_hash */
-    0,                         /* tp_call */
-    0,                         /* tp_str */
-    0,                         /* tp_getattro */
-    0,                         /* tp_setattro */
-    0,                         /* tp_as_buffer */
+    nullptr,                   /* tp_print */
+    nullptr,                   /* tp_getattr */
+    nullptr,                   /* tp_setattr */
+    nullptr,                   /* tp_compare */
+    nullptr,                   /* tp_repr */
+    nullptr,                   /* tp_as_number */
+    nullptr,                   /* tp_as_sequence */
+    nullptr,                   /* tp_as_mapping */
+    nullptr,                   /* tp_hash */
+    nullptr,                   /* tp_call */
+    nullptr,                   /* tp_str */
+    nullptr,                   /* tp_getattro */
+    nullptr,                   /* tp_setattro */
+    nullptr,                   /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,        /* tp_flags */
     "SST Link",                /* tp_doc */
-    0,                         /* tp_traverse */
-    0,                         /* tp_clear */
-    0,                         /* tp_richcompare */
+    nullptr,                   /* tp_traverse */
+    nullptr,                   /* tp_clear */
+    nullptr,                   /* tp_richcompare */
     0,                         /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
+    nullptr,                   /* tp_iter */
+    nullptr,                   /* tp_iternext */
     linkMethods,               /* tp_methods */
-    0,                         /* tp_members */
-    0,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
+    nullptr,                   /* tp_members */
+    nullptr,                   /* tp_getset */
+    nullptr,                   /* tp_base */
+    nullptr,                   /* tp_dict */
+    nullptr,                   /* tp_descr_get */
+    nullptr,                   /* tp_descr_set */
     0,                         /* tp_dictoffset */
     (initproc)linkInit,        /* tp_init */
-    0,                         /* tp_alloc */
-    0,                         /* tp_new */
-    0,                         /* tp_free */
-    0,                         /* tp_is_gc */
-    0,                         /* tp_bases */
-    0,                         /* tp_mro */
-    0,                         /* tp_cache */
-    0,                         /* tp_subclasses */
-    0,                         /* tp_weaklist */
-    0,                         /* tp_del */
+    nullptr,                   /* tp_alloc */
+    nullptr,                   /* tp_new */
+    nullptr,                   /* tp_free */
+    nullptr,                   /* tp_is_gc */
+    nullptr,                   /* tp_bases */
+    nullptr,                   /* tp_mro */
+    nullptr,                   /* tp_cache */
+    nullptr,                   /* tp_subclasses */
+    nullptr,                   /* tp_weaklist */
+    nullptr,                   /* tp_del */
     0,                         /* tp_version_tag */
 };
 

--- a/src/sst/core/model/pymodel_link.h
+++ b/src/sst/core/model/pymodel_link.h
@@ -14,7 +14,7 @@
 #ifndef SST_CORE_MODEL_PYMODEL_LINK_H
 #define SST_CORE_MODEL_PYMODEL_LINK_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 extern "C" {
 

--- a/src/sst/core/model/pymodel_statgroup.cc
+++ b/src/sst/core/model/pymodel_statgroup.cc
@@ -39,7 +39,7 @@ extern "C" {
 static Params convertToParams(PyObject *dict)
 {
     Params res;
-    if ( dict != NULL ) {
+    if ( dict != nullptr ) {
         for ( auto p : generateStatisticParameters(dict) ) {
             res.insert(p.first, p.second);
         }
@@ -52,7 +52,7 @@ static Params convertToParams(PyObject *dict)
 
 static int sgInit(StatGroupPy_t *self, PyObject *args, PyObject *UNUSED(kwds))
 {
-    char *name = NULL;
+    char *name = nullptr;
     if ( !PyArg_ParseTuple(args, "s", &name) ) return -1;
 
     self->ptr = gModel->getGraph()->getStatGroup(name);
@@ -71,26 +71,26 @@ static PyObject* sgAddStat(PyObject *self, PyObject *args)
 {
     PyErr_Clear();
 
-    char *statName = NULL;
-    PyObject *paramsDict = NULL;
+    char *statName = nullptr;
+    PyObject *paramsDict = nullptr;
 
     int argOK = PyArg_ParseTuple(args, "s|O!", &statName, &PyDict_Type, &paramsDict);
     if ( !argOK )
-        return NULL;
+        return nullptr;
 
     Params params = convertToParams(paramsDict);
 
     ConfigStatGroup *csg = ((StatGroupPy_t*)self)->ptr;
     if ( !csg->addStatistic(statName, params) ) {
         PyErr_SetString(PyExc_RuntimeError, "Unable to create statistic");
-        return NULL;
+        return nullptr;
     }
     bool verified;
     std::string reason;
     std::tie(verified, reason) = csg->verifyStatsAndComponents(gModel->getGraph());
     if ( !verified ) {
         PyErr_SetString(PyExc_RuntimeError, reason.c_str());
-        return NULL;
+        return nullptr;
     }
     return PyLong_FromLong(0);
 }
@@ -106,7 +106,7 @@ static PyObject* sgAddComp(PyObject *self, PyObject *args)
         csg->addComponent(((ComponentPy_t*)args)->obj->getID());
     } else {
         PyErr_SetString(PyExc_TypeError, "Expected Component or SubComponent type");
-        return NULL;
+        return nullptr;
     }
 
     bool verified;
@@ -114,7 +114,7 @@ static PyObject* sgAddComp(PyObject *self, PyObject *args)
     std::tie(verified, reason) = csg->verifyStatsAndComponents(gModel->getGraph());
     if ( !verified ) {
         PyErr_SetString(PyExc_RuntimeError, reason.c_str());
-        return NULL;
+        return nullptr;
     }
     return PyLong_FromLong(0);
 }
@@ -127,11 +127,11 @@ static PyObject* sgSetOutput(PyObject *self, PyObject *args)
         StatOutputPy_t *out = (StatOutputPy_t*)args;
         if ( !((StatGroupPy_t*)self)->ptr->setOutput(out->id) ) {
             PyErr_SetString(PyExc_RuntimeError, "Unable to set Statistic Output");
-            return NULL;
+            return nullptr;
         }
     } else {
         PyErr_SetString(PyExc_TypeError, "Expected sst.StatisticOutput type");
-        return NULL;
+        return nullptr;
     }
 
     return PyLong_FromLong(0);
@@ -141,11 +141,11 @@ static PyObject* sgSetOutput(PyObject *self, PyObject *args)
 static PyObject* sgSetFreq(PyObject *self, PyObject *args)
 {
     if ( !PyString_Check(args) ) {
-        return NULL;
+        return nullptr;
     }
     if ( !((StatGroupPy_t*)self)->ptr->setFrequency(PyString_AsString(args)) ) {
         PyErr_SetString(PyExc_RuntimeError, "Invalid frequency");
-        return NULL;
+        return nullptr;
     }
 
     return PyLong_FromLong(0);
@@ -163,58 +163,58 @@ static PyMethodDef sgMethods[] = {
         "Configure how the stats should be written" },
     {   "setFrequency", sgSetFreq, METH_O,
         "Set the frequency or rate (ie: \"10ms\", \"25khz\") to write out the statistics" },
-    {   NULL, NULL, 0, NULL }
+    {   nullptr, nullptr, 0, nullptr }
 };
 
 
 PyTypeObject PyModel_StatGroupType = {
-    PyObject_HEAD_INIT(NULL)
+    PyObject_HEAD_INIT(nullptr)
     0,                         /* ob_size */
     "sst.StatisticGroup",      /* tp_name */
     sizeof(StatGroupPy_t),     /* tp_basicsize */
     0,                         /* tp_itemsize */
     (destructor)sgDealloc,     /* tp_dealloc */
-    0,                         /* tp_print */
-    0,                         /* tp_getattr */
-    0,                         /* tp_setattr */
-    0,                         /* tp_compare */
-    0,                         /* tp_repr */
-    0,                         /* tp_as_number */
-    0,                         /* tp_as_sequence */
-    0,                         /* tp_as_mapping */
-    0,                         /* tp_hash */
-    0,                         /* tp_call */
-    0,                         /* tp_str */
-    0,                         /* tp_getattro */
-    0,                         /* tp_setattro */
-    0,                         /* tp_as_buffer */
+    nullptr,                   /* tp_print */
+    nullptr,                   /* tp_getattr */
+    nullptr,                   /* tp_setattr */
+    nullptr,                   /* tp_compare */
+    nullptr,                   /* tp_repr */
+    nullptr,                   /* tp_as_number */
+    nullptr,                   /* tp_as_sequence */
+    nullptr,                   /* tp_as_mapping */
+    nullptr,                   /* tp_hash */
+    nullptr,                   /* tp_call */
+    nullptr,                   /* tp_str */
+    nullptr,                   /* tp_getattro */
+    nullptr,                   /* tp_setattro */
+    nullptr,                   /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,        /* tp_flags */
     "SST Statistic Group",     /* tp_doc */
-    0,                         /* tp_traverse */
-    0,                         /* tp_clear */
-    0,                         /* tp_richcompare */
+    nullptr,                   /* tp_traverse */
+    nullptr,                   /* tp_clear */
+    nullptr,                   /* tp_richcompare */
     0,                         /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
+    nullptr,                   /* tp_iter */
+    nullptr,                   /* tp_iternext */
     sgMethods,                 /* tp_methods */
-    0,                         /* tp_members */
-    0,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
+    nullptr,                   /* tp_members */
+    nullptr,                   /* tp_getset */
+    nullptr,                   /* tp_base */
+    nullptr,                   /* tp_dict */
+    nullptr,                   /* tp_descr_get */
+    nullptr,                   /* tp_descr_set */
     0,                         /* tp_dictoffset */
     (initproc)sgInit,          /* tp_init */
-    0,                         /* tp_alloc */
-    0,                         /* tp_new */
-    0,                         /* tp_free */
-    0,                         /* tp_is_gc */
-    0,                         /* tp_bases */
-    0,                         /* tp_mro */
-    0,                         /* tp_cache */
-    0,                         /* tp_subclasses */
-    0,                         /* tp_weaklist */
-    0,                         /* tp_del */
+    nullptr,                   /* tp_alloc */
+    nullptr,                   /* tp_new */
+    nullptr,                   /* tp_free */
+    nullptr,                   /* tp_is_gc */
+    nullptr,                   /* tp_bases */
+    nullptr,                   /* tp_mro */
+    nullptr,                   /* tp_cache */
+    nullptr,                   /* tp_subclasses */
+    nullptr,                   /* tp_weaklist */
+    nullptr,                   /* tp_del */
     0,                         /* tp_version_tag */
 };
 
@@ -222,8 +222,8 @@ PyTypeObject PyModel_StatGroupType = {
 
 static int soInit(StatOutputPy_t *self, PyObject *args, PyObject *UNUSED(kwds))
 {
-    char *type = NULL;
-    PyObject *params = NULL;
+    char *type = nullptr;
+    PyObject *params = nullptr;
     if ( !PyArg_ParseTuple(args, "s|O!", &type, &PyDict_Type, &params) ) return -1;
 
     std::vector<ConfigStatOutput>& vec = gModel->getGraph()->getStatOutputs();
@@ -232,7 +232,7 @@ static int soInit(StatOutputPy_t *self, PyObject *args, PyObject *UNUSED(kwds))
     vec.emplace_back(type);
     self->ptr = &vec.back();
 
-    if ( params != NULL ) {
+    if ( params != nullptr ) {
         self->ptr->params = convertToParams(params);
     }
 
@@ -249,15 +249,15 @@ static void soDealloc(StatOutputPy_t *self)
 
 static PyObject* soAddParam(PyObject *self, PyObject *args)
 {
-    char *param = NULL;
-    PyObject *value = NULL;
+    char *param = nullptr;
+    PyObject *value = nullptr;
     if ( !PyArg_ParseTuple(args, "sO", &param, &value) )
-        return NULL;
+        return nullptr;
 
     ConfigStatOutput *so = ((StatOutputPy_t*)self)->ptr;
-    if ( NULL == so ) return NULL;
+    if ( nullptr == so ) return nullptr;
 
-    PyObject *vstr = PyObject_CallMethod(value, (char*)"__str__", NULL);
+    PyObject *vstr = PyObject_CallMethod(value, (char*)"__str__", nullptr);
     so->addParameter(param, PyString_AsString(vstr));
     Py_XDECREF(vstr);
 
@@ -268,10 +268,10 @@ static PyObject* soAddParam(PyObject *self, PyObject *args)
 static PyObject* soAddParams(PyObject *self, PyObject *args)
 {
     ConfigStatOutput *so = ((StatOutputPy_t*)self)->ptr;
-    if ( NULL == so ) return NULL;
+    if ( nullptr == so ) return nullptr;
 
     if ( !PyDict_Check(args) ) {
-        return NULL;
+        return nullptr;
     }
 
     Py_ssize_t pos = 0;
@@ -279,8 +279,8 @@ static PyObject* soAddParams(PyObject *self, PyObject *args)
     long count = 0;
 
     while ( PyDict_Next(args, &pos, &key, &val) ) {
-        PyObject *kstr = PyObject_CallMethod(key, (char*)"__str__", NULL);
-        PyObject *vstr = PyObject_CallMethod(val, (char*)"__str__", NULL);
+        PyObject *kstr = PyObject_CallMethod(key, (char*)"__str__", nullptr);
+        PyObject *vstr = PyObject_CallMethod(val, (char*)"__str__", nullptr);
         so->addParameter(PyString_AsString(kstr), PyString_AsString(vstr));
         Py_XDECREF(kstr);
         Py_XDECREF(vstr);
@@ -298,59 +298,59 @@ static PyMethodDef soMethods[] = {
     { "addParams",
       soAddParams, METH_O,
       "Adds Multiple Parameters from a dict"},
-    { NULL, NULL, 0, NULL }
+    { nullptr, nullptr, 0, nullptr }
 };
 
 
 PyTypeObject PyModel_StatOutputType = {
-    PyObject_HEAD_INIT(NULL)
-    0,                         /* ob_size */
-    "sst.StatisticOutput",     /* tp_name */
-    sizeof(StatOutputPy_t),    /* tp_basicsize */
-    0,                         /* tp_itemsize */
-    (destructor)soDealloc,     /* tp_dealloc */
-    0,                         /* tp_print */
-    0,                         /* tp_getattr */
-    0,                         /* tp_setattr */
-    0,                         /* tp_compare */
-    0,                         /* tp_repr */
-    0,                         /* tp_as_number */
-    0,                         /* tp_as_sequence */
-    0,                         /* tp_as_mapping */
-    0,                         /* tp_hash */
-    0,                         /* tp_call */
-    0,                         /* tp_str */
-    0,                         /* tp_getattro */
-    0,                         /* tp_setattro */
-    0,                         /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,        /* tp_flags */
-    "SST Statistic Output",     /* tp_doc */
-    0,                         /* tp_traverse */
-    0,                         /* tp_clear */
-    0,                         /* tp_richcompare */
-    0,                         /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
-    soMethods,                 /* tp_methods */
-    0,                         /* tp_members */
-    0,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
-    0,                         /* tp_dictoffset */
-    (initproc)soInit,          /* tp_init */
-    0,                         /* tp_alloc */
-    0,                         /* tp_new */
-    0,                         /* tp_free */
-    0,                         /* tp_is_gc */
-    0,                         /* tp_bases */
-    0,                         /* tp_mro */
-    0,                         /* tp_cache */
-    0,                         /* tp_subclasses */
-    0,                         /* tp_weaklist */
-    0,                         /* tp_del */
-    0,                         /* tp_version_tag */
+    PyObject_HEAD_INIT(nullptr)
+    0,                           /* ob_size */
+    "sst.StatisticOutput",       /* tp_name */
+    sizeof(StatOutputPy_t),      /* tp_basicsize */
+    0,                           /* tp_itemsize */
+    (destructor)soDealloc,       /* tp_dealloc */
+    nullptr,                     /* tp_print */
+    nullptr,                     /* tp_getattr */
+    nullptr,                     /* tp_setattr */
+    nullptr,                     /* tp_compare */
+    nullptr,                     /* tp_repr */
+    nullptr,                     /* tp_as_number */
+    nullptr,                     /* tp_as_sequence */
+    nullptr,                     /* tp_as_mapping */
+    nullptr,                     /* tp_hash */
+    nullptr,                     /* tp_call */
+    nullptr,                     /* tp_str */
+    nullptr,                     /* tp_getattro */
+    nullptr,                     /* tp_setattro */
+    nullptr,                     /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,          /* tp_flags */
+    "SST Statistic Output",      /* tp_doc */
+    nullptr,                     /* tp_traverse */
+    nullptr,                     /* tp_clear */
+    nullptr,                     /* tp_richcompare */
+    0,                           /* tp_weaklistoffset */
+    nullptr,                     /* tp_iter */
+    nullptr,                     /* tp_iternext */
+    soMethods,                   /* tp_methods */
+    nullptr,                     /* tp_members */
+    nullptr,                     /* tp_getset */
+    nullptr,                     /* tp_base */
+    nullptr,                     /* tp_dict */
+    nullptr,                     /* tp_descr_get */
+    nullptr,                     /* tp_descr_set */
+    0,                           /* tp_dictoffset */
+    (initproc)soInit,            /* tp_init */
+    nullptr,                     /* tp_alloc */
+    nullptr,                     /* tp_new */
+    nullptr,                     /* tp_free */
+    nullptr,                     /* tp_is_gc */
+    nullptr,                     /* tp_bases */
+    nullptr,                     /* tp_mro */
+    nullptr,                     /* tp_cache */
+    nullptr,                     /* tp_subclasses */
+    nullptr,                     /* tp_weaklist */
+    nullptr,                     /* tp_del */
+    0,                           /* tp_version_tag */
 };
 
 

--- a/src/sst/core/model/pymodel_statgroup.cc
+++ b/src/sst/core/model/pymodel_statgroup.cc
@@ -12,23 +12,22 @@
 // distribution.
 
 #include "sst_config.h"
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 
 DISABLE_WARN_DEPRECATED_REGISTER
 #include <Python.h>
 REENABLE_WARNING
 
 #include <string.h>
-#include <sstream>
 
-#include <sst/core/model/pymodel.h>
-#include <sst/core/model/pymodel_comp.h>
-#include <sst/core/model/pymodel_statgroup.h>
+#include "sst/core/model/pymodel.h"
+#include "sst/core/model/pymodel_comp.h"
+#include "sst/core/model/pymodel_statgroup.h"
 
-#include <sst/core/sst_types.h>
-#include <sst/core/simulation.h>
-#include <sst/core/component.h>
-#include <sst/core/configGraph.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/simulation.h"
+#include "sst/core/component.h"
+#include "sst/core/configGraph.h"
 
 using namespace SST::Core;
 extern SST::Core::SSTPythonModelDefinition *gModel;

--- a/src/sst/core/model/pymodel_statgroup.h
+++ b/src/sst/core/model/pymodel_statgroup.h
@@ -14,7 +14,7 @@
 #ifndef SST_CORE_MODEL_PYMODEL_STATGROUP_H
 #define SST_CORE_MODEL_PYMODEL_STATGROUP_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 namespace SST {
     class ConfigStatGroup;

--- a/src/sst/core/model/sstmodel.cc
+++ b/src/sst/core/model/sstmodel.cc
@@ -10,8 +10,8 @@
 // distribution.
 
 
-#include <sst_config.h>
-#include <sst/core/model/sstmodel.h>
+#include "sst_config.h"
+#include "sst/core/model/sstmodel.h"
 
 using namespace SST;
 

--- a/src/sst/core/module.cc
+++ b/src/sst/core/module.cc
@@ -1,4 +1,17 @@
-#include <sst/core/module.h>
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+
+#include "sst/core/module.h"
 
 namespace SST {
 

--- a/src/sst/core/module.h
+++ b/src/sst/core/module.h
@@ -13,7 +13,7 @@
 #ifndef SST_CORE_MODULE_H
 #define SST_CORE_MODULE_H
 
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/eli/elementinfo.h"
 
 namespace SST {
   /**

--- a/src/sst/core/objectComms.h
+++ b/src/sst/core/objectComms.h
@@ -13,14 +13,14 @@
 #ifndef SST_CORE_OBJECTCOMMS_H
 #define SST_CORE_OBJECTCOMMS_H
 
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 #ifdef SST_CONFIG_HAVE_MPI
 DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
 REENABLE_WARNING
 #endif
 
-#include <sst/core/serialization/serializer.h>
+#include "sst/core/serialization/serializer.h"
 
 #include <typeinfo>
 
@@ -76,7 +76,7 @@ std::vector<char> serialize(dataType &data)
 template <typename dataType>
 dataType* deserialize(std::vector<char> &buffer)
 {
-    dataType *tgt = NULL;
+    dataType *tgt = nullptr;
 
     SST::Core::Serialization::serializer ser;
 

--- a/src/sst/core/oneshot.cc
+++ b/src/sst/core/oneshot.cc
@@ -9,12 +9,13 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
 
-#include <sst/core/simulation.h>
-#include <sst/core/timeConverter.h>
+#include "sst/core/oneshot.h"
 
-#include <sst/core/oneshot.h>
+#include "sst/core/simulation.h"
+#include "sst/core/timeConverter.h"
+
 
 namespace SST {
 

--- a/src/sst/core/oneshot.h
+++ b/src/sst/core/oneshot.h
@@ -13,11 +13,11 @@
 #ifndef SST_CORE_ONESHOT_H
 #define SST_CORE_ONESHOT_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 #include <cinttypes>
 
-#include <sst/core/action.h>
+#include "sst/core/action.h"
 
 #define _ONESHOT_DBG(fmt, args...)__DBG(DBG_ONESHOT, OneShot, fmt, ## args)
 

--- a/src/sst/core/output.cc
+++ b/src/sst/core/output.cc
@@ -38,7 +38,7 @@ namespace SST {
 // Initialize The Static Member Variables
 Output      Output::m_defaultObject;
 std::string Output::m_sstGlobalSimFileName = "";
-std::FILE*  Output::m_sstGlobalSimFileHandle = 0;
+std::FILE*  Output::m_sstGlobalSimFileHandle = nullptr;
 uint32_t    Output::m_sstGlobalSimFileAccessCount = 0;
 
 std::unordered_map<std::thread::id, uint32_t> Output::m_threadMap;
@@ -80,11 +80,11 @@ void Output::init(const std::string& prefix, uint32_t verbose_level,
         m_verboseLevel = verbose_level;
         m_verboseMask  = verbose_mask;
         m_sstLocalFileName = localoutputfilename;
-        m_sstLocalFileHandle = 0;
+        m_sstLocalFileHandle = nullptr;
         m_sstLocalFileAccessCount = 0;
-        m_targetFileHandleRef = 0;
-        m_targetFileNameRef = 0;
-        m_targetFileAccessCountRef = 0;
+        m_targetFileHandleRef = nullptr;
+        m_targetFileNameRef = nullptr;
+        m_targetFileAccessCountRef = nullptr;
     
         setTargetOutput(location);
 
@@ -289,10 +289,10 @@ void Output::openSSTTargetFile() const
 
     if (true == m_objInitialized) {
         // If the target output is a file, See if the output file is created and opened
-        if ((FILE == m_targetLoc) && (0 == *m_targetFileHandleRef)) {
+        if ((FILE == m_targetLoc) && (nullptr == *m_targetFileHandleRef)) {
   
             // Check to see if the File has not been opened.
-            if ((*m_targetFileAccessCountRef > 0) && (0 == *m_targetFileHandleRef)) {
+            if ((*m_targetFileAccessCountRef > 0) && (nullptr == *m_targetFileHandleRef)) {
                 tempFileName = *m_targetFileNameRef;
                 
                 // Append the rank to file name if MPI_COMM_WORLD is GT 1
@@ -326,7 +326,7 @@ void Output::closeSSTTargetFile()
 
         // If the access count is zero, and the file has been opened, then close it
         if ((0 == *m_targetFileAccessCountRef) && 
-            (0 != *m_targetFileHandleRef) &&
+            (nullptr != *m_targetFileHandleRef) &&
             (FILE == m_targetLoc)) {
             fclose (*m_targetFileHandleRef);
         }

--- a/src/sst/core/output.cc
+++ b/src/sst/core/output.cc
@@ -25,7 +25,7 @@
 
 // Core Headers
 #include "sst/core/simulation.h"
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 
 #ifdef SST_CONFIG_HAVE_MPI
 DISABLE_WARN_MISSING_OVERRIDE
@@ -48,7 +48,7 @@ int Output::m_mpiRank = 0;
 
 Output::Output(const std::string& prefix, uint32_t verbose_level,   
                uint32_t verbose_mask,output_location_t location, 
-               std::string localoutputfilename /*=""*/)
+               const std::string& localoutputfilename /*=""*/)
 {
     m_objInitialized = false;
 
@@ -70,7 +70,7 @@ Output::Output()
 
 void Output::init(const std::string& prefix, uint32_t verbose_level,  
                   uint32_t verbose_mask, output_location_t location, 
-                  std::string localoutputfilename /*=""*/)
+                  const std::string& localoutputfilename /*=""*/)
 {
     // Only initialize if the object has not yet been initialized.
     if (false == m_objInitialized) {
@@ -303,7 +303,7 @@ void Output::openSSTTargetFile() const
                 
                 // Now try to open the file
                 handle = fopen(tempFileName.c_str(), "w");
-                if (NULL != handle){
+                if (nullptr != handle){
                     *m_targetFileHandleRef = handle;
                 } else {
                     // We got an error of some sort
@@ -434,8 +434,8 @@ std::string Output::buildPrefixString(uint32_t line, const std::string& file, co
 }
 
 
-void Output::outputprintf(uint32_t line, const std::string &file,
-                          const std::string &func, const char* format, va_list arg) const
+void Output::outputprintf(uint32_t line, const std::string& file,
+                          const std::string& func, const char* format, va_list arg) const
 {
     std::string newFmt;
     

--- a/src/sst/core/output.h
+++ b/src/sst/core/output.h
@@ -31,7 +31,7 @@
 
 #include <stdarg.h>
 
-#include <sst/core/rankInfo.h>
+#include "sst/core/rankInfo.h"
 
 extern int main(int argc, char **argv);
 
@@ -114,7 +114,7 @@ public:
     // CONSTRUCTION / DESTRUCTION
     Output(const std::string& prefix, uint32_t verbose_level,
            uint32_t verbose_mask, output_location_t location,
-           std::string localoutputfilename = "");
+           const std::string& localoutputfilename = "");
 
     /** Default Constructor.  User must call init() to properly initialize obj.
         Until init() is called, no output will occur.
@@ -173,7 +173,7 @@ public:
     // INITIALIZATION
     void init(const std::string& prefix, uint32_t verbose_level,
                uint32_t verbose_mask, output_location_t location,
-               std::string localoutputfilename = "");
+               const std::string& localoutputfilename = "");
 
     /** Output the message with formatting as specified by the format parameter.
         The output will be prepended with the expanded prefix set in the object.
@@ -510,8 +510,8 @@ private:
                                   const std::string& file,
                                   const std::string& func) const;
     void outputprintf(uint32_t line,
-                      const std::string &file,
-                      const std::string &func,
+                      const std::string& file,
+                      const std::string& func,
                       const char *format,
                       va_list arg) const;
     void outputprintf(const char *format, va_list arg) const;
@@ -519,7 +519,7 @@ private:
     friend int ::main(int argc, char **argv);
     static Output& setDefaultObject(const std::string& prefix, uint32_t verbose_level,
                uint32_t verbose_mask, output_location_t location,
-               std::string localoutputfilename = "")
+               const std::string& localoutputfilename = "")
     {
         m_defaultObject.init(prefix, verbose_level, verbose_mask, location, localoutputfilename);
         return getDefaultObject();

--- a/src/sst/core/params.cc
+++ b/src/sst/core/params.cc
@@ -10,9 +10,9 @@
 // distribution.
 //
 
-#include <sst_config.h>
-#include <sst/core/params.h>
-#include <sst/core/unitAlgebra.h>
+#include "sst_config.h"
+#include "sst/core/params.h"
+#include "sst/core/unitAlgebra.h"
 
 #include <map>
 #include <vector>
@@ -79,7 +79,7 @@ Params::count(const key_type& k)
 }
 
 void
-Params::print_all_params(std::ostream &os, std::string prefix) const
+Params::print_all_params(std::ostream &os, const std::string& prefix) const
 {
     for (const_iterator i = data.begin() ; i != data.end() ; ++i) {
         os << prefix << "key=" << keyMapReverse[i->first] << ", value=" << i->second << std::endl;
@@ -87,7 +87,7 @@ Params::print_all_params(std::ostream &os, std::string prefix) const
 }
 
 void
-Params::print_all_params(Output &out, std::string prefix) const
+Params::print_all_params(Output &out, const std::string& prefix) const
 {
     for (const_iterator i = data.begin() ; i != data.end() ; ++i) {
         out.output("%s%s = %s\n", prefix.c_str(), keyMapReverse[i->first].c_str(), i->second.c_str());
@@ -96,7 +96,7 @@ Params::print_all_params(Output &out, std::string prefix) const
 
 
 void
-Params::insert(std::string key, std::string value, bool overwrite)
+Params::insert(const std::string& key, const std::string& value, bool overwrite)
 {
     if ( overwrite ) {
         data[getKey(key)] = value;
@@ -216,7 +216,7 @@ Params::serialize_order(SST::Core::Serialization::serializer &ser)
 }    
 
 uint32_t
-Params::getKey(const std::string &str) const
+Params::getKey(const std::string& str) const
 {
     std::lock_guard<SST::Core::ThreadSafe::Spinlock> lock(keyLock);
     std::map<std::string, uint32_t>::iterator i = keyMap.find(str);
@@ -227,7 +227,7 @@ Params::getKey(const std::string &str) const
 }
 
 uint32_t
-Params::getKey(const std::string &str)
+Params::getKey(const std::string& str)
 {
     std::lock_guard<SST::Core::ThreadSafe::Spinlock> lock(keyLock);
     std::map<std::string, uint32_t>::iterator i = keyMap.find(str);
@@ -244,7 +244,7 @@ Params::getKey(const std::string &str)
 
 #if 0
  template<>
- uint32_t Params::find(const std::string &k) const
+ uint32_t Params::find(const std::string& k) const
  {
      bool tmp;
      uint32_t default_value = uint32_t();
@@ -254,30 +254,25 @@ Params::getKey(const std::string &str)
 
  #define SST_PARAMS_IMPLEMENT_TEMPLATE_SPECIALIZATION(type) \
      template<> \
-     type Params::find(const std::string &k, type default_value, bool &found) const { \
-         std::cout << "******* specialized" << std::endl; \
+     type Params::find(const std::string& k, type default_value, bool &found) const { \
          return find_impl<type>(k,default_value,found);  \
      } \
      template<> \
-     type Params::find(const std::string &k, std::string default_value, bool &found) const {  \
-         std::cout << "******* specialized" << std::endl; \
+     type Params::find(const std::string& k, const std::string& default_value, bool &found) const {  \
          return find_impl<type>(k,default_value,found); \
      } \
      template <> \
-     type Params::find(const std::string &k, type default_value ) const { \
-         std::cout << "******* specialized" << std::endl; \
+     type Params::find(const std::string& k, type default_value ) const { \
          bool tmp; \
          return find_impl<type>(k, default_value, tmp); \
      } \
      template <> \
-     type Params::find(const std::string &k, std::string default_value ) const { \
-         std::cout << "******* specialized" << std::endl; \
+     type Params::find(const std::string& k, const std::string& default_value ) const { \
          bool tmp; \
          return find_impl<type>(k, default_value, tmp); \
      } \
      template <> \
-     type Params::find(const std::string &k) const {      \
-         std::cout << "******* specialized" << std::endl; \
+     type Params::find(const std::string& k) const {      \
          bool tmp; \
          type default_value = type(); \
          return find_impl<type>(k, default_value, tmp); \
@@ -296,8 +291,7 @@ Params::getKey(const std::string &str)
  // std::string has to be special cased because of signature conflicts
  //SST_PARAMS_IMPLEMENT_TEMPLATE_SPECIALIZATION(std::string)
  template<>
- std::string Params::find<std::string>(const std::string &k, std::string default_value, bool &found) const {
-     std::cout << "******* specialized" << std::endl;
+ std::string Params::find<std::string>(const std::string& k, const std::string& default_value, bool &found) const {
      return find_impl<std::string>(k,default_value,found);
  }
 #endif

--- a/src/sst/core/params.h
+++ b/src/sst/core/params.h
@@ -267,7 +267,7 @@ public:
     template <class T>
     typename std::enable_if<std::is_same<bool,T>::value, T>::type
     find(const std::string& k, const char* default_value, bool &found ) const {
-        if ( 0 == default_value ) {
+        if ( nullptr == default_value ) {
             return find_impl<T>(k, static_cast<T>(0), found);
         }
         return find_impl<T>(k, std::string(default_value), found);
@@ -316,7 +316,7 @@ public:
     typename std::enable_if<std::is_same<bool,T>::value, T>::type
     find(const std::string& k, const char* default_value ) const {
         bool tmp;
-        if ( 0 == default_value ) {
+        if ( nullptr == default_value ) {
             return find_impl<T>(k, static_cast<T>(0), tmp);
         }
         return find_impl<T>(k, std::string(default_value), tmp);

--- a/src/sst/core/params.h
+++ b/src/sst/core/params.h
@@ -12,8 +12,8 @@
 #ifndef SST_CORE_PARAM_H
 #define SST_CORE_PARAM_H
 
-#include <sst/core/output.h>
-#include <sst/core/from_string.h>
+#include "sst/core/output.h"
+#include "sst/core/from_string.h"
 
 #include <cassert>
 #include <inttypes.h>
@@ -23,11 +23,11 @@
 #include <stack>
 #include <stdlib.h>
 #include <utility>
-#include <sst/core/threadsafe.h>
+#include "sst/core/threadsafe.h"
 
-#include <sst/core/serialization/serializable.h>
-#include <sst/core/serialization/serializer.h>
-#include <sst/core/output.h>
+#include "sst/core/serialization/serializable.h"
+#include "sst/core/serialization/serializer.h"
+#include "sst/core/output.h"
 
 int main(int argc, char *argv[]);
 
@@ -100,7 +100,7 @@ NO_VARIABLE:
      * converted to type T, an invalid_argument exception is thrown.
      */
     template <class T>
-    inline T find_impl(const std::string &k, T default_value, bool &found) const {
+    inline T find_impl(const std::string& k, T default_value, bool &found) const {
         verifyParam(k);
         // const_iterator i = data.find(getKey(k));
         const std::string& value = getString(k,found);
@@ -135,7 +135,7 @@ NO_VARIABLE:
      * @param found - set to true if the the parameter was found
      */
     template <class T>
-    inline T find_impl(const std::string &k, std::string default_value, bool &found) const {
+    inline T find_impl(const std::string& k, const std::string& default_value, bool &found) const {
         verifyParam(k);
         const std::string& value = getString(k,found);
         if ( !found ) {
@@ -235,7 +235,7 @@ public:
      */
     template <class T>
     typename std::enable_if<not std::is_same<std::string,T>::value, T>::type
-    find(const std::string &k, T default_value, bool &found) const {
+    find(const std::string& k, T default_value, bool &found) const {
         return find_impl<T>(k,default_value,found);
     }
     
@@ -250,7 +250,7 @@ public:
      * @param found - set to true if the the parameter was found
      */
     template <class T>
-    T find(const std::string &k, std::string default_value, bool &found) const {
+    T find(const std::string& k, const std::string& default_value, bool &found) const {
         return find_impl<T>(k,default_value,found);
     }
     
@@ -266,7 +266,7 @@ public:
      */
     template <class T>
     typename std::enable_if<std::is_same<bool,T>::value, T>::type
-    find(const std::string &k, const char* default_value, bool &found ) const {
+    find(const std::string& k, const char* default_value, bool &found ) const {
         if ( 0 == default_value ) {
             return find_impl<T>(k, static_cast<T>(0), found);
         }
@@ -282,7 +282,7 @@ public:
      * @param default_value - Default value to return if parameter isn't found
      */
     template <class T>
-    T find(const std::string &k, T default_value ) const {
+    T find(const std::string& k, T default_value ) const {
         bool tmp;
         return find_impl<T>(k, default_value, tmp);
     }
@@ -297,7 +297,7 @@ public:
      *   specified as a string
      */
     template <class T>
-    T find(const std::string &k, std::string default_value ) const {
+    T find(const std::string& k, const std::string& default_value ) const {
         bool tmp;
         return find_impl<T>(k, default_value, tmp);
     }
@@ -314,7 +314,7 @@ public:
      */
     template <class T>
     typename std::enable_if<std::is_same<bool,T>::value, T>::type
-    find(const std::string &k, const char* default_value ) const {
+    find(const std::string& k, const char* default_value ) const {
         bool tmp;
         if ( 0 == default_value ) {
             return find_impl<T>(k, static_cast<T>(0), tmp);
@@ -330,7 +330,7 @@ public:
      * @param k - Parameter name
      */
     template <class T>
-    T find(const std::string &k) const {
+    T find(const std::string& k) const {
         bool tmp;
         T default_value = T();
         return find_impl<T>(k, default_value, tmp);
@@ -348,7 +348,7 @@ public:
      */
     template <class T>
     typename std::enable_if<not std::is_same<bool, T>::value, T>::type
-    find(const std::string &k, bool &found) const {
+    find(const std::string& k, bool &found) const {
         T default_value = T();
         return find_impl<T>(k, default_value, found);
     }
@@ -393,7 +393,7 @@ public:
         while( ss.good() ) {
             std::string substr;
             getline( ss, substr, ',' );
-            // vec.push_back(strtol(substr.c_str(), NULL, 0));
+            // vec.push_back(strtol(substr.c_str(), nullptr, 0));
             try {
                 vec.push_back(SST::Core::from_string<T>(substr));
             }
@@ -407,14 +407,14 @@ public:
     }
 
     /** Print all key/value parameter pairs to specified ostream */
-    void print_all_params(std::ostream &os, std::string prefix = "") const;
-    void print_all_params(Output &out, std::string prefix = "") const;
+    void print_all_params(std::ostream &os, const std::string& prefix = "") const;
+    void print_all_params(Output &out, const std::string& prefix = "") const;
 
 
 
     /** Add a key value pair into the param object.
      */
-    void insert(std::string key, std::string value, bool overwrite = true);
+    void insert(const std::string& key, const std::string& value, bool overwrite = true);
 
     void insert(const Params& params);
 
@@ -468,8 +468,8 @@ private:
     bool verify_enabled;
     static bool g_verify_enabled;
 
-    uint32_t getKey(const std::string &str) const;
-    uint32_t getKey(const std::string &str);
+    uint32_t getKey(const std::string& str) const;
+    uint32_t getKey(const std::string& str);
 
     /* Friend main() because it broadcasts the maps */
     friend int ::main(int argc, char *argv[]);
@@ -487,15 +487,15 @@ private:
 
  #define SST_PARAMS_DECLARE_TEMPLATE_SPECIALIZATION(type) \
      template<> \
-     type Params::find(const std::string &k, type default_value, bool &found) const; \
+     type Params::find(const std::string& k, type default_value, bool &found) const; \
      template<> \
-     type Params::find(const std::string &k, std::string default_value, bool &found) const; \
+     type Params::find(const std::string& k, const std::string& default_value, bool &found) const; \
      template <> \
-     type Params::find(const std::string &k, type default_value ) const; \
+     type Params::find(const std::string& k, type default_value ) const; \
      template <> \
-     type Params::find(const std::string &k, std::string default_value ) const; \
+     type Params::find(const std::string& k, const std::string& default_value ) const; \
      template <> \
-     type Params::find(const std::string &k) const;
+     type Params::find(const std::string& k) const;
   
  
  SST_PARAMS_DECLARE_TEMPLATE_SPECIALIZATION(int32_t)
@@ -510,7 +510,7 @@ private:
  // std::string has to be special cased because of signature conflicts
  // SST_PARAMS_DECLARE_TEMPLATE_SPECIALIZATION(std::string)
  template<>
- std::string Params::find<std::string>(const std::string &k, std::string default_value, bool &found) const;
+ std::string Params::find<std::string>(const std::string& k, const std::string& default_value, bool &found) const;
 #endif
 
 

--- a/src/sst/core/part/sstpart.h
+++ b/src/sst/core/part/sstpart.h
@@ -13,9 +13,9 @@
 #ifndef SST_CORE_PART_BASE
 #define SST_CORE_PART_BASE
 
-#include <sst/core/rankInfo.h>
-#include <sst/core/warnmacros.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/rankInfo.h"
+#include "sst/core/warnmacros.h"
+#include "sst/core/eli/elementinfo.h"
 
 #include <map>
 

--- a/src/sst/core/pollingLinkQueue.cc
+++ b/src/sst/core/pollingLinkQueue.cc
@@ -12,7 +12,7 @@
 
 #include "sst_config.h"
 
-#include <sst/core/pollingLinkQueue.h>
+#include "sst/core/pollingLinkQueue.h"
 
 namespace SST {
 
@@ -43,7 +43,7 @@ namespace SST {
     
     Activity* PollingLinkQueue::pop()
     {
-	if ( data.size() == 0 ) return NULL;
+	if ( data.size() == 0 ) return nullptr;
 	std::multiset<Activity*,Activity::less_time>::iterator it = data.begin();
 	Activity* ret_val = (*it);
 	data.erase(it);
@@ -52,7 +52,7 @@ namespace SST {
 
     Activity* PollingLinkQueue::front()
     {
-	if ( data.size() == 0 ) return NULL;
+	if ( data.size() == 0 ) return nullptr;
 	return *data.begin();
     }
 

--- a/src/sst/core/pollingLinkQueue.h
+++ b/src/sst/core/pollingLinkQueue.h
@@ -14,7 +14,7 @@
 
 #include <set>
 
-#include <sst/core/activityQueue.h>
+#include "sst/core/activityQueue.h"
 
 namespace SST {
 

--- a/src/sst/core/profile.h
+++ b/src/sst/core/profile.h
@@ -13,7 +13,7 @@
 #define SST_CORE_CORE_PROFILE_H
 
 #include <chrono>
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/rankInfo.h
+++ b/src/sst/core/rankInfo.h
@@ -14,7 +14,7 @@
 #ifndef SST_CORE_RANKINFO_H
 #define SST_CORE_RANKINFO_H
 
-#include <sst/core/serialization/serializable.h>
+#include "sst/core/serialization/serializable.h"
 
 namespace SST {
 

--- a/src/sst/core/rankSyncParallelSkip.cc
+++ b/src/sst/core/rankSyncParallelSkip.cc
@@ -10,8 +10,9 @@
 // distribution.
 
 #include "sst_config.h"
-#include <sst/core/warnmacros.h>
 #include "sst/core/rankSyncParallelSkip.h"
+
+#include "sst/core/warnmacros.h"
 
 #include "sst/core/serialization/serializer.h"
 

--- a/src/sst/core/rankSyncParallelSkip.h
+++ b/src/sst/core/rankSyncParallelSkip.h
@@ -13,9 +13,9 @@
 #define SST_CORE_RANKSYNCPARALLELSKIP_H
 
 #include "sst/core/sst_types.h"
-#include <sst/core/syncManager.h>
-#include <sst/core/threadsafe.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/syncManager.h"
+#include "sst/core/threadsafe.h"
+#include "sst/core/warnmacros.h"
 
 #include <map>
 

--- a/src/sst/core/rankSyncSerialSkip.cc
+++ b/src/sst/core/rankSyncSerialSkip.cc
@@ -22,7 +22,7 @@
 #include "sst/core/timeConverter.h"
 #include "sst/core/profile.h"
 
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 #ifdef SST_CONFIG_HAVE_MPI
 DISABLE_WARN_MISSING_OVERRIDE
 #include <mpi.h>
@@ -222,7 +222,7 @@ RankSyncSerialSkip::exchange(void)
     }
     
     // If we have an Exit object, fire it to see if we need end simulation
-    // if ( exit != NULL ) exit->check();
+    // if ( exit != nullptr ) exit->check();
     
     // Check to see when the next event is scheduled, then do an
     // all_reduce with min operator and set next sync time to be

--- a/src/sst/core/rankSyncSerialSkip.h
+++ b/src/sst/core/rankSyncSerialSkip.h
@@ -13,8 +13,8 @@
 #define SST_CORE_RANKSYNCSERIALSKIP_H
 
 #include "sst/core/sst_types.h"
-#include <sst/core/syncManager.h>
-#include <sst/core/threadsafe.h>
+#include "sst/core/syncManager.h"
+#include "sst/core/threadsafe.h"
 
 #include <map>
 

--- a/src/sst/core/rng/marsaglia.cc
+++ b/src/sst/core/rng/marsaglia.cc
@@ -9,9 +9,10 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
 
 #include "marsaglia.h"
+
 #include <cstdlib>
 #include <cstring>
 
@@ -32,7 +33,7 @@ MarsagliaRNG::MarsagliaRNG(unsigned int initial_z, unsigned int initial_w) {
 */
 MarsagliaRNG::MarsagliaRNG() {
 	struct timeval now;
-        gettimeofday(&now, NULL);
+        gettimeofday(&now, nullptr);
 
         m_z = (uint32_t) now.tv_usec;
 	m_w = (uint32_t) now.tv_sec;

--- a/src/sst/core/rng/marsaglia.h
+++ b/src/sst/core/rng/marsaglia.h
@@ -11,7 +11,7 @@
 
 #ifndef SST_CORE_RNG_MARSAGLIA_H
 #define SST_CORE_RNG_MARSAGLIA_H
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 #include <stdint.h>
 #include <sys/time.h>

--- a/src/sst/core/rng/mersenne.cc
+++ b/src/sst/core/rng/mersenne.cc
@@ -9,7 +9,7 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
 
 #include "mersenne.h"
 
@@ -26,7 +26,7 @@ MersenneRNG::MersenneRNG() {
 	numbers = (uint32_t*) malloc(sizeof(uint32_t) * 624);
 
 	struct timeval now;
-	gettimeofday(&now, NULL);
+	gettimeofday(&now, nullptr);
 
 	numbers[0] = (uint32_t) now.tv_usec;
 	index = 0;

--- a/src/sst/core/rng/poisson.cc
+++ b/src/sst/core/rng/poisson.cc
@@ -10,7 +10,8 @@
 // distribution.
 
 
-#include <sst_config.h>
+#include "sst_config.h"
+
 #include "poisson.h"
 
 using namespace SST::RNG;

--- a/src/sst/core/rng/sstrng.cc
+++ b/src/sst/core/rng/sstrng.cc
@@ -10,6 +10,6 @@
 // distribution.
 
 
-#include <sst_config.h>
+#include "sst_config.h"
 #include "sstrng.h"
 

--- a/src/sst/core/rng/xorshift.cc
+++ b/src/sst/core/rng/xorshift.cc
@@ -9,7 +9,7 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
 
 #include "xorshift.h"
 #include <cstdlib>
@@ -23,7 +23,7 @@ using namespace SST::RNG;
 */
 XORShiftRNG::XORShiftRNG() {
 	struct timeval now;
-	gettimeofday(&now, NULL);
+	gettimeofday(&now, nullptr);
 
 	x = (uint32_t) now.tv_usec;
 	y = (uint32_t) now.tv_sec;

--- a/src/sst/core/serialization/serializable.cc
+++ b/src/sst/core/serialization/serializable.cc
@@ -22,7 +22,7 @@ namespace Core {
 namespace Serialization {
 
 static need_delete_statics<serializable_factory> del_statics;
-serializable_factory::builder_map* serializable_factory::builders_ = 0;
+serializable_factory::builder_map* serializable_factory::builders_ = nullptr;
 
 void
 serializable::serializable_abort(uint32_t line, const char* file, const char* func, const char* obj)
@@ -36,7 +36,7 @@ uint32_t
 // serializable_factory::add_builder(serializable_builder* builder, uint32_t cls_id)
 serializable_factory::add_builder(serializable_builder* builder, const char* name)
 {
-  if (builders_ == 0) {
+  if (builders_ == nullptr) {
     builders_ = new builder_map;
   }
 
@@ -55,7 +55,7 @@ serializable_factory::add_builder(serializable_builder* builder, const char* nam
 
   builder_map& bmap = *builders_;
   serializable_builder*& current = bmap[hash];
-  if (current != 0){
+  if (current != nullptr){
     // std::cerr << sprockit::printf(
     //   "amazingly %s and %s both hash to same serializable id %u",
     //   current->name(), builder->name(), hash) << std::endl;

--- a/src/sst/core/serialization/serializable.cc
+++ b/src/sst/core/serialization/serializable.cc
@@ -8,10 +8,11 @@
  *  For more information, see the LICENSE file in the top
  *  SST/macroscale directory.
  */
+#include "sst_config.h"
 
-#include <sst/core/serialization/serializable.h>
-#include <sst/core/serialization/statics.h>
-#include <sst/core/output.h>
+#include "sst/core/serialization/serializable.h"
+#include "sst/core/serialization/statics.h"
+#include "sst/core/output.h"
 
 #include <cstring>
 #include <iostream>

--- a/src/sst/core/serialization/serializable.h
+++ b/src/sst/core/serialization/serializable.h
@@ -12,8 +12,8 @@
 #ifndef SST_CORE_SERIALIZATION_SERIALIZABLE_H
 #define SST_CORE_SERIALIZATION_SERIALIZABLE_H
 
-#include <sst/core/serialization/serializer.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/serialization/serializer.h"
+#include "sst/core/warnmacros.h"
 #include <unordered_map>
 #include <typeinfo>
 #include <stdint.h>
@@ -304,7 +304,7 @@ template<class T> const uint32_t serializable_builder_impl<T>::cls_id_
 #define DeclareSerializable(obj)
 
 
-#include <sst/core/serialization/serialize_serializable.h>
+#include "sst/core/serialization/serialize_serializable.h"
 
 #endif
 

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -12,8 +12,8 @@
 #ifndef SERIALIZE_H
 #define SERIALIZE_H
 
-#include <sst/core/serialization/serializer.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/serialization/serializer.h"
+#include "sst/core/warnmacros.h"
 //#include <sprockit/debug.h>
 //DeclareDebugSlot(serialize);
 
@@ -129,12 +129,12 @@ operator&(serializer& ser, T& t){
 }
 }
 
-#include <sst/core/serialization/serialize_array.h>
-#include <sst/core/serialization/serialize_deque.h>
-#include <sst/core/serialization/serialize_list.h>
-#include <sst/core/serialization/serialize_map.h>
-#include <sst/core/serialization/serialize_set.h>
-#include <sst/core/serialization/serialize_vector.h>
-#include <sst/core/serialization/serialize_string.h>
+#include "sst/core/serialization/serialize_array.h"
+#include "sst/core/serialization/serialize_deque.h"
+#include "sst/core/serialization/serialize_list.h"
+#include "sst/core/serialization/serialize_map.h"
+#include "sst/core/serialization/serialize_set.h"
+#include "sst/core/serialization/serialize_vector.h"
+#include "sst/core/serialization/serialize_string.h"
 
 #endif // SERIALIZE_H

--- a/src/sst/core/serialization/serialize_array.h
+++ b/src/sst/core/serialization/serialize_array.h
@@ -12,7 +12,7 @@
 #ifndef SERIALIZE_ARRAY_H
 #define SERIALIZE_ARRAY_H
 
-#include <sst/core/serialization/serializer.h>
+#include "sst/core/serialization/serializer.h"
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/serialization/serialize_buffer_accessor.h
+++ b/src/sst/core/serialization/serialize_buffer_accessor.h
@@ -71,7 +71,7 @@ class ser_buffer_accessor {
 
   void
   clear(){
-    bufstart_ = bufptr_ = 0;
+    bufstart_ = bufptr_ = nullptr;
     max_size_ = size_ = 0;
   }
 
@@ -83,8 +83,8 @@ class ser_buffer_accessor {
 
  protected:
   ser_buffer_accessor() :
-    bufstart_(0),
-    bufptr_(0),
+    bufstart_(nullptr),
+    bufptr_(nullptr),
     size_(0)
   {
   }

--- a/src/sst/core/serialization/serialize_buffer_accessor.h
+++ b/src/sst/core/serialization/serialize_buffer_accessor.h
@@ -12,10 +12,9 @@
 #ifndef SERIALIZE_ACCESSOR_H
 #define SERIALIZE_ACCESSOR_H
 
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 #include <cstring>
 #include <exception>
-//#include <sst/core/serialization/errors.h>
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/serialization/serialize_deque.h
+++ b/src/sst/core/serialization/serialize_deque.h
@@ -13,7 +13,7 @@
 #define SERIALIZE_DEQUE_H
 
 #include <deque>
-#include <sst/core/serialization/serializer.h>
+#include "sst/core/serialization/serializer.h"
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/serialization/serialize_list.h
+++ b/src/sst/core/serialization/serialize_list.h
@@ -13,7 +13,7 @@
 #define SERIALIZE_LIST_H
 
 #include <list>
-#include <sst/core/serialization/serializer.h>
+#include "sst/core/serialization/serializer.h"
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/serialization/serialize_map.h
+++ b/src/sst/core/serialization/serialize_map.h
@@ -13,7 +13,7 @@
 #define SERIALIZE_MAP_H
 
 #include <map>
-#include <sst/core/serialization/serializer.h>
+#include "sst/core/serialization/serializer.h"
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/serialization/serialize_packer.h
+++ b/src/sst/core/serialization/serialize_packer.h
@@ -12,7 +12,7 @@
 #ifndef SERIALIZE_PACKER_H
 #define SERIALIZE_PACKER_H
 
-#include <sst/core/serialization/serialize_buffer_accessor.h>
+#include "sst/core/serialization/serialize_buffer_accessor.h"
 #include <string>
 
 namespace SST {

--- a/src/sst/core/serialization/serialize_serializable.cc
+++ b/src/sst/core/serialization/serialize_serializable.cc
@@ -9,9 +9,9 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-//#include <sprockit/ptr_type.h>
-//#include <sprockit/spkt_string.h>
-#include <sst/core/serialization/serialize_serializable.h>
+#include "sst_config.h"
+#include "sst/core/serialization/serialize_serializable.h"
+
 #include <iostream>
 
 namespace SST {

--- a/src/sst/core/serialization/serialize_serializable.cc
+++ b/src/sst/core/serialization/serialize_serializable.cc
@@ -53,7 +53,7 @@ unpack_serializable(serializable*& s, serializer& ser){
   ser.unpack(cls_id);
   if (cls_id == null_ptr_id) {
     // debug_printf(dbg::serialize, "null pointer object");
-      s = NULL;
+      s = nullptr;
   }
   else {
     // debug_printf(dbg::serialize, "unpacking class id %ld", cls_id);

--- a/src/sst/core/serialization/serialize_serializable.h
+++ b/src/sst/core/serialization/serialize_serializable.h
@@ -12,10 +12,9 @@
 #ifndef SERIALIZE_SERIALIZABLE_H
 #define SERIALIZE_SERIALIZABLE_H
 
-#include <sst/core/serialization/serializable.h>
-#include <sst/core/serialization/serializer.h>
-#include <sst/core/serialization/serialize.h>
-//#include <sprockit/ptr_type.h>
+#include "sst/core/serialization/serializable.h"
+#include "sst/core/serialization/serializer.h"
+#include "sst/core/serialization/serialize.h"
 #include <iostream>
 
 namespace SST {

--- a/src/sst/core/serialization/serialize_set.h
+++ b/src/sst/core/serialization/serialize_set.h
@@ -13,7 +13,7 @@
 #define SERIALIZE_SET_H
 
 #include <set>
-#include <sst/core/serialization/serializer.h>
+#include "sst/core/serialization/serializer.h"
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/serialization/serialize_sizer.h
+++ b/src/sst/core/serialization/serialize_sizer.h
@@ -12,7 +12,7 @@
 #ifndef SERIALIZE_SIZER_H
 #define SERIALIZE_SIZER_H
 
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 namespace SST {
 namespace Core {
 namespace Serialization {

--- a/src/sst/core/serialization/serialize_string.h
+++ b/src/sst/core/serialization/serialize_string.h
@@ -12,7 +12,7 @@
 #ifndef SERIALIZE_STRING_H
 #define SERIALIZE_STRING_H
 
-#include <sst/core/serialization/serializer.h>
+#include "sst/core/serialization/serializer.h"
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/serialization/serialize_unpacker.h
+++ b/src/sst/core/serialization/serialize_unpacker.h
@@ -12,7 +12,7 @@
 #ifndef SERIALIZE_UNPACKER_H
 #define SERIALIZE_UNPACKER_H
 
-#include <sst/core/serialization/serialize_buffer_accessor.h>
+#include "sst/core/serialization/serialize_buffer_accessor.h"
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/serialization/serialize_vector.h
+++ b/src/sst/core/serialization/serialize_vector.h
@@ -13,7 +13,7 @@
 #define SERIALIZE_VECTOR_H
 
 #include <vector>
-#include <sst/core/serialization/serializer.h>
+#include "sst/core/serialization/serializer.h"
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/serialization/serializer.cc
+++ b/src/sst/core/serialization/serializer.cc
@@ -1,17 +1,18 @@
-/*
- *  This file is part of SST/macroscale:
- *               The macroscale architecture simulator from the SST suite.
- *  Copyright (c) 2009-2019 NTESS.
- *  This software is distributed under the BSD License.
- *  Under the terms of Contract DE-NA0003525 with NTESS,
- *  the U.S. Government retains certain rights in this software.
- *  For more information, see the LICENSE file in the top
- *  SST/macroscale directory.
- */
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+// 
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+// 
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+#include "sst_config.h"
 
-#include <sst/core/serialization/serializer.h>
-#include <sst/core/serialization/serializable.h>
-#include <sst/core/output.h>
+#include "sst/core/serialization/serializer.h"
+#include "sst/core/serialization/serializable.h"
+#include "sst/core/output.h"
 
 namespace SST {
 namespace Core {
@@ -65,7 +66,7 @@ ser_packer::pack_string(std::string& str)
 }
 
 void
-ser_sizer::size_string(std::string &str)
+ser_sizer::size_string(std::string& str)
 {
   size_ += sizeof(int);
   size_ += str.size();

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -13,9 +13,9 @@
 #define SPROCKIT_COMMON_MESSAGES_spkt_serializer_H_INCLUDED
 
 //#include <sprockit/spkt_config.h>
-#include <sst/core/serialization/serialize_packer.h>
-#include <sst/core/serialization/serialize_sizer.h>
-#include <sst/core/serialization/serialize_unpacker.h>
+#include "sst/core/serialization/serialize_packer.h"
+#include "sst/core/serialization/serialize_sizer.h"
+#include "sst/core/serialization/serialize_unpacker.h"
 #include <typeinfo>
 
 #include <cstring>

--- a/src/sst/core/serialization/statics.cc
+++ b/src/sst/core/serialization/statics.cc
@@ -16,12 +16,12 @@ namespace SST {
 namespace Core {
 namespace Serialization {
 
-std::list<statics::clear_fxn>* statics::fxns_ = 0;
+std::list<statics::clear_fxn>* statics::fxns_ = nullptr;
 
 void
 statics::register_finish(clear_fxn fxn)
 {
-  if (fxns_ == 0){
+  if (fxns_ == nullptr){
     fxns_ = new std::list<statics::clear_fxn>;
   }
   fxns_->push_back(fxn);
@@ -30,7 +30,7 @@ statics::register_finish(clear_fxn fxn)
 void
 statics::finish()
 {
-  if (fxns_ == 0)
+  if (fxns_ == nullptr)
     return;
 
   std::list<clear_fxn>::iterator it, end = fxns_->end();
@@ -40,7 +40,7 @@ statics::finish()
   }
   fxns_->clear();
   delete fxns_;
-  fxns_ = 0;
+  fxns_ = nullptr;
 }
 
 }

--- a/src/sst/core/serialization/statics.cc
+++ b/src/sst/core/serialization/statics.cc
@@ -8,8 +8,9 @@
 // This file is part of the SST software package. For license
 // information, see the LICENSE file in the top level directory of the
 // distribution.
+#include "sst_config.h"
 
-#include <sst/core/serialization/statics.h>
+#include "sst/core/serialization/statics.h"
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/sharedRegion.cc
+++ b/src/sst/core/sharedRegion.cc
@@ -10,8 +10,9 @@
 // distribution.
 
 
-#include <sst_config.h>
-#include <sst/core/warnmacros.h>
+#include "sst_config.h"
+#include "sst/core/sharedRegionImpl.h"
+#include "sst/core/warnmacros.h"
 
 #include <unistd.h>
 #include <string>
@@ -23,9 +24,8 @@
 
 #include <sys/types.h>
 
-#include <sst/core/simulation.h>
-#include <sst/core/sharedRegionImpl.h>
-#include <sst/core/objectComms.h>
+#include "sst/core/simulation.h"
+#include "sst/core/objectComms.h"
 
 
 namespace SST {
@@ -88,21 +88,21 @@ RegionInfo::~RegionInfo(void)
     if ( memory ) {
         setProtected(false);
         free(memory);
-        memory = NULL;
+        memory = nullptr;
     }
     initialized = ready = false;
     size_t nSharers = sharers.size();
     for ( size_t i = 0 ; i < nSharers ; i++ ) {
         if ( sharers[i] ) {
             delete sharers[i];
-            sharers[i] = NULL;
+            sharers[i] = nullptr;
             --shareCount;
         }
     }
 }
 
 
-bool RegionInfo::initialize(const std::string &key, size_t size, uint8_t initByte, SharedRegionMerger *mergeObj)
+bool RegionInfo::initialize(const std::string& key, size_t size, uint8_t initByte, SharedRegionMerger *mergeObj)
 {
     if ( initialized ) return true;
 
@@ -144,7 +144,7 @@ void RegionInfo::removeSharer(SharedRegionImpl *sri)
     for ( size_t i = 0 ; i < nShare ; i++ ) {
         if ( sharers[i] == sri ) {
             delete sri;
-            sharers[i] = NULL;
+            sharers[i] = nullptr;
             shareCount--;
         }
     }
@@ -219,20 +219,20 @@ SharedRegionManagerImpl::~SharedRegionManagerImpl()
 
 
 
-SharedRegion* SharedRegionManagerImpl::getLocalSharedRegion(const std::string &key, size_t size, uint8_t initByte)
+SharedRegion* SharedRegionManagerImpl::getLocalSharedRegion(const std::string& key, size_t size, uint8_t initByte)
 {
     std::lock_guard<std::mutex> lock(mtx);
     RegionInfo& ri = regions[key];
     if ( ri.isInitialized() ) {
         if ( ri.getSize() != size ) Simulation::getSimulation()->getSimulationOutput().fatal(CALL_INFO, 1, "Mismatched Sizes!\n");
     } else {
-        if ( false == ri.initialize(key, size, initByte, NULL) ) Simulation::getSimulation()->getSimulationOutput().fatal(CALL_INFO, 1, "Shared Region Initialized Failed!\n");
+        if ( false == ri.initialize(key, size, initByte, nullptr) ) Simulation::getSimulation()->getSimulationOutput().fatal(CALL_INFO, 1, "Shared Region Initialized Failed!\n");
     }
     return ri.addSharer(this);
 }
 
 
-SharedRegion* SharedRegionManagerImpl::getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger, uint8_t initByte)
+SharedRegion* SharedRegionManagerImpl::getGlobalSharedRegion(const std::string& key, size_t size, SharedRegionMerger *merger, uint8_t initByte)
 {
     std::lock_guard<std::mutex> lock(mtx);
     RegionInfo& ri = regions[key];

--- a/src/sst/core/sharedRegion.h
+++ b/src/sst/core/sharedRegion.h
@@ -12,7 +12,7 @@
 #ifndef SST_CORE_CORE_SHAREDREGION_H
 #define SST_CORE_CORE_SHAREDREGION_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 #include <string>
 #include <vector>
@@ -66,8 +66,8 @@ protected:
     virtual const void* getConstPtr(const SharedRegion* sr) const = 0;
 
 public:
-    virtual SharedRegion* getLocalSharedRegion(const std::string &key, size_t size, uint8_t initByte = 0) = 0;
-    virtual SharedRegion* getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger = NULL, uint8_t initByte = 0) = 0;
+    virtual SharedRegion* getLocalSharedRegion(const std::string& key, size_t size, uint8_t initByte = 0) = 0;
+    virtual SharedRegion* getGlobalSharedRegion(const std::string& key, size_t size, SharedRegionMerger *merger = nullptr, uint8_t initByte = 0) = 0;
 
     virtual void publishRegion(SharedRegion*) = 0;
     virtual bool isRegionReady(const SharedRegion*) = 0;

--- a/src/sst/core/sharedRegionImpl.h
+++ b/src/sst/core/sharedRegionImpl.h
@@ -12,18 +12,16 @@
 #ifndef SST_CORE_CORE_SHAREDREGIONIMPL_H
 #define SST_CORE_CORE_SHAREDREGIONIMPL_H
 
-#include <sst/core/sst_types.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/warnmacros.h"
 
 #include <string>
 #include <vector>
-#include <set>
 #include <map>
 #include <mutex>
 
-#include <sst/core/sharedRegion.h>
-#include <sst/core/serialization/serializable.h>
-//#include <sst/core/changeSet.h>
+#include "sst/core/sharedRegion.h"
+#include "sst/core/serialization/serializable.h"
 
 namespace SST {
 
@@ -36,7 +34,7 @@ public:
     size_t length;
     /*const*/ uint8_t *data;
     
-    ChangeSet(size_t offset, size_t length, /*const*/ uint8_t *data = NULL) : offset(offset), length(length), data(data) { }
+    ChangeSet(size_t offset, size_t length, /*const*/ uint8_t *data = nullptr) : offset(offset), length(length), data(data) { }
 
     void serialize_order(SST::Core::Serialization::serializer &ser) override {
         ser & offset;
@@ -67,7 +65,7 @@ public:
 
     public:
         RegionMergeInfo() {}
-        RegionMergeInfo(int rank, const std::string &key) : rank(rank), key(key) { }
+        RegionMergeInfo(int rank, const std::string& key) : rank(rank), key(key) { }
         virtual ~RegionMergeInfo() { }
 
         virtual bool merge(RegionInfo *UNUSED(ri)) { return true; }
@@ -89,7 +87,7 @@ public:
 
     public:
         BulkMergeInfo() : RegionMergeInfo() {}
-        BulkMergeInfo(int rank, const std::string &key, void *data, size_t length) : RegionMergeInfo(rank, key),
+        BulkMergeInfo(int rank, const std::string& key, void *data, size_t length) : RegionMergeInfo(rank, key),
             length(length), data(data)
         { }
 
@@ -122,7 +120,7 @@ public:
         std::vector<ChangeSet> changeSets;
     public:
         ChangeSetMergeInfo() : RegionMergeInfo() {}
-        ChangeSetMergeInfo(int rank, const std::string & key,
+        ChangeSetMergeInfo(int rank, const std::string& key,
                 // std::vector<SharedRegionMerger::ChangeSet> & changeSets) : RegionMergeInfo(rank, key),
                 std::vector<ChangeSet> & changeSets) : RegionMergeInfo(rank, key),
             changeSets(changeSets)
@@ -161,12 +159,12 @@ private:
 
 
 public:
-    RegionInfo() : realSize(0), apparentSize(0), memory(NULL),
-        shareCount(0), publishCount(0), merger(NULL),
+    RegionInfo() : realSize(0), apparentSize(0), memory(nullptr),
+        shareCount(0), publishCount(0), merger(nullptr),
         didBulk(false), initialized(false), ready(false)
     { }
     ~RegionInfo();
-    bool initialize(const std::string &key, size_t size, uint8_t initByte, SharedRegionMerger *mergeObj);
+    bool initialize(const std::string& key, size_t size, uint8_t initByte, SharedRegionMerger *mergeObj);
     bool isInitialized() const { return initialized; }
     bool isReady() const { return ready; }
 
@@ -185,7 +183,7 @@ public:
     size_t getSize() const { return apparentSize; }
     size_t getNumSharers() const { return shareCount; }
 
-    bool shouldMerge() const { return (NULL != merger); }
+    bool shouldMerge() const { return (nullptr != merger); }
     SharedRegionMerger* getMerger() { return merger; }
     /** Returns the size of the data to be transferred */
     RegionMergeInfo* getMergeInfo();
@@ -230,8 +228,8 @@ public:
     SharedRegionManagerImpl();
     ~SharedRegionManagerImpl();
 
-    virtual SharedRegion* getLocalSharedRegion(const std::string &key, size_t size, uint8_t initByte = 0) override;
-    virtual SharedRegion* getGlobalSharedRegion(const std::string &key, size_t size, SharedRegionMerger *merger = NULL, uint8_t initByte = 0) override;
+    virtual SharedRegion* getLocalSharedRegion(const std::string& key, size_t size, uint8_t initByte = 0) override;
+    virtual SharedRegion* getGlobalSharedRegion(const std::string& key, size_t size, SharedRegionMerger *merger = nullptr, uint8_t initByte = 0) override;
 
     virtual void publishRegion(SharedRegion*) override;
     virtual bool isRegionReady(const SharedRegion*) override;

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -11,35 +11,32 @@
 
 
 #include "sst_config.h"
-#include <sst/core/simulation.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/simulation.h"
+#include "sst/core/warnmacros.h"
 
 #include <utility>
 
-//#include <sst/core/archive.h>
-#include <sst/core/clock.h>
-#include <sst/core/config.h>
-#include <sst/core/configGraph.h>
-#include <sst/core/heartbeat.h>
-//#include <sst/core/event.h>
-#include <sst/core/exit.h>
-#include <sst/core/factory.h>
-//#include <sst/core/graph.h>
-#include <sst/core/linkMap.h>
-#include <sst/core/linkPair.h>
-#include <sst/core/sharedRegionImpl.h>
-#include <sst/core/output.h>
-#include <sst/core/stopAction.h>
-#include <sst/core/stringize.h>
-#include <sst/core/syncBase.h>
-#include <sst/core/syncManager.h>
-#include <sst/core/syncQueue.h>
-#include <sst/core/threadSync.h>
-#include <sst/core/timeConverter.h>
-#include <sst/core/timeLord.h>
-#include <sst/core/timeVortex.h>
-#include <sst/core/unitAlgebra.h>
-#include <sst/core/statapi/statengine.h>
+#include "sst/core/clock.h"
+#include "sst/core/config.h"
+#include "sst/core/configGraph.h"
+#include "sst/core/heartbeat.h"
+#include "sst/core/exit.h"
+#include "sst/core/factory.h"
+#include "sst/core/linkMap.h"
+#include "sst/core/linkPair.h"
+#include "sst/core/sharedRegionImpl.h"
+#include "sst/core/output.h"
+#include "sst/core/stopAction.h"
+#include "sst/core/stringize.h"
+#include "sst/core/syncBase.h"
+#include "sst/core/syncManager.h"
+#include "sst/core/syncQueue.h"
+#include "sst/core/threadSync.h"
+#include "sst/core/timeConverter.h"
+#include "sst/core/timeLord.h"
+#include "sst/core/timeVortex.h"
+#include "sst/core/unitAlgebra.h"
+#include "sst/core/statapi/statengine.h"
 
 #define SST_SIMTIME_MAX  0xffffffffffffffff
 
@@ -121,9 +118,9 @@ void Simulation::shutdown()
 
 Simulation::Simulation( Config* cfg, RankInfo my_rank, RankInfo num_ranks, SimTime_t min_part) :
     runMode(cfg->runMode),
-    timeVortex(NULL),
+    timeVortex(nullptr),
     interThreadMinLatency(MAX_SIMTIME_T),
-    threadSync(NULL),
+    threadSync(nullptr),
     currentSimCycle(0),
     endSimCycle(0),
     currentPriority(0),
@@ -174,7 +171,7 @@ Simulation::Simulation()
 
 
 Component*
-Simulation::createComponent( ComponentId_t id, std::string &name, 
+Simulation::createComponent( ComponentId_t id, const std::string& name, 
                              Params &params )
 {
     return factory->CreateComponent(id, name, params);
@@ -182,7 +179,7 @@ Simulation::createComponent( ComponentId_t id, std::string &name,
 
 
 void
-Simulation::requireEvent(std::string name)
+Simulation::requireEvent(const std::string& name)
 {
     factory->RequireEvent(name);
 }
@@ -300,7 +297,7 @@ int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTi
     {
         ConfigComponent* ccomp = &(*iter);
         if ( ccomp->rank == myRank ) {
-            compInfoMap.insert(new ComponentInfo(ccomp, ccomp->name, NULL, new LinkMap()));
+            compInfoMap.insert(new ComponentInfo(ccomp, ccomp->name, nullptr, new LinkMap()));
         }
     }
 
@@ -329,14 +326,14 @@ int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTi
 
             // Add this link to the appropriate LinkMap
             ComponentInfo* cinfo = compInfoMap.getByID(clink.component[0]);
-            if ( cinfo == NULL ) {
+            if ( cinfo == nullptr ) {
                 // This shouldn't happen and is an error
                 sim_output.fatal(CALL_INFO,1,"Couldn't find ComponentInfo in map.");
             }
             cinfo->getLinkMap()->insertLink(clink.port[0],lp.getLeft());
 
             cinfo = compInfoMap.getByID(clink.component[1]);
-            if ( cinfo == NULL ) {
+            if ( cinfo == nullptr ) {
                 // This shouldn't happen and is an error
                 sim_output.fatal(CALL_INFO,1,"Couldn't find ComponentInfo in map.");
             }
@@ -365,7 +362,7 @@ int Simulation::performWireUp( ConfigGraph& graph, const RankInfo& myRank, SimTi
 
             // Add this link to the appropriate LinkMap for the local component
             ComponentInfo* cinfo = compInfoMap.getByID(clink.component[local]);
-            if ( cinfo == NULL ) {
+            if ( cinfo == nullptr ) {
                 // This shouldn't happen and is an error
                 sim_output.fatal(CALL_INFO,1,"Couldn't find ComponentInfo in map.");
             }
@@ -763,7 +760,7 @@ void Simulation::unregisterClock(TimeConverter *tc, Clock::HandlerBase* handler,
     }
 }
 
-TimeConverter* Simulation::registerOneShot(std::string timeDelay, OneShot::HandlerBase* handler, int priority)
+TimeConverter* Simulation::registerOneShot(const std::string& timeDelay, OneShot::HandlerBase* handler, int priority)
 {
     return registerOneShot(UnitAlgebra(timeDelay), handler, priority);
 }
@@ -854,7 +851,7 @@ Core::ThreadSafe::Barrier Simulation::runBarrier;
 Core::ThreadSafe::Barrier Simulation::exitBarrier;
 Core::ThreadSafe::Barrier Simulation::finishBarrier;
 std::mutex Simulation::simulationMutex;
-TimeConverter* Simulation::minPartTC = NULL;
+TimeConverter* Simulation::minPartTC = nullptr;
 SimTime_t Simulation::minPart;
 
 

--- a/src/sst/core/simulation.h
+++ b/src/sst/core/simulation.h
@@ -23,13 +23,13 @@
 
 #include <unordered_map>
 
-#include <sst/core/output.h>
-#include <sst/core/clock.h>
-#include <sst/core/oneshot.h>
-#include <sst/core/unitAlgebra.h>
-#include <sst/core/rankInfo.h>
+#include "sst/core/output.h"
+#include "sst/core/clock.h"
+#include "sst/core/oneshot.h"
+#include "sst/core/unitAlgebra.h"
+#include "sst/core/rankInfo.h"
 
-#include <sst/core/componentInfo.h>
+#include "sst/core/componentInfo.h"
 
 /* Forward declare for Friendship */
 extern int main(int argc, char **argv);
@@ -159,7 +159,7 @@ public:
         Note: OneShot cannot be canceled, and will always callback after
               the timedelay.
     */
-    TimeConverter* registerOneShot(std::string timeDelay, OneShot::HandlerBase* handler, int priority);
+    TimeConverter* registerOneShot(const std::string& timeDelay, OneShot::HandlerBase* handler, int priority);
     TimeConverter* registerOneShot(const UnitAlgebra& timeDelay, OneShot::HandlerBase* handler, int priority);
     
     /** Insert an activity to fire at a specified time */
@@ -187,8 +187,8 @@ public:
     /** Return pointer to map of links for a given component id */
     LinkMap* getComponentLinkMap(ComponentId_t id) const {
         ComponentInfo* info = compInfoMap.getByID(id);
-        if ( NULL == info ) {
-            return NULL;
+        if ( nullptr == info ) {
+            return nullptr;
         } else {
             return info->getLinkMap();
         }
@@ -207,7 +207,7 @@ public:
     {
 		ComponentInfo* i = compInfoMap.getByID(id);
 		// CompInfoMap_t::const_iterator i = compInfoMap.find(id);
-		if ( NULL != i ) {
+		if ( nullptr != i ) {
 			return i->getComponent();
 		} else {
             printf("Simulation::getComponent() couldn't find component with id = %" PRIu64 "\n", id);
@@ -220,7 +220,7 @@ public:
     {        
 		ComponentInfo* i = compInfoMap.getByID(id);
 		// CompInfoMap_t::const_iterator i = compInfoMap.find(id);
-		if ( NULL != i ) {
+		if ( nullptr != i ) {
 			return i;
 		} else {
             printf("Simulation::getComponentInfo() couldn't find component with id = %" PRIu64 "\n", id);
@@ -234,8 +234,8 @@ public:
 	Set the output directory for this simulation
 	@param outDir Path of directory to place simulation outputs in
     */
-    void setOutputDirectory(std::string& outDir) {
-	output_directory = outDir;
+    void setOutputDirectory(const std::string& outDir) {
+        output_directory = outDir;
     }
 
     /**
@@ -243,14 +243,14 @@ public:
 	@return Directory in which simulation outputs are placed
     */
     std::string& getOutputDirectory() {
-	return output_directory;
+        return output_directory;
     }
 
     /** Signifies that an event type is required for this simulation
      *  Causes to Factory to verify that the required event type can be found.
      *  @param name fully qualified libraryName.EventName
      */
-    void requireEvent(std::string name);
+    void requireEvent(const std::string& name);
 
     /**
      * Returns the time of the next item to be executed
@@ -309,7 +309,7 @@ private:
 
 
 
-    Component* createComponent(ComponentId_t id, std::string &name, 
+    Component* createComponent(ComponentId_t id, const std::string& name, 
                                Params &params);
 
     TimeVortex* getTimeVortex() const { return timeVortex; }

--- a/src/sst/core/sparseVectorMap.h
+++ b/src/sst/core/sparseVectorMap.h
@@ -15,7 +15,7 @@
 #define SST_CORE_SPARSEVECTORMAP_H
 
 #include "sst/core/sst_types.h"
-#include <sst/core/serialization/serializable.h>
+#include "sst/core/serialization/serializable.h"
 
 #include <vector>
 

--- a/src/sst/core/sst_types.h
+++ b/src/sst/core/sst_types.h
@@ -12,8 +12,6 @@
 #ifndef SST_CORE_SST_TYPES_H
 #define SST_CORE_SST_TYPES_H
 
-//#include <sst_stdint.h>
-
 #include <cstdint>
 
 namespace SST {

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -316,16 +316,16 @@ int SSTInfoConfig::parseCmdLine(int argc, char* argv[])
     m_AppName = argv[0];
 
     static const struct option longOpts[] = {
-        {"help",        no_argument,        0, 'h'},
-        {"version",     no_argument,        0, 'v'},
-        {"debug",       no_argument,        0, 'd'},
-        {"nodisplay",   no_argument,        0, 'n'},
-        {"xml",         no_argument,        0, 'x'},
-        {"quiet",       no_argument,        0, 'q'},
-        {"outputxml",   required_argument,  0, 'o'},
-        {"libs",        required_argument,  0, 'l'},
-        {"elemenfilt",  required_argument,  0, 0},
-        {nullptr, 0, 0, 0}
+        {"help",        no_argument,        nullptr, 'h'},
+        {"version",     no_argument,        nullptr, 'v'},
+        {"debug",       no_argument,        nullptr, 'd'},
+        {"nodisplay",   no_argument,        nullptr, 'n'},
+        {"xml",         no_argument,        nullptr, 'x'},
+        {"quiet",       no_argument,        nullptr, 'q'},
+        {"outputxml",   required_argument,  nullptr, 'o'},
+        {"libs",        required_argument,  nullptr, 'l'},
+        {"elemenfilt",  required_argument,  nullptr, 0},
+        {nullptr, 0, nullptr, 0}
     };
     while (1) {
         int opt_idx = 0;

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -9,8 +9,11 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
-#include <sst/core/warnmacros.h>
+
+#include "sst_config.h"
+#include "sst/core/sstinfo.h"
+
+#include "sst/core/warnmacros.h"
 
 #include <cstdio>
 #include <cerrno>
@@ -23,18 +26,15 @@
 #include <getopt.h>
 #include <ctime>
 
-#include <sst/core/elemLoader.h>
-#include <sst/core/component.h>
-#include <sst/core/subcomponent.h>
-#include <sst/core/part/sstpart.h>
-#include <sst/core/sstpart.h>
+#include "sst/core/elemLoader.h"
+#include "sst/core/component.h"
+#include "sst/core/subcomponent.h"
+#include "sst/core/part/sstpart.h"
+#include "sst/core/sstpart.h"
 #include "sst/core/build_info.h"
 
 #include "sst/core/env/envquery.h"
 #include "sst/core/env/envconfig.h"
-
-#include <sst/core/tinyxml/tinyxml.h>
-#include <sst/core/sstinfo.h>
 
 
 using namespace std;
@@ -88,7 +88,7 @@ public:
 
 
 // Forward Declarations
-void initLTDL(std::string searchPath);
+void initLTDL(const std::string& searchPath);
 void shutdownLTDL();
 static void processSSTElementFiles();
 void outputSSTElementInfo();
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
 }
 
 
-static void addELI(ElemLoader &loader, const std::string &lib, bool optional)
+static void addELI(ElemLoader &loader, const std::string& lib, bool optional)
 {
 
     if ( g_configuration.debugEnabled() )
@@ -226,7 +226,7 @@ void OverallOutputter::outputXML()
 {
     unsigned int            x;
     char                    TimeStamp[32];
-    std::time_t             now = std::time(NULL);
+    std::time_t             now = std::time(nullptr);
     std::tm*                ptm = std::localtime(&now);
 
     // Create a Timestamp Format: 2015.02.15_20:20:00
@@ -325,7 +325,7 @@ int SSTInfoConfig::parseCmdLine(int argc, char* argv[])
         {"outputxml",   required_argument,  0, 'o'},
         {"libs",        required_argument,  0, 'l'},
         {"elemenfilt",  required_argument,  0, 0},
-        {NULL, 0, 0, 0}
+        {nullptr, 0, 0, 0}
     };
     while (1) {
         int opt_idx = 0;
@@ -378,8 +378,9 @@ int SSTInfoConfig::parseCmdLine(int argc, char* argv[])
 }
 
 
-void SSTInfoConfig::addFilter(std::string name)
+void SSTInfoConfig::addFilter(const std::string& name_str)
 {
+    std::string name(name_str);
     if ( name.size() > 3 && name.substr(0, 3) == "lib" )
         name = name.substr(3);
 
@@ -395,7 +396,7 @@ void SSTInfoConfig::addFilter(std::string name)
 }
 
 
-bool doesLibHaveFilters(const std::string &libName)
+bool doesLibHaveFilters(const std::string& libName)
 {
     auto range = g_configuration.getFilterMap().equal_range(libName);
     for ( auto x = range.first ; x != range.second ; ++x ) {
@@ -405,7 +406,7 @@ bool doesLibHaveFilters(const std::string &libName)
     return false;
 }
 
-bool shouldPrintElement(const std::string &libName, const std::string elemName)
+bool shouldPrintElement(const std::string& libName, const std::string& elemName)
 {
     auto range = g_configuration.getFilterMap().equal_range(libName);
     if ( range.first == range.second )

--- a/src/sst/core/sstinfo.h
+++ b/src/sst/core/sstinfo.h
@@ -17,7 +17,8 @@
 #include <vector>
 #include <set>
 
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/eli/elementinfo.h"
+#include "sst/core/tinyxml/tinyxml.h"
 
 class TiXmlNode;
 
@@ -73,7 +74,7 @@ public:
 private:
     void outputUsage();
     void outputVersion();
-    void addFilter(std::string name);
+    void addFilter(const std::string& name);
 
 private:
     char*                     m_AppName;

--- a/src/sst/core/sstpart.cc
+++ b/src/sst/core/sstpart.cc
@@ -1,4 +1,17 @@
-#include <sst/core/sstpart.h>
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+
+#include "sst/core/sstpart.h"
 
 namespace SST {
 namespace Partition {

--- a/src/sst/core/sstpart.h
+++ b/src/sst/core/sstpart.h
@@ -13,9 +13,9 @@
 #ifndef SST_CORE_PART_BASE
 #define SST_CORE_PART_BASE
 
-#include <sst/core/rankInfo.h>
-#include <sst/core/warnmacros.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/rankInfo.h"
+#include "sst/core/warnmacros.h"
+#include "sst/core/eli/elementinfo.h"
 
 #include <map>
 

--- a/src/sst/core/sstregistertool.cc
+++ b/src/sst/core/sstregistertool.cc
@@ -30,11 +30,11 @@
 //Function declarations
 static void print_usage();
 void sstRegister(char* argv[]);
-void sstUnregister(std::string element);
+void sstUnregister(const std::string& element);
 std::vector<std::string> listModels(int option);
 void sstUnregisterMultiple(std::vector<std::string> elementsArray);
 void autoUnregister();
-bool validModel(std::string s);
+bool validModel(const std::string& s);
 
 //Global constants
 const std::string START_DELIMITER = "[";
@@ -55,10 +55,10 @@ int main(int argc, char* argv[]) {
 	//Check for configuration file
 	sprintf(cfgPath, SST_INSTALL_PREFIX "/etc/sst/sstsimulator.conf");
 	FILE* cfgFile = fopen(cfgPath, "r+");
-	if(NULL == cfgFile) {
+	if(nullptr == cfgFile) {
 		char* envHome = getenv("HOME");
 
-		if(NULL == envHome) {
+		if(nullptr == envHome) {
 			sprintf(cfgPath, "~/.sst/sstsimulator.conf");
 		} else {
 			sprintf(cfgPath, "%s/.sst/sstsimulator.conf", envHome);
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) {
 
 		cfgFile = fopen(cfgPath, "r+");
 
-		if(NULL == cfgFile) {
+		if(nullptr == cfgFile) {
 			fprintf(stderr, "Unable to open configuration at either: %s or %s, one of these files must be editable.\n",
 				SST_INSTALL_PREFIX "/etc/sst/sstsimulator.conf", cfgPath);
 			exit(-1);
@@ -130,7 +130,7 @@ void sstRegister(char* argv[]){
 
 	cfgFile = fopen(cfgPath, "w+");
 
-	if(NULL == cfgFile) {
+	if(nullptr == cfgFile) {
 		fprintf(stderr, "Unable to open: %s for writing.\n",
 			cfgPath);
 		exit(-1);
@@ -145,7 +145,7 @@ void sstRegister(char* argv[]){
 //Takes a string argument and searches the sstsimulator config file for that name.
 //Removes the component from the file - unregistering it from SST
 //Input: command line arguments
-void sstUnregister(std::string element){
+void sstUnregister(const std::string& element){
 	std::string str1;
 	std::string s = "";
 	std::string tempfile;
@@ -182,7 +182,7 @@ void sstUnregister(std::string element){
 //listModels
 //Prints to STDOUT all of the registered models
 //Input: an int option that determines what will be returned:
-//	option == 0: NULL vector
+//	option == 0: nullptr vector
 //	option == 1: a vector containing all of the registered components (both valid and invalid)
 //	option == 2: a vector containing only the INVALID components
 //Returns: a vector of strings.
@@ -267,7 +267,7 @@ void sstUnregisterMultiple(std::vector<std::string> elementsArray){
 //Checks the path of the model to determine if it physically exists on the drive
 //Input: a string containing the path
 //Returns: a true or false
-bool validModel(std::string s){
+bool validModel(const std::string& s){
 	std::size_t locationStart = s.find("/");
 	std::string str1 = s.substr(locationStart);//grabs the rest of the line from / to the end
 	char* path = new char[str1.length() + 1];

--- a/src/sst/core/statapi/stataccumulator.h
+++ b/src/sst/core/statapi/stataccumulator.h
@@ -16,11 +16,11 @@
 #include <cmath>
 #include <limits>
 
-#include <sst/core/sst_types.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/warnmacros.h"
 
-#include <sst/core/statapi/statbase.h>
-#include <sst/core/statapi/statoutput.h>
+#include "sst/core/statapi/statbase.h"
+#include "sst/core/statapi/statoutput.h"
 
 namespace SST {
 namespace Statistics {

--- a/src/sst/core/statapi/statbase.cc
+++ b/src/sst/core/statapi/statbase.cc
@@ -9,18 +9,18 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
+#include "sst/core/statapi/statbase.h"
 
-#include <sst/core/baseComponent.h>
-#include <sst/core/statapi/statbase.h>
-#include <sst/core/statapi/stataccumulator.h>
-#include <sst/core/statapi/stathistogram.h>
-#include <sst/core/statapi/statnull.h>
-#include <sst/core/statapi/statuniquecount.h>
-#include <sst/core/statapi/statoutputconsole.h>
-#include <sst/core/statapi/statoutputcsv.h>
-#include <sst/core/statapi/statoutputjson.h>
-#include <sst/core/statapi/statoutputtxt.h>
+#include "sst/core/baseComponent.h"
+#include "sst/core/statapi/stataccumulator.h"
+#include "sst/core/statapi/stathistogram.h"
+#include "sst/core/statapi/statnull.h"
+#include "sst/core/statapi/statuniquecount.h"
+#include "sst/core/statapi/statoutputconsole.h"
+#include "sst/core/statapi/statoutputcsv.h"
+#include "sst/core/statapi/statoutputjson.h"
+#include "sst/core/statapi/statoutputtxt.h"
 
 namespace SST {
 namespace Statistics {

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -14,13 +14,13 @@
 
 #include <string>
 
-#include <sst/core/sst_types.h>
-#include <sst/core/warnmacros.h>
-#include <sst/core/params.h>
-#include <sst/core/oneshot.h>
-#include <sst/core/statapi/statfieldinfo.h>
-#include <sst/core/eli/elementinfo.h>
-#include <sst/core/serialization/serializable.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/warnmacros.h"
+#include "sst/core/params.h"
+#include "sst/core/oneshot.h"
+#include "sst/core/statapi/statfieldinfo.h"
+#include "sst/core/eli/elementinfo.h"
+#include "sst/core/serialization/serializable.h"
 
 namespace SST {
 class BaseComponent;
@@ -37,8 +37,8 @@ public:
     std::string name;
     Params params;
 
-    StatisticInfo(const std::string &name) : name(name) { }
-    StatisticInfo(const std::string &name, const Params &params) : name(name), params(params) { }
+    StatisticInfo(const std::string& name) : name(name) { }
+    StatisticInfo(const std::string& name, const Params &params) : name(name), params(params) { }
     StatisticInfo() { } /* DO NOT USE:  For serialization */
 
     void serialize_order(SST::Core::Serialization::serializer &ser) override {
@@ -504,6 +504,6 @@ struct ImplementsStatFields {
 } //namespace SST
 
 //we need to make sure null stats are instantiated for whatever types we use
-#include <sst/core/statapi/statnull.h>
+#include "sst/core/statapi/statnull.h"
 
 #endif

--- a/src/sst/core/statapi/statengine.cc
+++ b/src/sst/core/statapi/statengine.cc
@@ -9,20 +9,20 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
+#include "sst/core/statapi/statengine.h"
 
-#include <sst/core/warnmacros.h>
-#include <sst/core/output.h>
-#include <sst/core/factory.h>
-#include <sst/core/timeLord.h>
-#include <sst/core/timeConverter.h>
-#include <sst/core/simulation.h>
-#include <sst/core/statapi/statbase.h>
-#include <sst/core/statapi/statengine.h>
-#include <sst/core/statapi/statoutput.h>
-#include <sst/core/configGraph.h>
-#include <sst/core/baseComponent.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/warnmacros.h"
+#include "sst/core/output.h"
+#include "sst/core/factory.h"
+#include "sst/core/timeLord.h"
+#include "sst/core/timeConverter.h"
+#include "sst/core/simulation.h"
+#include "sst/core/statapi/statbase.h"
+#include "sst/core/statapi/statoutput.h"
+#include "sst/core/configGraph.h"
+#include "sst/core/baseComponent.h"
+#include "sst/core/eli/elementinfo.h"
 
 #include <algorithm>
 #include <string>
@@ -225,7 +225,7 @@ StatisticOutput* StatisticProcessingEngine::createStatisticOutput(const ConfigSt
     auto lcType = cfg.type;
     std::transform(lcType.begin(), lcType.end(), lcType.begin(), ::tolower);
     StatisticOutput *so = Factory::getFactory()->Create<StatisticOutput>(lcType, unsafeParams, unsafeParams);
-    if (NULL == so) {
+    if (nullptr == so) {
         m_output.fatal(CALL_INFO, 1, " - Unable to instantiate Statistic Output %s\n", cfg.type.c_str());
     }
 
@@ -580,7 +580,7 @@ StatisticProcessingEngine::isStatisticInCompStatMap(const std::string& compName,
     // See if the map contains an entry for this Component ID
     if (m_CompStatMap.find(compId) == m_CompStatMap.end() ) {
         // Nope, this component ID has not been registered
-        return NULL;
+        return nullptr;
     }
     
     // The CompStatMap has Component ID registered, get the array associated with it    
@@ -599,7 +599,7 @@ StatisticProcessingEngine::isStatisticInCompStatMap(const std::string& compName,
     }
     
     // We did not find the stat in this component
-    return NULL;
+    return nullptr;
 }
 
 void StatisticProcessingEngine::addStatisticToCompStatMap(StatisticBase* Stat,
@@ -625,7 +625,7 @@ void StatisticProcessingEngine::addStatisticToCompStatMap(StatisticBase* Stat,
 
 
 
-StatisticProcessingEngine* StatisticProcessingEngine::instance = NULL;
+StatisticProcessingEngine* StatisticProcessingEngine::instance = nullptr;
 
 } //namespace Statistics
 } //namespace SST

--- a/src/sst/core/statapi/statengine.h
+++ b/src/sst/core/statapi/statengine.h
@@ -12,16 +12,16 @@
 #ifndef _H_SST_CORE_STATISTICS_ENGINE
 #define _H_SST_CORE_STATISTICS_ENGINE
 
-#include <sst/core/sst_types.h>
-#include <sst/core/statapi/statfieldinfo.h>
-#include <sst/core/statapi/statgroup.h>
-#include <sst/core/statapi/statbase.h>
-#include <sst/core/statapi/statnull.h>
-#include <sst/core/unitAlgebra.h>
-#include <sst/core/clock.h>
-#include <sst/core/oneshot.h>
-#include <sst/core/threadsafe.h>
-#include <sst/core/factory.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/statapi/statfieldinfo.h"
+#include "sst/core/statapi/statgroup.h"
+#include "sst/core/statapi/statbase.h"
+#include "sst/core/statapi/statnull.h"
+#include "sst/core/unitAlgebra.h"
+#include "sst/core/clock.h"
+#include "sst/core/oneshot.h"
+#include "sst/core/threadsafe.h"
+#include "sst/core/factory.h"
 
 /* Forward declare for Friendship */
 extern int main(int argc, char **argv);
@@ -71,8 +71,8 @@ public:
     void performGlobalStatisticOutput(bool endOfSimFlag = false);
 
     template <class T>
-    Statistic<T>* createStatistic(BaseComponent *comp, const std::string &type,
-                                  const std::string &statName, const std::string &statSubId,
+    Statistic<T>* createStatistic(BaseComponent *comp, const std::string& type,
+                                  const std::string& statName, const std::string& statSubId,
                                   Params &params)
     {
 

--- a/src/sst/core/statapi/statfieldinfo.cc
+++ b/src/sst/core/statapi/statfieldinfo.cc
@@ -10,10 +10,10 @@
 // distribution.
 
 #include "sst_config.h"
+#include "sst/core/statapi/statfieldinfo.h"
 
-#include <sst/core/stringize.h>
-#include <sst/core/simulation.h>
-#include <sst/core/statapi/statfieldinfo.h>
+#include "sst/core/stringize.h"
+#include "sst/core/simulation.h"
 
 namespace SST {
 namespace Statistics {

--- a/src/sst/core/statapi/statfieldinfo.h
+++ b/src/sst/core/statapi/statfieldinfo.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/sst_types.h"
 #include <map>
+#include <string>
 
 namespace SST {
 namespace Statistics {

--- a/src/sst/core/statapi/statgroup.cc
+++ b/src/sst/core/statapi/statgroup.cc
@@ -9,18 +9,18 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
+#include "sst/core/statapi/statgroup.h"
 
 #include <algorithm>
 
-#include <sst/core/statapi/statgroup.h>
-#include <sst/core/statapi/statbase.h>
-#include <sst/core/statapi/statengine.h>
-#include <sst/core/statapi/statoutput.h>
-#include <sst/core/statapi/statgroup.h>
-#include <sst/core/configGraph.h>
-#include <sst/core/baseComponent.h>
-#include <sst/core/output.h>
+#include "sst/core/statapi/statgroup.h"
+#include "sst/core/statapi/statbase.h"
+#include "sst/core/statapi/statengine.h"
+#include "sst/core/statapi/statoutput.h"
+#include "sst/core/configGraph.h"
+#include "sst/core/baseComponent.h"
+#include "sst/core/output.h"
 
 namespace SST {
 namespace Statistics {

--- a/src/sst/core/statapi/statgroup.h
+++ b/src/sst/core/statapi/statgroup.h
@@ -12,8 +12,8 @@
 #ifndef _H_SST_CORE_STATISTICS_GROUP
 #define _H_SST_CORE_STATISTICS_GROUP
 
-#include <sst/core/sst_types.h>
-#include <sst/core/unitAlgebra.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/unitAlgebra.h"
 
 #include <string>
 #include <vector>

--- a/src/sst/core/statapi/stathistogram.h
+++ b/src/sst/core/statapi/stathistogram.h
@@ -13,11 +13,11 @@
 #ifndef _H_SST_CORE_HISTOGRAM_STATISTIC_
 #define _H_SST_CORE_HISTOGRAM_STATISTIC_
 
-#include <sst/core/sst_types.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/warnmacros.h"
 
-#include <sst/core/statapi/statbase.h>
-#include <sst/core/statapi/statoutput.h>
+#include "sst/core/statapi/statbase.h"
+#include "sst/core/statapi/statoutput.h"
 
 namespace SST {
 namespace Statistics {

--- a/src/sst/core/statapi/statnull.h
+++ b/src/sst/core/statapi/statnull.h
@@ -13,10 +13,10 @@
 #ifndef _H_SST_CORE_NULL_STATISTIC_
 #define _H_SST_CORE_NULL_STATISTIC_
 
-#include <sst/core/sst_types.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/warnmacros.h"
 
-#include <sst/core/statapi/statbase.h>
+#include "sst/core/statapi/statbase.h"
 
 namespace SST {
 namespace Statistics {

--- a/src/sst/core/statapi/statoutput.cc
+++ b/src/sst/core/statapi/statoutput.cc
@@ -10,12 +10,12 @@
 // distribution.
 
 #include "sst_config.h"
+#include "sst/core/statapi/statoutput.h"
 
 #include "sst/core/output.h"
-#include <sst/core/statapi/statoutput.h>
-#include <sst/core/statapi/statgroup.h>
-#include <sst/core/stringize.h>
-#include <sst/core/simulation.h>
+#include "sst/core/statapi/statgroup.h"
+#include "sst/core/stringize.h"
+#include "sst/core/simulation.h"
 
 namespace SST {
 namespace Statistics {
@@ -113,7 +113,7 @@ StatisticFieldInfo* StatisticOutput::getRegisteredField(fieldHandle_t fieldHandl
     if (fieldHandle <= m_highestFieldHandle) {
         return m_outputFieldInfoArray[fieldHandle];
     }
-    return NULL;
+    return nullptr;
 }
 
 void

--- a/src/sst/core/statapi/statoutput.h
+++ b/src/sst/core/statapi/statoutput.h
@@ -13,12 +13,12 @@
 #define _H_SST_CORE_STATISTICS_OUTPUT
 
 #include "sst/core/sst_types.h"
-#include <sst/core/warnmacros.h>
-#include <sst/core/module.h>
-#include <sst/core/params.h>
-#include <sst/core/statapi/statfieldinfo.h>
-#include <sst/core/statapi/statbase.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/warnmacros.h"
+#include "sst/core/module.h"
+#include "sst/core/params.h"
+#include "sst/core/statapi/statfieldinfo.h"
+#include "sst/core/statapi/statbase.h"
+#include "sst/core/eli/elementinfo.h"
 #include <unordered_map>
 
 #include <mutex>
@@ -113,7 +113,7 @@ public:
      * @param fieldHandle - The handle of the registered field.
      * @return Pointer to the registered field info.
      */
-    // Get the Field Information object, NULL is returned if not found
+    // Get the Field Information object, nullptr is returned if not found
     StatisticFieldInfo* getRegisteredField(fieldHandle_t fieldHandle);
 
     /** Return the information on a registered field via known names.
@@ -144,7 +144,7 @@ public:
         }
 
         delete NewStatFieldInfo;
-        return NULL;
+        return nullptr;
     }
 
     /** Return the array of registered field infos. */
@@ -241,7 +241,7 @@ private:
 
 protected:
     StatisticOutput() {;} // For serialization only
-    void setStatisticOutputName(std::string name) {m_statOutputName = name;}
+    void setStatisticOutputName(const std::string& name) {m_statOutputName = name;}
 
     void lock() { m_lock.lock(); }
     void unlock() { m_lock.unlock(); }

--- a/src/sst/core/statapi/statoutputconsole.cc
+++ b/src/sst/core/statapi/statoutputconsole.cc
@@ -9,10 +9,10 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
+#include "sst/core/statapi/statoutputconsole.h"
 
-#include <sst/core/simulation.h>
-#include <sst/core/statapi/statoutputconsole.h>
+#include "sst/core/simulation.h"
 
 namespace SST {
 namespace Statistics {
@@ -74,7 +74,7 @@ void StatisticOutputConsole::outputField(fieldHandle_t fieldHandle, int32_t data
     char buffer[256];
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
-    if (NULL != FieldInfo) {
+    if (nullptr != FieldInfo) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
         sprintf(buffer, "%s.%s = %" PRId32, FieldInfo->getFieldName().c_str(), typeName, data);
         m_OutputBuffer += buffer;
@@ -87,7 +87,7 @@ void StatisticOutputConsole::outputField(fieldHandle_t fieldHandle, uint32_t dat
     char buffer[256];
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
-    if (NULL != FieldInfo) {
+    if (nullptr != FieldInfo) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
         sprintf(buffer, "%s.%s = %" PRIu32, FieldInfo->getFieldName().c_str(), typeName, data);
         m_OutputBuffer += buffer;
@@ -100,7 +100,7 @@ void StatisticOutputConsole::outputField(fieldHandle_t fieldHandle, int64_t data
     char buffer[256];
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
-    if (NULL != FieldInfo) {
+    if (nullptr != FieldInfo) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
         sprintf(buffer, "%s.%s = %" PRId64, FieldInfo->getFieldName().c_str(), typeName, data);
         m_OutputBuffer += buffer;
@@ -113,7 +113,7 @@ void StatisticOutputConsole::outputField(fieldHandle_t fieldHandle, uint64_t dat
     char buffer[256];
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
-    if (NULL != FieldInfo) {
+    if (nullptr != FieldInfo) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
         sprintf(buffer, "%s.%s = %" PRIu64, FieldInfo->getFieldName().c_str(), typeName, data);
         m_OutputBuffer += buffer;
@@ -126,7 +126,7 @@ void StatisticOutputConsole::outputField(fieldHandle_t fieldHandle, float data)
     char buffer[256];
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
-    if (NULL != FieldInfo) {
+    if (nullptr != FieldInfo) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
         sprintf(buffer, "%s.%s = %f", FieldInfo->getFieldName().c_str(), typeName, data);
         m_OutputBuffer += buffer;
@@ -139,7 +139,7 @@ void StatisticOutputConsole::outputField(fieldHandle_t fieldHandle, double data)
     char buffer[256];
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
-    if (NULL != FieldInfo) {
+    if (nullptr != FieldInfo) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
         sprintf(buffer, "%s.%s = %f", FieldInfo->getFieldName().c_str(), typeName, data);
         m_OutputBuffer += buffer;

--- a/src/sst/core/statapi/statoutputconsole.h
+++ b/src/sst/core/statapi/statoutputconsole.h
@@ -14,7 +14,7 @@
 
 #include "sst/core/sst_types.h"
 
-#include <sst/core/statapi/statoutput.h>
+#include "sst/core/statapi/statoutput.h"
 
 namespace SST {
 namespace Statistics {

--- a/src/sst/core/statapi/statoutputcsv.cc
+++ b/src/sst/core/statapi/statoutputcsv.cc
@@ -9,11 +9,11 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
+#include "sst/core/statapi/statoutputcsv.h"
 
-#include <sst/core/simulation.h>
-#include <sst/core/statapi/statoutputcsv.h>
-#include <sst/core/stringize.h>
+#include "sst/core/simulation.h"
+#include "sst/core/stringize.h"
 
 namespace SST {
 namespace Statistics {
@@ -274,7 +274,7 @@ bool StatisticOutputCSV::openFile(void)
     if ( m_useCompression ) {
 #ifdef HAVE_LIBZ
         m_gzFile = gzopen(m_FilePath.c_str(), "w");
-        if (NULL == m_gzFile){
+        if (nullptr == m_gzFile){
             // We got an error of some sort
             Output out = Simulation::getSimulation()->getSimulationOutput();
             out.fatal(CALL_INFO, 1, 
@@ -286,7 +286,7 @@ bool StatisticOutputCSV::openFile(void)
 #endif
     } else {
         m_hFile = fopen(m_FilePath.c_str(), "w");
-        if (NULL == m_hFile){
+        if (nullptr == m_hFile){
             // We got an error of some sort
             Output out = Simulation::getSimulation()->getSimulationOutput();
             out.fatal(CALL_INFO, 1, 

--- a/src/sst/core/statapi/statoutputcsv.h
+++ b/src/sst/core/statapi/statoutputcsv.h
@@ -14,7 +14,7 @@
 
 #include "sst/core/sst_types.h"
 
-#include <sst/core/statapi/statoutput.h>
+#include "sst/core/statapi/statoutput.h"
 
 #ifdef HAVE_LIBZ
 #include <zlib.h>

--- a/src/sst/core/statapi/statoutputhdf5.cc
+++ b/src/sst/core/statapi/statoutputhdf5.cc
@@ -9,24 +9,24 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
+#include "sst/core/statapi/statoutputhdf5.h"
 
 #include <algorithm>
 
-#include <sst/core/simulation.h>
-#include <sst/core/warnmacros.h>
-#include <sst/core/baseComponent.h>
-#include <sst/core/statapi/statoutputhdf5.h>
-#include <sst/core/statapi/statgroup.h>
-#include <sst/core/stringize.h>
+#include "sst/core/simulation.h"
+#include "sst/core/warnmacros.h"
+#include "sst/core/baseComponent.h"
+#include "sst/core/statapi/statgroup.h"
+#include "sst/core/stringize.h"
 
 namespace SST {
 namespace Statistics {
 
 StatisticOutputHDF5::StatisticOutputHDF5(Params& outputParameters)
     : StatisticOutput (outputParameters),
-    m_hFile(NULL),
-    m_currentDataSet(NULL)
+    m_hFile(nullptr),
+    m_currentDataSet(nullptr)
 {
     // Announce this output object's name
     Output &out = Simulation::getSimulationOutput();
@@ -75,7 +75,7 @@ void StatisticOutputHDF5::printUsage()
 
 void StatisticOutputHDF5::implStartRegisterFields(StatisticBase *stat)
 {
-    if ( m_currentDataSet != NULL ) {
+    if ( m_currentDataSet != nullptr ) {
         m_currentDataSet->setCurrentStatistic(stat);
     } else {
         m_currentDataSet = initStatistic(stat);
@@ -93,7 +93,7 @@ void StatisticOutputHDF5::implStopRegisterFields()
 {
     m_currentDataSet->finalizeCurrentStatistic();
     if ( !m_currentDataSet->isGroup() )
-        m_currentDataSet = NULL;
+        m_currentDataSet = nullptr;
 }
 
 
@@ -110,7 +110,7 @@ void StatisticOutputHDF5::implStartRegisterGroup(StatisticGroup* group )
 void StatisticOutputHDF5::implStopRegisterGroup()
 {
     m_currentDataSet->finalizeGroupRegistration();
-    m_currentDataSet = NULL;
+    m_currentDataSet = nullptr;
 }
 
 
@@ -132,7 +132,7 @@ void StatisticOutputHDF5::endOfSimulation()
 
 void StatisticOutputHDF5::implStartOutputEntries(StatisticBase* statistic)
 {
-    if ( m_currentDataSet == NULL )
+    if ( m_currentDataSet == nullptr )
         m_currentDataSet = getStatisticInfo(statistic);
     m_currentDataSet->startNewEntry(statistic);
 }
@@ -141,7 +141,7 @@ void StatisticOutputHDF5::implStopOutputEntries()
 {
     m_currentDataSet->finishEntry();
     if ( !m_currentDataSet->isGroup() )
-        m_currentDataSet = NULL;
+        m_currentDataSet = nullptr;
 }
 
 
@@ -156,7 +156,7 @@ void StatisticOutputHDF5::implStartOutputGroup(StatisticGroup* group)
 void StatisticOutputHDF5::implStopOutputGroup()
 {
     m_currentDataSet->finishGroupEntry();
-    m_currentDataSet = NULL;
+    m_currentDataSet = nullptr;
 }
 
 
@@ -290,7 +290,7 @@ void StatisticOutputHDF5::StatisticInfo::finalizeCurrentStatistic()
     size_t dataSize = currentData.size() * sizeof(StatData_u);
     memType = new H5::CompType(dataSize);
     for ( size_t i = 0 ; i < nFields ; i++ ) {
-        const std::string &name = fieldNames[i];
+        const std::string& name = fieldNames[i];
         size_t offset = (char*)&currentData[i] - (char*)&currentData[0];
         H5::DataType type = getMemTypeForStatType(typeList[i]);
         memType->insertMember(name, offset, type);
@@ -407,7 +407,7 @@ void StatisticOutputHDF5::GroupInfo::registerField(StatisticFieldInfo *fi)
 
 void StatisticOutputHDF5::GroupInfo::finalizeCurrentStatistic()
 {
-    m_currentStat = NULL;
+    m_currentStat = nullptr;
 }
 
 
@@ -532,7 +532,7 @@ void StatisticOutputHDF5::GroupInfo::startNewEntry(StatisticBase *stat)
 void StatisticOutputHDF5::GroupInfo::finishEntry()
 {
     m_currentStat->finishEntry();
-    m_currentStat = NULL;
+    m_currentStat = nullptr;
 }
 
 void StatisticOutputHDF5::GroupInfo::finishGroupEntry()

--- a/src/sst/core/statapi/statoutputhdf5.h
+++ b/src/sst/core/statapi/statoutputhdf5.h
@@ -14,8 +14,8 @@
 
 #include "sst/core/sst_types.h"
 
-#include <sst/core/statapi/statoutput.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/statapi/statoutput.h"
+#include "sst/core/warnmacros.h"
 
 DISABLE_WARN_MISSING_OVERRIDE
 #include "H5Cpp.h"

--- a/src/sst/core/statapi/statoutputjson.cc
+++ b/src/sst/core/statapi/statoutputjson.cc
@@ -9,13 +9,13 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
 
-#include <sst/core/simulation.h>
-#include <sst/core/statapi/statoutputcsv.h>
-#include <sst/core/stringize.h>
+#include "sst/core/statapi/statoutputjson.h"
 
-#include <sst/core/statapi/statoutputjson.h>
+#include "sst/core/simulation.h"
+#include "sst/core/statapi/statoutputcsv.h"
+#include "sst/core/stringize.h"
 
 namespace SST {
 namespace Statistics {
@@ -242,7 +242,7 @@ bool StatisticOutputJSON::openFile(void)
 {
 	m_hFile = fopen(m_FilePath.c_str(), "w");
 	
-	if (NULL == m_hFile) {
+	if (nullptr == m_hFile) {
 		// We got an error of some sort
 		Output out = Simulation::getSimulation()->getSimulationOutput();
 		out.fatal(CALL_INFO, 1, " : StatisticOutputJSON - Problem opening File %s - %s\n", m_FilePath.c_str(), strerror(errno));

--- a/src/sst/core/statapi/statoutputjson.h
+++ b/src/sst/core/statapi/statoutputjson.h
@@ -14,7 +14,7 @@
 
 #include "sst/core/sst_types.h"
 
-#include <sst/core/statapi/statoutput.h>
+#include "sst/core/statapi/statoutput.h"
 
 namespace SST {
 namespace Statistics {

--- a/src/sst/core/statapi/statoutputtxt.cc
+++ b/src/sst/core/statapi/statoutputtxt.cc
@@ -9,11 +9,11 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
+#include "sst_config.h"
+#include "sst/core/statapi/statoutputtxt.h"
 
-#include <sst/core/simulation.h>
-#include <sst/core/statapi/statoutputtxt.h>
-#include <sst/core/stringize.h>
+#include "sst/core/simulation.h"
+#include "sst/core/stringize.h"
 
 namespace SST {
 namespace Statistics {
@@ -195,7 +195,7 @@ void StatisticOutputTxt::outputField(fieldHandle_t fieldHandle, int32_t data)
     char buffer[256];
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
     
-    if (NULL != FieldInfo) {
+    if (nullptr != FieldInfo) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
 
         if (true == m_outputInlineHeader) {
@@ -213,7 +213,7 @@ void StatisticOutputTxt::outputField(fieldHandle_t fieldHandle, uint32_t data)
     char buffer[256];
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
-    if (NULL != FieldInfo) {
+    if (nullptr != FieldInfo) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
 
         if (true == m_outputInlineHeader) {
@@ -231,7 +231,7 @@ void StatisticOutputTxt::outputField(fieldHandle_t fieldHandle, int64_t data)
     char buffer[256];
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
-    if (NULL != FieldInfo) {
+    if (nullptr != FieldInfo) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
 
         if (true == m_outputInlineHeader) {
@@ -249,7 +249,7 @@ void StatisticOutputTxt::outputField(fieldHandle_t fieldHandle, uint64_t data)
     char buffer[256];
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
-    if (NULL != FieldInfo) {
+    if (nullptr != FieldInfo) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
 
         if (true == m_outputInlineHeader) {
@@ -267,7 +267,7 @@ void StatisticOutputTxt::outputField(fieldHandle_t fieldHandle, float data)
     char buffer[256];
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
-    if (NULL != FieldInfo) {
+    if (nullptr != FieldInfo) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
 
         if (true == m_outputInlineHeader) {
@@ -285,7 +285,7 @@ void StatisticOutputTxt::outputField(fieldHandle_t fieldHandle, double data)
     char buffer[256];
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
-    if (NULL != FieldInfo) {
+    if (nullptr != FieldInfo) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
 
         if (true == m_outputInlineHeader) {
@@ -304,7 +304,7 @@ bool StatisticOutputTxt::openFile(void)
     if ( m_useCompression ) {
 #ifdef HAVE_LIBZ
         m_gzFile = gzopen(m_FilePath.c_str(), "w");
-        if (NULL == m_gzFile){
+        if (nullptr == m_gzFile){
             // We got an error of some sort
             Output out = Simulation::getSimulation()->getSimulationOutput();
             out.fatal(CALL_INFO, 1, " : StatisticOutputCompressedTxt - Problem opening File %s - %s\n", m_FilePath.c_str(), strerror(errno));
@@ -315,7 +315,7 @@ bool StatisticOutputTxt::openFile(void)
 #endif
     } else {
         m_hFile = fopen(m_FilePath.c_str(), "w");
-        if (NULL == m_hFile){
+        if (nullptr == m_hFile){
             // We got an error of some sort
             Output out = Simulation::getSimulation()->getSimulationOutput();
             out.fatal(CALL_INFO, 1, " : StatisticOutputTxt - Problem opening File %s - %s\n", m_FilePath.c_str(), strerror(errno));

--- a/src/sst/core/statapi/statoutputtxt.h
+++ b/src/sst/core/statapi/statoutputtxt.h
@@ -14,7 +14,7 @@
 
 #include "sst/core/sst_types.h"
 
-#include <sst/core/statapi/statoutput.h>
+#include "sst/core/statapi/statoutput.h"
 
 #ifdef HAVE_LIBZ
 #include <zlib.h>

--- a/src/sst/core/statapi/statuniquecount.h
+++ b/src/sst/core/statapi/statuniquecount.h
@@ -13,10 +13,10 @@
 #ifndef _H_SST_CORE_UNIQUE_COUNT_STATISTIC_
 #define _H_SST_CORE_UNIQUE_COUNT_STATISTIC_
 
-#include <sst/core/sst_types.h>
-#include <sst/core/warnmacros.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/warnmacros.h"
 
-#include <sst/core/statapi/statbase.h>
+#include "sst/core/statapi/statbase.h"
 
 namespace SST {
 class BaseComponent;

--- a/src/sst/core/stopAction.h
+++ b/src/sst/core/stopAction.h
@@ -15,8 +15,8 @@
 #include <iostream>
 #include <cinttypes>
 
-#include <sst/core/action.h>
-#include <sst/core/output.h>
+#include "sst/core/action.h"
+#include "sst/core/output.h"
 
 namespace SST {
 
@@ -38,7 +38,7 @@ public:
 
     /** Create a new StopAction which includes a message to be printed when it fires
      */
-    StopAction(std::string msg) {
+    StopAction(const std::string& msg) {
         setPriority(STOPACTIONPRIORITY);
         print_message = true;
         message = msg;
@@ -51,7 +51,7 @@ public:
         endSimulation();
     }
 
-    void print(const std::string &header, Output &out) const override {
+    void print(const std::string& header, Output &out) const override {
         out.output("%s StopAction to be delivered at %" PRIu64 "\n", header.c_str(), getDeliveryTime());
     }
 

--- a/src/sst/core/stringize.h
+++ b/src/sst/core/stringize.h
@@ -68,18 +68,18 @@ inline std::string to_string(uint64_t val) {
 };
 
 
-inline bool strcasecmp(const std::string &s1, const std::string &s2) {
+inline bool strcasecmp(const std::string& s1, const std::string& s2) {
     return !::strcasecmp(s1.c_str(), s2.c_str());
 }
 
-inline void to_lower(std::string &s) {
+inline void to_lower(std::string& s) {
     for ( size_t i = 0 ; i < s.size() ; i++ ) {
         s[i] = std::tolower(s[i]);
     }
 }
 
 
-inline void trim(std::string &s) {
+inline void trim(std::string& s) {
     auto start = s.find_first_not_of(" \t\n\r\v\f");
     if ( start != 0 ) {
         s.replace(s.begin(), s.begin() + (start), "");
@@ -101,7 +101,7 @@ struct char_delimiter {
     /**
      * @return pair<iter, iter> = <tok_end, next_tok>
      */
-    void operator()(iter &first, iter last, std::string &token) {
+    void operator()(iter &first, iter last, std::string& token) {
         token.clear();
 
         /* Skip any leading separators */
@@ -122,14 +122,14 @@ struct escaped_list_separator {
     std::string q;
     std::string s;
 
-    escaped_list_separator(const std::string &esc="\\", const std::string &sep=",", const std::string &quote="\"")
+    escaped_list_separator(const std::string& esc="\\", const std::string& sep=",", const std::string& quote="\"")
         : e(esc), q(quote), s(sep) { }
 
 
     /**
      * @return pair<iter, iter> = <tok_end, next_tok>
      */
-    void operator()(iter &first, iter last, std::string &token) {
+    void operator()(iter &first, iter last, std::string& token) {
         token.clear();
 
         bool inside_quotes = false;
@@ -193,7 +193,7 @@ public:
     iter begin() { return iter(f, first, last); }
     iter end() { return iter(f, last, last); }
 
-    Tokenizer(const std::string &s, const TokenizerFunc& f = TokenizerFunc())
+    Tokenizer(const std::string& s, const TokenizerFunc& f = TokenizerFunc())
         : first(s.begin()), last(s.end()), f(f) { }
 
 private:

--- a/src/sst/core/subcomponent.cc
+++ b/src/sst/core/subcomponent.cc
@@ -9,9 +9,9 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#include <sst_config.h>
-#include <sst/core/subcomponent.h>
-#include <sst/core/factory.h>
+#include "sst_config.h"
+#include "sst/core/subcomponent.h"
+#include "sst/core/factory.h"
 
 namespace SST {
 
@@ -32,7 +32,7 @@ SubComponent::SubComponent(ComponentId_t id) :
 
 
 SubComponent*
-SubComponent::loadSubComponent(std::string type, Params& params)
+SubComponent::loadSubComponent(const std::string& type, Params& params)
 {
     return BaseComponent::loadSubComponent(type, getTrueComponentPrivate(), params);
 }

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -13,11 +13,11 @@
 #ifndef SST_CORE_SUBCOMPONENT_H
 #define SST_CORE_SUBCOMPONENT_H
 
-#include <sst/core/warnmacros.h>
-#include <sst/core/baseComponent.h>
-#include <sst/core/component.h>
-#include <sst/core/module.h>
-#include <sst/core/eli/elementinfo.h>
+#include "sst/core/warnmacros.h"
+#include "sst/core/baseComponent.h"
+#include "sst/core/component.h"
+#include "sst/core/module.h"
+#include "sst/core/eli/elementinfo.h"
 
 namespace SST {
 
@@ -59,7 +59,7 @@ protected:
     Component* const parent __attribute__ ((deprecated("The parent data member will be removed in SST version 10.0.  With the new subcomponent structure, direct access to your parent is not allowed.")));
 
     /* Deprecate?   Old ELI style*/
-    SubComponent* loadSubComponent(std::string type, Params& params) __attribute__ ((deprecated("This version of loadSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
+    SubComponent* loadSubComponent(const std::string& type, Params& params) __attribute__ ((deprecated("This version of loadSubComponent will be removed in SST version 10.0.  Please switch to new user defined API (LoadUserSubComponent(std::string, int, ARGS...)).")));
 
 
 private:

--- a/src/sst/core/syncBase.h
+++ b/src/sst/core/syncBase.h
@@ -14,7 +14,7 @@
 
 #include "sst/core/sst_types.h"
 
-#include <sst/core/rankInfo.h>
+#include "sst/core/rankInfo.h"
 
 namespace SST {
 

--- a/src/sst/core/syncManager.cc
+++ b/src/sst/core/syncManager.cc
@@ -10,9 +10,9 @@
 // distribution.
 
 #include "sst_config.h"
-
-#include <sst/core/warnmacros.h>
 #include "sst/core/syncManager.h"
+
+#include "sst/core/warnmacros.h"
 
 #include "sst/core/exit.h"
 #include "sst/core/simulation.h"
@@ -37,7 +37,7 @@ REENABLE_WARNING
 namespace SST {
 
 // Static data members
-NewRankSync* SyncManager::rankSync = NULL;
+NewRankSync* SyncManager::rankSync = nullptr;
 Core::ThreadSafe::Barrier SyncManager::RankExecBarrier[6];
 Core::ThreadSafe::Barrier SyncManager::LinkUntimedBarrier[3];
 SimTime_t SyncManager::next_rankSync = MAX_SIMTIME_T;
@@ -50,7 +50,7 @@ public:
     ~EmptyRankSync() {}
 
     /** Register a Link which this Sync Object is responsible for */
-    ActivityQueue* registerLink(const RankInfo& UNUSED(to_rank), const RankInfo& UNUSED(from_rank), LinkId_t UNUSED(link_id), Link* UNUSED(link)) override { return NULL; }
+    ActivityQueue* registerLink(const RankInfo& UNUSED(to_rank), const RankInfo& UNUSED(from_rank), LinkId_t UNUSED(link_id), Link* UNUSED(link)) override { return nullptr; }
 
     void execute(int UNUSED(thread)) override {}
     void exchangeLinkUntimedData(int UNUSED_WO_MPI(thread), std::atomic<int>& UNUSED_WO_MPI(msg_count)) override {
@@ -98,7 +98,7 @@ public:
 
     /** Register a Link which this Sync Object is responsible for */
     void registerLink(LinkId_t UNUSED(link_id), Link* UNUSED(link)) override {}
-    ActivityQueue* getQueueForThread(int UNUSED(tid)) override { return NULL; }
+    ActivityQueue* getQueueForThread(int UNUSED(tid)) override { return nullptr; }
 };
 
 
@@ -106,7 +106,7 @@ SyncManager::SyncManager(const RankInfo& rank, const RankInfo& num_ranks, TimeCo
     Action(),
     rank(rank),
     num_ranks(num_ranks),
-    threadSync(NULL),
+    threadSync(nullptr),
     min_part(min_part)
 {
     sim = Simulation::getSimulation();
@@ -152,7 +152,7 @@ ActivityQueue*
 SyncManager::registerLink(const RankInfo& to_rank, const RankInfo& from_rank, LinkId_t link_id, Link* link)
 {
     if ( to_rank == from_rank ) {
-        return NULL;  // This should never happen
+        return nullptr;  // This should never happen
     }
 
     if ( to_rank.rank == from_rank.rank ) {
@@ -204,7 +204,7 @@ SyncManager::execute(void)
 
         RankExecBarrier[3].wait();
         
-        if ( exit != NULL && rank.thread == 0 ) exit->check();
+        if ( exit != nullptr && rank.thread == 0 ) exit->check();
 
         RankExecBarrier[4].wait();
 

--- a/src/sst/core/syncQueue.cc
+++ b/src/sst/core/syncQueue.cc
@@ -11,12 +11,11 @@
 
 
 #include "sst_config.h"
-#include <sst/core/serialization/serializer.h>
-#include <sst/core/syncQueue.h>
+#include "sst/core/syncQueue.h"
 
-#include <sst/core/event.h>
-
-#include <sst/core/simulation.h>
+#include "sst/core/serialization/serializer.h"
+#include "sst/core/event.h"
+#include "sst/core/simulation.h"
 
 
 namespace SST {
@@ -25,7 +24,7 @@ using namespace Core::ThreadSafe;
 using namespace Core::Serialization;
 
 SyncQueue::SyncQueue() :
-    ActivityQueue(), buffer(NULL), buf_size(0)
+    ActivityQueue(), buffer(nullptr), buf_size(0)
 {
 }
 
@@ -58,19 +57,19 @@ Activity*
 SyncQueue::pop()
 {
     // NEED TO FATAL
-	// if ( data.size() == 0 ) return NULL;
+	// if ( data.size() == 0 ) return nullptr;
 	// std::vector<Activity*>::iterator it = data.begin();
 	// Activity* ret_val = (*it);
 	// data.erase(it);
 	// return ret_val;
-    return NULL;
+    return nullptr;
 }
 
 Activity*
 SyncQueue::front()
 {
     // NEED TO FATAL
-	return NULL;
+	return nullptr;
 }
 
 void
@@ -94,7 +93,7 @@ SyncQueue::getData()
     size_t size = ser.size();
 
     if ( buf_size < ( size + sizeof(SyncQueue::Header) ) ) {
-        if ( buffer != NULL ) {
+        if ( buffer != nullptr ) {
             delete[] buffer;
         }
         

--- a/src/sst/core/syncQueue.h
+++ b/src/sst/core/syncQueue.h
@@ -12,12 +12,10 @@
 #ifndef SST_CORE_SYNCQUEUE_H
 #define SST_CORE_SYNCQUEUE_H
 
-//#include <sst/core/serialization.h>
-
 #include <vector>
 
-#include <sst/core/activityQueue.h>
-#include <sst/core/threadsafe.h>
+#include "sst/core/activityQueue.h"
+#include "sst/core/threadsafe.h"
 
 namespace SST {
 

--- a/src/sst/core/threadSync.cc
+++ b/src/sst/core/threadSync.cc
@@ -16,7 +16,6 @@
 #include "sst/core/exit.h"
 #include "sst/core/link.h"
 #include "sst/core/simulation.h"
-//#include "sst/core/syncQueue.h"
 #include "sst/core/timeConverter.h"
 
 namespace SST {

--- a/src/sst/core/threadSyncQueue.h
+++ b/src/sst/core/threadSyncQueue.h
@@ -13,7 +13,7 @@
 #ifndef SST_CORE_THREADSYNCQUEUE_H
 #define SST_CORE_THREADSYNCQUEUE_H
 
-#include <sst/core/activityQueue.h>
+#include "sst/core/activityQueue.h"
 
 namespace SST {
 
@@ -39,7 +39,7 @@ public:
     /** Not supported */
     Activity* pop() override {
         // Need to fatal
-        return NULL;
+        return nullptr;
     }
     
     /** Insert a new activity into the queue */
@@ -50,7 +50,7 @@ public:
     /** Not supported */
     Activity* front() override {
         // Need to fatal
-        return NULL;
+        return nullptr;
     }
 
     void clear() {

--- a/src/sst/core/threadSyncSimpleSkip.cc
+++ b/src/sst/core/threadSyncSimpleSkip.cc
@@ -16,7 +16,6 @@
 #include "sst/core/exit.h"
 #include "sst/core/link.h"
 #include "sst/core/simulation.h"
-//#include "sst/core/syncQueue.h"
 #include "sst/core/timeConverter.h"
 
 namespace SST {

--- a/src/sst/core/threadsafe.h
+++ b/src/sst/core/threadsafe.h
@@ -27,7 +27,7 @@
 
 #include <time.h>
 
-#include <sst/core/profile.h>
+#include "sst/core/profile.h"
 
 namespace SST {
 namespace Core {
@@ -103,7 +103,7 @@ public:
                         struct timespec ts;
                         ts.tv_sec = 0;
                         ts.tv_nsec = 1000;
-                        nanosleep(&ts, NULL);
+                        nanosleep(&ts, nullptr);
                     }
                 } while ( gen == generation.load(std::memory_order_acquire) );
             }
@@ -201,7 +201,7 @@ public:
 
     bool try_insert(const T& arg)
     {
-        cell_t *cell = NULL;
+        cell_t *cell = nullptr;
         size_t pos = wPtr.load(std::memory_order_relaxed);
         for (;;) {
             cell = &data[pos % dsize];
@@ -224,7 +224,7 @@ public:
 
     bool try_remove(T &res)
     {
-        cell_t *cell = NULL;
+        cell_t *cell = nullptr;
         size_t pos = rPtr.load(std::memory_order_relaxed);
         for (;;) {
             cell = &data[pos % dsize];

--- a/src/sst/core/timeConverter.h
+++ b/src/sst/core/timeConverter.h
@@ -12,7 +12,7 @@
 #ifndef SST_CORE_TIMECONVERTER_H
 #define SST_CORE_TIMECONVERTER_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 namespace SST {
 

--- a/src/sst/core/timeLord.cc
+++ b/src/sst/core/timeLord.cc
@@ -11,21 +11,22 @@
 
 
 #include "sst_config.h"
-#include <sst/core/warnmacros.h>
-#include <sst/core/timeLord.h>
+#include "sst/core/timeLord.h"
+
+#include "sst/core/warnmacros.h"
 
 #include <cstdio>
 #include <cstring>
 
-#include <sst/core/output.h>
-#include <sst/core/linkMap.h>
-#include <sst/core/timeConverter.h>
+#include "sst/core/output.h"
+#include "sst/core/linkMap.h"
+#include "sst/core/timeConverter.h"
 
 namespace SST {
 
 using Core::ThreadSafe::Spinlock;
 
-TimeConverter* TimeLord::getTimeConverter(std::string ts) {
+TimeConverter* TimeLord::getTimeConverter(const std::string& ts) {
     // See if this is in the cache
     std::lock_guard<std::recursive_mutex> lock(slock);
     if ( parseCache.find(ts) == parseCache.end() ) {
@@ -87,7 +88,7 @@ TimeConverter* TimeLord::getTimeConverter(const UnitAlgebra& ts) {
     return tc;
 }
 
-void TimeLord::init(std::string _timeBaseString)
+void TimeLord::init(const std::string& _timeBaseString)
 {
     initialized = true;
     timeBaseString = _timeBaseString;
@@ -110,7 +111,7 @@ TimeLord::~TimeLord() {
     parseCache.clear();
 }
 
-SimTime_t TimeLord::getSimCycles(std::string ts, std::string UNUSED(where))
+SimTime_t TimeLord::getSimCycles(const std::string& ts, const std::string& UNUSED(where))
 {
     // See if this is in the cache
     std::lock_guard<std::recursive_mutex> lock(slock);

--- a/src/sst/core/timeLord.h
+++ b/src/sst/core/timeLord.h
@@ -14,14 +14,14 @@
 #ifndef SST_CORE_TIMELORD_H
 #define SST_CORE_TIMELORD_H
 
-#include <sst/core/sst_types.h>
+#include "sst/core/sst_types.h"
 
 #include <map>
 #include <string>
 
-#include <sst/core/simulation.h>
-#include <sst/core/unitAlgebra.h>
-#include <sst/core/threadsafe.h>
+#include "sst/core/simulation.h"
+#include "sst/core/unitAlgebra.h"
+#include "sst/core/threadsafe.h"
 
 extern int main(int argc, char **argv);
 
@@ -49,7 +49,7 @@ class TimeLord {
       'm' (milli). Allowable frequency prefixes are 'k' (kilo), 'M'
       (mega), and 'G' (giga).
    */
-    TimeConverter* getTimeConverter(std::string ts);
+    TimeConverter* getTimeConverter(const std::string& ts);
     /**
      * Create a new TimeConverter object using the specified units.
      *
@@ -60,7 +60,7 @@ class TimeLord {
     /** Not a Public API.
      * Returns the number of raw simulation cycles given by a specified time string
      */
-    SimTime_t getSimCycles(std::string timeString, std::string where);
+    SimTime_t getSimCycles(const std::string& timeString, const std::string& where);
     /**
      * Return the Time Base of the TimeLord
      */
@@ -77,7 +77,7 @@ class TimeLord {
     friend class SST::Simulation;
     friend int ::main(int argc, char **argv);
 
-    void init(std::string timeBaseString);
+    void init(const std::string& timeBaseString);
 
     // Needed by the simulator to turn minPart back into a
     // TimeConverter object.

--- a/src/sst/core/timeVortex.cc
+++ b/src/sst/core/timeVortex.cc
@@ -1,4 +1,17 @@
-#include <sst/core/timeVortex.h>
+// Copyright 2009-2019 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2019, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+
+#include "sst/core/timeVortex.h"
 
 namespace SST {
 

--- a/src/sst/core/timeVortex.h
+++ b/src/sst/core/timeVortex.h
@@ -12,8 +12,8 @@
 #ifndef SST_CORE_TIMEVORTEX_H
 #define SST_CORE_TIMEVORTEX_H
 
-#include <sst/core/activityQueue.h>
-#include <sst/core/module.h>
+#include "sst/core/activityQueue.h"
+#include "sst/core/module.h"
 
 namespace SST {
 

--- a/src/sst/core/tinyxml/tinyxml.h
+++ b/src/sst/core/tinyxml/tinyxml.h
@@ -38,7 +38,7 @@ distribution.
 #include <string.h>
 #include <assert.h>
 
-#include <sst/core/warnmacros.h>
+#include "sst/core/warnmacros.h"
 DISABLE_WARN_MISSING_OVERRIDE
 
 // Help out windows:

--- a/src/sst/core/uninitializedQueue.cc
+++ b/src/sst/core/uninitializedQueue.cc
@@ -11,15 +11,15 @@
 
 
 #include "sst_config.h"
+#include "sst/core/uninitializedQueue.h"
 
 #include <ostream>
 
-#include <sst/core/warnmacros.h>
-#include <sst/core/uninitializedQueue.h>
+#include "sst/core/warnmacros.h"
 
 namespace SST {
 
-    UninitializedQueue::UninitializedQueue(std::string message) :
+    UninitializedQueue::UninitializedQueue(const std::string& message) :
 	ActivityQueue(), message(message) {}
 
     UninitializedQueue::UninitializedQueue() :

--- a/src/sst/core/uninitializedQueue.h
+++ b/src/sst/core/uninitializedQueue.h
@@ -13,7 +13,7 @@
 #ifndef SST_CORE_UNINITIALIZEDQUEUE_H
 #define SST_CORE_UNINITIALIZEDQUEUE_H
 
-#include <sst/core/activityQueue.h>
+#include "sst/core/activityQueue.h"
 
 namespace SST {
 
@@ -26,7 +26,7 @@ public:
     /** Create a new Queue
      * @param message - Message to print when something attempts to use this Queue
      */
-    UninitializedQueue(std::string message);
+    UninitializedQueue(const std::string& message);
     UninitializedQueue(); // Only used for serialization
     ~UninitializedQueue();
 

--- a/src/sst/core/unitAlgebra.cc
+++ b/src/sst/core/unitAlgebra.cc
@@ -11,23 +11,20 @@
 
 #include "sst_config.h"
 
+#include "unitAlgebra.h"
+
 #include <string>
 #include <iostream>
 #include <algorithm>
 
-#include "unitAlgebra.h"
-
-#include <sst/core/output.h>
-#include <sst/core/simulation.h>
-
-// #include <boost/assign.hpp>
-
+#include "sst/core/output.h"
+#include "sst/core/simulation.h"
 
 using namespace std;
 using namespace SST;
 
 // Helper functions and data structures used only in this file
-static void split(string input, string delims, vector<string>& tokens) {
+static void split(const std::string& input, const std::string& delims, vector<string>& tokens) {
     if ( input.length() == 0 ) return;
     size_t start = 0;
     size_t stop = 0;;
@@ -120,7 +117,7 @@ Units::reduce()
 }
 
 void
-Units::addUnit(std::string units, sst_big_num& multiplier, bool invert)
+Units::addUnit(const std::string& units, sst_big_num& multiplier, bool invert)
 {
     std::lock_guard<std::recursive_mutex> lock(unit_lock);
     // Check to see if the unit matches one of the registered unit
@@ -193,7 +190,7 @@ Units::addUnit(std::string units, sst_big_num& multiplier, bool invert)
 }
 
 void
-Units::registerBaseUnit(string u)
+Units::registerBaseUnit(const std::string& u)
 {
     std::lock_guard<std::recursive_mutex> lock(unit_lock);
     if ( valid_base_units.find(u) != valid_base_units.end() ) return;
@@ -204,7 +201,7 @@ Units::registerBaseUnit(string u)
 }
 
 void
-Units::registerCompoundUnit(string u, string v)
+Units::registerCompoundUnit(const std::string& u, const std::string& v)
 {
     std::lock_guard<std::recursive_mutex> lock(unit_lock);
     if ( valid_compound_units.find(u) != valid_compound_units.end() ) return;
@@ -214,7 +211,7 @@ Units::registerCompoundUnit(string u, string v)
     return;
 }
 
-Units::Units(std::string units, sst_big_num& multiplier)
+Units::Units(const std::string& units, sst_big_num& multiplier)
 {   
     // Get the numerator and the denominator
     string s_numerator;
@@ -330,7 +327,7 @@ Units::toString() const
 // UnitAlgebra
 
 string
-UnitAlgebra::trim(std::string str)
+UnitAlgebra::trim(const std::string& str)
 {
     // Find whitespace in front
     int front_index = 0;
@@ -344,7 +341,7 @@ UnitAlgebra::trim(std::string str)
 }
 
 void
-UnitAlgebra::init(std::string val)
+UnitAlgebra::init(const std::string& val)
 {
     //Trim off all whitespace on front and back
     string parse = trim(val);
@@ -377,7 +374,7 @@ UnitAlgebra::init(std::string val)
 }
     
 
-UnitAlgebra::UnitAlgebra(std::string val)
+UnitAlgebra::UnitAlgebra(const std::string& val)
 {
     init(val);
 }
@@ -533,7 +530,7 @@ UnitAlgebra::invert()
 }
 
 bool
-UnitAlgebra::hasUnits(std::string u) const
+UnitAlgebra::hasUnits(const std::string& u) const
 {
     sst_big_num multiplier = 1;
     Units check_units(u,multiplier);

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -14,17 +14,17 @@
 #ifndef SST_CORE_UNITALGEBRA_H
 #define SST_CORE_UNITALGEBRA_H
 
-#include <sst/core/sst_types.h>
-#include <sst/core/serialization/serializable.h>
-#include <sst/core/serialization/serializer.h>
+#include "sst/core/sst_types.h"
+#include "sst/core/serialization/serializable.h"
+#include "sst/core/serialization/serializer.h"
 
 #include <string>
 #include <map>
 #include <vector>
 #include <mutex>
 
-#include <sst/core/warnmacros.h>
-#include <sst/core/decimal_fixedpoint.h>
+#include "sst/core/warnmacros.h"
+#include "sst/core/decimal_fixedpoint.h"
 
 
 namespace SST {
@@ -60,21 +60,21 @@ private:
 
     void reduce();
     // Used in constructor to incrementally build up unit from string
-    void addUnit(std::string, sst_big_num& multiplier, bool invert);
+    void addUnit(const std::string&, sst_big_num& multiplier, bool invert);
 
 public:
     // Static data members and functions
     /** Create a new Base Unit type */
-    static void registerBaseUnit(std::string u);
+    static void registerBaseUnit(const std::string& u);
     /** Create a new Compound Unit type */
-    static void registerCompoundUnit(std::string u, std::string v);
+    static void registerCompoundUnit(const std::string& u, const std::string& v);
 
     // Non-static data members and functions
     /** Create a new instantiation of a Units with a base unit string, and multiplier
      * \param units String representing the new unit
      * \param multiplier Value by which to multiply to get to this unit
      */
-    Units(std::string units, sst_big_num& multiplier);
+    Units(const std::string& units, sst_big_num& multiplier);
     Units() {}
     virtual ~Units() {}
 
@@ -107,8 +107,8 @@ private:
     Units unit;
     sst_big_num value;
 
-    static std::string trim(std::string str);
-    void init(std::string val);
+    static std::string trim(const std::string& str);
+    void init(const std::string& val);
 
 public:
     UnitAlgebra() {}
@@ -127,7 +127,7 @@ public:
      COMPUNIT   := {Hz,hz,Bps,bps,event}
      \endcode
      */
-    UnitAlgebra(std::string val);
+    UnitAlgebra(const std::string& val);
     virtual ~UnitAlgebra();
 
     /** Print to an ostream the value */
@@ -195,7 +195,7 @@ public:
     /** Returns true if the units in the parameter string are found
      * in this object.
      */
-    bool hasUnits(std::string u) const;
+    bool hasUnits(const std::string& u) const;
     /** Return the raw value */
     sst_big_num getValue() const {return value;}
     /** Return the rounded value as a 64bit integer */


### PR DESCRIPTION
The following items were addressed:
1 – replaced NULL with nullptr
2 – replaced string with const string& in function definitions (where it made sense to)
3 – standardized string& as being “string& foo” instead of “string &foo” (the first version was more prevalent in the code base to start)
4 – added some missing copyright notices
5 – made sure all .cc files included sst_config.h as the first include

