### PR TITLE
statoutputhdf5 fix

### DIFF
--- a/src/sst/core/statapi/statoutputhdf5.cc
+++ b/src/sst/core/statapi/statoutputhdf5.cc
@@ -542,6 +542,10 @@ void StatisticOutputHDF5::GroupInfo::finishGroupEntry()
     }
 }
 
+const std::string& StatisticOutputHDF5::GroupInfo::getName() const
+{
+    return m_statGroup->name;
+}
 
 
 

--- a/src/sst/core/statapi/statoutputhdf5.h
+++ b/src/sst/core/statapi/statoutputhdf5.h
@@ -237,7 +237,7 @@ private:
         void finishGroupEntry() override;
         size_t getNumComponents() const { return m_components.size(); }
 
-        const std::string& getName() const { return m_statGroup->name; }
+        const std::string& getName() const;
     };
 
 


### PR DESCRIPTION
Moved a function to cc file to get rid of #include ordering dependencies.

