### PR TITLE
First Attempt at aarch64

### DIFF
--- a/src/sst/core/interprocess/sstmutex.h
+++ b/src/sst/core/interprocess/sstmutex.h
@@ -32,7 +32,9 @@ public:
     void processorPause(int currentCount) {
         if( currentCount < 64 ) {
 #if defined(__x86_64__)
-            asm volatile ("pause" : : : "memory");
+            __asm__ __volatile__ ("pause" : : : "memory");
+#elif ( defined(__arm__) || defined(__aarch64__) )
+            __asm__ __volatile__ ("yield");
 #else
             // Put some pause code in here
 #endif

--- a/src/sst/core/mempool.h
+++ b/src/sst/core/mempool.h
@@ -80,12 +80,7 @@ public:
         while ( !ret ) {
             bool ok = allocPool();
             if ( !ok ) return nullptr;
-#if ( defined( __amd64 ) || defined( __amd64__ ) || \
-        defined( __x86_64 ) || defined( __x86_64__ ) )
-            _mm_pause();
-#elif defined(__PPC64__)
-               asm volatile( "or 27, 27, 27" ::: "memory" );
-#endif
+            sst_pause();
             ret = freeList.try_remove();
         }
         ++numAlloc;

--- a/src/sst/core/rankSyncParallelSkip.cc
+++ b/src/sst/core/rankSyncParallelSkip.cc
@@ -279,7 +279,7 @@ RankSyncParallelSkip::exchange_master(int UNUSED(thread))
             send_queue.try_insert(send);
         }
         else {
-            _mm_pause();
+            sst_pause();
         }
     }
 

--- a/src/sst/core/threadsafe.h
+++ b/src/sst/core/threadsafe.h
@@ -131,13 +131,8 @@ public:
 
     inline void lock() {
         while ( latch.test_and_set(std::memory_order_acquire) ) {
-#if ( defined( __amd64 ) || defined( __amd64__ ) || \
-        defined( __x86_64 ) || defined( __x86_64__ ) )
-                sst_pause();
-#elif defined(__arm__)
-                sst_pause();
-#elif defined(__PPC64__)
-                sst_pause();
+            sst_pause();
+#if defined(__PPC64__)
                 __sync_synchronize();
 #endif
         }

--- a/src/sst/core/threadsafe.h
+++ b/src/sst/core/threadsafe.h
@@ -13,8 +13,13 @@
 #define SST_CORE_CORE_THREADSAFE_H
 
 #if ( defined( __amd64 ) || defined( __amd64__ ) || \
-        defined( __x86_64 ) || defined( __x86_64__ ) )
+      defined( __x86_64 ) || defined( __x86_64__ ) )
 #include <x86intrin.h>
+#define sst_pause() _mm_pause()
+#elif ( defined(__arm__) || defined(__arm) || defined(__aarch64__) )
+#define sst_pause() __asm__ __volatile__ ("yield")
+#elif defined(__PPC64__)
+#define sst_pause() __asm__ __volatile__ ( "or 27, 27, 27" ::: "memory" );
 #endif
 
 #include <thread>
@@ -91,12 +96,7 @@ public:
                 do {
                     count++;
                     if ( count < 1024 ) {
-#if ( defined( __amd64 ) || defined( __amd64__ ) || \
-        defined( __x86_64 ) || defined( __x86_64__ ) )
-                        _mm_pause();
-#elif defined(__PPC64__)
-           asm volatile( "or 27, 27, 27" ::: "memory" );
-#endif
+                        sst_pause();
             } else if ( count < (1024*1024) ) {
                         std::this_thread::yield();
                     } else {
@@ -133,9 +133,11 @@ public:
         while ( latch.test_and_set(std::memory_order_acquire) ) {
 #if ( defined( __amd64 ) || defined( __amd64__ ) || \
         defined( __x86_64 ) || defined( __x86_64__ ) )
-                _mm_pause();
+                sst_pause();
+#elif defined(__arm__)
+                sst_pause();
 #elif defined(__PPC64__)
-                asm volatile( "or 27, 27, 27" ::: "memory" );
+                sst_pause();
                 __sync_synchronize();
 #endif
         }
@@ -250,12 +252,7 @@ public:
             if ( try_remove(res) ) {
                 return res;
             }
-#if ( defined( __amd64 ) || defined( __amd64__ ) || \
-        defined( __x86_64 ) || defined( __x86_64__ ) )
-            _mm_pause();
-#elif defined(__PPC64__)
-           asm volatile( "or 27, 27, 27" ::: "memory" );
-#endif
+            sst_pause();
         }
     }
 };
@@ -315,12 +312,7 @@ public:
             if ( try_remove(res) ) {
                 return res;
             }
-#if ( defined( __amd64 ) || defined( __amd64__ ) || \
-        defined( __x86_64 ) || defined( __x86_64__ ) )
-            _mm_pause();
-#elif defined(__PPC64__)
-           asm volatile( "or 27, 27, 27" ::: "memory" );
-#endif
+            sst_pause();
         }
     }
 


### PR DESCRIPTION
Update intrinsics for ThunderX2 (aarch64). 

Tested on mayer (devpack-gnu7/20200125) with four nodes. Note that, on mayer, there is a problem with openmpi and parmetis when linking.
```
  1) autotools      4) binutils/2.33.1   7) bzip2/1.0.6     10) numactl/2.0.12  13) openucx/1.7.0   16) pnetcdf/1.11.1  19) parmetis/4.0.3  22) superlu/5.2.1       25) fftw/3.3.8             28) mayer/sst-base
  2) cmake/3.14.5   5) gnu7/7.2.0        8) xz/5.2.4        11) hwloc/1.11.11   14) openmpi4/4.0.2  17) phdf5/1.10.5    20) metis/5.1.0     23) superlu_dist/5.4.0  26) singularity/3.5.3
  3) git/2.19.2     6) zlib/1.2.11       9) yaml-cpp/0.6.2  12) pmix/2.2.3      15) netcdf/4.6.3    18) cgns/3.4.0      21) openblas/0.3.4  24) boost/1.72.0        27) devpack-gnu7/20200125

```

simpleElementExample, merlin (torus_128_test.py), and memH (testBackendSimpleDRAM-1.py, testKingsley.py, sdl-3.py, sdl3-2.py).

Stats on testKingsley.py and sdl3-2 were correct but result was jumbled due to I/O.
