### PR TITLE
#8: Implemented Statistic Object creation

### DIFF
--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "sst/core/component.h"
+#include "sst/core/configGraph.h"
 #include "sst/core/subcomponent.h"
 #include "sst/core/unitAlgebra.h"
 #include "sst/core/factory.h"

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -27,7 +27,7 @@ class BaseComponent;
 
 class ConfigComponent;
 
-namespace EXPERIMENTAL {
+namespace Experimental {
 
 class ConfigStatistic;
 
@@ -43,7 +43,7 @@ class StatisticInfo;
 class ComponentInfo {
 
 public:
-    typedef std::vector<EXPERIMENTAL::ConfigStatistic>      statEnableList_t;        /*!< List of Enabled Statistics */
+    typedef std::vector<Experimental::ConfigStatistic>      statEnableList_t;        /*!< List of Enabled Statistics */
 
 
     // Share Flags for SubComponent loading

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -26,7 +26,13 @@ class LinkMap;
 class BaseComponent;
 
 class ConfigComponent;
+
+namespace EXPERIMENTAL {
+
 class ConfigStatistic;
+
+}
+
 class ComponentInfoMap;
 class TimeConverter;
 
@@ -37,7 +43,7 @@ class StatisticInfo;
 class ComponentInfo {
 
 public:
-    typedef std::vector<ConfigStatistic>      statEnableList_t;        /*!< List of Enabled Statistics */
+    typedef std::vector<EXPERIMENTAL::ConfigStatistic>      statEnableList_t;        /*!< List of Enabled Statistics */
 
 
     // Share Flags for SubComponent loading

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -26,6 +26,7 @@ class LinkMap;
 class BaseComponent;
 
 class ConfigComponent;
+class ConfigStatistic;
 class ComponentInfoMap;
 class TimeConverter;
 
@@ -36,7 +37,7 @@ class StatisticInfo;
 class ComponentInfo {
 
 public:
-    typedef std::vector<Statistics::StatisticInfo>      statEnableList_t;        /*!< List of Enabled Statistics */
+    typedef std::vector<ConfigStatistic>      statEnableList_t;        /*!< List of Enabled Statistics */
 
 
     // Share Flags for SubComponent loading

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -36,11 +36,15 @@ void ConfigLink::updateLatencies(TimeLord *timeLord)
     latency[1] = timeLord->getSimCycles(latency_str[1], __FUNCTION__);
 }
 
+namespace EXPERIMENTAL {
+
 void ConfigStatistic::addParameter(const std::string& key, const std::string& value, bool overwrite)
 {
     bool bk = params.enableVerify(false);
     params.insert(key, value, overwrite);
     params.enableVerify(bk);
+}
+
 }
 
 bool ConfigStatGroup::addComponent(ComponentId_t id)
@@ -425,7 +429,7 @@ ConfigComponent* ConfigComponent::findSubComponentByName(const std::string& name
     return nullptr;
 }
 
-ConfigStatistic* ConfigComponent::addStatistic(StatisticId_t sid, const std::string& statisticName)
+EXPERIMENTAL::ConfigStatistic* ConfigComponent::addStatistic(StatisticId_t sid, const std::string& statisticName)
 {
     // Check for Enable All Statistics
     if (statisticName == STATALLFLAG) {
@@ -456,7 +460,7 @@ ConfigStatistic* ConfigComponent::addStatistic(StatisticId_t sid, const std::str
       }
 
       enabledStatistics.emplace(enabledStatistics.begin(),
-          ConfigStatistic(sid, id, statisticName));
+          EXPERIMENTAL::ConfigStatistic(sid, id, statisticName));
 
 
       return &(enabledStatistics.front());
@@ -465,12 +469,12 @@ ConfigStatistic* ConfigComponent::addStatistic(StatisticId_t sid, const std::str
     return nullptr;
 }
 
-ConfigStatistic* ConfigComponent::findStatistic(StatisticId_t sid) const
+EXPERIMENTAL::ConfigStatistic* ConfigComponent::findStatistic(StatisticId_t sid) const
 {
     // Check for the current component statistics
-    for ( const ConfigStatistic &s : enabledStatistics ) {
+    for ( const EXPERIMENTAL::ConfigStatistic &s : enabledStatistics ) {
         if ( s.id == sid ) {
-            ConfigStatistic* res = const_cast<ConfigStatistic*>(&s);
+            EXPERIMENTAL::ConfigStatistic* res = const_cast<EXPERIMENTAL::ConfigStatistic*>(&s);
             if ( res != nullptr ) {
                 return res;
             }
@@ -479,7 +483,7 @@ ConfigStatistic* ConfigComponent::findStatistic(StatisticId_t sid) const
 
     // Check for the subComponents statistics
     for ( auto &s : subComponents ) {
-        ConfigStatistic* res = s.findStatistic(sid);
+        EXPERIMENTAL::ConfigStatistic* res = s.findStatistic(sid);
         if ( res != nullptr ) {
             return res;
         }
@@ -871,7 +875,7 @@ ConfigComponent* ConfigGraph::findComponentByName(const std::string& name) {
     return nullptr;
 }
 
-ConfigStatistic* ConfigGraph::findStatistic(StatisticId_t id) const
+EXPERIMENTAL::ConfigStatistic* ConfigGraph::findStatistic(StatisticId_t id) const
 {
    return comps[COMPONENT_ID_MASK(id)].findStatistic(id);
 }

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -36,6 +36,12 @@ void ConfigLink::updateLatencies(TimeLord *timeLord)
     latency[1] = timeLord->getSimCycles(latency_str[1], __FUNCTION__);
 }
 
+void ConfigStatistic::addParameter(const std::string& key, const std::string& value, bool overwrite)
+{
+    bool bk = params.enableVerify(false);
+    params.insert(key, value, overwrite);
+    params.enableVerify(bk);
+}
 
 bool ConfigStatGroup::addComponent(ComponentId_t id)
 {
@@ -181,6 +187,22 @@ ComponentId_t ConfigComponent::getNextSubComponentID()
         return graph->findComponent(COMPONENT_ID_MASK(id))->getNextSubComponentID();
     }
         
+}
+
+StatisticId_t ConfigComponent::getNextStatisticID()
+{
+    // If we are the ultimate component, get nextStatID and increment
+    // for next time
+    if ( id == COMPONENT_ID_MASK(id) ) {
+        uint16_t statId = nextStatID;
+        nextStatID++;
+        return STATISTIC_ID_CREATE( id, statId );
+    }
+    else {
+        // Get the ultimate parent and call getNextStatisticID on
+        // it
+        return graph->findComponent(COMPONENT_ID_MASK(id))->getNextStatisticID();
+    }
 }
 
 ConfigComponent* ConfigComponent::getParent() const {
@@ -400,6 +422,69 @@ ConfigComponent* ConfigComponent::findSubComponentByName(const std::string& name
             }
         }
     }
+    return nullptr;
+}
+
+ConfigStatistic* ConfigComponent::addStatistic(StatisticId_t sid, const std::string& statisticName)
+{
+    // Check for Enable All Statistics
+    if (statisticName == STATALLFLAG) {
+        // Force the STATALLFLAG to always be on the bottom of the list.
+        // First check to see if anything is in the vector, if vector is empty,
+        // a STATALLFLAG flag will be added to the vector
+        if (false == enabledStatistics.empty()) {
+            // The vector is populated, so see if the STATALLFLAG
+            // already exists if it does, we are done
+            if (STATALLFLAG != enabledStatistics.back().name) {
+                // Add a STATALLFLAG to end of the vector
+                enabledStatistics.emplace_back(STATALLFLAG);
+                return &(enabledStatistics.back());
+            }
+        } else {
+            // Add a STATALLFLAG to end of the vector
+            enabledStatistics.emplace_back(STATALLFLAG);
+            return &(enabledStatistics.back());
+        }
+    } else {
+
+      /* Check for existing statistic with this name */
+      for ( auto &i : enabledStatistics ) {
+          if ( i.name == statisticName)
+          {
+              return nullptr;
+          }
+      }
+
+      enabledStatistics.emplace(enabledStatistics.begin(),
+          ConfigStatistic(sid, id, statisticName));
+
+
+      return &(enabledStatistics.front());
+    }
+
+    return nullptr;
+}
+
+ConfigStatistic* ConfigComponent::findStatistic(StatisticId_t sid) const
+{
+    // Check for the current component statistics
+    for ( const ConfigStatistic &s : enabledStatistics ) {
+        if ( s.id == sid ) {
+            ConfigStatistic* res = const_cast<ConfigStatistic*>(&s);
+            if ( res != nullptr ) {
+                return res;
+            }
+        }
+    }
+
+    // Check for the subComponents statistics
+    for ( auto &s : subComponents ) {
+        ConfigStatistic* res = s.findStatistic(sid);
+        if ( res != nullptr ) {
+            return res;
+        }
+    }
+
     return nullptr;
 }
 
@@ -784,6 +869,11 @@ ConfigComponent* ConfigGraph::findComponentByName(const std::string& name) {
     cc = cc->findSubComponentByName(origname.substr(index+1,std::string::npos));
     if ( cc ) return cc;
     return nullptr;
+}
+
+ConfigStatistic* ConfigGraph::findStatistic(StatisticId_t id) const
+{
+   return comps[COMPONENT_ID_MASK(id)].findStatistic(id);
 }
 
 ConfigGraph*

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -36,7 +36,7 @@ void ConfigLink::updateLatencies(TimeLord *timeLord)
     latency[1] = timeLord->getSimCycles(latency_str[1], __FUNCTION__);
 }
 
-namespace EXPERIMENTAL {
+namespace Experimental {
 
 void ConfigStatistic::addParameter(const std::string& key, const std::string& value, bool overwrite)
 {
@@ -429,7 +429,7 @@ ConfigComponent* ConfigComponent::findSubComponentByName(const std::string& name
     return nullptr;
 }
 
-EXPERIMENTAL::ConfigStatistic* ConfigComponent::addStatistic(StatisticId_t sid, const std::string& statisticName)
+Experimental::ConfigStatistic* ConfigComponent::addStatistic(StatisticId_t sid, const std::string& statisticName)
 {
     // Check for Enable All Statistics
     if (statisticName == STATALLFLAG) {
@@ -460,7 +460,7 @@ EXPERIMENTAL::ConfigStatistic* ConfigComponent::addStatistic(StatisticId_t sid, 
       }
 
       enabledStatistics.emplace(enabledStatistics.begin(),
-          EXPERIMENTAL::ConfigStatistic(sid, id, statisticName));
+          Experimental::ConfigStatistic(sid, id, statisticName));
 
 
       return &(enabledStatistics.front());
@@ -469,12 +469,12 @@ EXPERIMENTAL::ConfigStatistic* ConfigComponent::addStatistic(StatisticId_t sid, 
     return nullptr;
 }
 
-EXPERIMENTAL::ConfigStatistic* ConfigComponent::findStatistic(StatisticId_t sid) const
+Experimental::ConfigStatistic* ConfigComponent::findStatistic(StatisticId_t sid) const
 {
     // Check for the current component statistics
-    for ( const EXPERIMENTAL::ConfigStatistic &s : enabledStatistics ) {
+    for ( const Experimental::ConfigStatistic &s : enabledStatistics ) {
         if ( s.id == sid ) {
-            EXPERIMENTAL::ConfigStatistic* res = const_cast<EXPERIMENTAL::ConfigStatistic*>(&s);
+            Experimental::ConfigStatistic* res = const_cast<Experimental::ConfigStatistic*>(&s);
             if ( res != nullptr ) {
                 return res;
             }
@@ -483,7 +483,7 @@ EXPERIMENTAL::ConfigStatistic* ConfigComponent::findStatistic(StatisticId_t sid)
 
     // Check for the subComponents statistics
     for ( auto &s : subComponents ) {
-        EXPERIMENTAL::ConfigStatistic* res = s.findStatistic(sid);
+        Experimental::ConfigStatistic* res = s.findStatistic(sid);
         if ( res != nullptr ) {
             return res;
         }
@@ -875,7 +875,7 @@ ConfigComponent* ConfigGraph::findComponentByName(const std::string& name) {
     return nullptr;
 }
 
-EXPERIMENTAL::ConfigStatistic* ConfigGraph::findStatistic(StatisticId_t id) const
+Experimental::ConfigStatistic* ConfigGraph::findStatistic(StatisticId_t id) const
 {
    return comps[COMPONENT_ID_MASK(id)].findStatistic(id);
 }

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -124,7 +124,7 @@ private:
 
 };
 
-namespace EXPERIMENTAL {
+namespace Experimental {
 
 class ConfigStatistic : public SST::Core::Serialization::serializable {
 public:
@@ -155,7 +155,7 @@ public:
         ser & params;
     }
 
-    ImplementSerializable(SST::EXPERIMENTAL::ConfigStatistic)
+    ImplementSerializable(SST::Experimental::ConfigStatistic)
 
 
     static constexpr StatisticId_t stat_null_id = std::numeric_limits<StatisticId_t>::max();
@@ -240,7 +240,7 @@ public:
     std::vector<LinkId_t>         links;             /*!< List of links connected */
     Params                        params;            /*!< Set of Parameters */
     uint8_t                       statLoadLevel;     /*!< Statistic load level for this component */
-    std::vector<EXPERIMENTAL::ConfigStatistic>  enabledStatistics; /*!< List of subcomponents */
+    std::vector<Experimental::ConfigStatistic>  enabledStatistics; /*!< List of subcomponents */
     std::vector<ConfigComponent>  subComponents; /*!< List of subcomponents */
     std::vector<double>           coords;
     uint16_t                      nextSubID;         /*!< Next subID to use for children, if component, if subcomponent, subid of parent */
@@ -274,8 +274,8 @@ public:
     ConfigComponent* findSubComponent(ComponentId_t);
     const ConfigComponent* findSubComponent(ComponentId_t) const;
     ConfigComponent* findSubComponentByName(const std::string& name);
-    EXPERIMENTAL::ConfigStatistic* addStatistic(StatisticId_t, const std::string& statisticName);
-    EXPERIMENTAL::ConfigStatistic* findStatistic(StatisticId_t) const;
+    Experimental::ConfigStatistic* addStatistic(StatisticId_t, const std::string& statisticName);
+    Experimental::ConfigStatistic* findStatistic(StatisticId_t) const;
     void enableStatistic(const std::string& statisticName, bool recursively = false);
     void addStatisticParameter(const std::string& statisticName, const std::string& param, const std::string& value, bool recursively = false);
     void setStatisticParameters(const std::string& statisticName, const Params &params, bool recursively = false);
@@ -459,7 +459,7 @@ public:
     const ConfigComponent* findComponent(ComponentId_t) const;
 
     bool containsStatistic(StatisticId_t id) const;
-    EXPERIMENTAL::ConfigStatistic* findStatistic(StatisticId_t) const;
+    Experimental::ConfigStatistic* findStatistic(StatisticId_t) const;
 
     /** Return the map of links */
     ConfigLinkMap_t& getLinkMap() {

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -124,6 +124,8 @@ private:
 
 };
 
+namespace EXPERIMENTAL {
+
 class ConfigStatistic : public SST::Core::Serialization::serializable {
 public:
     StatisticId_t id;                /*!< Unique ID of this statistic */
@@ -153,13 +155,14 @@ public:
         ser & params;
     }
 
-    ImplementSerializable(SST::ConfigStatistic)
+    ImplementSerializable(SST::EXPERIMENTAL::ConfigStatistic)
 
 
     static constexpr StatisticId_t stat_null_id = std::numeric_limits<StatisticId_t>::max();
 
 };
 
+}
 
 class ConfigStatGroup : public SST::Core::Serialization::serializable {
 public:
@@ -237,7 +240,7 @@ public:
     std::vector<LinkId_t>         links;             /*!< List of links connected */
     Params                        params;            /*!< Set of Parameters */
     uint8_t                       statLoadLevel;     /*!< Statistic load level for this component */
-    std::vector<ConfigStatistic>  enabledStatistics; /*!< List of subcomponents */
+    std::vector<EXPERIMENTAL::ConfigStatistic>  enabledStatistics; /*!< List of subcomponents */
     std::vector<ConfigComponent>  subComponents; /*!< List of subcomponents */
     std::vector<double>           coords;
     uint16_t                      nextSubID;         /*!< Next subID to use for children, if component, if subcomponent, subid of parent */
@@ -271,8 +274,8 @@ public:
     ConfigComponent* findSubComponent(ComponentId_t);
     const ConfigComponent* findSubComponent(ComponentId_t) const;
     ConfigComponent* findSubComponentByName(const std::string& name);
-    ConfigStatistic* addStatistic(StatisticId_t, const std::string& statisticName);
-    ConfigStatistic* findStatistic(StatisticId_t) const;
+    EXPERIMENTAL::ConfigStatistic* addStatistic(StatisticId_t, const std::string& statisticName);
+    EXPERIMENTAL::ConfigStatistic* findStatistic(StatisticId_t) const;
     void enableStatistic(const std::string& statisticName, bool recursively = false);
     void addStatisticParameter(const std::string& statisticName, const std::string& param, const std::string& value, bool recursively = false);
     void setStatisticParameters(const std::string& statisticName, const Params &params, bool recursively = false);
@@ -456,7 +459,7 @@ public:
     const ConfigComponent* findComponent(ComponentId_t) const;
 
     bool containsStatistic(StatisticId_t id) const;
-    ConfigStatistic* findStatistic(StatisticId_t) const;
+    EXPERIMENTAL::ConfigStatistic* findStatistic(StatisticId_t) const;
 
     /** Return the map of links */
     ConfigLinkMap_t& getLinkMap() {

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -124,6 +124,41 @@ private:
 
 };
 
+class ConfigStatistic : public SST::Core::Serialization::serializable {
+public:
+    StatisticId_t id;                /*!< Unique ID of this statistic */
+    ComponentId_t compId;                /*!< Unique ID of this component */
+    std::string name;
+    Params params;
+
+    ConfigStatistic(StatisticId_t id, ComponentId_t compId, const std::string& name) :
+      id(id),
+      compId(compId),
+      name(name)
+      { }
+
+    ConfigStatistic(const std::string& name) :
+      name(name)
+      { id = stat_null_id; }
+
+    ConfigStatistic() {id = stat_null_id; } /* Do not use */
+
+    inline const StatisticId_t& key()const { return id; }
+
+    void addParameter(const std::string& key, const std::string& value, bool overwrite);
+
+
+    void serialize_order(SST::Core::Serialization::serializer &ser) override {
+        ser & name;
+        ser & params;
+    }
+
+    ImplementSerializable(SST::ConfigStatistic)
+
+
+    static constexpr StatisticId_t stat_null_id = std::numeric_limits<StatisticId_t>::max();
+
+};
 
 
 class ConfigStatGroup : public SST::Core::Serialization::serializable {
@@ -202,10 +237,11 @@ public:
     std::vector<LinkId_t>         links;             /*!< List of links connected */
     Params                        params;            /*!< Set of Parameters */
     uint8_t                       statLoadLevel;     /*!< Statistic load level for this component */
-    std::vector<Statistics::StatisticInfo> enabledStatistics; /*!< List of statistics to be enabled */
+    std::vector<ConfigStatistic>  enabledStatistics; /*!< List of subcomponents */
     std::vector<ConfigComponent>  subComponents; /*!< List of subcomponents */
     std::vector<double>           coords;
     uint16_t                      nextSubID;         /*!< Next subID to use for children, if component, if subcomponent, subid of parent */
+    uint16_t                      nextStatID;        /*!< Next statID to use for children */
 
     static constexpr ComponentId_t null_id = std::numeric_limits<ComponentId_t>::max();
 
@@ -221,6 +257,7 @@ public:
     ConfigComponent() : id(null_id), statLoadLevel(STATISTICLOADLEVELUNINITIALIZED), nextSubID(1) { }
 
     ComponentId_t getNextSubComponentID();
+    StatisticId_t getNextStatisticID();
 
     ConfigComponent* getParent() const;
     std::string getFullName() const;
@@ -234,6 +271,8 @@ public:
     ConfigComponent* findSubComponent(ComponentId_t);
     const ConfigComponent* findSubComponent(ComponentId_t) const;
     ConfigComponent* findSubComponentByName(const std::string& name);
+    ConfigStatistic* addStatistic(StatisticId_t, const std::string& statisticName);
+    ConfigStatistic* findStatistic(StatisticId_t) const;
     void enableStatistic(const std::string& statisticName, bool recursively = false);
     void addStatisticParameter(const std::string& statisticName, const std::string& param, const std::string& value, bool recursively = false);
     void setStatisticParameters(const std::string& statisticName, const Params &params, bool recursively = false);
@@ -256,6 +295,7 @@ public:
         ser & subComponents;
         ser & coords;
         ser & nextSubID;
+        ser & nextStatID;
     }
 
     ImplementSerializable(SST::ConfigComponent)
@@ -276,7 +316,8 @@ private:
         weight(weight),
         rank(rank),
         statLoadLevel(STATISTICLOADLEVELUNINITIALIZED),
-        nextSubID(1)
+        nextSubID(1),
+        nextStatID(1)
     {
         coords.resize(3, 0.0);
     }
@@ -290,7 +331,8 @@ private:
         weight(weight),
         rank(rank),
         statLoadLevel(STATISTICLOADLEVELUNINITIALIZED),
-        nextSubID(parent_subid)
+        nextSubID(parent_subid),
+        nextStatID(parent_subid)
     {
         coords.resize(3, 0.0);
     }
@@ -412,6 +454,9 @@ public:
     ConfigComponent* findComponent(ComponentId_t);
     ConfigComponent* findComponentByName(const std::string& name);
     const ConfigComponent* findComponent(ComponentId_t) const;
+
+    bool containsStatistic(StatisticId_t id) const;
+    ConfigStatistic* findStatistic(StatisticId_t) const;
 
     /** Return the map of links */
     ConfigLinkMap_t& getLinkMap() {

--- a/src/sst/core/model/Makefile.inc
+++ b/src/sst/core/model/Makefile.inc
@@ -24,6 +24,8 @@ sst_core_python_sources = \
 	model/python/pymodel_comp.cc \
 	model/python/pymodel_unitalgebra.h \
 	model/python/pymodel_unitalgebra.cc \
+	model/python/pymodel_stat.h \
+	model/python/pymodel_stat.cc \
 	model/python/pymodel_statgroup.h \
 	model/python/pymodel_statgroup.cc
 

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -31,6 +31,7 @@ REENABLE_WARNING
 #include "sst/core/sst_types.h"
 #include "sst/core/model/python/pymodel.h"
 #include "sst/core/model/python/pymodel_comp.h"
+#include "sst/core/model/python/pymodel_stat.h"
 #include "sst/core/model/python/pymodel_link.h"
 #include "sst/core/model/python/pymodel_statgroup.h"
 #include "sst/core/model/python/pymodel_unitalgebra.h"
@@ -852,6 +853,7 @@ static PyObject* PyInit_sst(void)
     // Initialize our types
     PyModel_ComponentType.tp_new = PyType_GenericNew;
     PyModel_SubComponentType.tp_new = PyType_GenericNew;
+    PyModel_StatType.tp_new = PyType_GenericNew;
     PyModel_LinkType.tp_new = PyType_GenericNew;
     PyModel_UnitAlgebraType.tp_new = PyType_GenericNew;
     PyModel_StatGroupType.tp_new = PyType_GenericNew;
@@ -861,6 +863,7 @@ static PyObject* PyInit_sst(void)
          ( PyType_Ready(&PyModel_SubComponentType) < 0 ) ||
          ( PyType_Ready(&PyModel_LinkType) < 0 ) ||
          ( PyType_Ready(&PyModel_UnitAlgebraType) < 0 ) ||
+         ( PyType_Ready(&PyModel_StatType) < 0 ) ||
          ( PyType_Ready(&PyModel_StatGroupType) < 0 ) ||
          ( PyType_Ready(&PyModel_StatOutputType) < 0 ) ||
          ( PyType_Ready(&ModuleLoaderType) < 0 ) ) {
@@ -874,6 +877,7 @@ static PyObject* PyInit_sst(void)
 
     Py_INCREF(&PyModel_ComponentType);
     Py_INCREF(&PyModel_SubComponentType);
+    Py_INCREF(&PyModel_StatType);
     Py_INCREF(&PyModel_LinkType);
     Py_INCREF(&PyModel_UnitAlgebraType);
     Py_INCREF(&PyModel_StatGroupType);
@@ -885,6 +889,7 @@ static PyObject* PyInit_sst(void)
     PyModule_AddObject(module, "UnitAlgebra", (PyObject*)&PyModel_UnitAlgebraType);
     PyModule_AddObject(module, "Component", (PyObject*)&PyModel_ComponentType);
     PyModule_AddObject(module, "SubComponent", (PyObject*)&PyModel_SubComponentType);
+    PyModule_AddObject(module, "Statistic", (PyObject*)&PyModel_StatType);
     PyModule_AddObject(module, "StatisticGroup", (PyObject*)&PyModel_StatGroupType);
     PyModule_AddObject(module, "StatisticOutput", (PyObject*)&PyModel_StatOutputType);
     PyModule_AddObject(module, "ModuleLoader", (PyObject*)&ModuleLoaderType);

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -853,7 +853,7 @@ static PyObject* PyInit_sst(void)
     // Initialize our types
     PyModel_ComponentType.tp_new = PyType_GenericNew;
     PyModel_SubComponentType.tp_new = PyType_GenericNew;
-    EXPERIMENTAL::PyModel_StatType.tp_new = PyType_GenericNew;
+    Experimental::PyModel_StatType.tp_new = PyType_GenericNew;
     PyModel_LinkType.tp_new = PyType_GenericNew;
     PyModel_UnitAlgebraType.tp_new = PyType_GenericNew;
     PyModel_StatGroupType.tp_new = PyType_GenericNew;
@@ -863,7 +863,7 @@ static PyObject* PyInit_sst(void)
          ( PyType_Ready(&PyModel_SubComponentType) < 0 ) ||
          ( PyType_Ready(&PyModel_LinkType) < 0 ) ||
          ( PyType_Ready(&PyModel_UnitAlgebraType) < 0 ) ||
-         ( PyType_Ready(&EXPERIMENTAL::PyModel_StatType) < 0 ) ||
+         ( PyType_Ready(&Experimental::PyModel_StatType) < 0 ) ||
          ( PyType_Ready(&PyModel_StatGroupType) < 0 ) ||
          ( PyType_Ready(&PyModel_StatOutputType) < 0 ) ||
          ( PyType_Ready(&ModuleLoaderType) < 0 ) ) {
@@ -877,7 +877,7 @@ static PyObject* PyInit_sst(void)
 
     Py_INCREF(&PyModel_ComponentType);
     Py_INCREF(&PyModel_SubComponentType);
-    Py_INCREF(&EXPERIMENTAL::PyModel_StatType);
+    Py_INCREF(&Experimental::PyModel_StatType);
     Py_INCREF(&PyModel_LinkType);
     Py_INCREF(&PyModel_UnitAlgebraType);
     Py_INCREF(&PyModel_StatGroupType);
@@ -889,7 +889,7 @@ static PyObject* PyInit_sst(void)
     PyModule_AddObject(module, "UnitAlgebra", (PyObject*)&PyModel_UnitAlgebraType);
     PyModule_AddObject(module, "Component", (PyObject*)&PyModel_ComponentType);
     PyModule_AddObject(module, "SubComponent", (PyObject*)&PyModel_SubComponentType);
-    PyModule_AddObject(module, "Statistic", (PyObject*)&EXPERIMENTAL::PyModel_StatType);
+    PyModule_AddObject(module, "Statistic", (PyObject*)&Experimental::PyModel_StatType);
     PyModule_AddObject(module, "StatisticGroup", (PyObject*)&PyModel_StatGroupType);
     PyModule_AddObject(module, "StatisticOutput", (PyObject*)&PyModel_StatOutputType);
     PyModule_AddObject(module, "ModuleLoader", (PyObject*)&ModuleLoaderType);

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -853,7 +853,7 @@ static PyObject* PyInit_sst(void)
     // Initialize our types
     PyModel_ComponentType.tp_new = PyType_GenericNew;
     PyModel_SubComponentType.tp_new = PyType_GenericNew;
-    PyModel_StatType.tp_new = PyType_GenericNew;
+    EXPERIMENTAL::PyModel_StatType.tp_new = PyType_GenericNew;
     PyModel_LinkType.tp_new = PyType_GenericNew;
     PyModel_UnitAlgebraType.tp_new = PyType_GenericNew;
     PyModel_StatGroupType.tp_new = PyType_GenericNew;
@@ -863,7 +863,7 @@ static PyObject* PyInit_sst(void)
          ( PyType_Ready(&PyModel_SubComponentType) < 0 ) ||
          ( PyType_Ready(&PyModel_LinkType) < 0 ) ||
          ( PyType_Ready(&PyModel_UnitAlgebraType) < 0 ) ||
-         ( PyType_Ready(&PyModel_StatType) < 0 ) ||
+         ( PyType_Ready(&EXPERIMENTAL::PyModel_StatType) < 0 ) ||
          ( PyType_Ready(&PyModel_StatGroupType) < 0 ) ||
          ( PyType_Ready(&PyModel_StatOutputType) < 0 ) ||
          ( PyType_Ready(&ModuleLoaderType) < 0 ) ) {
@@ -877,7 +877,7 @@ static PyObject* PyInit_sst(void)
 
     Py_INCREF(&PyModel_ComponentType);
     Py_INCREF(&PyModel_SubComponentType);
-    Py_INCREF(&PyModel_StatType);
+    Py_INCREF(&EXPERIMENTAL::PyModel_StatType);
     Py_INCREF(&PyModel_LinkType);
     Py_INCREF(&PyModel_UnitAlgebraType);
     Py_INCREF(&PyModel_StatGroupType);
@@ -889,7 +889,7 @@ static PyObject* PyInit_sst(void)
     PyModule_AddObject(module, "UnitAlgebra", (PyObject*)&PyModel_UnitAlgebraType);
     PyModule_AddObject(module, "Component", (PyObject*)&PyModel_ComponentType);
     PyModule_AddObject(module, "SubComponent", (PyObject*)&PyModel_SubComponentType);
-    PyModule_AddObject(module, "Statistic", (PyObject*)&PyModel_StatType);
+    PyModule_AddObject(module, "Statistic", (PyObject*)&EXPERIMENTAL::PyModel_StatType);
     PyModule_AddObject(module, "StatisticGroup", (PyObject*)&PyModel_StatGroupType);
     PyModule_AddObject(module, "StatisticOutput", (PyObject*)&PyModel_StatOutputType);
     PyModule_AddObject(module, "ModuleLoader", (PyObject*)&ModuleLoaderType);

--- a/src/sst/core/model/python/pymodel_comp.cc
+++ b/src/sst/core/model/python/pymodel_comp.cc
@@ -283,10 +283,10 @@ static PyObject* compSetStatistic(PyObject *self, PyObject *args)
     if ( nullptr == c ) return nullptr;
 
     StatisticId_t stat_id = c->getNextStatisticID();
-    SST::EXPERIMENTAL::ConfigStatistic* stat = c->addStatistic(stat_id, name);
+    SST::Experimental::ConfigStatistic* stat = c->addStatistic(stat_id, name);
     if ( nullptr != stat ) {
         PyObject *argList = Py_BuildValue("Ok", self, stat_id);
-        PyObject *statObj = PyObject_CallObject((PyObject*)&EXPERIMENTAL::PyModel_StatType, argList);
+        PyObject *statObj = PyObject_CallObject((PyObject*)&Experimental::PyModel_StatType, argList);
         Py_DECREF(argList);
         return statObj;
     }

--- a/src/sst/core/model/python/pymodel_comp.cc
+++ b/src/sst/core/model/python/pymodel_comp.cc
@@ -283,10 +283,10 @@ static PyObject* compSetStatistic(PyObject *self, PyObject *args)
     if ( nullptr == c ) return nullptr;
 
     StatisticId_t stat_id = c->getNextStatisticID();
-    ConfigStatistic* stat = c->addStatistic(stat_id, name);
+    SST::EXPERIMENTAL::ConfigStatistic* stat = c->addStatistic(stat_id, name);
     if ( nullptr != stat ) {
         PyObject *argList = Py_BuildValue("Ok", self, stat_id);
-        PyObject *statObj = PyObject_CallObject((PyObject*)&PyModel_StatType, argList);
+        PyObject *statObj = PyObject_CallObject((PyObject*)&EXPERIMENTAL::PyModel_StatType, argList);
         Py_DECREF(argList);
         return statObj;
     }

--- a/src/sst/core/model/python/pymodel_stat.cc
+++ b/src/sst/core/model/python/pymodel_stat.cc
@@ -30,6 +30,9 @@ REENABLE_WARNING
 using namespace SST::Core;
 extern SST::Core::SSTPythonModelDefinition *gModel;
 
+namespace SST {
+
+namespace EXPERIMENTAL {
 
 extern "C" {
 
@@ -210,7 +213,9 @@ PyTypeObject PyModel_StatType = {
 };
 
 
-
 }  /* extern C */
 
+}
+
+}
 

--- a/src/sst/core/model/python/pymodel_stat.cc
+++ b/src/sst/core/model/python/pymodel_stat.cc
@@ -1,0 +1,216 @@
+// -*- c++ -*-
+
+// Copyright 2009-2020 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2020, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+#include "sst/core/warnmacros.h"
+
+DISABLE_WARN_DEPRECATED_REGISTER
+#include <Python.h>
+REENABLE_WARNING
+#include <sst/core/model/python/pymacros.h>
+
+#include <string.h>
+
+#include "sst/core/model/python/pymodel.h"
+#include "sst/core/model/python/pymodel_stat.h"
+
+#include "sst/core/sst_types.h"
+#include "sst/core/configGraph.h"
+
+using namespace SST::Core;
+extern SST::Core::SSTPythonModelDefinition *gModel;
+
+
+extern "C" {
+
+StatisticId_t PyStatistic::getID()
+{
+    return id;
+}
+
+std::string PyStatistic::getName() {
+    return getStat()->name;
+}
+
+ConfigStatistic* PyStatistic::getStat() {
+    return gModel->getGraph()->findStatistic(id);
+}
+
+int PyStatistic::compare(PyStatistic *other) {
+    if (id < other->id) return -1;
+    else if (id > other->id ) return 1;
+    else return 0;
+}
+
+static int statInit(StatisticPy_t *self, PyObject *args, PyObject *UNUSED(kwds))
+{
+    StatisticId_t id;
+    PyObject *parent;
+    // if ( !PyArg_ParseTuple(args, "Ossii", &parent, &name, &type, &slot, &id) )
+    if ( !PyArg_ParseTuple(args, "Ok", &parent, &id) )
+        return -1;
+
+    PyStatistic *obj = new PyStatistic(self,id);
+    self->obj = obj;
+
+    gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Creating statistic [%s]]\n", getStat((PyObject*)self)->name.c_str());
+
+    return 0;
+}
+
+
+static void statDealloc(StatisticPy_t *self)
+{
+    if ( self->obj ) delete self->obj;
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+
+
+static PyObject* statAddParam(PyObject *self, PyObject *args)
+{
+    char* param = nullptr;
+    PyObject *value = nullptr;
+    if ( !PyArg_ParseTuple(args, "sO", &param, &value) )
+        return nullptr;
+
+    ConfigStatistic *c = getStat(self);
+    if ( nullptr == c ) return nullptr;
+
+    // Get the string-ized value by calling __str__ function of the
+    // value object
+    PyObject *vstr = PyObject_CallMethod(value, (char*)"__str__", nullptr);
+    c->addParameter(param, SST_ConvertToCppString(vstr), true);
+    Py_XDECREF(vstr);
+
+    return SST_ConvertToPythonLong(0);
+}
+
+
+static PyObject* statAddParams(PyObject *self, PyObject *args)
+{
+
+    ConfigStatistic *c = getStat(self);
+    if ( nullptr == c ) return nullptr;
+
+    if ( !PyDict_Check(args) ) {
+        return nullptr;
+    }
+
+    Py_ssize_t pos = 0;
+    PyObject *key, *val;
+    long count = 0;
+
+    while ( PyDict_Next(args, &pos, &key, &val) ) {
+        PyObject *kstr = PyObject_CallMethod(key, (char*)"__str__", nullptr);
+        PyObject *vstr = PyObject_CallMethod(val, (char*)"__str__", nullptr);
+        c->addParameter(SST_ConvertToCppString(kstr), SST_ConvertToCppString(vstr), true);
+        Py_XDECREF(kstr);
+        Py_XDECREF(vstr);
+        count++;
+    }
+    return SST_ConvertToPythonLong(count);
+}
+
+#if PY_MAJOR_VERSION >= 3
+static PyObject* statCompare(PyObject *obj0, PyObject *obj1, int op) {
+    PyObject *result;
+    bool cmp = false;
+    switch(op) {
+        case Py_LT: cmp = ((PyStatistic*)obj0)->compare(((StatisticPy_t*)obj1)->obj) == -1; break;
+        case Py_LE: cmp = ((PyStatistic*)obj0)->compare(((StatisticPy_t*)obj1)->obj) != 1; break;
+        case Py_EQ: cmp = ((PyStatistic*)obj0)->compare(((StatisticPy_t*)obj1)->obj) == 0; break;
+        case Py_NE: cmp = ((PyStatistic*)obj0)->compare(((StatisticPy_t*)obj1)->obj) != 0; break;
+        case Py_GT: cmp = ((PyStatistic*)obj0)->compare(((StatisticPy_t*)obj1)->obj) == 1; break;
+        case Py_GE: cmp = ((PyStatistic*)obj0)->compare(((StatisticPy_t*)obj1)->obj) != -1; break;
+    }
+    result = cmp ? Py_True : Py_False;
+    Py_INCREF(result);
+    return result;
+}
+#else
+static int statCompare(PyObject *obj0, PyObject *obj1) {
+    return ((PyStatistic*)obj0)->compare(((PyStatistic*)obj1));
+}
+#endif
+
+static PyMethodDef statisticMethods[] = {
+    {   "addParam",
+        statAddParam, METH_VARARGS,
+        "Adds a parameter(name, value)"},
+    {   "addParams",
+        statAddParams, METH_O,
+        "Adds Multiple Parameters from a dict"},
+     {   nullptr, nullptr, 0, nullptr }
+};
+
+
+PyTypeObject PyModel_StatType = {
+    SST_PY_OBJ_HEAD
+    "sst.Statistic",           /* tp_name */
+    sizeof(StatisticPy_t),     /* tp_basicsize */
+    0,                         /* tp_itemsize */
+    (destructor)statDealloc,/* tp_dealloc */
+    SST_TP_VECTORCALL_OFFSET       /* Python3 only */
+    SST_TP_PRINT                   /* Python2 only */
+    nullptr,                         /* tp_getattr */
+    nullptr,                         /* tp_setattr */
+    SST_TP_COMPARE(nullptr)        /* Python2 only */
+    SST_TP_AS_SYNC                 /* Python3 only */
+    nullptr,                         /* tp_repr */
+    nullptr,                         /* tp_as_number */
+    nullptr,                         /* tp_as_sequence */
+    nullptr,                         /* tp_as_mapping */
+    nullptr,                         /* tp_hash */
+    nullptr,                         /* tp_call */
+    nullptr,                         /* tp_str */
+    nullptr,                         /* tp_getattro */
+    nullptr,                         /* tp_setattro */
+    nullptr,                         /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,              /* tp_flags */
+    "SST Statistic",                 /* tp_doc */
+    nullptr,                         /* tp_traverse */
+    nullptr,                         /* tp_clear */
+    SST_TP_RICH_COMPARE(statCompare)    /* Python3 only */
+    0,                               /* tp_weaklistoffset */
+    nullptr,                         /* tp_iter */
+    nullptr,                         /* tp_iternext */
+    statisticMethods,                /* tp_methods */
+    nullptr,                         /* tp_members */
+    nullptr,                         /* tp_getset */
+    nullptr,                         /* tp_base */
+    nullptr,                         /* tp_dict */
+    nullptr,                         /* tp_descr_get */
+    nullptr,                         /* tp_descr_set */
+    0,                               /* tp_dictoffset */
+    (initproc)statInit,              /* tp_init */
+    nullptr,                         /* tp_alloc */
+    nullptr,                         /* tp_new */
+    nullptr,                         /* tp_free */
+    nullptr,                         /* tp_is_gc */
+    nullptr,                         /* tp_bases */
+    nullptr,                         /* tp_mro */
+    nullptr,                         /* tp_cache */
+    nullptr,                         /* tp_subclasses */
+    nullptr,                         /* tp_weaklist */
+    nullptr,                         /* tp_del */
+    0,                               /* tp_version_tag */
+    SST_TP_FINALIZE                /* Python3 only */
+    SST_TP_VECTORCALL              /* Python3 only */
+};
+
+
+
+}  /* extern C */
+
+

--- a/src/sst/core/model/python/pymodel_stat.cc
+++ b/src/sst/core/model/python/pymodel_stat.cc
@@ -32,7 +32,7 @@ extern SST::Core::SSTPythonModelDefinition *gModel;
 
 namespace SST {
 
-namespace EXPERIMENTAL {
+namespace Experimental {
 
 extern "C" {
 

--- a/src/sst/core/model/python/pymodel_stat.h
+++ b/src/sst/core/model/python/pymodel_stat.h
@@ -16,8 +16,10 @@
 
 #include "sst/core/sst_types.h"
 
-extern "C" {
+namespace SST {
+namespace EXPERIMENTAL {
 
+extern "C" {
 
 struct StatisticPy_t;
 struct PyStatistic;
@@ -51,5 +53,7 @@ static inline ConfigStatistic* getStat(PyObject *pobj) {
 
 }  /* extern C */
 
+}
+}
 
 #endif

--- a/src/sst/core/model/python/pymodel_stat.h
+++ b/src/sst/core/model/python/pymodel_stat.h
@@ -17,7 +17,7 @@
 #include "sst/core/sst_types.h"
 
 namespace SST {
-namespace EXPERIMENTAL {
+namespace Experimental {
 
 extern "C" {
 

--- a/src/sst/core/model/python/pymodel_stat.h
+++ b/src/sst/core/model/python/pymodel_stat.h
@@ -1,0 +1,55 @@
+// -*- c++ -*-
+
+// Copyright 2009-2020 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2020, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_MODEL_PYMODEL_STAT_H
+#define SST_CORE_MODEL_PYMODEL_STAT_H
+
+#include "sst/core/sst_types.h"
+
+extern "C" {
+
+
+struct StatisticPy_t;
+struct PyStatistic;
+
+struct PyStatistic {
+    StatisticPy_t *pobj;
+    StatisticId_t id;
+
+    PyStatistic(StatisticPy_t *pobj, StatisticId_t id) : pobj(pobj), id(id) { }
+    virtual ~PyStatistic() { }
+    virtual ConfigStatistic* getStat();
+    virtual int compare(PyStatistic *other);
+    virtual std::string getName();
+    StatisticId_t getID();
+};
+
+struct StatisticPy_t {
+    PyObject_HEAD
+    PyStatistic *obj;
+};
+
+extern PyTypeObject PyModel_StatType;
+
+static inline ConfigStatistic* getStat(PyObject *pobj) {
+    ConfigStatistic *c = ((StatisticPy_t*)pobj)->obj->getStat();
+    if ( c == nullptr ) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to find ConfigStatistic");
+    }
+    return c;
+}
+
+}  /* extern C */
+
+
+#endif

--- a/src/sst/core/sst_types.h
+++ b/src/sst/core/sst_types.h
@@ -17,6 +17,7 @@
 namespace SST {
 
 typedef uint64_t  ComponentId_t;
+typedef uint64_t  StatisticId_t;
 typedef int32_t   LinkId_t;
 typedef uint64_t  Cycle_t;
 typedef uint64_t  SimTime_t;
@@ -25,11 +26,14 @@ typedef double          Time_t;
 #define MAX_SIMTIME_T 0xFFFFFFFFFFFFFFFFl
 /* Subcomponent IDs are in the high-16 bits of the Component ID */
 #define UNSET_COMPONENT_ID 0xFFFFFFFFFFFFFFFFULL
+#define UNSET_STATISTIC_ID 0xFFFFFFFFFFFFFFFFULL
 #define COMPONENT_ID_BITS 48
 #define COMPONENT_ID_MASK(x) ((x) & 0x0000FFFFFFFFFFFFULL)
 #define SUBCOMPONENT_ID_BITS 16
 #define SUBCOMPONENT_ID_MASK(x) ((x) >> COMPONENT_ID_BITS)
 #define SUBCOMPONENT_ID_CREATE(compId, sCompId) ((((uint64_t)sCompId) << COMPONENT_ID_BITS) | compId)
+#define STATISTIC_ID_BITS 48
+#define STATISTIC_ID_CREATE(compId, statId) ((((uint64_t)statId) << STATISTIC_ID_BITS) | compId)
 #define COMPDEFINED_SUBCOMPONENT_ID_CREATE(compId, sCompId) ((((uint64_t)sCompId) << COMPONENT_ID_BITS) | compId | 0x8000000000000000ULL)
 #define COMPDEFINED_SUBCOMPONENT_ID_MASK(x) ((x) >> 63)
 


### PR DESCRIPTION
This PR aims to provide a statistic object that can be manipulated from the python file.
More information are available [here](https://github.com/mperrinel/sst-core/wiki/Statistic-Python-Object).