### PR TITLE
Python3 updates

### DIFF
--- a/src/sst/core/model/python2/pymodel.cc
+++ b/src/sst/core/model/python2/pymodel.cc
@@ -460,7 +460,7 @@ static PyObject* enableAllStatisticsForComponentName(PyObject *UNUSED(self), PyO
     int           argOK = 0;
     char*         compName = nullptr;
     PyObject*     statParamDict = nullptr;
-    bool          apply_to_children = false;
+    int           apply_to_children = 0;
     
     PyErr_Clear();
 
@@ -488,7 +488,7 @@ static PyObject* enableStatisticForComponentName(PyObject *UNUSED(self), PyObjec
     char*         compName = nullptr;
     char*         statName = nullptr;
     PyObject*     statParamDict = nullptr;
-    bool          apply_to_children = false;
+    int           apply_to_children = 0;
 
     PyErr_Clear();
 
@@ -517,7 +517,7 @@ static PyObject* enableStatisticsForComponentName(PyObject *UNUSED(self), PyObje
     char*         stat_str = nullptr;
     PyObject*     statParamDict = nullptr;
     Py_ssize_t    numStats = 0;
-    bool          apply_to_children = false;
+    int           apply_to_children = 0;
 
     PyErr_Clear();
 
@@ -529,6 +529,7 @@ static PyObject* enableStatisticsForComponentName(PyObject *UNUSED(self), PyObje
     }
     else  {
         PyErr_Clear();
+        apply_to_children = 0;
         // Try list version
         argOK = PyArg_ParseTuple(args, "sO!|O!i", &compName, &PyList_Type, &statList, &PyDict_Type, &statParamDict, &apply_to_children);
         if ( argOK )  Py_INCREF(statList);
@@ -576,7 +577,7 @@ static PyObject* enableAllStatisticsForComponentType(PyObject *UNUSED(self), PyO
     int           argOK = 0;
     char*         compType = nullptr;
     PyObject*     statParamDict = nullptr;
-    bool          apply_to_children = false;
+    int           apply_to_children = 0;
 
     PyErr_Clear();
 
@@ -603,7 +604,7 @@ static PyObject* enableStatisticForComponentType(PyObject *UNUSED(self), PyObjec
     char*         compType = nullptr;
     char*         statName = nullptr;
     PyObject*     statParamDict = nullptr;
-    bool          apply_to_children = false;
+    int           apply_to_children = 0;
 
     PyErr_Clear();
 
@@ -632,7 +633,7 @@ static PyObject* enableStatisticsForComponentType(PyObject *UNUSED(self), PyObje
     char*         stat_str = nullptr;
     PyObject*     statParamDict = nullptr;
     Py_ssize_t    numStats = 0;
-    bool          apply_to_children = false;
+    int           apply_to_children = 0;
 
     PyErr_Clear();
 
@@ -644,6 +645,7 @@ static PyObject* enableStatisticsForComponentType(PyObject *UNUSED(self), PyObje
     }
     else  {
         PyErr_Clear();
+        apply_to_children = 0;
         // Try list version
         argOK = PyArg_ParseTuple(args, "sO!|O!i", &compType, &PyList_Type, &statList, &PyDict_Type, &statParamDict, &apply_to_children);
         if ( argOK )  Py_INCREF(statList);
@@ -678,7 +680,7 @@ static PyObject* setStatisticLoadLevelForComponentName(PyObject *UNUSED(self), P
     int           argOK = 0;
     char*         compName = nullptr;
     int           level = STATISTICLOADLEVELUNINITIALIZED;
-    bool          apply_to_children = false;
+    int           apply_to_children = 0;
 
     PyErr_Clear();
 
@@ -707,7 +709,7 @@ static PyObject* setStatisticLoadLevelForComponentType(PyObject *UNUSED(self), P
     int           argOK = 0;
     char*         compType = nullptr;
     uint8_t       level = STATISTICLOADLEVELUNINITIALIZED;
-    bool          apply_to_children = false;
+    int           apply_to_children = 0;
 
     PyErr_Clear();
 

--- a/src/sst/core/model/python2/pymodel_comp.cc
+++ b/src/sst/core/model/python2/pymodel_comp.cc
@@ -282,7 +282,7 @@ static PyObject* compSetStatisticLoadLevel(PyObject *self, PyObject *args) {
     int           argOK = 0;
     uint8_t       loadLevel = STATISTICLOADLEVELUNINITIALIZED;
     ConfigComponent *c = getComp(self);
-    bool          apply_to_children = false;
+    int           apply_to_children = 0;
 
     PyErr_Clear();
 
@@ -304,7 +304,7 @@ static PyObject* compEnableAllStatistics(PyObject *self, PyObject *args)
     int           argOK = 0;
     PyObject*     statParamDict = nullptr;
     ConfigComponent *c = getComp(self);
-    bool          apply_to_children = false;
+    int           apply_to_children = 0;
 
     PyErr_Clear();
 
@@ -334,7 +334,7 @@ static PyObject* compEnableStatistics(PyObject *self, PyObject *args)
     char*         stat_str = nullptr;
     PyObject*     statParamDict = nullptr;
     Py_ssize_t    numStats = 0;
-    bool          apply_to_children = false;
+    int           apply_to_children = 0;
     ConfigComponent *c = getComp(self);
 
     PyErr_Clear();
@@ -347,6 +347,7 @@ static PyObject* compEnableStatistics(PyObject *self, PyObject *args)
     }
     else  {
         PyErr_Clear();
+        apply_to_children = 0;
         // Try list version
         argOK = PyArg_ParseTuple(args, "O!|O!i", &PyList_Type, &statList, &PyDict_Type, &statParamDict, &apply_to_children);
         if ( argOK )  Py_INCREF(statList);

--- a/src/sst/core/model/python3/pymodel_statgroup.cc
+++ b/src/sst/core/model/python3/pymodel_statgroup.cc
@@ -140,10 +140,10 @@ static PyObject* sgSetOutput(PyObject *self, PyObject *args)
 
 static PyObject* sgSetFreq(PyObject *self, PyObject *args)
 {
-    if ( !PyBytes_Check(args) ) {
+    if ( !PyUnicode_Check(args) ) {
         return nullptr;
     }
-    if ( !((StatGroupPy_t*)self)->ptr->setFrequency(PyBytes_AsString(args)) ) {
+    if ( !((StatGroupPy_t*)self)->ptr->setFrequency(PyUnicode_AsUTF8(args)) ) {
         PyErr_SetString(PyExc_RuntimeError, "Invalid frequency");
         return nullptr;
     }


### PR DESCRIPTION
Apparently python3 passes unicode through to the cpython.  These move all PyByte calls to PyUnicode for python3.  Also fixed a potential memory corruption problem in both python 2 and 3.

