### PR TITLE
Export a CMake configuration for downstream projects

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,7 @@
 ACLOCAL_AMFLAGS = -I config
 
 SUBDIRS = \
+	share \
 	src \
 	doc
 

--- a/configure.ac
+++ b/configure.ac
@@ -172,6 +172,8 @@ AC_CONFIG_FILES([
   Makefile
   doc/Makefile
   doc/Doxyfile
+  share/Makefile
+  share/SSTConfig.cmake
   src/sst/sstsimulator.conf:src/sst/sst.conf
   src/Makefile
   src/sst/Makefile

--- a/share/Makefile.am
+++ b/share/Makefile.am
@@ -1,0 +1,2 @@
+cmakedir=$(prefix)/lib/cmake/SST
+cmake_DATA=SSTConfig.cmake

--- a/share/SSTConfig.cmake.in
+++ b/share/SSTConfig.cmake.in
@@ -1,0 +1,24 @@
+if (NOT TARGET SST::SSTCore)
+  add_library(SST::SSTCore INTERFACE IMPORTED)
+  set_target_properties(SST::SSTCore
+    PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES @prefix@/include
+    INTERFACE_COMPILE_FEATURES    cxx_std_11
+  )
+endif()
+
+if (NOT TARGET SST::SST)
+  add_executable(SST::SST IMPORTED)
+  set_target_properties(SST::SST PROPERTIES
+    IMPORTED_LOCATION @prefix@/bin/sst
+  )
+endif()
+macro(add_sst_library NAME)
+  if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(CMAKE_MODULE_LINKER_FLAGS "-undefined dynamic_lookup")
+  endif()
+  #ARGN is source list
+  add_library(${NAME} MODULE ${ARGN})
+  #ensure at least C++11, this can be overriden with higher
+  target_link_libraries(${NAME} PUBLIC SST::SSTCore)
+endmacro()


### PR DESCRIPTION
This exports a CMake config file compatible with `find_package` for CMake build systems.