### PR TITLE
Fix issue with wrong reported simulated time in some corner cases

### DIFF
--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -744,8 +744,8 @@ protected:
 
 
     /** Find a lookup table */
-    SharedRegion* getLocalSharedRegion(const std::string& key, size_t size);
-    SharedRegion* getGlobalSharedRegion(const std::string& key, size_t size, SharedRegionMerger *merger = nullptr);
+    SharedRegion* getLocalSharedRegion(const std::string& key, size_t size) __attribute__ ((deprecated("SharedRegion and its accompanying classes have been deprecated and will be removed in SST 12. Please use the new SharedObject classes found in sst/core/shared.")));
+    SharedRegion* getGlobalSharedRegion(const std::string& key, size_t size, SharedRegionMerger *merger = nullptr) __attribute__ ((deprecated("SharedRegion and its accompanying classes have been deprecated and will be removed in SST 12. Please use the new SharedObject classes found in sst/core/shared.")));
 
     /* Get the Simulation */
     Simulation* getSimulation() const { return sim; }

--- a/src/sst/core/exit.h
+++ b/src/sst/core/exit.h
@@ -57,7 +57,9 @@ public:
 
     unsigned int getRefCount();
     SimTime_t getEndTime() { return end_time; }
+    void setEndTime(SimTime_t time) { end_time = time; }
 
+    SimTime_t computeEndTime();
     void execute(void) override;
     void check();
 

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -72,12 +72,21 @@ using namespace SST;
 
 static SST::Output g_output;
 
+class SimulationHelper {
+public:
+    static void setSignal(int sig) {
+        Simulation::setSignal(sig);
+    }
 
+    static Simulation* createSimulation(Config *config, RankInfo my_rank, RankInfo num_ranks) {
+        return Simulation::createSimulation(config,my_rank,num_ranks);
+    }
+};
 
 static void
 SimulationSigHandler(int sig)
 {
-    Simulation::setSignal(sig);
+    SimulationHelper::setSignal(sig);
     if ( sig == SIGINT || sig == SIGTERM ) {
         signal(sig, SIG_DFL); // Restore default handler
     }
@@ -231,7 +240,7 @@ static void start_simulation(uint32_t tid, SimThreadInfo_t &info, Core::ThreadSa
     }
 
     ////// Create Simulation Objects //////
-    SST::Simulation* sim = Simulation::createSimulation(info.config, info.myRank, info.world_size, info.min_part);
+    SST::Simulation* sim = SimulationHelper::createSimulation(info.config, info.myRank, info.world_size);
 
     barrier.wait();
 


### PR DESCRIPTION
Fixed an issue where the wrong simulated time was reported in multirank runs when there were no links cut across ranks.
