### PR TITLE
Change runtime_error Catch to a Reference

### DIFF
--- a/src/sst/core/unitAlgebra.cc
+++ b/src/sst/core/unitAlgebra.cc
@@ -365,7 +365,7 @@ UnitAlgebra::init(const std::string& val)
     try {
         value = sst_big_num(number);
     }
-    catch (runtime_error e) {
+    catch (runtime_error& e) {
         Output abort = Output::getDefaultObject();
         abort.fatal(CALL_INFO,1,"Error: invalid number string: %s\n",number.c_str());
     }


### PR DESCRIPTION
Fix a GCC 9.2 compile warning.