### PR TITLE
remove constexpr const warnings

### DIFF
--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -269,9 +269,9 @@ struct SST_ELI_element_version_extraction {
     const unsigned minor;
     const unsigned tertiary;
 
-    constexpr unsigned getMajor() { return major; }
-    constexpr unsigned getMinor() { return minor; }
-    constexpr unsigned getTertiary() { return tertiary; }
+    constexpr unsigned getMajor() const { return major; }
+    constexpr unsigned getMinor() const { return minor; }
+    constexpr unsigned getTertiary() const { return tertiary; }
 };
 
 constexpr unsigned SST_ELI_getMajorNumberFromVersion(SST_ELI_element_version_extraction ver) {


### PR DESCRIPTION
Without these changes, we get a slew of warnings
````
      'constexpr' non-static member function will not be implicitly 'const' in C++14; add
      'const' to avoid a change in behavior [-Wconstexpr-not-const]
    constexpr unsigned getMajor() { return major; }
````