### PR TITLE
Fix for issue #407

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,10 @@ SST_CHECK_MEM_POOL()
 
 SST_ENABLE_DEBUG_OUTPUT()
 SST_ENABLE_DEBUG_EVENT_TRACKING()
+
+AS_IF([test "$use_mempool" = "no" -a "$enable_debug_event_tracking" = "yes"],
+[AC_MSG_ERROR([Event Tracking cannot be enabled with mem-pools disabled.])])
+
 SST_ENABLE_CORE_PROFILE()
 
 SST_CHECK_FPIC()

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -77,7 +77,7 @@ public:
     bool            print_timing;       /*!< Print SST timing information */
     bool            print_env;          /*!< Print SST environment */
 
-#if defined(USE_MEMPOOL) || defined(__SST_DEBUG_EVENT_TRACKING__)
+#ifdef USE_MEMPOOL
     std::string     event_dump_file;    /*!< File to dump undeleted events to */
 #endif
 

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -77,7 +77,7 @@ public:
     bool            print_timing;       /*!< Print SST timing information */
     bool            print_env;          /*!< Print SST environment */
 
-#ifdef USE_MEMPOOL
+#if defined(USE_MEMPOOL) || defined(__SST_DEBUG_EVENT_TRACKING__)
     std::string     event_dump_file;    /*!< File to dump undeleted events to */
 #endif
 


### PR DESCRIPTION
This fix is for issue #407, the problem only occurs if both --enable-event-tracking is on and --disable-mem-pools are set.  

In config.h, event_dump_file is only defined if USE_MEMPOOLS is defined (which it is normally).  However, in config.cc if __SST_DEBUG_EVENT_TRACKING__ is defined, then it uses event_dump_file.  

The problem only occurs if both __SST_DEBUG_EVENT_TRACKING__ is defined and USE_MEMPOOLS is not defined -->  --enable-event-tracking is on and --disable-mem-pools configuration settings.

The change is done in configure.ac and checks for either if event tracking is turned on AND mem-pools are turned off, it will then fail the configure with an appropriate error message.