### PR TITLE
Add extra hooks for registering components with intel

### DIFF
--- a/src/sst/core/eli/elementinfo.cc
+++ b/src/sst/core/eli/elementinfo.cc
@@ -20,6 +20,8 @@ namespace SST {
 **************************************************************************/
 namespace ELI {
 
+void force_instantiate_bool(bool b, const char* name){}
+
 static const std::vector<int> SST_ELI_COMPILED_VERSION = {0, 9, 0};
 
 std::string

--- a/src/sst/core/eli/elibase.cc
+++ b/src/sst/core/eli/elibase.cc
@@ -33,12 +33,15 @@ LoadedLibraries::addLoader(const std::string& lib, const std::string& name,
     loaders_ = std::unique_ptr<LibraryMap>(new LibraryMap);
   }
   (*loaders_)[lib][name].push_back(loader);
-    return true;
+  return true;
 }
 
 const LoadedLibraries::LibraryMap&
 LoadedLibraries::getLoaders(){
-    return *loaders_;
+  if (!loaders_){
+    loaders_ = std::unique_ptr<LibraryMap>(new LibraryMap);
+  }
+  return *loaders_;
 }
 
 bool

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -520,6 +520,20 @@ struct ImplementsStatFields {
   static const char* ELI_fieldShortName(){ return #field; }
 
 
+#ifdef __INTEL_COMPILER
+#define SST_ELI_INSTANTIATE_STATISTIC(cls,field) \
+  bool force_instantiate_##cls##_##field = \
+     SST::ELI::InstantiateBuilderInfo< \
+        SST::Statistics::Statistic<field>,cls<field>>::isLoaded() \
+         && SST::ELI::InstantiateBuilder< \
+        SST::Statistics::Statistic<field>,cls<field>>::isLoaded() \
+         && SST::ELI::InstantiateBuilderInfo< \
+        SST::Statistics::Statistic<field>, \
+        SST::Statistics::NullStatistic<field>>::isLoaded() \
+         && SST::ELI::InstantiateBuilder< \
+        SST::Statistics::Statistic<field>, \
+        SST::Statistics::NullStatistic<field>>::isLoaded();
+#else
 #define SST_ELI_INSTANTIATE_STATISTIC(cls,field) \
   struct cls##_##field##_##shortName : public cls<field> { \
     cls##_##field##_##shortName(SST::BaseComponent* bc, const std::string& sn, \
@@ -538,6 +552,7 @@ struct ImplementsStatFields {
         SST::Statistics::NullStatistic<field>>::isLoaded(); \
    } \
   };
+#endif
 
 
 #define PP_NARG(...) PP_NARG_(__VA_ARGS__, PP_NSEQ())
@@ -556,6 +571,22 @@ struct ImplementsStatFields {
 #define STAT_GLUE_NAME(base,...) PP_GLUE(STAT_NAME,PP_NARG(__VA_ARGS__))(base,__VA_ARGS__)
 #define STAT_TUPLE(...) std::tuple<__VA_ARGS__>
 
+#ifdef __INTEL_COMPILER
+#define MAKE_MULTI_STATISTIC(cls,name,tuple,...) \
+  bool force_instantiate_stat_name = \
+     SST::ELI::InstantiateBuilderInfo< \
+        SST::Statistics::Statistic<tuple>,cls<__VA_ARGS__>>::isLoaded() \
+    && SST::ELI::InstantiateBuilder< \
+        SST::Statistics::Statistic<tuple>,cls<__VA_ARGS__>>::isLoaded() \
+    && SST::ELI::InstantiateBuilderInfo< \
+        SST::Statistics::Statistic<tuple>, \
+        SST::Statistics::NullStatistic<tuple>>::isLoaded() \
+    && SST::ELI::InstantiateBuilder< \
+        SST::Statistics::Statistic<tuple>, \
+        SST::Statistics::NullStatistic<tuple>>::isLoaded(); \
+    } \
+  };
+#else
 #define MAKE_MULTI_STATISTIC(cls,name,tuple,...) \
   struct name : public cls<__VA_ARGS__> { \
     name(SST::BaseComponent* bc, const std::string& sn, \
@@ -574,6 +605,7 @@ struct ImplementsStatFields {
         SST::Statistics::NullStatistic<tuple>>::isLoaded(); \
     } \
   };
+#endif
 
 #define SST_ELI_INSTANTIATE_MULTI_STATISTIC(cls,...) \
   MAKE_MULTI_STATISTIC(cls,STAT_GLUE_NAME(cls,__VA_ARGS__),STAT_TUPLE(__VA_ARGS__),__VA_ARGS__)


### PR DESCRIPTION
Intel does not generate symbols for functions or variables that are only found in header files. It is the only compiler to do so.  This requires us to force instantiation of certain types in the source files. 

This fixes Intel compilers via two steps:
1. A macro is provided to force registration in source fields
1. An undefined reference is generated automatically if the instantiate macro is missing
