### PR TITLE
Bug fixes and memory/exection time optimizations for large graphs.

### DIFF
--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -675,14 +675,8 @@ private:
         sub_info->share_flags = share_flags;
         sub_info->parent_info = my_info;
 
-        // Check to see if this is documented, and if so, try to load it through the ElementBuilder
-        Params myParams;
-        if ( sub_info->getParams() != nullptr ) {
-            myParams.insert(*sub_info->getParams());
-        }
-
         if ( isSubComponentLoadableUsingAPI<T>(sub_info->type) ) {
-            auto ret = Factory::getFactory()->Create<T>(sub_info->type, myParams, sub_info->id, myParams, args...);
+            auto ret = Factory::getFactory()->Create<T>(sub_info->type, *sub_info->params, sub_info->id, *sub_info->params, args...);
             return ret;
         }
         return nullptr;

--- a/src/sst/core/cfgoutput/dotConfigOutput.cc
+++ b/src/sst/core/cfgoutput/dotConfigOutput.cc
@@ -45,7 +45,7 @@ void DotConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph) {
                 fprintf(outputFile, "subgraph cluster_%u_%u {\n", r, t);
                 fprintf(outputFile, "label=\"Thread %u\";\n", t);
                 for ( auto compItr : compMap ) {
-                    if ( compItr.rank.rank == r && compItr.rank.thread == t ) {
+                    if ( compItr->rank.rank == r && compItr->rank.thread == t ) {
                         generateDot( compItr, linkMap, cfg->dot_verbosity );
                     }
                 }
@@ -58,7 +58,7 @@ void DotConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph) {
     } else {
         fprintf(outputFile, "node [shape=record];\ngraph [style=invis];\n\n");
         for ( auto compItr : compMap ) {
-            fprintf(outputFile, "subgraph cluster_%" PRIu64 " {\n", compItr.id);
+            fprintf(outputFile, "subgraph cluster_%" PRIu64 " {\n", compItr->id);
             generateDot( compItr, linkMap, cfg->dot_verbosity );
             fprintf(outputFile, "}\n\n");
         }
@@ -72,24 +72,24 @@ void DotConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph) {
 }
 
 
-void DotConfigGraphOutput::generateDot(const ConfigComponent& comp, const ConfigLinkMap_t& linkMap, const uint32_t dot_verbosity) const {
+void DotConfigGraphOutput::generateDot(const ConfigComponent* comp, const ConfigLinkMap_t& linkMap, const uint32_t dot_verbosity) const {
 
     // Display component type
     if (dot_verbosity >= 2) {
-        fprintf(outputFile, "%" PRIu64 " [label=\"{<main> %s\\n%s", comp.id, comp.name.c_str(), comp.type.c_str());
+        fprintf(outputFile, "%" PRIu64 " [label=\"{<main> %s\\n%s", comp->id, comp->name.c_str(), comp->type.c_str());
     } else {
-        fprintf(outputFile, "%" PRIu64 " [label=\"{<main> %s", comp.id, comp.name.c_str());
+        fprintf(outputFile, "%" PRIu64 " [label=\"{<main> %s", comp->id, comp->name.c_str());
     }
 
     // Display ports
     if (dot_verbosity >= 6) {
-        int j = comp.links.size();
+        int j = comp->links.size();
         if(j != 0){
             fprintf(outputFile, " |\n");
         }
-        for(LinkId_t i : comp.links) {
+        for(LinkId_t i : comp->links) {
             const ConfigLink &link = linkMap[i];
-            const int port = (link.component[0] == comp.id) ? 0 : 1;
+            const int port = (link.component[0] == comp->id) ? 0 : 1;
             fprintf(outputFile, "<%s> Port: %s", link.port[port].c_str(), link.port[port].c_str());
             if(j > 1){
                 fprintf(outputFile, " |\n");
@@ -101,15 +101,15 @@ void DotConfigGraphOutput::generateDot(const ConfigComponent& comp, const Config
 
     // Display subComponents
     if (dot_verbosity >= 4) {
-        for ( auto &sc : comp.subComponents ) {
-            fprintf(outputFile, "%" PRIu64 " [color=gray,label=\"{<main> %s\\n%s", sc.id, sc.name.c_str(), sc.type.c_str());
-            int j = sc.links.size();
+        for ( auto &sc : comp->subComponents ) {
+            fprintf(outputFile, "%" PRIu64 " [color=gray,label=\"{<main> %s\\n%s", sc->id, sc->name.c_str(), sc->type.c_str());
+            int j = sc->links.size();
             if(j != 0){
                 fprintf(outputFile, " |\n");
             }
-            for(LinkId_t i : sc.links) {
+            for(LinkId_t i : sc->links) {
                 const ConfigLink &link = linkMap[i];
-                const int port = (link.component[0] == sc.id) ? 0 : 1;
+                const int port = (link.component[0] == sc->id) ? 0 : 1;
                 fprintf(outputFile, "<%s> Port: %s", link.port[port].c_str(), link.port[port].c_str());
                 if(j > 1){
                     fprintf(outputFile, " |\n");
@@ -117,7 +117,7 @@ void DotConfigGraphOutput::generateDot(const ConfigComponent& comp, const Config
                 j--;
             }
             fprintf(outputFile, "}\"];\n");
-            fprintf(outputFile, "%" PRIu64 ":\"main\" -- %" PRIu64 ":\"main\" [style=dotted];\n\n", comp.id, sc.id);
+            fprintf(outputFile, "%" PRIu64 ":\"main\" -- %" PRIu64 ":\"main\" [style=dotted];\n\n", comp->id, sc->id);
         }
     }
 }

--- a/src/sst/core/cfgoutput/dotConfigOutput.h
+++ b/src/sst/core/cfgoutput/dotConfigOutput.h
@@ -25,7 +25,7 @@ public:
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 
 protected:
-    void generateDot(const ConfigComponent& comp, const ConfigLinkMap_t& linkMap, const uint32_t dot_verbosity) const;
+    void generateDot(const ConfigComponent* comp, const ConfigLinkMap_t& linkMap, const uint32_t dot_verbosity) const;
     void generateDot(const ConfigLink& link, const uint32_t dot_verbosity) const;
 };
 

--- a/src/sst/core/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.cc
@@ -58,28 +58,28 @@ void JSONConfigGraphOutput::generate(const Config* UNUSED(cfg), ConfigGraph* gra
 }
 
 
-void JSONConfigGraphOutput::generateJSON(const std::string& indent, const ConfigComponent& comp, const ConfigLinkMap_t& linkMap) const {
+void JSONConfigGraphOutput::generateJSON(const std::string& indent, const ConfigComponent* comp, const ConfigLinkMap_t& linkMap) const {
 
     int num = 0;
-    std::string temp = indent + "\"name\" : \"" + comp.name + "\",\n" + indent + "\"type\" : \"" + comp.type + "\",\n";
+    std::string temp = indent + "\"name\" : \"" + comp->name + "\",\n" + indent + "\"type\" : \"" + comp->type + "\",\n";
     fprintf(outputFile, "%s", temp.c_str());
 
-    num = comp.links.size();
+    num = comp->links.size();
     if (num > 0){
         fprintf(outputFile,    "%s\"ports\" : [\n", indent.c_str());
-        for(LinkId_t i : comp.links) {
+        for(LinkId_t i : comp->links) {
             const ConfigLink &link = linkMap[i];
-            const int port = (link.component[0] == comp.id) ? 0 : 1;
+            const int port = (link.component[0] == comp->id) ? 0 : 1;
             fprintf(outputFile, "%s\t{ \"name\" : \"%s\"}", indent.c_str(), link.port[port].c_str());
             num--; (num > 0) ? fprintf(outputFile, ",\n") : fprintf(outputFile, "\n");
         }
         fprintf(outputFile, "%s],\n", indent.c_str());
     }
 
-    num = comp.subComponents.size();
+    num = comp->subComponents.size();
     if (num > 0){
         fprintf(outputFile, "%s\"subcomponents\" : [\n", indent.c_str());
-        for (auto &scItr : comp.subComponents) {
+        for (auto &scItr : comp->subComponents) {
             fprintf(outputFile, "%s\t{\n", indent.c_str());
             generateJSON( indent + "\t\t", scItr, linkMap);
             fprintf(outputFile, "%s\t}", indent.c_str());
@@ -88,12 +88,12 @@ void JSONConfigGraphOutput::generateJSON(const std::string& indent, const Config
         fprintf(outputFile, "%s],\n", indent.c_str());
     }
 
-    num = comp.enabledStatNames.size();
+    num = comp->enabledStatNames.size();
     if (num > 0){
         fprintf(outputFile, "%s\"statistics\" : [\n", indent.c_str());
-        for (auto& pair : comp.enabledStatNames) {
+        for (auto& pair : comp->enabledStatNames) {
             auto& name = pair.first;
-            auto* si = comp.findStatistic(pair.second);
+            auto* si = comp->findStatistic(pair.second);
             temp = indent + "\t{\n" + indent + "\t\t\"name\" : \"" + name + "\"";
             fprintf(outputFile, "%s", temp.c_str());
             int num2 = si->params.size();
@@ -113,10 +113,10 @@ void JSONConfigGraphOutput::generateJSON(const std::string& indent, const Config
         fprintf(outputFile, "%s],\n", indent.c_str());
     }
 
-    num = comp.params.size();
+    num = comp->params.size();
     fprintf(outputFile, "%s\"params\" : [\n", indent.c_str());
-    for(auto &paramsItr : comp.params.getKeys()) {
-        temp = indent + "\t{ \"name\" : \"" + paramsItr + "\", \"value\" : \"" + comp.params.find<std::string>(paramsItr) + "\" }";
+    for(auto &paramsItr : comp->params.getKeys()) {
+        temp = indent + "\t{ \"name\" : \"" + paramsItr + "\", \"value\" : \"" + comp->params.find<std::string>(paramsItr) + "\" }";
         fprintf(outputFile, "%s", temp.c_str());
         num--; (num > 0) ? fprintf(outputFile, ",\n") : fprintf(outputFile, "\n");
     }
@@ -126,9 +126,9 @@ void JSONConfigGraphOutput::generateJSON(const std::string& indent, const Config
 void JSONConfigGraphOutput::generateJSON(const ConfigLink& link, const ConfigComponentMap_t& compMap) const {
     int minLatIdx = (link.latency[0] <= link.latency[1]) ? 0 : 1;
     std::string temp = "\t\t{\n\t\t\t\"name\" : \"" + link.name + "\",\n" +
-        "\t\t\t\"left\" : \"" + compMap[link.component[0]].name + "\",\n" +
+        "\t\t\t\"left\" : \"" + compMap[link.component[0]]->name + "\",\n" +
         "\t\t\t\"leftPort\" : \"" + link.port[0] + "\",\n" +
-        "\t\t\t\"right\" : \"" + compMap[link.component[1]].name + "\",\n" +
+        "\t\t\t\"right\" : \"" + compMap[link.component[1]]->name + "\",\n" +
         "\t\t\t\"rightPort\" : \"" + link.port[1] + "\",\n" +
         "\t\t\t\"latency\" : \"" + link.latency_str[minLatIdx] + "\"\n";
     fprintf(outputFile, "%s", temp.c_str());

--- a/src/sst/core/cfgoutput/jsonConfigOutput.h
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.h
@@ -26,8 +26,8 @@ public:
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 
 protected:
-    void generateJSON(const std::string& indent, const ConfigComponent& comp, const ConfigLinkMap_t& linkMap) const;
-  void generateJSON(const ConfigLink& link, const ConfigComponentMap_t& compMap) const;
+    void generateJSON(const std::string& indent, const ConfigComponent* comp, const ConfigLinkMap_t& linkMap) const;
+    void generateJSON(const ConfigLink& link, const ConfigComponentMap_t& compMap) const;
 };
 
 }

--- a/src/sst/core/cfgoutput/pythonConfigOutput.h
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.h
@@ -30,9 +30,9 @@ public:
 protected:
     ConfigGraph* getGraph() { return graph; }
     void generateParams( const Params &params );
-    void generateCommonComponent( const char* objName, const ConfigComponent &comp);
-    void generateSubComponent( const char* owner, const ConfigComponent &comp );
-    void generateComponent( const ConfigComponent &comp );
+    void generateCommonComponent( const char* objName, const ConfigComponent* comp);
+    void generateSubComponent( const char* owner, const ConfigComponent* comp );
+    void generateComponent( const ConfigComponent* comp );
     void generateStatGroup(const ConfigGraph* graph, const ConfigStatGroup &grp);
 
     const std::string& getLinkObject(LinkId_t id);

--- a/src/sst/core/cfgoutput/xmlConfigOutput.cc
+++ b/src/sst/core/cfgoutput/xmlConfigOutput.cc
@@ -49,17 +49,17 @@ void XMLConfigGraphOutput::generate(const Config* UNUSED(cfg),
     fprintf(outputFile, "</component>\n");
 }
 
-void XMLConfigGraphOutput::generateXML(const std::string& indent, const ConfigComponent& comp,
+void XMLConfigGraphOutput::generateXML(const std::string& indent, const ConfigComponent* comp,
                 const ConfigLinkMap_t& UNUSED(linkMap)) const {
 
     fprintf(outputFile, "%s<component id=\"system.%s\" name=\"%s\" type=\"%s\">\n",
-        indent.c_str(), comp.name.c_str(), comp.name.c_str(), comp.type.c_str());
+        indent.c_str(), comp->name.c_str(), comp->name.c_str(), comp->type.c_str());
 
-    // for(auto paramsItr = comp.params.begin(); paramsItr != comp.params.end(); paramsItr++) {
-    auto keys = comp.params.getKeys();
+    // for(auto paramsItr = comp->params.begin(); paramsItr != comp->params.end(); paramsItr++) {
+    auto keys = comp->params.getKeys();
     for(auto paramsItr = keys.begin(); paramsItr != keys.end(); paramsItr++) {
         std::string paramName  = *paramsItr;
-        std::string paramValue = comp.params.find<std::string>(*paramsItr);
+        std::string paramValue = comp->params.find<std::string>(*paramsItr);
 
         fprintf(outputFile, "%s%s<param name=\"%s\" value=\"%s\"/>\n",
             indent.c_str(), "   ",
@@ -72,8 +72,8 @@ void XMLConfigGraphOutput::generateXML(const std::string& indent, const ConfigCo
 void XMLConfigGraphOutput::generateXML(const std::string& indent, const ConfigLink& link,
     const ConfigComponentMap_t& compMap) const {
 
-    const ConfigComponent* link_left  = &compMap[link.component[0]];
-    const ConfigComponent* link_right = &compMap[link.component[1]];
+    const ConfigComponent* link_left  = compMap[link.component[0]];
+    const ConfigComponent* link_right = compMap[link.component[1]];
 
     fprintf(outputFile, "%s<link id=\"%s\" name=\"%s\"\n%s%sleft=\"%s\" right=\"%s\"\n%s%sleftport=\"%s\" rightport=\"%s\"/>\n",
         indent.c_str(), link.name.c_str(), link.name.c_str(),

--- a/src/sst/core/cfgoutput/xmlConfigOutput.h
+++ b/src/sst/core/cfgoutput/xmlConfigOutput.h
@@ -25,7 +25,7 @@ public:
     virtual void generate(const Config* cfg,
                 ConfigGraph* graph) override;
 protected:
-        void generateXML(const std::string& indent, const ConfigComponent& comp,
+        void generateXML(const std::string& indent, const ConfigComponent* comp,
         const ConfigLinkMap_t& linkMap) const;
         void generateXML(const std::string& indent, const ConfigLink& link,
         const ConfigComponentMap_t& compMap) const;

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -63,22 +63,22 @@ ComponentInfo::ComponentInfo(ConfigComponent* ccomp, const std::string& name, Co
 
     // See how many subcomponents are in each slot so we know how to name them
     std::map<std::string, int> counts;
-    for ( auto &sc : ccomp->subComponents ) {
-        counts[sc.name]++;
+    for ( auto sc : ccomp->subComponents ) {
+        counts[sc->name]++;
     }
 
-    for ( auto &sc : ccomp->subComponents ) {
+    for ( auto sc : ccomp->subComponents ) {
         std::string sub_name(name);
         sub_name += ":";
-        sub_name += sc.name;
+        sub_name += sc->name;
         // If there is more than one subcomponent in this slot, need
         // to add [index] to the end.
-        if ( counts[sc.name] > 1 ) {
+        if ( counts[sc->name] > 1 ) {
             sub_name += "[";
-            sub_name += std::to_string(sc.slot_num);
+            sub_name += std::to_string(sc->slot_num);
             sub_name += "]";
         }
-        subComponents.emplace_hint(subComponents.end(), std::piecewise_construct, std::make_tuple(sc.id), std::forward_as_tuple(&sc, sub_name, this, new LinkMap()));
+        subComponents.emplace_hint(subComponents.end(), std::piecewise_construct, std::make_tuple(sc->id), std::forward_as_tuple(sc, sub_name, this, new LinkMap()));
     }
 }
 

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -110,7 +110,7 @@ private:
        For python defined SubComponents, this field is created during
        python execution.
     */
-    const Params *params;
+    Params *params;
 
     TimeConverter* defaultTimeBase;
 

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -146,48 +146,48 @@ void ConfigComponent::print(std::ostream &os) const {
         iter->second.params.print_all_params(os, "      ");
     }
     os << "  SubComponents:\n";
-    for ( auto & sc : subComponents ) {
-        sc.print(os);
+    for ( auto sc : subComponents ) {
+        sc->print(os);
     }
 }
 
-ConfigComponent
+ConfigComponent*
 ConfigComponent::cloneWithoutLinks() const
 {
-    ConfigComponent ret;
-    ret.id = id;
-    ret.name = name;
-    ret.slot_num = slot_num;
-    ret.type = type;
-    ret.weight = weight;
-    ret.rank = rank;
-    ret.params = params;
-    ret.statLoadLevel = statLoadLevel;
-    ret.statistics = statistics;
-    ret.enabledStatNames = enabledStatNames;
-    ret.enabledAllStats = enabledAllStats;
-    ret.coords = coords;
-    for ( auto &i : subComponents ) {
-        ret.subComponents.emplace_back(i.cloneWithoutLinks());
+    ConfigComponent* ret = new ConfigComponent();
+    ret->id = id;
+    ret->name = name;
+    ret->slot_num = slot_num;
+    ret->type = type;
+    ret->weight = weight;
+    ret->rank = rank;
+    ret->params = params;
+    ret->statLoadLevel = statLoadLevel;
+    ret->statistics = statistics;
+    ret->enabledStatNames = enabledStatNames;
+    ret->enabledAllStats = enabledAllStats;
+    ret->coords = coords;
+    for ( auto i : subComponents ) {
+        ret->subComponents.emplace_back(i->cloneWithoutLinks());
     }
     return ret;
 }
 
 
-ConfigComponent
+ConfigComponent*
 ConfigComponent::cloneWithoutLinksOrParams() const
 {
-    ConfigComponent ret;
-    ret.id = id;
-    ret.name = name;
-    ret.slot_num = slot_num;
-    ret.type = type;
-    ret.weight = weight;
-    ret.rank = rank;
-    ret.statLoadLevel = statLoadLevel;
-    ret.coords = coords;
-    for ( auto &i : subComponents ) {
-        ret.subComponents.emplace_back(i.cloneWithoutLinksOrParams());
+    ConfigComponent* ret = new ConfigComponent();
+    ret->id = id;
+    ret->name = name;
+    ret->slot_num = slot_num;
+    ret->type = type;
+    ret->weight = weight;
+    ret->rank = rank;
+    ret->statLoadLevel = statLoadLevel;
+    ret->coords = coords;
+    for ( auto i : subComponents ) {
+        ret->subComponents.emplace_back(i->cloneWithoutLinksOrParams());
     }
     return ret;
 }
@@ -240,8 +240,8 @@ std::string ConfigComponent::getFullName() const {
 void ConfigComponent::setRank(RankInfo r)
 {
     rank = r;
-    for ( auto &i : subComponents ) {
-        i.setRank(r);
+    for ( auto i : subComponents ) {
+        i->setRank(r);
     }
 
 }
@@ -250,8 +250,8 @@ void ConfigComponent::setRank(RankInfo r)
 void ConfigComponent::setWeight(double w)
 {
     weight = w;
-    for ( auto &i : subComponents ) {
-        i.setWeight(w);
+    for ( auto i : subComponents ) {
+        i->setWeight(w);
     }
 }
 
@@ -293,7 +293,7 @@ ConfigComponent::enableStatistic(const std::string& statisticName, const SST::Pa
     //       lists will always be the same size.
     if ( recursively ) {
         for ( auto &sc : subComponents ) {
-            sc.enableStatistic(statisticName, params, true);
+            sc->enableStatistic(statisticName, params, true);
         }
     }
 
@@ -369,8 +369,8 @@ void ConfigComponent::addStatisticParameter(const std::string& statisticName, co
     //       a corresponding params entry in enabledStatParams list.  The two
     //       lists will always be the same size.
     if ( recursively ) {
-        for ( auto &sc : subComponents ) {
-            sc.addStatisticParameter(statisticName, param, value, true);
+        for ( auto sc : subComponents ) {
+            sc->addStatisticParameter(statisticName, param, value, true);
         }
     }
 
@@ -391,8 +391,8 @@ void ConfigComponent::addStatisticParameter(const std::string& statisticName, co
 void ConfigComponent::setStatisticParameters(const std::string& statisticName, const Params &params, bool recursively)
 {
     if ( recursively ) {
-        for ( auto &sc : subComponents ) {
-            sc.setStatisticParameters(statisticName, params, true);
+        for ( auto sc : subComponents ) {
+            sc->setStatisticParameters(statisticName, params, true);
         }
     }
 
@@ -409,8 +409,8 @@ void ConfigComponent::setStatisticLoadLevel(uint8_t level, bool recursively)
     statLoadLevel = level;
 
     if ( recursively ) {
-        for ( auto &sc : subComponents ) {
-            sc.setStatisticLoadLevel(level, true);
+        for ( auto sc : subComponents ) {
+            sc->setStatisticLoadLevel(level, true);
         }
     }
 }
@@ -419,17 +419,17 @@ void ConfigComponent::setStatisticLoadLevel(uint8_t level, bool recursively)
 ConfigComponent* ConfigComponent::addSubComponent(ComponentId_t sid, const std::string& name, const std::string& type, int slot_num)
 {
     /* Check for existing subComponent with this name */
-    for ( auto &i : subComponents ) {
-        if ( i.name == name && i.slot_num == slot_num )
+    for ( auto i : subComponents ) {
+        if ( i->name == name && i->slot_num == slot_num )
             return nullptr;
     }
 
     uint16_t parent_sub_id = SUBCOMPONENT_ID_MASK(id);
 
-    subComponents.emplace_back(
-        ConfigComponent(sid, graph, parent_sub_id, name, slot_num, type, this->weight, this->rank));
+    subComponents.push_back(
+        new ConfigComponent(sid, graph, parent_sub_id, name, slot_num, type, this->weight, this->rank));
 
-    return &(subComponents.back());
+    return subComponents.back();
 }
 
 ConfigComponent* ConfigComponent::findSubComponent(ComponentId_t sid)
@@ -441,8 +441,8 @@ const ConfigComponent* ConfigComponent::findSubComponent(ComponentId_t sid) cons
 {
     if ( sid == this->id ) return this;
 
-    for ( auto &s : subComponents ) {
-        const ConfigComponent* res = s.findSubComponent(sid);
+    for ( auto s : subComponents ) {
+        const ConfigComponent* res = s->findSubComponent(sid);
         if ( res != nullptr )
             return res;
     }
@@ -470,15 +470,15 @@ ConfigComponent* ConfigComponent::findSubComponentByName(const std::string& name
     }
 
     // Now, see if we have something in this slot and slot_num
-    for ( auto& sc : subComponents ) {
-        if ( sc.name == slot && sc.slot_num == slot_num ) {
+    for ( auto sc : subComponents ) {
+        if ( sc->name == slot && sc->slot_num == slot_num ) {
             // Found the subcomponent
             if ( colon_index == std::string::npos ) {
                 // Last level of hierarchy
-                return &sc;
+                return sc;
             }
             else {
-                return sc.findSubComponentByName(slot.substr(colon_index+1,std::string::npos));
+                return sc->findSubComponentByName(slot.substr(colon_index+1,std::string::npos));
             }
         }
     }
@@ -525,8 +525,8 @@ ConfigComponent::findStatistic(StatisticId_t sid) const {
 std::vector<LinkId_t> ConfigComponent::allLinks() const {
     std::vector<LinkId_t> res;
     res.insert(res.end(), links.begin(), links.end());
-    for ( auto& sc : subComponents ) {
-        std::vector<LinkId_t> s = sc.allLinks();
+    for ( auto sc : subComponents ) {
+        std::vector<LinkId_t> s = sc->allLinks();
         res.insert(res.end(), s.begin(), s.end());
     }
     return res;
@@ -571,8 +571,8 @@ ConfigComponent::checkPorts() const
     }
 
     // Now loop over all subcomponents and call the check function
-    for ( auto& subcomp : subComponents ) {
-        subcomp.checkPorts();
+    for ( auto subcomp : subComponents ) {
+        subcomp->checkPorts();
     }
 }
 
@@ -582,7 +582,7 @@ ConfigGraph::setComponentRanks(RankInfo rank)
     for ( ConfigComponentMap_t::iterator iter = comps.begin();
                             iter != comps.end(); ++iter )
     {
-        iter->setRank(rank);
+        (*iter)->setRank(rank);
     }
 }
 
@@ -592,7 +592,7 @@ ConfigGraph::containsComponentInRank(RankInfo rank)
     for ( ConfigComponentMap_t::iterator iter = comps.begin();
                             iter != comps.end(); ++iter )
     {
-        if ( iter->rank == rank ) return true;
+        if ( (*iter)->rank == rank ) return true;
     }
     return false;
 
@@ -604,8 +604,8 @@ ConfigGraph::checkRanks(RankInfo ranks)
     for ( ConfigComponentMap_t::iterator iter = comps.begin();
                             iter != comps.end(); ++iter )
     {
-        if ( !iter->rank.isAssigned() || !ranks.inRange(iter->rank) ) {
-            fprintf(stderr, "Bad rank: %u %u\n", iter->rank.rank, iter->rank.thread);
+        if ( !(*iter)->rank.isAssigned() || !ranks.inRange((*iter)->rank) ) {
+            fprintf(stderr, "Bad rank: %u %u\n", (*iter)->rank.rank, (*iter)->rank.thread);
             return false;
         }
     }
@@ -641,12 +641,12 @@ ConfigGraph::checkForStructuralErrors()
         // initialized in order, but just in case...
         if ( clink.component[0] == ULONG_MAX ) {
             output.output("WARNING:  Found dangling link: %s.  It is connected on one side to component %s.\n",clink.name.c_str(),
-                   comps[clink.component[1]].name.c_str());
+                   comps[clink.component[1]]->name.c_str());
             found_error = true;
         }
         if ( clink.component[1] == ULONG_MAX ) {
             output.output("WARNING:  Found dangling link: %s.  It is connected on one side to component %s.\n",clink.name.c_str(),
-                   comps[clink.component[0]].name.c_str());
+                   comps[clink.component[0]]->name.c_str());
             found_error = true;
         }
     }
@@ -659,7 +659,7 @@ ConfigGraph::checkForStructuralErrors()
     for ( ConfigComponentMap_t::iterator iter = comps.begin();
           iter != comps.end(); ++iter )
     {
-        ConfigComponent* ccomp = &(*iter);
+        ConfigComponent* ccomp = *iter;
         ccomp->checkPorts();
     }
 
@@ -671,7 +671,7 @@ ComponentId_t
 ConfigGraph::addComponent(const std::string& name, const std::string& type, float weight, RankInfo rank)
 {
     ComponentId_t cid = nextComponentId++;
-    comps.insert(ConfigComponent(cid, this, name, type, weight, rank));
+    comps.insert(new ConfigComponent(cid, this, name, type, weight, rank));
 
     auto ret = compsByName.insert(std::make_pair(name,cid));
     // Check to see if the name has already been used
@@ -685,7 +685,7 @@ ComponentId_t
 ConfigGraph::addComponent(const std::string& name, const std::string& type)
 {
     ComponentId_t cid = nextComponentId++;
-    comps.insert(ConfigComponent(cid, this, name, type, 1.0f, RankInfo()));
+    comps.insert(new ConfigComponent(cid, this, name, type, 1.0f, RankInfo()));
 
     auto ret = compsByName.insert(std::make_pair(name,cid));
     // Check to see if the name has already been used
@@ -695,6 +695,11 @@ ConfigGraph::addComponent(const std::string& name, const std::string& type)
     return cid;
 }
 
+void
+ConfigGraph::addGlobalParam(const std::string& global_set, const std::string& key, const std::string& value)
+{
+    Params::insert_global(global_set,key,value);
+}
 
 
 void
@@ -789,10 +794,10 @@ const ConfigComponent* ConfigGraph::findComponent(ComponentId_t id) const
 {
     /* Check to make sure we're part of the same component */
     if ( COMPONENT_ID_MASK(id) == id ) {
-        return &comps[id];
+        return comps[id];
     }
 
-    return comps[COMPONENT_ID_MASK(id)].findSubComponent(id);
+    return comps[COMPONENT_ID_MASK(id)]->findSubComponent(id);
 }
 
 ConfigComponent* ConfigGraph::findComponentByName(const std::string& name) {
@@ -804,7 +809,7 @@ ConfigComponent* ConfigGraph::findComponentByName(const std::string& name) {
     // Check to see if component was found
     if ( itr == compsByName.end() ) return nullptr;
 
-    ConfigComponent* cc = &comps[itr->second];
+    ConfigComponent* cc = comps[itr->second];
 
     // If this was just a component name
     if ( index == std::string::npos ) return cc;
@@ -840,20 +845,20 @@ ConfigGraph::getSubGraph(const std::set<uint32_t>& rank_set)
     // sure things go in in order into both comps and links, then tie
     // it all together.
     for ( ConfigComponentMap_t::iterator it = comps.begin(); it != comps.end(); ++it) {
-        const ConfigComponent& comp = *it;
+        const ConfigComponent* comp = *it;
 
-        if ( rank_set.find(comp.rank.rank) != rank_set.end() ) {
-            graph->comps.insert(comp.cloneWithoutLinks());
+        if ( rank_set.find(comp->rank.rank) != rank_set.end() ) {
+            graph->comps.insert(comp->cloneWithoutLinks());
         }
         else {
             // See if the other side of any of component's links is in
             // set, if so, add to graph
-            for ( LinkId_t l : comp.allLinks() ) {
+            for ( LinkId_t l : comp->allLinks() ) {
                 const ConfigLink& link = links[l];
-                ComponentId_t remote = COMPONENT_ID_MASK(link.component[0]) == COMPONENT_ID_MASK(comp.id) ?
+                ComponentId_t remote = COMPONENT_ID_MASK(link.component[0]) == COMPONENT_ID_MASK(comp->id) ?
                     link.component[1] : link.component[0];
-                if ( rank_set.find(comps[COMPONENT_ID_MASK(remote)].rank.rank) != rank_set.end() ) {
-                    graph->comps.insert(comp.cloneWithoutLinksOrParams());
+                if ( rank_set.find(comps[COMPONENT_ID_MASK(remote)]->rank.rank) != rank_set.end() ) {
+                    graph->comps.insert(comp->cloneWithoutLinksOrParams());
                     break;
                 }
             }
@@ -909,22 +914,22 @@ ConfigGraph::getPartitionGraph()
     // insert both components and links in order of ID, which is the
     // key for the SparseVectorMap
     for ( ConfigComponentMap_t::iterator it = comps.begin(); it != comps.end(); ++it ) {
-        const ConfigComponent& comp = *it;
+        const ConfigComponent* comp = *it;
 
-        pcomps.insert(PartitionComponent(comp));
+        pcomps.insert(new PartitionComponent(comp));
     }
 
 
     for ( ConfigLinkMap_t::iterator it = links.begin(); it != links.end(); ++it ) {
         const ConfigLink& link = *it;
 
-        const ConfigComponent& comp0 = comps[COMPONENT_ID_MASK(link.component[0])];
-        const ConfigComponent& comp1 = comps[COMPONENT_ID_MASK(link.component[1])];
+        const ConfigComponent* comp0 = comps[COMPONENT_ID_MASK(link.component[0])];
+        const ConfigComponent* comp1 = comps[COMPONENT_ID_MASK(link.component[1])];
 
         plinks.insert(PartitionLink(link));
 
-        pcomps[comp0.id].links.push_back(link.id);
-        pcomps[comp1.id].links.push_back(link.id);
+        pcomps[comp0->id]->links.push_back(link.id);
+        pcomps[comp1->id]->links.push_back(link.id);
     }
     return graph;
 }
@@ -941,7 +946,7 @@ ConfigGraph::getCollapsedPartitionGraph()
 
 
     // Mark all Components as not visited
-    for ( ConfigComponentMap_t::iterator it = comps.begin(); it != comps.end(); ++it ) it->visited = false;
+    for ( ConfigComponentMap_t::iterator it = comps.begin(); it != comps.end(); ++it ) (*it)->visited = false;
 
     // SparseVectorMap is slow for random inserts, so make sure we
     // insert both components and links in order of ID, which is the
@@ -951,36 +956,37 @@ ConfigGraph::getCollapsedPartitionGraph()
     // into a SparseVectorMap, we are inserting in order.
     std::set<ComponentId_t> group;
     for ( ConfigComponentMap_t::iterator it = comps.begin(); it != comps.end(); ++it ) {
+        auto comp = *it;
         // If this component ended up in a connected group we already
         // looked at, skip it
-        if ( it->visited ) continue;
+        if ( comp->visited ) continue;
 
         // Get the no-cut group for this component
         group.clear();
-        getConnectedNoCutComps(it->id,group);
+        getConnectedNoCutComps(comp->id,group);
 
         // Create a new PartitionComponent for this group
         ComponentId_t id = pcomps.size();
-        PartitionComponent& pcomp = pcomps.insert(PartitionComponent(id));
+        PartitionComponent* pcomp = pcomps.insert(new PartitionComponent(id));
 
         // Iterate over the group and add the weights and add any
         // links that connect outside the group
         for ( std::set<ComponentId_t>::const_iterator i = group.begin(); i != group.end(); ++i ) {
-            const ConfigComponent& comp = comps[*i];
+            const ConfigComponent* comp = comps[*i];
             // Compute the new weight
-            pcomp.weight += comp.weight;
+            pcomp->weight += comp->weight;
             // Inserting in order because the iterator is from an
             // ordered set
-            pcomp.group.insert(*i);
+            pcomp->group.insert(*i);
 
             // Walk through all the links and insert the ones that connect
             // outside the group
-            for ( LinkId_t id : comp.allLinks() ) {
+            for ( LinkId_t id : comp->allLinks() ) {
                 const ConfigLink& link = links[id];
 
                 if ( group.find(COMPONENT_ID_MASK(link.component[0])) == group.end() ||
                      group.find(COMPONENT_ID_MASK(link.component[1])) == group.end() ) {
-                    pcomp.links.push_back(link.id);
+                    pcomp->links.push_back(link.id);
                 }
                 else {
                     deleted_links.insert(link.id);
@@ -1005,11 +1011,11 @@ ConfigGraph::getCollapsedPartitionGraph()
     // links to see if it points to something in the group.  If so,
     // change ID to point to super group.
     for ( PartitionComponentMap_t::iterator i = pcomps.begin(); i != pcomps.end(); ++i ) {
-        PartitionComponent& pcomp = *i;
-        for ( LinkIdMap_t::iterator j = pcomp.links.begin(); j != pcomp.links.end(); ++j ) {
+        PartitionComponent* pcomp = *i;
+        for ( LinkIdMap_t::iterator j = pcomp->links.begin(); j != pcomp->links.end(); ++j ) {
             PartitionLink& plink = plinks[*j];
-            if ( pcomp.group.contains(plink.component[0]) ) plink.component[0] = pcomp.id;
-            if ( pcomp.group.contains(plink.component[1]) ) plink.component[1] = pcomp.id;
+            if ( pcomp->group.contains(plink.component[0]) ) plink.component[0] = pcomp->id;
+            if ( pcomp->group.contains(plink.component[1]) ) plink.component[1] = pcomp->id;
         }
     }
 
@@ -1022,11 +1028,11 @@ ConfigGraph::annotateRanks(PartitionGraph* graph)
     PartitionComponentMap_t& pcomps = graph->getComponentMap();
 
     for ( PartitionComponentMap_t::iterator it = pcomps.begin(); it != pcomps.end(); ++it ) {
-        const PartitionComponent& comp = *it;
+        const PartitionComponent* comp = *it;
 
-        for ( ComponentIdMap_t::const_iterator c_iter = comp.group.begin();
-              c_iter != comp.group.end(); ++ c_iter ) {
-            comps[*c_iter].setRank(comp.rank);
+        for ( ComponentIdMap_t::const_iterator c_iter = comp->group.begin();
+              c_iter != comp->group.end(); ++ c_iter ) {
+            comps[*c_iter]->setRank(comp->rank);
         }
     }
 }
@@ -1038,10 +1044,10 @@ ConfigGraph::getConnectedNoCutComps(ComponentId_t start, std::set<ComponentId_t>
     group.insert(COMPONENT_ID_MASK(start));
 
     // First, get the component
-    ConfigComponent& comp = comps[start];
-    comp.visited = true;
+    ConfigComponent* comp = comps[start];
+    comp->visited = true;
 
-    for ( LinkId_t id : comp.allLinks() ) {
+    for ( LinkId_t id : comp->allLinks() ) {
         ConfigLink& link = links[id];
 
         // If this is a no_cut link, need to follow it to next

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -236,7 +236,7 @@ public:
     bool enabledAllStats;
     ConfigStatistic allStatConfig;
 
-    std::vector<ConfigComponent>  subComponents; /*!< List of subcomponents */
+    std::vector<ConfigComponent*> subComponents; /*!< List of subcomponents */
     std::vector<double>           coords;
     uint16_t                      nextSubID;         /*!< Next subID to use for children, if component, if subcomponent, subid of parent */
     bool                          visited;           /*! Used when traversing graph to indicate component was visited already */
@@ -249,13 +249,14 @@ public:
     /** Print Component information */
     void print(std::ostream &os) const;
 
-    ConfigComponent cloneWithoutLinks() const;
-    ConfigComponent cloneWithoutLinksOrParams() const;
+    ConfigComponent* cloneWithoutLinks() const;
+    ConfigComponent* cloneWithoutLinksOrParams() const;
 
     ~ConfigComponent() {}
     ConfigComponent()
         : id(null_id), statLoadLevel(STATISTICLOADLEVELUNINITIALIZED), enabledAllStats(false), nextSubID(1),
-          visited(false) {}
+          visited(false) {
+    }
 
     ComponentId_t getNextSubComponentID();
     StatisticId_t getNextStatisticID();
@@ -281,6 +282,9 @@ public:
     void addStatisticParameter(const std::string& statisticName, const std::string& param, const std::string& value, bool recursively = false);
     void setStatisticParameters(const std::string& statisticName, const Params &params, bool recursively = false);
     void setStatisticLoadLevel(uint8_t level, bool recursively = false);
+
+    void addGlobalParamSet(const std::string& set) {
+        params.addGlobalParamSet(set); }
 
     std::vector<LinkId_t> allLinks() const;
 
@@ -338,7 +342,7 @@ private:
 // typedef std::map<std::string,ConfigLink> ConfigLinkMap_t;
 // typedef SparseVectorMap<std::string,ConfigLink> ConfigLinkMap_t;
 /** Map IDs to Components */
-typedef SparseVectorMap<ComponentId_t,ConfigComponent> ConfigComponentMap_t;
+typedef SparseVectorMap<ComponentId_t,ConfigComponent*> ConfigComponentMap_t;
 /** Map names to Components */
 typedef std::map<std::string,ComponentId_t> ConfigComponentNameMap_t;
 /** Map names to Parameter Sets: XML only */
@@ -357,7 +361,7 @@ public:
     void print(std::ostream &os) const {
         os << "Printing graph" << std::endl;
         for (ConfigComponentMap_t::const_iterator i = comps.begin() ; i != comps.end() ; ++i) {
-            i->print(os);
+            (*i)->print(os);
         }
     }
 
@@ -388,6 +392,8 @@ public:
     /** Create a new component */
     ComponentId_t addComponent(const std::string& name, const std::string& type);
 
+    /** Add a parameter to a global param set */
+    void addGlobalParam(const std::string& global_set, const std::string& key, const std::string& value);
 
     /** Set the statistic output module */
     void setStatisticOutput(const std::string& name);
@@ -497,10 +503,10 @@ public:
 
     ComponentIdMap_t          group;
 
-    PartitionComponent(const ConfigComponent& cc) {
-        id = cc.id;
-        weight = cc.weight;
-        rank = cc.rank;
+    PartitionComponent(const ConfigComponent* cc) {
+        id = cc->id;
+        weight = cc->weight;
+        rank = cc->rank;
     }
 
     PartitionComponent(LinkId_t id) :
@@ -549,7 +555,7 @@ public:
     }
 };
 
-typedef SparseVectorMap<ComponentId_t,PartitionComponent> PartitionComponentMap_t;
+typedef SparseVectorMap<ComponentId_t,PartitionComponent*> PartitionComponentMap_t;
 typedef SparseVectorMap<LinkId_t,PartitionLink> PartitionLinkMap_t;
 
 class PartitionGraph {
@@ -562,7 +568,7 @@ public:
     void print(std::ostream &os) const {
         os << "Printing graph" << std::endl;
         for (PartitionComponentMap_t::const_iterator i = comps.begin() ; i != comps.end() ; ++i) {
-            i->print(os,this);
+            (*i)->print(os,this);
         }
     }
 

--- a/src/sst/core/impl/partitioners/linpart.cc
+++ b/src/sst/core/impl/partitioners/linpart.cc
@@ -53,7 +53,7 @@ void SSTLinearPartition::performPartition(PartitionGraph* graph) {
         compItr != compMap.end();
         compItr++) {
 
-        compItr->rank = currentAllocatingRank;
+        (*compItr)->rank = currentAllocatingRank;
         componentsOnCurrentRank++;
 
 
@@ -62,7 +62,7 @@ void SSTLinearPartition::performPartition(PartitionGraph* graph) {
             if ( componentRemainder > 0 ) {
                 --componentRemainder;
                 ++compItr;
-                compItr->rank = currentAllocatingRank;
+                (*compItr)->rank = currentAllocatingRank;
             }
 
             /* Advance our currentAllocatingRank */

--- a/src/sst/core/impl/partitioners/rrobin.cc
+++ b/src/sst/core/impl/partitioners/rrobin.cc
@@ -36,7 +36,7 @@ void SSTRoundRobinPartition::performPartition(PartitionGraph* graph) {
             compItr != compMap.end();
             compItr++) {
 
-        compItr->rank = rank;
+        (*compItr)->rank = rank;
 
         rank.rank++;
         if ( rank.rank == world_size.rank ) {

--- a/src/sst/core/impl/partitioners/simplepart.cc
+++ b/src/sst/core/impl/partitioners/simplepart.cc
@@ -118,11 +118,11 @@ SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo UNUSED(my_ra
         /////////////////////////////////////////////////////////////////////////////////////
         // Sub-divide and repeat
         for(int i = 0; i < lengthA; i++) {
-            component_map[setA[i]].rank = convertPartNum(rankA);
+            component_map[setA[i]]->rank = convertPartNum(rankA);
         }
 
         for(int i = 0; i < lengthB; i++) {
-            component_map[setB[i]].rank = convertPartNum(rankB);
+            component_map[setB[i]]->rank = convertPartNum(rankB);
         }
 
         const uint32_t A1_rank = rankA;
@@ -192,7 +192,7 @@ SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo UNUSED(my_ra
                 compItr != component_map.end();
                 ++compItr) {
 
-                compItr->rank = RankInfo(0,0);
+                (*compItr)->rank = RankInfo(0,0);
             }
         } else {
 
@@ -216,7 +216,7 @@ SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo UNUSED(my_ra
                  compItr != component_map.end();
                  ++compItr) {
 
-                ComponentId_t theComponent = (*compItr).id;
+                ComponentId_t theComponent = (*compItr)->id;
 
                 map<ComponentId_t, SimTime_t>* compConnectMap = new map<ComponentId_t, SimTime_t>();
                 timeTable[theComponent] = compConnectMap;
@@ -227,7 +227,7 @@ SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo UNUSED(my_ra
                     setB[indexB++] = theComponent;
                 }
 
-                LinkIdMap_t component_links = (*compItr).links;
+                LinkIdMap_t component_links = (*compItr)->links;
 
                 PartitionLinkMap_t& linkMap = graph->getLinkMap();
 

--- a/src/sst/core/impl/partitioners/singlepart.cc
+++ b/src/sst/core/impl/partitioners/singlepart.cc
@@ -27,8 +27,8 @@ void SSTSinglePartition::performPartition(ConfigGraph* graph) {
 
     ConfigComponentMap_t& compMap = graph->getComponentMap();
 
-    for(auto compItr = compMap.begin(); compItr != compMap.end(); compItr++) {
-        compItr->rank = RankInfo(0,0);
+    for(auto comp : compMap ) {
+        comp->rank = RankInfo(0,0);
     }
 
 }

--- a/src/sst/core/impl/partitioners/zoltpart.cc
+++ b/src/sst/core/impl/partitioners/zoltpart.cc
@@ -57,9 +57,9 @@ static void sst_zoltan_get_vertex_list(void* data, int UNUSED(sizeGID), int UNUS
 
         for(PartitionComponentMap_t::iterator comp_itr = c_graph->getComponentMap().begin();
             comp_itr != c_graph->getComponentMap().end(); comp_itr++) {
-            globalIDs[next_entry] = (int) comp_itr->id;
+            globalIDs[next_entry] = (int) (*comp_itr)->id;
             localIDs[next_entry] = localID++;
-            obj_wgts[next_entry] = comp_itr->weight;
+            obj_wgts[next_entry] = (*comp_itr)->weight;
 
             next_entry++;
         }
@@ -291,14 +291,14 @@ void SSTZoltanPartition::performPartition(PartitionGraph* graph) {
         PartitionComponentMap_t& config_map = graph->getComponentMap();
         PartitionComponentMap_t::iterator config_map_itr;
         for(config_map_itr = config_map.begin(); config_map_itr != config_map.end(); config_map_itr++) {
-            config_map_itr->rank = RankInfo(0,0);
+            (*config_map_itr)->rank = RankInfo(0,0);
         }
 
         partOutput->verbose(CALL_INFO, 1, 0, "Rank 0 will export %d partition graph vertices.\n", num_vertices_export);
 
         // Go over what we have to export, set the component to the appropriate rank
         for(int i = 0; i < num_vertices_export; ++i) {
-            config_map[export_global_ids[i]].rank = RankInfo(export_ranks[i], 0);
+            config_map[export_global_ids[i]]->rank = RankInfo(export_ranks[i], 0);
             rank_assignments[export_ranks[i]]++;
         }
     }

--- a/src/sst/core/memuse.cc
+++ b/src/sst/core/memuse.cc
@@ -26,6 +26,21 @@ REENABLE_WARNING
 
 using namespace SST::Core;
 
+uint64_t SST::Core::localMemSize() {
+
+    struct rusage sim_ruse;
+    getrusage(RUSAGE_SELF, &sim_ruse);
+
+    uint64_t local_rss = sim_ruse.ru_maxrss;
+
+#ifdef SST_COMPILE_MACOSX
+    return (local_rss / 1024);
+#else
+    return local_rss;
+#endif
+
+};
+
 uint64_t SST::Core::maxLocalMemSize() {
 
     struct rusage sim_ruse;

--- a/src/sst/core/memuse.h
+++ b/src/sst/core/memuse.h
@@ -18,6 +18,7 @@
 namespace SST {
 namespace Core {
 
+uint64_t localMemSize();
 uint64_t maxLocalMemSize();
 uint64_t maxGlobalMemSize();
 uint64_t maxLocalPageFaults();

--- a/src/sst/core/model/python/pymodel.h
+++ b/src/sst/core/model/python/pymodel.h
@@ -37,8 +37,8 @@ namespace Core {
 class SSTPythonModelDefinition : public SSTModelDescription {
 
 public:
-    SSTPythonModelDefinition(const std::string& script_file, int verbosity, Config* config, int argc, char **argv);
-    SSTPythonModelDefinition(const std::string& script_file, int verbosity, Config* config);
+    SSTPythonModelDefinition(const std::string& script_file, int verbosity, Config* config, double start_time, int argc, char **argv);
+    SSTPythonModelDefinition(const std::string& script_file, int verbosity, Config* config, double start_time);
     virtual ~SSTPythonModelDefinition();
 
     ConfigGraph* createConfigGraph() override;
@@ -54,7 +54,7 @@ protected:
     std::vector<size_t> nameStack;
     std::map<std::string, ComponentId_t> compNameMap;
     ComponentId_t nextComponentId;
-
+    double start_time;
 
 public:  /* Public, but private.  Called only from Python functions */
     Config* getConfig(void) const { return config; }
@@ -87,6 +87,12 @@ public:  /* Public, but private.  Called only from Python functions */
     void addStatisticOutputParameter(const std::string& param, const std::string& value) { graph->addStatisticOutputParameter(param, value); }
     void setStatisticLoadLevel(uint8_t loadLevel) { graph->setStatisticLoadLevel(loadLevel); }
 
+    void addGlobalParameter(const char* set, const char* key, const char* value, bool overwrite) {
+        Params::insert_global(set,key,value,overwrite);
+    }
+
+    UnitAlgebra getElapsedExecutionTime() const;
+    UnitAlgebra getLocalMemoryUsage() const;
 };
 
 std::map<std::string,std::string> generateStatisticParameters(PyObject* statParamDict);

--- a/src/sst/core/model/python/pymodel_comp.cc
+++ b/src/sst/core/model/python/pymodel_comp.cc
@@ -40,9 +40,9 @@ extern SST::Core::SSTPythonModelDefinition *gModel;
 
 ConfigComponent* ComponentHolder::getSubComp(const std::string& name, int slot_num)
 {
-    for ( auto &sc : getComp()->subComponents ) {
-        if ( sc.name == name && sc.slot_num == slot_num)
-            return &sc;
+    for ( auto sc : getComp()->subComponents ) {
+        if ( sc->name == name && sc->slot_num == slot_num)
+            return sc;
     }
     return nullptr;
 }
@@ -488,6 +488,22 @@ compCreateStatistic(PyObject* self, PyObject* args) {
     return buildStatisticObject(cs->id);
 }
 
+static PyObject* compAddGlobalParamSet(PyObject* self, PyObject* arg)
+{
+    const char *set = nullptr;
+    PyErr_Clear();
+    set = SST_ConvertToCppString(arg);
+
+    ConfigComponent *c = getComp(self);
+
+    if ( set != nullptr ) {
+        c->addGlobalParamSet(set);
+    } else {
+        return nullptr;
+    }
+    return SST_ConvertToPythonLong(0);
+}
+
 static PyMethodDef componentMethods[]
     = { { "addParam", compAddParam, METH_VARARGS, "Adds a parameter(name, value)" },
         { "addParams", compAddParams, METH_O, "Adds Multiple Parameters from a dict" },
@@ -511,6 +527,8 @@ static PyMethodDef componentMethods[]
           "Bind a subcomponent to slot <name>, with type <type>" },
         { "setCoordinates", compSetCoords, METH_VARARGS,
           "Set (X,Y,Z) coordinates of this component, for use with visualization" },
+        { "addGlobalParamSet", compAddGlobalParamSet, METH_O,
+          "Add global parameter set to the component" },
         { nullptr, nullptr, 0, nullptr } };
 
 #if PY_MAJOR_VERSION == 3
@@ -622,6 +640,8 @@ static PyMethodDef subComponentMethods[]
         { "setStatistic", compSetStatistic, METH_VARARGS, "Reuse a statistic for the binding" },
         { "setSubComponent", compSetSubComponent, METH_VARARGS,
           "Bind a subcomponent to slot <name>, with type <type>" },
+        { "addGlobalParamSet", compAddGlobalParamSet, METH_O,
+          "Add global parameter set to the component" },
         { "setCoordinates", compSetCoords, METH_VARARGS,
           "Set (X,Y,Z) coordinates of this component, for use with visualization" },
         { nullptr, nullptr, 0, nullptr } };

--- a/src/sst/core/model/python/pymodel_stat.cc
+++ b/src/sst/core/model/python/pymodel_stat.cc
@@ -163,13 +163,19 @@ static PyMethodDef statisticMethods[]
         { "addParams", statAddParams, METH_O, "Adds Multiple Parameters from a dict" },
         { nullptr, nullptr, 0, nullptr } };
 
+#if PY_MAJOR_VERSION == 3
+#if PY_MINOR_VERSION == 8
+DISABLE_WARN_DEPRECATED_DECLARATION
+#endif
+#endif
 PyTypeObject PyModel_StatType = {
-    SST_PY_OBJ_HEAD "sst.Statistic", /* tp_name */
+    SST_PY_OBJ_HEAD
+    "sst.Statistic",                 /* tp_name */
     sizeof(StatisticPy_t),           /* tp_basicsize */
     0,                               /* tp_itemsize */
     (destructor)statDealloc,         /* tp_dealloc */
     SST_TP_VECTORCALL_OFFSET         /* Python3 only */
-        SST_TP_PRINT                 /* Python2 only */
+    SST_TP_PRINT                     /* Python2 only */
     nullptr,                         /* tp_getattr */
     nullptr,                         /* tp_setattr */
     SST_TP_COMPARE(nullptr)          /* Python2 only */
@@ -213,8 +219,14 @@ PyTypeObject PyModel_StatType = {
     nullptr,                         /* tp_del */
     0,                               /* tp_version_tag */
     SST_TP_FINALIZE                  /* Python3 only */
-        SST_TP_VECTORCALL            /* Python3 only */
+    SST_TP_VECTORCALL                /* Python3 only */
+    SST_TP_PRINT_DEP                 /* Python3.8 only */
 };
+#if PY_MAJOR_VERSION == 3
+#if PY_MINOR_VERSION == 8
+REENABLE_WARNING
+#endif
+#endif
 
 } /* extern C */
 

--- a/src/sst/core/objectComms.h
+++ b/src/sst/core/objectComms.h
@@ -37,7 +37,7 @@ std::vector<char> serialize(dataType &data)
     ser.start_sizing();
     ser & data;
 
-    int size = ser.size();
+    size_t size = ser.size();
 
     std::vector<char> buffer;
     buffer.resize(size);

--- a/src/sst/core/params.cc
+++ b/src/sst/core/params.cc
@@ -18,6 +18,7 @@
 #include <vector>
 #include <string>
 
+#define SET_NAME_KEYWORD "GLOBAL_SET_NAME"
 
 namespace SST {
 
@@ -25,41 +26,50 @@ const std::string&
 Params::getString(const std::string& name, bool& found) const
 {
     static std::string empty;
-    const_iterator i = data.find(getKey(name));
-    if ( i == data.end() ) {
-        found = false;
-        return empty;
+    for ( auto map : data ) {
+        auto value = map->find(getKey(name));
+        if ( value != map->end() ) {
+            found = true;
+            return value->second;
+        }
     }
-    found = true;
-    return i->second;
+    found = false;
+    return empty;
 }
 
 size_t
 Params::size() const
 {
-    return data.size();
+    return getKeys().size();
 }
 
 bool
 Params::empty() const
 {
-    return data.empty();
+    return getKeys().empty();
 }
 
 Params::Params() :
-    data(), verify_enabled(true)
-{}
+    my_data(), verify_enabled(true)
+{
+    data.push_back(&my_data);
+}
 
 Params::Params(const Params& old) :
+    my_data(old.my_data),
     data(old.data),
     allowedKeys(old.allowedKeys),
     verify_enabled(old.verify_enabled)
-{}
+{
+    data[0] = &my_data;
+}
 
 
 Params&
 Params::operator=(const Params& old) {
+    my_data = old.my_data;
     data = old.data;
+    data[0] = &my_data;
     verify_enabled = old.verify_enabled;
     allowedKeys = old.allowedKeys;
     return *this;
@@ -68,29 +78,60 @@ Params::operator=(const Params& old) {
 void
 Params::clear()
 {
+    my_data.clear();
     data.clear();
+    data.push_back(&my_data);
 }
 
 
 size_t
 Params::count(const key_type& k) const
 {
-    return data.count(getKey(k));
+    int key = getKey(k);
+    for ( auto map : data ) {
+        size_t count = map->count(key);
+        if ( count > 0 ) return count;
+    }
+    return 0;
 }
 
 void
 Params::print_all_params(std::ostream &os, const std::string& prefix) const
 {
-    for (const_iterator i = data.begin() ; i != data.end() ; ++i) {
-        os << prefix << "key=" << keyMapReverse[i->first] << ", value=" << i->second << std::endl;
+    int level = 0;
+    for ( auto map : data ) {
+        if ( level == 0 ) {
+            if ( !map->empty() ) os << "Local params:" << std::endl;
+            level++;
+        }
+        else if ( level == 1 ) {
+            os << "Global params:" << std::endl;
+            level++;
+        }
+
+        for ( auto value : *map ) {
+            os << "  " << prefix << "key=" << keyMapReverse[value.first] << ", value=" << value.second << std::endl;
+        }
     }
 }
 
 void
 Params::print_all_params(Output &out, const std::string& prefix) const
 {
-    for (const_iterator i = data.begin() ; i != data.end() ; ++i) {
-        out.output("%s%s = %s\n", prefix.c_str(), keyMapReverse[i->first].c_str(), i->second.c_str());
+    int level = 0;
+    for ( auto map : data ) {
+        if ( level == 0 ) {
+            if ( !map->empty() ) out.output("Local params:\n");
+            level++;
+        }
+        else if ( level == 1 ) {
+            out.output("Global params:\n");
+            level++;
+        }
+
+        for ( auto value : *map ) {
+            out.output("%s%s = %s\n", prefix.c_str(), keyMapReverse[value.first].c_str(), value.second.c_str());
+        }
     }
 }
 
@@ -99,26 +140,35 @@ void
 Params::insert(const std::string& key, const std::string& value, bool overwrite)
 {
     if ( overwrite ) {
-        data[getKey(key)] = value;
+        my_data[getKey(key)] = value;
     }
     else {
         uint32_t id = getKey(key);
-        data.insert(std::make_pair(id, value));
+        my_data.insert(std::make_pair(id, value));
     }
 }
 
 void
 Params::insert(const Params& params)
 {
-    data.insert(params.data.begin(), params.data.end());
+    my_data.insert(params.my_data.begin(), params.my_data.end());
+    for ( size_t i = 1; i < params.data.size(); ++i ) {
+        bool already_there = false;
+        for ( auto x : data ) {
+            if ( params.data[i] == x ) already_there = true;
+        }
+        if ( !already_there ) data.push_back(params.data[i]);
+    }
 }
 
 std::set<std::string>
 Params::getKeys() const
 {
     std::set<std::string> ret;
-    for (const_iterator i = data.begin() ; i != data.end() ; ++i) {
-        ret.insert(keyMapReverse[i->first]);
+    for ( auto map : data ) {
+        for ( auto value : *map ) {
+            ret.insert(keyMapReverse[value.first]);
+        }
     }
     return ret;
 }
@@ -129,24 +179,27 @@ Params::find_scoped_params(const std::string& prefix, const char* delims) const
     int num_delims = ::strlen(delims);
     Params ret;
     ret.enableVerify(false);
-    for (const_iterator i = data.begin() ; i != data.end() ; ++i) {
-        auto& fullKeyName = keyMapReverse[i->first];
-        std::string key = fullKeyName.substr(0, prefix.length());
-        auto start = prefix.length();
-        if (key == prefix) {
-          char next = fullKeyName[start];
-          bool delimMatches = false;
-          for (int i=0; i < num_delims; ++i){
-            if (next == delims[i]){
-              delimMatches = true;
-              break;
+    for ( auto map : data ) {
+        for ( auto value : *map ) {
+            auto& fullKeyName = keyMapReverse[value.first];
+            std::string key = fullKeyName.substr(0, prefix.length());
+            auto start = prefix.length();
+            if (key == prefix) {
+                char next = fullKeyName[start];
+                bool delimMatches = false;
+                for (int i=0; i < num_delims; ++i){
+                    if (next == delims[i]){
+                        delimMatches = true;
+                        break;
+                    }
+                }
+                if (delimMatches){
+                    ret.insert(keyMapReverse[value.first].substr(start +1), value.second);
+                }
             }
-          }
-          if (delimMatches){
-            ret.insert(keyMapReverse[i->first].substr(start +1), i->second);
-          }
         }
     }
+
     ret.allowedKeys = allowedKeys;
     ret.enableVerify(verify_enabled);
     return ret;
@@ -157,10 +210,34 @@ Params::find_prefix_params(const std::string& prefix) const
 {
     Params ret;
     ret.enableVerify(false);
-    for (const_iterator i = data.begin() ; i != data.end() ; ++i) {
-        std::string key = keyMapReverse[i->first].substr(0, prefix.length());
-        if (key == prefix) {
-            ret.insert(keyMapReverse[i->first].substr(prefix.length()), i->second);
+
+    for ( auto map : data ) {
+        for ( auto value : *map ) {
+            std::string key = keyMapReverse[value.first].substr(0, prefix.length());
+            if (key == prefix) {
+                ret.insert(keyMapReverse[value.first].substr(prefix.length()), value.second);
+            }
+        }
+    }
+    ret.allowedKeys = allowedKeys;
+    ret.enableVerify(verify_enabled);
+
+    return ret;
+}
+
+Params
+Params::get_scoped_params(const std::string& scope) const
+{
+    Params ret;
+    ret.enableVerify(false);
+
+    std::string prefix = scope + ".";
+    for ( auto map : data ) {
+        for ( auto value : *map ) {
+            std::string key = keyMapReverse[value.first].substr(0, prefix.length());
+            if (key == prefix) {
+                ret.insert(keyMapReverse[value.first].substr(prefix.length()), value.second);
+            }
         }
     }
     ret.allowedKeys = allowedKeys;
@@ -172,7 +249,10 @@ Params::find_prefix_params(const std::string& prefix) const
 bool
 Params::contains(const key_type &k) const
 {
-    return data.find(getKey(k)) != data.end();
+    for ( auto map : data ) {
+        if ( map->find(getKey(k)) != map->end() ) return true;
+    }
+        return false;
 }
 
 void
@@ -188,15 +268,19 @@ Params::popAllowedKeys()
 }
 
 void
-Params::verifyParam(const key_type &k) const
+#ifdef USE_PARAM_WARNINGS
+Params::verifyParam(const key_type& k) const
+#else
+Params::verifyParam(const key_type& UNUSED(k)) const
+#endif
 {
+#ifdef USE_PARAM_WARNINGS
     if ( !g_verify_enabled || !verify_enabled ) return;
 
     for ( std::vector<KeySet_t>::const_reverse_iterator ri = allowedKeys.rbegin() ; ri != allowedKeys.rend() ; ++ri ) {
         if ( ri->find(k) != ri->end() ) return;
     }
 
-#ifdef USE_PARAM_WARNINGS
     SST::Output outXX("ParamWarning: ", 0, 0, Output::STDERR);
     outXX.output(CALL_INFO, "Warning: Parameter \"%s\" is undocumented.\n", k.c_str());
 #endif
@@ -212,18 +296,24 @@ Params::getParamName(uint32_t id)
 void
 Params::serialize_order(SST::Core::Serialization::serializer &ser)
 {
-    ser & data;
-}
-
-uint32_t
-Params::getKey(const std::string& str) const
-{
-    std::lock_guard<SST::Core::ThreadSafe::Spinlock> lock(keyLock);
-    auto i = keyMap.find(str);
-    if ( i == keyMap.end() ) {
-        return (uint32_t)-1;
+    ser & my_data;
+    // Serialize global params
+    std::vector<std::string> globals;
+    switch ( ser.mode() )
+    {
+    case SST::Core::Serialization::serializer::PACK:
+    case SST::Core::Serialization::serializer::SIZER:
+        for ( size_t i = 1; i < data.size(); ++i ) {
+            globals.push_back((*data[i])[0]);
+        }
+        ser & globals;
+        break;
+    case SST::Core::Serialization::serializer::UNPACK:
+        ser & globals;
+        data.push_back(&my_data);
+        for ( auto x : globals ) data.push_back(&global_params[x]);
+        break;
     }
-    return i->second;
 }
 
 uint32_t
@@ -235,12 +325,34 @@ Params::getKey(const std::string& str)
         uint32_t id = nextKeyID++;
         keyMap.insert(std::make_pair(str, id));
         keyMapReverse.push_back(str);
+        // ID 0 is reserved for holding metadata
         assert(keyMapReverse.size() == nextKeyID);
         return id;
     }
     return i->second;
 }
 
+void
+Params::addGlobalParamSet(const std::string& set)
+{
+    data.push_back(&global_params[set]);
+}
+
+
+void
+Params::insert_global(const std::string& global_key, const std::string& key, const std::string& value, bool overwrite)
+{
+    std::lock_guard<SST::Core::ThreadSafe::Spinlock> lock(globalLock);
+    if ( global_params.count(global_key) == 0 ) {
+        global_params[global_key][0] = global_key;
+    }
+    if ( overwrite ) {
+        global_params[global_key][getKey(key)] = value;
+    }
+    else {
+        global_params[global_key].insert(std::make_pair(getKey(key), value));
+    }
+}
 
 /**
    Private function for parsing string into array tokens.
@@ -443,9 +555,14 @@ Params::getArrayTokens(const std::string& value, std::vector<std::string>& token
 #endif
 
 std::map<std::string, uint32_t> Params::keyMap;
-std::vector<std::string> Params::keyMapReverse;
+// Index 0 in params is used for set name
+std::vector<std::string> Params::keyMapReverse({"<set_name>"});
+uint32_t Params::nextKeyID = 1;
 Core::ThreadSafe::Spinlock Params::keyLock;
-uint32_t Params::nextKeyID;
+Core::ThreadSafe::Spinlock Params::globalLock;
+// ID 0 is reserved for holding metadata
 bool Params::g_verify_enabled = false;
+
+std::map<std::string,std::map<uint32_t,std::string> > Params::global_params;
 
 }

--- a/src/sst/core/params.h
+++ b/src/sst/core/params.h
@@ -192,7 +192,7 @@ public:
      * of Params.  Useful when generating a new set of Params to
      * pass off to a module.
      *
-     * @return returns the previous state of the flay
+     * @return returns the previous state of the flag
      */
     bool enableVerify(bool enable) { bool old = verify_enabled; verify_enabled = enable; return old; }
 

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -285,8 +285,8 @@ Simulation_impl::processGraphInfo( ConfigGraph& graph, const RankInfo& UNUSED(my
         for ( auto iter = links.begin(); iter != links.end(); ++iter ) {
             ConfigLink &clink = *iter;
             RankInfo rank[2];
-            rank[0] = comps[COMPONENT_ID_MASK(clink.component[0])].rank;
-            rank[1] = comps[COMPONENT_ID_MASK(clink.component[1])].rank;
+            rank[0] = comps[COMPONENT_ID_MASK(clink.component[0])]->rank;
+            rank[1] = comps[COMPONENT_ID_MASK(clink.component[1])]->rank;
             // We only care about links that are on my rank, but
             // different threads
 
@@ -351,7 +351,7 @@ int Simulation_impl::performWireUp( ConfigGraph& graph, const RankInfo& myRank, 
     for ( ConfigComponentMap_t::iterator iter = graph.comps.begin();
             iter != graph.comps.end(); ++iter )
     {
-        ConfigComponent* ccomp = &(*iter);
+        ConfigComponent* ccomp = *iter;
         if ( ccomp->rank == myRank ) {
             compInfoMap.insert(new ComponentInfo(ccomp, ccomp->name, nullptr, new LinkMap()));
         }
@@ -365,8 +365,8 @@ int Simulation_impl::performWireUp( ConfigGraph& graph, const RankInfo& myRank, 
     {
         ConfigLink &clink = *iter;
         RankInfo rank[2];
-        rank[0] = graph.comps[COMPONENT_ID_MASK(clink.component[0])].rank;
-        rank[1] = graph.comps[COMPONENT_ID_MASK(clink.component[1])].rank;
+        rank[0] = graph.comps[COMPONENT_ID_MASK(clink.component[0])]->rank;
+        rank[1] = graph.comps[COMPONENT_ID_MASK(clink.component[1])]->rank;
 
         if ( rank[0] != myRank && rank[1] != myRank ) {
             // Nothing to be done
@@ -443,7 +443,7 @@ int Simulation_impl::performWireUp( ConfigGraph& graph, const RankInfo& myRank, 
     // Now, build all the components
     for ( auto iter = graph.comps.begin(); iter != graph.comps.end(); ++iter )
     {
-        ConfigComponent* ccomp = &(*iter);
+        ConfigComponent* ccomp = *iter;
 
         if ( ccomp->rank == myRank ) {
             Component* tmp;

--- a/src/sst/core/sparseVectorMap.h
+++ b/src/sst/core/sparseVectorMap.h
@@ -62,8 +62,8 @@ private:
 
         // Check to see if it goes top or bottom
         if ( size == 0 ) return 0;
-        if ( id < data[0].key() ) return 0;
         if ( id > data[size-1].key() ) return size;
+        if ( id < data[0].key() ) return 0;
 
         int bottom = 0;
         int top = size - 1;
@@ -151,25 +151,6 @@ public:
     typedef typename std::vector<classT>::iterator iterator;
     typedef typename std::vector<classT>::const_iterator const_iterator;
 
-    // Essentially insert with a hint to look at end first.  this is
-    // just here for backward compatibility for now.  Will be replaced
-    // with insert() once things stabilize.
-    classT& push_back(const classT& val) __attribute__ ((deprecated("SparseVectorMap::push_back() is deprecated and will be removed in sst 12. please simply use SparseVectorMap::insert().")))
-    {
-        // first look to see if it goes on the end.  if not, then find
-        // where it goes.
-        if ( data.size() == 0 ) {
-            data.push_back(val);
-            return data.back();
-        }
-        if ( val.key() > data[data.size()-1].key() ) {
-            data.push_back(val);
-            return data.back();
-        }
-
-        // didn't belong at end, call regular insert
-        return insert(val);
-    }
 
     /**
        Insert new value into SparseVectorMap.  The inserted class must
@@ -263,6 +244,250 @@ public:
 
     */
     const classT& operator[] (keyT id) const
+    {
+        int index = binary_search_find(id);
+        if ( index == -1 ) {
+            // Need to error out
+        }
+        return data[index];
+    }
+
+    /**
+       Clears the contents of the SparseVectorMap
+     */
+    void clear() { data.clear(); }
+
+    /**
+       Returns the number of items in the SparseVectorMap
+
+       @return number of items
+     */
+    size_t size() { return data.size(); }
+
+};
+
+
+/**
+   Class that stores data in a vector, but can access the data similar
+   to a map.  The data structure is O(log n) on reads, but is O(n) to
+   insert.  The primary use case is when data is inserted in order, but
+   accessed randomly.  You can also create the SparseVectorMap with a
+   vector already loaded with the data.  If the data is not already
+   sorted, it will call std::sort on the data, which likely has an
+   average complexity of O(n log n).  This data structure should not
+   be used for large lists where inserts do not happen in sorted order.
+
+   NOTE: Since the data is stored in the vector, reference returned
+   from the various accessor functions will not be valid longterm.  If
+   an insert causes the vector to be resized, all references returned
+   before that reallocation may (likely will) be invalid.  References
+   are only guaranteed to be valid until the next write to the data
+   structure.
+ */
+template <typename keyT, typename classT>
+class SparseVectorMap<keyT,classT*> {
+private:
+    friend class SST::Core::Serialization::serialize<SparseVectorMap<keyT,classT*> >;
+
+    /**
+       Finds the insertion point for new data
+
+       @param id ID of the data that needs to be inserted.
+
+       @return Index where new data should be inserted.  If key is
+       already in the map, it will return -1.
+     */
+    std::vector<classT*> data;
+    int binary_search_insert(keyT id) const
+    {
+        // For insert, we've found the right place when id < n && id >
+        // n-1.  We then insert at n.
+
+        int size = data.size();
+
+        // Check to see if it goes top or bottom
+        if ( size == 0 ) return 0;
+        if ( id > data[size-1]->key() ) return size;
+        if ( id < data[0]->key() ) return 0;
+
+        int bottom = 0;
+        int top = size - 1;
+        int middle;
+
+        while ( bottom <= top ) {
+            middle = bottom + (top - bottom) / 2;
+            if ( id == data[middle]->key() ) return -1;  // Already in map
+            if ( id < data[middle]->key() ) {
+                // May be the right place, need to see if id is greater
+                // than the one before the current middle.  If so, then we
+                // have the right place.
+                if ( id > data[middle-1]->key() ) return middle;
+                else {
+                    top = middle - 1;
+                }
+            }
+            else {
+                bottom = middle + 1;
+            }
+        }
+        /* Shouldn't be reached */
+        return -1;
+    }
+
+    /**
+       Finds the index where the data associated with the given key is
+       found in the vector
+
+       @param id ID of the data that needs to be found.
+
+       @return Index where data for the provided ID is found.  It
+       returns -1 if the key is not found in the data vector.
+     */
+    int binary_search_find(keyT id) const
+    {
+        int bottom = 0;
+        int top = data.size() - 1;
+        int middle;
+
+        if ( data.size() == 0 ) return -1;
+        while (bottom <= top) {
+            middle = bottom + ( top - bottom ) / 2;
+            if ( id == data[middle]->key() ) return middle;
+            else if ( id < data[middle]->key() ) top = middle - 1;
+            else bottom = middle + 1;
+        }
+        return -1;
+    }
+
+    friend class ConfigGraph;
+
+public:
+
+    /**
+       Default constructor for SparseVectorMap
+     */
+    SparseVectorMap() {}
+
+    /**
+       Constructor that allows you to pass an already filled in array
+       with data.  The data in the passed in vector will be swapped
+       into the data vector of the sparsevectormap and the passed in
+       vector will be empty.
+
+       @param new_data Vector of data to swap into the sparsevectormap
+       data
+
+       @param sorted Specifies whether the vector is already sorted in
+       ascending order. if not, it will be sorted after swapping the
+       data in.
+    */
+    SparseVectorMap(std::vector<classT*>& new_data, bool sorted = false)
+    {
+        data.swap(new_data);
+        if (!sorted) {
+            std::sort(data.begin(),data.end,
+                [] (const classT* lhs, const classT* rhs) -> bool
+                    {
+                        return lhs->key() < rhs->key();
+                    });
+        }
+    }
+
+    typedef typename std::vector<classT*>::iterator iterator;
+    typedef typename std::vector<classT*>::const_iterator const_iterator;
+
+    /**
+       Insert new value into SparseVectorMap.  The inserted class must
+       have a key() function with return type keyT.
+
+       @param val value to add to SparseVectorMap
+
+       @return reference to the inserted item, or to the existing item
+       if it was already present in the map.
+
+    */
+   classT* insert(classT* val)
+    {
+        int index = binary_search_insert(val->key());
+        if ( index == -1 ) return data[binary_search_find(val->key())];  // already in the map
+        iterator it = data.begin();
+        it += index;
+        data.insert(it, val);
+        return data[index];
+    }
+
+    /**
+       Returns the begin iterator to the underlying vector.
+
+       @return begin iterator to data vector
+     */
+    iterator begin() { return data.begin(); }
+
+    /**
+       Returns the end iterator to the underlying vector.
+
+       @return end iterator to data vector
+     */
+    iterator end() { return data.end(); }
+
+    /**
+       Returns the const begin iterator to the underlying vector.
+
+       @return const begin iterator to data vector
+     */
+    const_iterator begin() const { return data.begin(); }
+
+    /**
+       Returns the const end iterator to the underlying vector.
+
+       @return const end iterator to data vector
+     */
+    const_iterator end() const { return data.end(); }
+
+    /**
+       Checks if the provided id is found in the SparseVectorMap
+
+       @param id id to check for
+
+       @return true if id is found, false otherwise
+     */
+    bool contains(keyT id) const
+    {
+        if ( binary_search_find(id) == -1 ) return false;
+        return true;
+    }
+
+    /**
+       Operator returns a reference to data with the specified id.
+       Value can be modified.  This will only return references to
+       existing values, you must use insert() for new values.
+
+       @param id id of the value to return (value returned by key())
+
+       @return reference to the requested item.
+
+    */
+    classT* operator[] (keyT id)
+    {
+        int index = binary_search_find(id);
+        if ( index == -1 ) {
+            // Need to error out
+        }
+        return data[index];
+    }
+
+    /**
+       Operator returns a const reference to data with the specified
+       id.  Value cannot be modified.  This will only return
+       references to existing values, you must use insert() for new
+       values.
+
+       @param id id of the value to return (value returned by key())
+
+       @return const reference to the requested item.
+
+    */
+    const classT* operator[] (keyT id) const
     {
         int index = binary_search_find(id);
         if ( index == -1 ) {
@@ -404,26 +629,6 @@ public:
 
     typedef typename std::vector<keyT>::iterator iterator;
     typedef typename std::vector<keyT>::const_iterator const_iterator;
-
-    // Essentially insert with a hint to look at end first.  This is
-    // just here for backward compatibility for now.  Will be replaced
-    // with insert() once things stabilize.
-    keyT& push_back(const keyT& val) __attribute__ ((deprecated("SparseVectorMap::push_back is deprecated and will be removed in SST 12. Please simply use SparseVectorMap::insert.")))
-    {
-        // First look to see if it goes on the end.  If not, then find
-        // where it goes.
-        if ( data.size() == 0 ) {
-            data.push_back(val);
-            return data.back();
-        }
-        if ( val.key() > data[data.size()-1].key() ) {
-            data.push_back(val);
-            return data.back();
-        }
-
-        // Didn't belong at end, call regular insert
-        return insert(val);
-    }
 
     /**
        Insert new value into SparseVectorMap.  The inserted class must

--- a/src/sst/core/testElements/coreTest_ParamComponent.cc
+++ b/src/sst/core/testElements/coreTest_ParamComponent.cc
@@ -55,11 +55,15 @@ coreTestParamComponent::coreTestParamComponent(ComponentId_t id, Params& params)
 
 	const std::string f64v_str = params.find<std::string>("double-param");
 	const double f64v = params.find<double>("double-param");
-	printf("double       value = \"%s\" = %f = %e\n", f64v_str.c_str(), f64v, f64v);
+	printf("double       value = \"%s\" = %lf = %e\n", f64v_str.c_str(), f64v, f64v);
 
 	const std::string strv = params.find<std::string>("string-param");
 	printf("string       value = \"%s\"\n", strv.c_str());
 
+
+    // Test scoped params
+    Params p = params.get_scoped_params("scope");
+    p.print_all_params(Simulation::getSimulationOutput());
 }
 
 coreTestParamComponent::coreTestParamComponent() :

--- a/src/sst/core/testElements/coreTest_ParamComponent.h
+++ b/src/sst/core/testElements/coreTest_ParamComponent.h
@@ -36,9 +36,18 @@ public:
     )
 
     SST_ELI_DOCUMENT_PARAMS(
- 	{ "int-param",  "Check for integer values", "-1" },
-	{ "str-param",  "Check for string values",  "test" },
-	{ "bool-param", "Check for bool values", "true" }
+ 	{ "int32t-param",  "Check for integer values", "-1" },
+ 	{ "uint32t-param",  "Check for integer values", "0" },
+ 	{ "int64t-param",  "Check for integer values", "-1" },
+ 	{ "uint64t-param",  "Check for integer values", "0" },
+ 	{ "bool-true-param",  "Check for bool values", "true" },
+ 	{ "bool-false-param",  "Check for bool values", "false" },
+ 	{ "float-param",  "Check for float values", "1.0" },
+ 	{ "double-param",  "Check for double values", "1.0" },
+	{ "string-param",  "Check for string values",  "test" },
+	{ "scope.int32", "Check scoped params", "-1" },
+	{ "scope.bool", "Check scoped params", "true" },
+	{ "scope.string", "Check scoped params", "test" }
     )
 
     // Optional since there is nothing to document

--- a/tests/test_ParamComponent.py
+++ b/tests/test_ParamComponent.py
@@ -5,8 +5,17 @@ import sst
 sst.setProgramOption("timebase", "1 ps")
 sst.setProgramOption("stopAtCycle", "25us")
 
+global_params = {
+    "bool-true-param" : "yes",
+    "bool-false-param" : "no",
+    "scope.string" : "scope test"
+    }
+
+sst.addGlobalParam("test_set","string-param","teststring123")
+sst.addGlobalParams("test_set",global_params)
+
 # Define the simulation components
-param_c0 = sst.Component("c0.0", "coreTestElement.simpleParamComponent")
+param_c0 = sst.Component("c0.0", "coreTestElement.coreTestParamComponent")
 param_c0.addParams({
 	"int32t-param" : 2147483647,
 	"uint32t-param" : "4294967295",
@@ -15,12 +24,12 @@ param_c0.addParams({
 	"bool-true-param" : True,
 	"bool-false-param" : False,
 	"float-param" : 1.0101,
-	"double-param" : 1.3333e-10,
-	"string-param" : "teststring123"
+	"double-param" : 1.3333e-10
 })
+param_c0.addGlobalParamSet("test_set")
 
 # Define the simulation components
-param_c1 = sst.Component("c1.0", "coreTestElement.simpleParamComponent")
+param_c1 = sst.Component("c1.0", "coreTestElement.coreTestParamComponent")
 param_c1.addParams({
 	"int32t-param" : -2147483648,
 	"uint32t-param" : 0,
@@ -29,12 +38,12 @@ param_c1.addParams({
 	"bool-true-param" : "true",
 	"bool-false-param" : "false",
 	"float-param" : 1.00000000e-15,
-	"double-param" : 1.3333e-52,
-	"string-param" : "teststring123"
+	"double-param" : 1.3333e-52
 })
+param_c1.addGlobalParamSet("test_set")
 
 # Define the simulation components
-param_c2 = sst.Component("c2.0", "coreTestElement.simpleParamComponent")
+param_c2 = sst.Component("c2.0", "coreTestElement.coreTestParamComponent")
 param_c2.addParams({
 	"int32t-param" : "2147483647",
 	"uint32t-param" : "4294967295",
@@ -43,6 +52,22 @@ param_c2.addParams({
 	"bool-true-param" : 1,
 	"bool-false-param" : 0,
 	"float-param" : "-1.0000e-15",
-	"double-param" : "-1.33e-18",
-	"string-param" : "teststring123"
+	"double-param" : "-1.33e7",
+	"string-param" : "teststring456"
 })
+param_c2.addGlobalParamSet("test_set")
+
+# Define the simulation components
+param_c3 = sst.Component("c3.0", "coreTestElement.coreTestParamComponent")
+param_c3.addParams({
+	"int32t-param" : "2147483647",
+	"uint32t-param" : "4294967295",
+	"int64t-param" : "-9223372036854775808",
+	"uint64t-param" : "18446744073709551615",
+	"float-param" : "-1.0000e-15",
+	"double-param" : "-1.33e7",
+	"string-param" : "teststring456",
+        "scope.int32" : "100",
+        "scope.bool" : "no"
+})
+param_c3.addGlobalParamSet("test_set")


### PR DESCRIPTION
- Fixed a big in objectComms where the serialization size was stored in a 32-bit int.
- Changed ConfigGraph so it stored pointers to ConfigComponents instead of the actual objects.
  - Made it so that SparseVectorMap could store pointers
- Added global parameters.  You can now specify a named global set of parameters.  When adding to Param objects, only a pointer to the set will be kept.
