### PR TITLE
Minor cleanup of graph generation.

### DIFF
--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -302,7 +302,7 @@ private:
 /** Map IDs to Components */
 typedef SparseVectorMap<ComponentId_t,ConfigComponent> ConfigComponentMap_t;
 /** Map names to Components */
-// typedef std::map<std::string,ConfigComponent*> ConfigComponentNameMap_t;
+typedef std::map<std::string,ConfigComponent*> ConfigComponentNameMap_t;
 /** Map names to Parameter Sets: XML only */
 typedef std::map<std::string,Params*> ParamsMap_t;
 /** Map names to variable values:  XML only */
@@ -323,7 +323,10 @@ public:
         }
     }
 
-    ConfigGraph() {
+    ConfigGraph() :
+        output(Output::getDefaultObject()),
+        nextComponentId(0)
+    {
         links.clear();
         comps.clear();
         // Init the statistic output settings
@@ -343,9 +346,9 @@ public:
 
     // API for programmatic initialization
     /** Create a new component with weight and rank */
-    ComponentId_t addComponent(ComponentId_t id, const std::string& name, const std::string& type, float weight, RankInfo rank);
+    ComponentId_t addComponent(const std::string& name, const std::string& type, float weight, RankInfo rank);
     /** Create a new component */
-    ComponentId_t addComponent(ComponentId_t id, const std::string& name, const std::string& type);
+    ComponentId_t addComponent(const std::string& name, const std::string& type);
 
 
     /** Set the statistic output module */
@@ -403,6 +406,7 @@ public:
 
     bool containsComponent(ComponentId_t id) const;
     ConfigComponent* findComponent(ComponentId_t);
+    ConfigComponent* findComponentByName(const std::string& name);
     const ConfigComponent* findComponent(ComponentId_t) const;
 
     /** Return the map of links */
@@ -431,12 +435,15 @@ private:
     friend class Simulation;
     friend class SSTSDLModelDefinition;
 
+    Output& output;
+
+    ComponentId_t nextComponentId;
+
     ConfigLinkMap_t      links;
     ConfigComponentMap_t comps;
-    // ConfigComponentNameMap_t compsByName;
+    ConfigComponentNameMap_t compsByName;
     std::map<std::string, ConfigStatGroup> statGroups;
 
-    // temporary as a test
     std::map<std::string,LinkId_t> link_names;
 
     std::vector<ConfigStatOutput> statOutputs; // [0] is default

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -263,6 +263,10 @@ public:
 private:
 
     friend class ConfigGraph;
+    /** Checks to make sure port names are valid and that a port isn't used twice
+     */
+    void checkPorts() const;
+
     /** Create a new Component */
     ConfigComponent(ComponentId_t id, ConfigGraph* graph, const std::string& name, const std::string& type, float weight, RankInfo rank) :
         id(id),
@@ -302,7 +306,7 @@ private:
 /** Map IDs to Components */
 typedef SparseVectorMap<ComponentId_t,ConfigComponent> ConfigComponentMap_t;
 /** Map names to Components */
-typedef std::map<std::string,ConfigComponent*> ConfigComponentNameMap_t;
+typedef std::map<std::string,ComponentId_t> ConfigComponentNameMap_t;
 /** Map names to Parameter Sets: XML only */
 typedef std::map<std::string,Params*> ParamsMap_t;
 /** Map names to variable values:  XML only */

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -115,24 +115,25 @@ bool Factory::isPortNameValid(const std::string& type, const std::string& port_n
     auto* lib = ELI::InfoDatabase::getLibrary<Component>(elemlib);
     std::stringstream err;
     if (lib) {
-      auto* compInfo = lib->getInfo(elem);
-      if (compInfo){
-        portNames = &compInfo->getPortnames();
-      }
-    } else {
-      auto* lib = ELI::InfoDatabase::getLibrary<SubComponent>(elemlib);
-      if (lib){
-        auto* subcompInfo = lib->getInfo(elemlib);
-        if (subcompInfo){
-          portNames = &subcompInfo->getPortnames();
-        } else {
-          //this is going to fail
-          err << "Valid SubComponents: ";
-          for (auto& pair : lib->getMap()){
-            err << pair.first << "\n";
-          }
+        auto* compInfo = lib->getInfo(elem);
+        if (compInfo){
+            portNames = &compInfo->getPortnames();
         }
-      }
+    }
+    if ( nullptr == portNames ) {
+        auto* lib = ELI::InfoDatabase::getLibrary<SubComponent>(elemlib);
+        if (lib){
+            auto* subcompInfo = lib->getInfo(elem);
+            if (subcompInfo){
+                portNames = &subcompInfo->getPortnames();
+            } else {
+                //this is going to fail
+                err << "Valid SubComponents: ";
+                for (auto& pair : lib->getMap()){
+                    err << pair.first << "\n";
+                }
+            }
+        }
     }
 
 

--- a/src/sst/core/model/python2/pymodel.h
+++ b/src/sst/core/model/python2/pymodel.h
@@ -66,29 +66,12 @@ public:  /* Public, but private.  Called only from Python functions */
     ComponentId_t getNextComponentId() { return nextComponentId++; }
 
     ComponentId_t addComponent(const char *name, const char *type) {
-        ComponentId_t id = getNextComponentId();
-        graph->addComponent(id, name, type);
-        compNameMap[std::string(name)] = id;
+        auto id = graph->addComponent(name, type);
         return id;
     }
 
-    ComponentId_t findComponentByName(const char *name) const {
-        std::string origname(name);
-        auto index = origname.find(":");
-        std::string compname = origname.substr(0,index);
-        auto itr = compNameMap.find(compname);
-        
-        // Check to see if component was found
-        if ( itr == compNameMap.end() ) return UNSET_COMPONENT_ID;
-        
-        // If this was just a component name
-        if ( index == std::string::npos ) return itr->second;
-        
-        // See if this is a valid subcomponent name
-        ConfigComponent* cc = graph->findComponent(itr->second);
-        cc = cc->findSubComponentByName(origname.substr(index+1,std::string::npos));
-        if ( cc ) return cc->id;
-        return UNSET_COMPONENT_ID;
+    ConfigComponent* findComponentByName(const char *name) const {
+        return graph->findComponentByName(std::string(name));
     }
     
     void addLink(ComponentId_t id, const char *link_name, const char *port, const char *latency, bool no_cut) const {graph->addLink(id, link_name, port, latency, no_cut); }

--- a/src/sst/core/model/python3/pymodel.cc
+++ b/src/sst/core/model/python3/pymodel.cc
@@ -229,28 +229,28 @@ static PyObject* findComponentByName(PyObject* UNUSED(self), PyObject* args)
     int argOK = PyArg_ParseTuple(args, "s", &name);
 
     if ( argOK ) {
-        ComponentId_t id = gModel->findComponentByName(name);
+        ConfigComponent* cc = gModel->findComponentByName(name);
 
-        if ( id == UNSET_COMPONENT_ID ) {
+        if ( nullptr == cc) {
             Py_INCREF(Py_None);
-	    return Py_None;
-	}
+            return Py_None;
+        }
 
 
-        if ( SUBCOMPONENT_ID_MASK(id) == 0 ) {
+        if ( SUBCOMPONENT_ID_MASK(cc->id) == 0 ) {
             // Component
-            PyObject *argList = Py_BuildValue("ssk", name, "irrelephant", id);
-	    PyObject *res = PyObject_CallObject((PyObject *) &PyModel_ComponentType, argList);
-	    Py_DECREF(argList);
-	    return res;
-	}
-	else {
+            PyObject *argList = Py_BuildValue("ssk", name, "irrelephant", cc->id);
+            PyObject *res = PyObject_CallObject((PyObject *) &PyModel_ComponentType, argList);
+            Py_DECREF(argList);
+            return res;
+        }
+        else {
             // SubComponent
-            PyObject *argList = Py_BuildValue("Ok", Py_None, id);
-	    PyObject *res = PyObject_CallObject((PyObject *) &PyModel_SubComponentType, argList);
-	    Py_DECREF(argList);
-	    return res;
-	}
+            PyObject *argList = Py_BuildValue("Ok", Py_None, cc->id);
+            PyObject *res = PyObject_CallObject((PyObject *) &PyModel_SubComponentType, argList);
+            Py_DECREF(argList);
+            return res;
+        }
     }
     else {
         return nullptr;
@@ -561,13 +561,11 @@ static PyObject* enableStatisticsForComponentName(PyObject *UNUSED(self), PyObje
         auto params = generateStatisticParameters(statParamDict);
 
         // Get the component
-        ComponentId_t id = gModel->findComponentByName(compName);
-        if ( UNSET_COMPONENT_ID == id ) {
+        ConfigComponent* cc = gModel->findComponentByName(compName);
+        if ( nullptr == cc ) {
             gModel->getOutput()->fatal(CALL_INFO,1,"component name not found in call to enableStatisticsForComponentName(): %s\n",compName);
         }
 
-        ConfigComponent* c = gModel->getGraph()->findComponent(id);
-        
         // Figure out how many stats there are
         numStats = PyList_Size(statList);
 
@@ -575,11 +573,11 @@ static PyObject* enableStatisticsForComponentName(PyObject *UNUSED(self), PyObje
         for (uint32_t x = 0; x < numStats; x++) {
             PyObject* pylistitem = PyList_GetItem(statList, x);
             const char *name = PyUnicode_AsUTF8(pylistitem);
-            c->enableStatistic(name,apply_to_children);
+            cc->enableStatistic(name,apply_to_children);
 
             // Add the parameters
             for ( auto p : params ) {
-                c->addStatisticParameter(name, p.first, p.second, apply_to_children);
+                cc->addStatisticParameter(name, p.first, p.second, apply_to_children);
             }
 
         }        
@@ -707,14 +705,12 @@ static PyObject* setStatisticLoadLevelForComponentName(PyObject *UNUSED(self), P
 
     if (argOK) {
         // Get the component
-        ComponentId_t id = gModel->findComponentByName(compName);
-        if ( UNSET_COMPONENT_ID == id ) {
+        ConfigComponent* cc = gModel->findComponentByName(compName);
+        if ( nullptr == cc ) {
             gModel->getOutput()->fatal(CALL_INFO,1,"component name not found in call to setStatisticLoadLevelForComponentName(): %s\n",compName);
         }
 
-        ConfigComponent* c = gModel->getGraph()->findComponent(id);
-
-        c->setStatisticLoadLevel(level,apply_to_children);
+        cc->setStatisticLoadLevel(level,apply_to_children);
     }
     else {
         return nullptr;

--- a/src/sst/core/model/python3/pymodel.h
+++ b/src/sst/core/model/python3/pymodel.h
@@ -66,29 +66,12 @@ public:  /* Public, but private.  Called only from Python functions */
     ComponentId_t getNextComponentId() { return nextComponentId++; }
 
     ComponentId_t addComponent(const char *name, const char *type) {
-        ComponentId_t id = getNextComponentId();
-        graph->addComponent(id, name, type);
-        compNameMap[std::string(name)] = id;
+        auto id = graph->addComponent(name, type);
         return id;
     }
 
-    ComponentId_t findComponentByName(const char *name) const {
-        std::string origname(name);
-        auto index = origname.find(":");
-        std::string compname = origname.substr(0,index);
-        auto itr = compNameMap.find(compname);
-        
-        // Check to see if component was found
-        if ( itr == compNameMap.end() ) return UNSET_COMPONENT_ID;
-        
-        // If this was just a component name
-        if ( index == std::string::npos ) return itr->second;
-        
-        // See if this is a valid subcomponent name
-        ConfigComponent* cc = graph->findComponent(itr->second);
-        cc = cc->findSubComponentByName(origname.substr(index+1,std::string::npos));
-        if ( cc ) return cc->id;
-        return UNSET_COMPONENT_ID;
+    ConfigComponent* findComponentByName(const char *name) const {
+        return graph->findComponentByName(std::string(name));
     }
     
     void addLink(ComponentId_t id, const char *link_name, const char *port, const char *latency, bool no_cut) const {graph->addLink(id, link_name, port, latency, no_cut); }


### PR DESCRIPTION
- Added check for multiple use of ports (fixes issue #530)
- Moved component id assignment into ConfigGraph from the python model
- Moved check for duplicate Component names into graph generation from
  CponfigGraph::checkForStructuralErrors().  This was done because of
  the extra memory requirement to do the check after the fact when
  dealing with large graphs.
