### PR TITLE
Preview clean up

### DIFF
--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -474,6 +474,62 @@ protected:
         
         return loadUserSubComponentByIndex<T,ARGS...>(slot_name, index, share_flags, args...);        
     }
+
+
+    /** Convenience function for reporting fatal conditions.  The
+        function will create a new Output object and call fatal()
+        using the supplied parameters.  Before calling
+        Output::fatal(), the function will also print other
+        information about the (sub)component that called fatal and
+        about the simulation state.
+
+        From Output::fatal: Message will be sent to the output
+        location and to stderr.  The output will be prepended with the
+        expanded prefix set in the object.
+        NOTE: fatal() will call MPI_Abort(exit_code) to terminate simulation.
+
+        @param line Line number of calling function (use CALL_INFO macro)
+        @param file File name calling function (use CALL_INFO macro)
+        @param func Function name calling function (use CALL_INFO macro)
+        @param exit_code The exit code used for termination of simulation.
+               will be passed to MPI_Abort()
+        @param format Format string.  All valid formats for printf are available.
+        @param ... Arguments for format.
+     */
+    void fatal(uint32_t line, const char* file, const char* func,
+               int exit_code,
+               const char* format, ...)    const
+                  __attribute__ ((format (printf, 6, 7))) ;
+
+    
+    /** Convenience function for testing for and reporting fatal
+        conditions.  If the condition holds, fatal() will be called,
+        otherwise, the function will return.  The function will create
+        a new Output object and call fatal() using the supplied
+        parameters.  Before calling Output::fatal(), the function will
+        also print other information about the (sub)component that
+        called fatal and about the simulation state.
+
+        From Output::fatal: Message will be sent to the output
+        location and to stderr.  The output will be prepended with the
+        expanded prefix set in the object.
+        NOTE: fatal() will call MPI_Abort(exit_code) to terminate simulation.
+
+        @param condition on which to call fatal(); fatal() is called
+        if the bool is false.
+        @param line Line number of calling function (use CALL_INFO macro)
+        @param file File name calling function (use CALL_INFO macro)
+        @param func Function name calling function (use CALL_INFO macro)
+        @param exit_code The exit code used for termination of simulation.
+               will be passed to MPI_Abort()
+        @param format Format string.  All valid formats for printf are available.
+        @param ... Arguments for format.
+     */
+    void fatal(bool condition, uint32_t line, const char* file, const char* func,
+                      int exit_code,
+                      const char* format, ...)    const
+        __attribute__ ((format (printf, 7, 8)));
+
     
 private:
 

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -44,9 +44,11 @@ public:
     static const uint64_t SHARE_STATS = 0x2;
     static const uint64_t INSERT_STATS = 0x4;
 
+#ifndef SST_ENABLE_PREVIEW_BUILD
     // Temporary, only for backward compatibility with loadSubComponent
     static const uint64_t IS_LEGACY_SUBCOMPONENT = 0x32;
-
+#endif
+    
     static const uint64_t SHARE_NONE = 0x0;
 
 private:

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -181,6 +181,7 @@ public:
 
         virtual void inspectNetworkData(Request* req) = 0;
 
+#ifndef SST_ENABLE_PREVIEW_BUILD
         /**
          *  The ID uniquely identifies the component in which this
          *  subcomponent is instantiated.  It does not uniquely define
@@ -190,6 +191,7 @@ public:
          *  subfield of the statistic.
          */
         virtual void initialize(std::string id) = 0;
+#endif
     };
 
     /** Functor classes for handling of callbacks */
@@ -267,6 +269,7 @@ public:
         SubComponent(id)
     { }
 
+#ifndef SST_ENABLE_PREVIEW_BUILD
     /** Second half of building the interface.
         Initialize network interface
         @param portName - Name of port to connect to
@@ -279,7 +282,7 @@ public:
     virtual bool initialize(const std::string& portName, const UnitAlgebra& link_bw,
                             int vns, const UnitAlgebra& in_buf_size,
                             const UnitAlgebra& out_buf_size) = 0;
-
+#endif
     /**
      * Sends a network request during the init() phase
      */


### PR DESCRIPTION
Needed to put in more #ifndef guards for SimpleNetwork for preview builds.

Added two versions of fatal calls to BaseComponent as a convenience for reported errors and terminating.  The only difference is one takes a bool condition variable to act somewhat like an assert (couldn't use assert as the name since assert is a macro).