### PR TITLE
Updates to Link API

### DIFF
--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -291,8 +291,9 @@ BaseComponent::configureLink(const std::string& name, TimeConverter* time_base, 
         // If no functor, this is a polling link
         if ( handler == nullptr ) {
             tmp->setPolling();
+        } else {
+            tmp->setFunctor(handler);
         }
-        tmp->setFunctor(handler);
         if ( nullptr != time_base ) tmp->setDefaultTimeBase(time_base);
         else tmp->setDefaultTimeBase(my_info->defaultTimeBase);
         tmp->setAsConfigured();

--- a/src/sst/core/event.h
+++ b/src/sst/core/event.h
@@ -53,7 +53,11 @@ public:
     virtual Event* clone();
 
     /** Sets the link id used for delivery.  For use by SST Core only */
+#if !SST_BUILDING_CORE
+    inline void setDeliveryLink(LinkId_t id, Link *link) __attribute__ ((deprecated("this function was not intended to be used outside of SST Core and will be removed in SST 12."))) {
+#else
     inline void setDeliveryLink(LinkId_t id, Link *link) {
+#endif
 #ifdef SST_ENFORCE_EVENT_ORDERING
         enforce_link_order = id;
 #else
@@ -63,17 +67,29 @@ public:
     }
 
     /** Gets the link id used for delivery.  For use by SST Core only */
+#if !SST_BUILDING_CORE
+    inline Link* getDeliveryLink() __attribute__ ((deprecated("this function was not intended to be used outside of SST Core and will be removed in SST 12."))) {
+#else
     inline Link* getDeliveryLink() {
+#endif
         return delivery_link;
     }
 
     /** For use by SST Core only */
+#if !SST_BUILDING_CORE
+    inline void setRemoteEvent() __attribute__  ((deprecated("this function was not intended to be used outside of SST Core and will be removed in SST 12."))) {
+#else
     inline void setRemoteEvent() {
+#endif
         delivery_link = nullptr;
     }
 
     /** Gets the link id associated with this event.  For use by SST Core only */
+#if !SST_BUILDING_CORE
+    inline LinkId_t getLinkId(void) const __attribute__ ((deprecated("this function was not intended to be used outside of SST Core and will be removed in SST 12."))) {
+#else
     inline LinkId_t getLinkId(void) const {
+#endif
 #ifdef SST_ENFORCE_EVENT_ORDERING
         return enforce_link_order;
 #else

--- a/src/sst/core/interfaces/stringEvent.h
+++ b/src/sst/core/interfaces/stringEvent.h
@@ -33,18 +33,9 @@ public:
         SST::Event(), str(str)
     { }
 
-    /** Copies an existing StringEvent */
-    StringEvent(const StringEvent &me) : SST::Event()
-    {
-        str = me.str;
-        setDeliveryLink(me.getLinkId(), nullptr);
-    }
-
-    /** Copies an existing StringEvent */
-    StringEvent(const StringEvent *me) : SST::Event()
-    {
-        str = me->str;
-        setDeliveryLink(me->getLinkId(), nullptr);
+    /** Clone a StringEvent */
+    virtual Event* clone() override {
+        return new StringEvent(*this);
     }
 
     /** Returns the contents of this Event */

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -114,6 +114,23 @@ void Link::addRecvLatency(SimTime_t cycles, TimeConverter* timebase) {
     pair_link->latency += timebase->convertToCoreTime(cycles);
 }
 
+void Link::setFunctor(Event::HandlerBase* functor) {
+    if ( UNLIKELY( type != HANDLER ) ) {
+        Simulation::getSimulation()->getSimulationOutput().fatal(CALL_INFO, 1, "Cannot call setFunctor on a Polling Link\n");
+    }
+
+    rFunctor = functor;
+}
+
+void Link::replaceFunctor(Event::HandlerBase* functor) {
+    if ( UNLIKELY( type != HANDLER ) ) {
+        Simulation::getSimulation()->getSimulationOutput().fatal(CALL_INFO, 1, "Cannot call replaceFunctor on a Polling Link\n");
+    }
+
+    if ( rFunctor ) delete rFunctor;
+    rFunctor = functor;
+}
+
 void Link::send( SimTime_t delay, TimeConverter* tc, Event* event ) {
     if ( tc == nullptr ) {
         Simulation::getSimulation()->getSimulationOutput().fatal(CALL_INFO, 1, "Cannot send an event on Link with nullptr TimeConverter\n");

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -38,12 +38,15 @@ public:
     friend class ThreadSync;
     friend class Simulation_impl;
     // friend class SyncBase;
-    friend class ThreadSync;
     friend class SyncManager;
     friend class ComponentInfo;
 
     /** Create a new link with a given ID */
+#if !SST_BUILDING_CORE
+    Link(LinkId_t id) __attribute__ ((deprecated("this function was not intended to be used outside of SST core and will be removed in SST 12.")));
+#else
     Link(LinkId_t id);
+#endif
 
     virtual ~Link();
 
@@ -72,93 +75,126 @@ public:
     void addRecvLatency(SimTime_t cycles, TimeConverter* timebase);
 
     /** Set the callback function to be called when a message is
-     * delivered.
+     * delivered. Not available for Polling links.
      * @param functor Functor to call when message is delivered
      */
-    void setFunctor(Event::HandlerBase* functor) {
-        rFunctor = functor;
-    }
+    void setFunctor(Event::HandlerBase* functor);
 
     /** Replace the callback function to be called when a message is
      * delivered. Any previous handler will be deleted.
+     * Not available for Polling links.
      * @param functor Functor to call when message is delivered
      */
-    void replaceFunctor(Event::HandlerBase* functor) {
-        if ( rFunctor ) delete rFunctor;
-        rFunctor = functor;
-    }
+    void replaceFunctor(Event::HandlerBase* functor);
 
     /** Specifies that this link has no callback, and is poll-based only */
+#if !SST_BUILDING_CORE
+    void setPolling() __attribute__ ((deprecated("this function was not intended to be used outside of SST core and will be removed in SST 12.")));
+#else
     void setPolling();
+#endif
 
     /** Send an event over the link with additional delay. Sends an event
-      over a link with an additional delay specified with a
-      TimeConverter. I.e. the total delay is the link's delay + the
-      additional specified delay.
-      @param delay - additional delay
-      @param tc - time converter to specify units for the additional delay
-      @param event - the Event to send
-      */
+     * over a link with an additional delay specified with a
+     * TimeConverter. I.e. the total delay is the link's delay + the
+     * additional specified delay.
+     * @param delay - additional delay
+     * @param tc - time converter to specify units for the additional delay
+     * @param event - the Event to send
+     */
     void send( SimTime_t delay, TimeConverter* tc, Event* event );
 
     /** Send an event with additional delay. Sends an event over a link
-      with additional delay specified by the Link's default
-      timebase.
-      @param delay The additional delay, in units of the default Link timebase
-      @param event The event to send
-      */
+     * with additional delay specified by the Link's default
+     * timebase.
+     * @param delay The additional delay, in units of the default Link timebase
+     * @param event The event to send
+     */
     inline void send( SimTime_t delay, Event* event ) {
         send(delay,defaultTimeBase,event);
     }
 
     /** Send an event with the Link's default delay
-      @param event The event to send
-    */
+     * @param event The event to send
+     */
     inline void send( Event* event ) {
         send( 0, event );
     }
 
 
     /** Retrieve a pending event from the Link. For links which do not
-      have a set event handler, they can be polled with this function.
-      Returns nullptr if there is no pending event.
-    */
+     * have a set event handler, they can be polled with this function.
+     * Returns nullptr if there is no pending event.
+     * Not available for HANDLER-type links.
+     * @return Event if one is available
+     * @return nullptr if no Event is available
+     */
     Event* recv();
 
 
     /** Manually set the default detaulTimeBase
-      @param tc TimeConverter object for the timebase */
+     * @param tc TimeConverter object for the timebase 
+     */
     void setDefaultTimeBase(TimeConverter* tc);
-    /** Return the default Time Base for this link */
+
+    /** Return the default Time Base for this link 
+     * @return the default Time Base for this link
+     */
     TimeConverter* getDefaultTimeBase();
 
     /** Causes an event to be delivered to the registered callback */
+#if !SST_BUILDING_CORE
+    inline void deliverEvent(Event* event) const __attribute__ ((deprecated("this function was not intended to be used outside of SST core and will be removed in SST 12."))) {
+#else
     inline void deliverEvent(Event* event) const {
+#endif
         (*rFunctor)(event);
     }
 
-    /** Return the ID of this link */
+    /** Return the ID of this link 
+     * @return the unique ID for this link
+     */
     LinkId_t getId() { return id; }
 
-    /** Send data during the init() phase. */
+    /** Send data during the init() or complete() phase. 
+     * @param data event to send
+     */
     void sendUntimedData(Event* data);
-    /** Receive an event (if any) during the init() phase */
+
+    /** Receive an event (if any) during the init() or complete() phase.
+     * @return Event if one is available
+     * @return nullptr if no Event is available
+     */
     Event* recvUntimedData();
 
-    /** Send data during the complete() phase. */
+    /** Send data during the init() or complete() phase. 
+     * Same as sendUntimedData()
+     * @param init_data data to send
+     */
     void sendInitData(Event* init_data) {
         sendUntimedData(init_data);
     }
-    /** Receive an event (if any) during the complete() phase */
+
+    /** Receive an event (if any) during the init() or complete() phase. 
+     * Same as recvUntimedData()
+     * @return Event if one is available
+     * @return nullptr if no Event is available
+     */
     Event* recvInitData() {
         return recvUntimedData();
     }
 
-
+#if !SST_BUILDING_CORE
+    void setAsConfigured() __attribute__ ((deprecated("this function was not intended to be used outside of SST core and will be removed in SST 12."))) {
+#else
     void setAsConfigured() {
+#endif
         configured = true;
     }
 
+    /** Return whether link has been configured
+     * @return whether link is configured
+     */
     bool isConfigured() {
         return configured;
     }

--- a/src/sst/core/linkMap.h
+++ b/src/sst/core/linkMap.h
@@ -119,8 +119,17 @@ private:
     // }
 
 public:
+#if !SST_BUILDING_CORE
+    LinkMap() /*: allowedPorts(nullptr)*/ __attribute__ ((deprecated("LinkMap class was not intended to be used outside of SST Core and will be removed in SST 12."))) {}
+#else
     LinkMap() /*: allowedPorts(nullptr)*/ {}
+#endif
+
+#if !SST_BUILDING_CORE
+    ~LinkMap() __attribute__ ((deprecated("LinkMap class was not intended to be used outside of SST Core and will be removed in SST 12."))) {
+#else
     ~LinkMap() {
+#endif
         // Delete all the links in the map
         for ( std::map<std::string,Link*>::iterator it = linkMap.begin(); it != linkMap.end(); ++it ) {
             delete it->second;
@@ -142,12 +151,20 @@ public:
      * Add a port name to the list of allowed ports.
      * Used by SelfLinks, as these are undocumented.
      */
+#if !SST_BUILDING_CORE
+    void addSelfPort(const std::string& name) __attribute__ ((deprecated("LinkMap class was not intended to be used outside of SST Core and will be removed in SST 12.")))
+#else
     void addSelfPort(const std::string& name)
+#endif
     {
         selfPorts.push_back(name);
     }
 
+#if !SST_BUILDING_CORE
+    bool isSelfPort(const std::string& name) const __attribute__ ((deprecated("LinkMap class was not intended to be used otuside of SST Core and will be removed in SST 12."))) {
+#else
     bool isSelfPort(const std::string& name) const {
+#endif
         for ( std::vector<std::string>::const_iterator i = selfPorts.begin() ; i != selfPorts.end() ; ++i ) {
             /* Compare name with stored name, which may have wildcards */
             // if ( checkPort(i->c_str(), x) ) {
@@ -159,16 +176,29 @@ public:
     }
 
     /** Inserts a new pair of name and link into the map */
+#if !SST_BUILDING_CORE
+    void insertLink(const std::string& name, Link* link) __attribute__ ((deprecated("LinkMap class was not intended to be used outside of SST Core and will be removed in SST 12."))) {
+#else
     void insertLink(const std::string& name, Link* link) {
+#endif
         linkMap.insert(std::pair<std::string,Link*>(name,link));
     }
 
+#if !SST_BUILDING_CORE
+    void removeLink(const std::string& name) __attribute__ ((deprecated("LinkMap class was not intended to be used outside of SST Core and will be removed in SST 12."))) {
+#else
     void removeLink(const std::string& name) {
+#endif
         linkMap.erase(name);
     }
 
     /** Returns a Link pointer for a given name */
+#if !SST_BUILDING_CORE
+    Link* getLink(const std::string& name) __attribute__ ((deprecated("LinkMap class was not intended to be used outside of SST Core and will be removed in SST 12."))) {
+#else
     Link* getLink(const std::string& name) {
+#endif
+
 //         if ( !checkPort(name) ) {
 // #ifdef USE_PARAM_WARNINGS
 //             std::cerr << "Warning:  Using undocumented port '" << name << "'." << std::endl;
@@ -183,14 +213,23 @@ public:
        Checks to see if LinkMap is empty.
        @return True if Link map is empty, false otherwise
     */
+#if !SST_BUILDING_CORE
+    bool empty() __attribute__ ((deprecated("LinkMap class was not intended to be used outside of SST Core and will be removed in SST 12."))) {
+#else
     bool empty() {
+#endif
+
         return linkMap.empty();
     }
 
     // FIXME: Kludge for now, fix later.  Need to make LinkMap look
     // like a regular map instead.
     /** Return a reference to the internal map */
+#if !SST_BUILDING_CORE
+    std::map<std::string,Link*>& getLinkMap() __attribute__ ((deprecated("LinkMap class was not intended to be used outside of SST Core and will be removed in SST 12."))) {
+#else
     std::map<std::string,Link*>& getLinkMap() {
+#endif
         return linkMap;
     }
 

--- a/src/sst/core/linkPair.h
+++ b/src/sst/core/linkPair.h
@@ -24,7 +24,11 @@ namespace SST {
 class LinkPair {
 public:
     /** Create a new LinkPair with specified ID */
+#if !SST_BUILDING_CORE
+    LinkPair(LinkId_t id) __attribute__ ((deprecated("LinkPair class was not intended to be used outside of SST Core and will be removed in SST 12."))) :
+#else
     LinkPair(LinkId_t id) :
+#endif
         left(new Link(id)),
         right(new Link(id))
     {
@@ -34,17 +38,34 @@ public:
         right->pair_link = left;
 
     }
+
+#if !SST_BUILDING_CORE
+    virtual ~LinkPair() __attribute__ ((deprecated("LinkPair class was not intended to be used outside of SST Core and will be removed in SST 12."))) {}
+#else
     virtual ~LinkPair() {}
+#endif
 
     /** return the ID of the LinkPair */
+#if !SST_BUILDING_CORE
+    LinkId_t getId() __attribute__ ((deprecated("LinkPair class was not intended to be used outside of SST Core and will be removed in SST 12."))) {
+#else
     LinkId_t getId() {
+#endif
         return my_id;
     }
 
     /** Return the Left Link */
+#if !SST_BUILDING_CORE
+    inline Link* getLeft() __attribute__ ((deprecated("LinkPair class was not intended to be used outside of SST Core and will be removed in SST 12."))) {return left;}
+#else
     inline Link* getLeft() {return left;}
+#endif
     /** Return the Right Link */
+#if !SST_BUILDING_CORE
+    inline Link* getRight() __attribute__ ((deprecated("LinkPair class was not intended to be used outside of SST Core and will be removed in SST 12."))) {return right;}
+#else
     inline Link* getRight() {return right;}
+#endif
 
 private:
 


### PR DESCRIPTION
Adds error when setting handlers on polling links
Deprecates core-internal functions for use by components in Event/Link and also the LinkPair & LinkMap classes