### PR TITLE
Moving MPI check to only be required if Ranks > 1

### DIFF
--- a/src/sst/core/testingframework/sst_unittest.py
+++ b/src/sst/core/testingframework/sst_unittest.py
@@ -307,13 +307,14 @@ class SSTTestCase(unittest.TestCase):
         # Update the os launch command if we are running multi-rank
         num_cores = host_os_get_num_cores_on_system()
 
-        # Check to see if mpirun is available
+        # Perform any multi-rank checks/setup
         mpi_avail = False
-        rtn = os.system("which mpirun > /dev/null")
-        if rtn == 0:
-            mpi_avail = True
-
         if num_ranks > 1:
+            # Check to see if mpirun is available
+            rtn = os.system("which mpirun > /dev/null")
+            if rtn == 0:
+                mpi_avail = True
+
             numa_param = ""
             if 2 <= num_cores <= 4:
                 numa_param = "-map-by numa:pe=2 -oversubscribe"

--- a/src/sst/core/testingframework/sst_unittest.py
+++ b/src/sst/core/testingframework/sst_unittest.py
@@ -309,17 +309,14 @@ class SSTTestCase(unittest.TestCase):
 
         # Perform any multi-rank checks/setup
         mpi_avail = False
+        numa_param = ""
         if num_ranks > 1:
             # Check to see if mpirun is available
-            rtn = os.system("which mpirun > /dev/null")
+            rtn = os.system("which mpirun > /dev/null 2>&1")
             if rtn == 0:
                 mpi_avail = True
 
-            numa_param = ""
-            if 2 <= num_cores <= 4:
-                numa_param = "-map-by numa:pe=2 -oversubscribe"
-            elif num_cores >= 4:
-                numa_param = "-map-by numa:pe=2"
+            numa_param = "-map-by numa:PE={0}".format(num_threads)
 
             oscmd = "mpirun -np {0} {1} -output-filename {2} {3}".format(num_ranks,
                                                                          numa_param,


### PR DESCRIPTION
Moving test to check for existence of OpenMPI so that it does not generate errors on rank=1 tests in Jenkins.   Also changed how we compute the numa_param.  Lastly added some support code to allow tests to get the diff file on compares.