### PR TITLE
Migrates SST Random Distributions to new names without the SST Prefix

### DIFF
--- a/src/sst/core/rng/constant.h
+++ b/src/sst/core/rng/constant.h
@@ -13,7 +13,6 @@
 #define _H_SST_CORE_RNG_EMPTY
 
 #include "math.h"
-
 #include "distrib.h"
 
 using namespace SST::RNG;
@@ -22,56 +21,48 @@ namespace SST {
 namespace RNG {
 
 /**
-    \class SSTConstantDistribution constant.h "sst/core/rng/constant.h"
+    \class ConstantDistribution constant.h "sst/core/rng/constant.h"
 
     Implements a distribution which always returns a constant value (provided by the user). This
     can be used in situations where the user may not want to apply a distribution.
 */
-class SSTConstantDistribution : public SSTRandomDistribution {
+class ConstantDistribution : public RandomDistribution {
 
-    public:
-        /**
-            Creates a constant distribution which returns a constant value.
-            \param v Is the constant value the user wants returned by the distribution
-        */
-    SSTConstantDistribution(double v) :
-    SSTRandomDistribution() {
-        mean = v;
-    }
+public:
+    /**
+        Creates a constant distribution which returns a constant value.
+        \param v Is the constant value the user wants returned by the distribution
+    */
+    ConstantDistribution(double v) : RandomDistribution() { mean = v; }
 
-        /**
-            Destroys the constant distribution
-        */
-    ~SSTConstantDistribution() {
+    /**
+        Destroys the constant distribution
+    */
+    ~ConstantDistribution() {}
 
-    }
+    /**
+        Gets the next double for the distribution, in this case it will return the constant
+        value specified by the user
+        \return Constant value specified by the user when creating the class
+    */
+    double getNextDouble() { return mean; }
 
-        /**
-            Gets the next double for the distribution, in this case it will return the constant
-            value specified by the user
-            \return Constant value specified by the user when creating the class
-        */
-    double getNextDouble() {
-        return mean;
-    }
+    /**
+        Gets the constant value for the distribution
+        \return Constant value specified by the user when creating the class
+    */
+    double getMean() { return mean; }
 
-        /**
-            Gets the constant value for the distribution
-            \return Constant value specified by the user when creating the class
-        */
-    double getMean() {
-        return mean;
-    }
-
-    protected:
-        /**
-            Describes the constant value to return from the distribution.
-        */
-        double mean;
-
+protected:
+    /**
+        Describes the constant value to return from the distribution.
+    */
+    double mean;
 };
 
-}
-}
+using SSTConstantDistribution = SST::RNG::ConstantDistribution;
+
+} // namespace RNG
+} // namespace SST
 
 #endif

--- a/src/sst/core/rng/discrete.h
+++ b/src/sst/core/rng/discrete.h
@@ -14,8 +14,9 @@
 
 #include "math.h"
 
-#include <cstdlib>  // for malloc/free
+#include <cstdlib> // for malloc/free
 
+#include "rng.h"
 #include "distrib.h"
 #include "mersenne.h"
 
@@ -25,32 +26,31 @@ namespace SST {
 namespace RNG {
 
 /**
-    \class SSTDiscreteDistribution discrete.h "sst/core/rng/discrete.h"
+    \class DiscreteDistribution discrete.h "sst/core/rng/discrete.h"
 
     Creates a discrete distribution for use within SST. This distribution is the same across
     platforms and compilers.
 */
-class SSTDiscreteDistribution : public SSTRandomDistribution {
+class DiscreteDistribution : public SST::RNG::RandomDistribution {
 
-    public:
-        /**
-            Creates an exponential distribution with a specific lambda
-            \param lambda The lambda of the exponential distribution
-        */
-    SSTDiscreteDistribution(const double* probs, const uint32_t probsCount) :
-        SSTRandomDistribution(),
-        probCount(probsCount) {
+public:
+    /**
+        Creates an exponential distribution with a specific lambda
+        \param lambda The lambda of the exponential distribution
+    */
+    DiscreteDistribution(const double* probs, const uint32_t probsCount)
+        : SST::RNG::RandomDistribution(), probCount(probsCount) {
 
-        probabilities = (double*) malloc(sizeof(double) * probsCount);
-    double prob_sum = 0;
+        probabilities = (double*)malloc(sizeof(double) * probsCount);
+        double prob_sum = 0;
 
-    for(uint32_t i = 0; i < probsCount; i++) {
-        probabilities[i] = prob_sum;
-        prob_sum += probs[i];
-    }
+        for (uint32_t i = 0; i < probsCount; i++) {
+            probabilities[i] = prob_sum;
+            prob_sum += probs[i];
+        }
 
-            baseDistrib = new MersenneRNG();
-            deleteDistrib = true;
+        baseDistrib = new MersenneRNG();
+        deleteDistrib = true;
     }
 
     /**
@@ -58,74 +58,76 @@ class SSTDiscreteDistribution : public SSTRandomDistribution {
         \param lambda The lambda of the exponential distribution
         \param baseDist The base random number generator to take the distribution from.
     */
-    SSTDiscreteDistribution(const double* probs, const uint32_t probsCount, SST::RNG::Random* baseDist) :
-        probCount(probsCount) {
+    DiscreteDistribution(const double* probs, const uint32_t probsCount, SST::RNG::Random* baseDist)
+        : probCount(probsCount) {
 
-        probabilities = (double*) malloc(sizeof(double) * probsCount);
-    double prob_sum = 0;
+        probabilities = (double*)malloc(sizeof(double) * probsCount);
+        double prob_sum = 0;
 
-    for(uint32_t i = 0; i < probsCount; i++) {
-        probabilities[i] = prob_sum;
-        prob_sum += probs[i];
-    }
+        for (uint32_t i = 0; i < probsCount; i++) {
+            probabilities[i] = prob_sum;
+            prob_sum += probs[i];
+        }
 
         baseDistrib = baseDist;
-            deleteDistrib = false;
+        deleteDistrib = false;
     }
 
-        /**
-            Destroys the exponential distribution
-        */
-    ~SSTDiscreteDistribution() {
+    /**
+        Destroys the exponential distribution
+    */
+    ~DiscreteDistribution() {
         free(probabilities);
 
-        if(deleteDistrib) {
+        if (deleteDistrib) {
             delete baseDistrib;
         }
     }
 
-        /**
-            Gets the next (random) double value in the distribution
-            \return The next random double from the discrete distribution, this is the double converted of the index where the probability is located
-        */
+    /**
+        Gets the next (random) double value in the distribution
+        \return The next random double from the discrete distribution, this is the double converted of the index where
+       the probability is located
+    */
     double getNextDouble() {
         const double nextD = baseDistrib->nextUniform();
 
         uint32_t index = 0;
 
-        for(; index < probCount; index++) {
-            if(probabilities[index] >= nextD) {
+        for (; index < probCount; index++) {
+            if (probabilities[index] >= nextD) {
                 break;
             }
         }
 
-        return (double) index;
+        return (double)index;
     }
 
-    protected:
-        /**
-            Sets the base random number generator for the distribution.
-        */
-        SST::RNG::Random* baseDistrib;
+protected:
+    /**
+        Sets the base random number generator for the distribution.
+    */
+    SST::RNG::Random* baseDistrib;
 
-        /**
-            Controls whether the base distribution should be deleted when this class is destructed.
-        */
-        bool deleteDistrib;
+    /**
+        Controls whether the base distribution should be deleted when this class is destructed.
+    */
+    bool deleteDistrib;
 
-        /**
-            The discrete probability list
-        */
-        double* probabilities;
+    /**
+        The discrete probability list
+    */
+    double* probabilities;
 
-        /**
-            Count of discrete probabilities
-        */
-        uint32_t probCount;
-
+    /**
+        Count of discrete probabilities
+    */
+    uint32_t probCount;
 };
 
-}
-}
+using SSTDiscreteDistribution = SST::RNG::DiscreteDistribution;
+
+} // namespace RNG
+} // namespace SST
 
 #endif

--- a/src/sst/core/rng/distrib.h
+++ b/src/sst/core/rng/distrib.h
@@ -9,40 +9,39 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-
 #ifndef _H_SST_CORE_RNG_DISTRIB
 #define _H_SST_CORE_RNG_DISTRIB
-
 
 namespace SST {
 namespace RNG {
 
 /**
- * \class SSTRandomDistribution
+ * \class RandomDistribution
  * Base class of statistical distributions in SST.
  */
-class SSTRandomDistribution {
+class RandomDistribution {
 
-    public:
-        /**
-            Obtains the next double from the distribution
-            \return The next double in the distribution being sampled
-        */
-        virtual double getNextDouble() = 0;
+public:
+    /**
+        Obtains the next double from the distribution
+        \return The next double in the distribution being sampled
+    */
+    virtual double getNextDouble() = 0;
 
-        /**
-            Destroys the distribution
-        */
-        virtual ~SSTRandomDistribution() {};
+    /**
+        Destroys the distribution
+    */
+    virtual ~RandomDistribution() {};
 
-        /**
-            Creates the base (abstract) class of a distribution
-        */
-        SSTRandomDistribution() {};
-
+    /**
+        Creates the base (abstract) class of a distribution
+    */
+    RandomDistribution() {};
 };
 
-}
-}
+using SSTRandomDistribution = SST::RNG::RandomDistribution;
+
+} // namespace RNG
+} // namespace SST
 
 #endif

--- a/src/sst/core/rng/expon.h
+++ b/src/sst/core/rng/expon.h
@@ -14,6 +14,7 @@
 
 #include "math.h"
 
+#include "rng.h"
 #include "distrib.h"
 #include "mersenne.h"
 
@@ -23,84 +24,80 @@ namespace SST {
 namespace RNG {
 
 /**
-    \class SSTExponentialDistribution expon.h "sst/core/rng/expon.h"
+    \class ExponentialDistribution expon.h "sst/core/rng/expon.h"
 
     Creates an exponential distribution for use within SST. This distribution is the same across
     platforms and compilers.
 */
-class SSTExponentialDistribution : public SSTRandomDistribution {
+class ExponentialDistribution : public RandomDistribution {
 
-    public:
-        /**
-            Creates an exponential distribution with a specific lambda
-            \param mn The lambda of the exponential distribution
-        */
-    SSTExponentialDistribution(const double mn)  :
-    SSTRandomDistribution() {
+public:
+    /**
+        Creates an exponential distribution with a specific lambda
+        \param mn The lambda of the exponential distribution
+    */
+    ExponentialDistribution(const double mn) : RandomDistribution() {
 
         lambda = mn;
         baseDistrib = new MersenneRNG();
         deleteDistrib = true;
     }
 
-        /**
-            Creates an exponential distribution with a specific lambda and a base random number generator
-            \param mn The lambda of the exponential distribution
-            \param baseDist The base random number generator to take the distribution from.
-        */
-    SSTExponentialDistribution(const double mn, SST::RNG::Random* baseDist)  :
-    SSTRandomDistribution() {
+    /**
+        Creates an exponential distribution with a specific lambda and a base random number generator
+        \param mn The lambda of the exponential distribution
+        \param baseDist The base random number generator to take the distribution from.
+    */
+    ExponentialDistribution(const double mn, SST::RNG::Random* baseDist) : RandomDistribution() {
 
         lambda = mn;
         baseDistrib = baseDist;
         deleteDistrib = false;
     }
 
-        /**
-            Destroys the exponential distribution
-        */
-    ~SSTExponentialDistribution() {
-        if(deleteDistrib) {
+    /**
+        Destroys the exponential distribution
+    */
+    ~ExponentialDistribution() {
+        if (deleteDistrib) {
             delete baseDistrib;
         }
     }
 
-        /**
-            Gets the next (random) double value in the distribution
-            \return The next random double from the distribution
-        */
-    double getNextDouble()  {
+    /**
+        Gets the next (random) double value in the distribution
+        \return The next random double from the distribution
+    */
+    double getNextDouble() {
         const double next = baseDistrib->nextUniform();
-        return log(1 - next) / ( -1 * lambda );
+        return log(1 - next) / (-1 * lambda);
     }
 
-        /**
-            Gets the lambda with which the distribution was created
-            \return The lambda which the user created the distribution with
-        */
-    double getLambda()  {
-        return lambda;
-    }
+    /**
+        Gets the lambda with which the distribution was created
+        \return The lambda which the user created the distribution with
+    */
+    double getLambda() { return lambda; }
 
+protected:
+    /**
+        Sets the lambda of the exponential distribution.
+    */
+    double lambda;
+    /**
+        Sets the base random number generator for the distribution.
+    */
+    SST::RNG::Random* baseDistrib;
 
-    protected:
-        /**
-            Sets the lambda of the exponential distribution.
-        */
-        double lambda;
-        /**
-            Sets the base random number generator for the distribution.
-        */
-        SST::RNG::Random* baseDistrib;
-
-        /**
-            Controls whether the base distribution should be deleted when this class is destructed.
-        */
-        bool deleteDistrib;
-
+    /**
+        Controls whether the base distribution should be deleted when this class is destructed.
+    */
+    bool deleteDistrib;
 };
 
-}
-}
+using SSTExponentialDistribution = SST::RNG::ExponentialDistribution;
+
+} // namespace RNG
+} // namespace SST
 
 #endif

--- a/src/sst/core/rng/gaussian.h
+++ b/src/sst/core/rng/gaussian.h
@@ -14,6 +14,7 @@
 
 #include "math.h"
 
+#include "rng.h"
 #include "distrib.h"
 #include "mersenne.h"
 
@@ -23,20 +24,19 @@ namespace SST {
 namespace RNG {
 
 /**
-    \class SSTGaussianDistribution gaussian.h "sst/core/rng/gaussian.h"
+    \class GaussianDistribution gaussian.h "sst/core/rng/gaussian.h"
 
     Creates a Gaussian (normal) distribution for which to sample
 */
-class SSTGaussianDistribution : public SSTRandomDistribution {
+class GaussianDistribution : public RandomDistribution {
 
-    public:
-        /**
-            Creates a new distribution with a predefined random number generator with a specified mean and standard deviation.
-            \param mn The mean of the Gaussian distribution
-            \param sd The standard deviation of the Gaussian distribution
-        */
-    SSTGaussianDistribution(double mn, double sd)  :
-    SSTRandomDistribution() {
+public:
+    /**
+        Creates a new distribution with a predefined random number generator with a specified mean and standard
+       deviation. \param mn The mean of the Gaussian distribution \param sd The standard deviation of the Gaussian
+       distribution
+    */
+    GaussianDistribution(double mn, double sd) : RandomDistribution() {
 
         mean = mn;
         stddev = sd;
@@ -47,14 +47,12 @@ class SSTGaussianDistribution : public SSTRandomDistribution {
         deleteDistrib = true;
     }
 
-        /**
-            Creates a new distribution with a predefined random number generator with a specified mean and standard deviation.
-            \param mn The mean of the Gaussian distribution
-            \param sd The standard deviation of the Gaussian distribution
-            \param baseRNG The random number generator as the base of the distribution
-        */
-    SSTGaussianDistribution(double mn, double sd, SST::RNG::Random* baseRNG)  :
-    SSTRandomDistribution() {
+    /**
+        Creates a new distribution with a predefined random number generator with a specified mean and standard
+       deviation. \param mn The mean of the Gaussian distribution \param sd The standard deviation of the Gaussian
+       distribution \param baseRNG The random number generator as the base of the distribution
+    */
+    GaussianDistribution(double mn, double sd, SST::RNG::Random* baseRNG) : RandomDistribution() {
 
         mean = mn;
         stddev = sd;
@@ -65,21 +63,21 @@ class SSTGaussianDistribution : public SSTRandomDistribution {
         deleteDistrib = false;
     }
 
-        /**
-            Destroys the Gaussian distribution.
-        */
-    ~SSTGaussianDistribution()  {
-        if(deleteDistrib) {
+    /**
+        Destroys the Gaussian distribution.
+    */
+    ~GaussianDistribution() {
+        if (deleteDistrib) {
             delete baseDistrib;
         }
     }
 
-        /**
-            Gets the next double value in the distribution
-            \return The next double value of the distribution (in this case a Gaussian distribution)
-        */
-    double getNextDouble()  {
-        if(usePair) {
+    /**
+        Gets the next double value in the distribution
+        \return The next double value of the distribution (in this case a Gaussian distribution)
+    */
+    double getNextDouble() {
+        if (usePair) {
             usePair = false;
             return unusedPair;
         } else {
@@ -89,13 +87,13 @@ class SSTGaussianDistribution : public SSTRandomDistribution {
                 gauss_u = baseDistrib->nextUniform();
                 gauss_v = baseDistrib->nextUniform();
                 sq_sum = (gauss_u * gauss_u) + (gauss_v * gauss_v);
-            } while(sq_sum >= 1 || sq_sum == 0);
+            } while (sq_sum >= 1 || sq_sum == 0);
 
-            if(baseDistrib->nextUniform() < 0.5) {
+            if (baseDistrib->nextUniform() < 0.5) {
                 gauss_u *= -1.0;
             }
 
-            if(baseDistrib->nextUniform() < 0.5) {
+            if (baseDistrib->nextUniform() < 0.5) {
                 gauss_v *= -1.0;
             }
 
@@ -107,51 +105,50 @@ class SSTGaussianDistribution : public SSTRandomDistribution {
         }
     }
 
-        /**
-            Gets the mean of the distribution
-            \return The mean of the Guassian distribution
-        */
-    double getMean()  {
-        return mean;
-    }
+    /**
+        Gets the mean of the distribution
+        \return The mean of the Guassian distribution
+    */
+    double getMean() { return mean; }
 
-        /**
-            Gets the standard deviation of the distribution
-            \return The standard deviation of the Gaussian distribution
-        */
-    double getStandardDev()  {
-        return stddev;
-    }
+    /**
+        Gets the standard deviation of the distribution
+        \return The standard deviation of the Gaussian distribution
+    */
+    double getStandardDev() { return stddev; }
 
-    protected:
-        /**
-            The mean of the Gaussian distribution
-        */
-        double mean;
-        /**
-            The standard deviation of the Gaussian distribution
-        */
-        double stddev;
-        /**
-            The base random number generator for the distribution
-        */
-        SST::RNG::Random* baseDistrib;
-        /**
-            Random numbers for the distribution are read in pairs, this stores the second of the pair
-        */
-        double unusedPair;
-        /**
-            Random numbers for the distribution are read in pairs, this tells the code to use the second of the pair
-        */
-        bool usePair;
+protected:
+    /**
+        The mean of the Gaussian distribution
+    */
+    double mean;
+    /**
+        The standard deviation of the Gaussian distribution
+    */
+    double stddev;
+    /**
+        The base random number generator for the distribution
+    */
+    SST::RNG::Random* baseDistrib;
+    /**
+        Random numbers for the distribution are read in pairs, this stores the second of the pair
+    */
+    double unusedPair;
+    /**
+        Random numbers for the distribution are read in pairs, this tells the code to use the second of the pair
+    */
+    bool usePair;
 
-        /**
-            Controls whether the destructor deletes the distribution (we need to ensure we do this IF we created the distribution)
-        */
-        bool deleteDistrib;
+    /**
+        Controls whether the destructor deletes the distribution (we need to ensure we do this IF we created the
+       distribution)
+    */
+    bool deleteDistrib;
 };
 
-}
-}
+using SSTGaussianDistribution = SST::RNG::GaussianDistribution;
+
+} // namespace RNG
+} // namespace SST
 
 #endif

--- a/src/sst/core/rng/marsaglia.cc
+++ b/src/sst/core/rng/marsaglia.cc
@@ -11,6 +11,7 @@
 
 #include "sst_config.h"
 
+#include "rng.h"
 #include "marsaglia.h"
 
 #include <cstdlib>
@@ -22,7 +23,8 @@ using namespace SST::RNG;
 /*
     Seed the Marsaglia method with two initializers that must be non-zero.
 */
-MarsagliaRNG::MarsagliaRNG(unsigned int initial_z, unsigned int initial_w) {
+MarsagliaRNG::MarsagliaRNG(unsigned int initial_z, unsigned int initial_w) :
+	SST::RNG::Random() {
     m_z = initial_z;
     m_w = initial_w;
 }
@@ -31,7 +33,8 @@ MarsagliaRNG::MarsagliaRNG(unsigned int initial_z, unsigned int initial_w) {
     Generate a new random number generator with a random selection for the
     seed.
 */
-MarsagliaRNG::MarsagliaRNG() {
+MarsagliaRNG::MarsagliaRNG() :
+	SST::RNG::Random() {
     struct timeval now;
         gettimeofday(&now, nullptr);
 

--- a/src/sst/core/rng/marsaglia.h
+++ b/src/sst/core/rng/marsaglia.h
@@ -21,8 +21,8 @@
 
 #define MARSAGLIA_UINT32_MAX 4294967295U
 #define MARSAGLIA_UINT64_MAX 18446744073709551615ULL
-#define MARSAGLIA_INT32_MAX  2147483647L
-#define MARSAGLIA_INT64_MAX  9223372036854775807LL
+#define MARSAGLIA_INT32_MAX 2147483647L
+#define MARSAGLIA_INT64_MAX 9223372036854775807LL
 
 namespace SST {
 namespace RNG {
@@ -39,33 +39,32 @@ namespace RNG {
 */
 class MarsagliaRNG : public SST::RNG::Random {
 
-    public:
+public:
     /**
         Creates a new Marsaglia RNG using the initial seeds.
         @param[in] initial_z One of the random seed pairs
         @param[in] initial_w One of the random seed pairs.
     */
-        MarsagliaRNG(unsigned int initial_z,
-                unsigned int initial_w);
+    MarsagliaRNG(unsigned int initial_z, unsigned int initial_w);
 
     /**
         Creates a new Marsaglia RNG using random initial seeds (which are
         read from the system clock). Note that these will create variation
         between runs and between platforms.
     */
-        MarsagliaRNG();
+    MarsagliaRNG();
 
     /**
         Restart the random number generator with new seeds
         @param[in] new_z A new Z-seed
         @param[in] new_w A new W-seed
     */
-    void    restart(unsigned int new_z, unsigned int new_w);
+    void restart(unsigned int new_z, unsigned int new_w);
 
     /**
         Generates the next random number as a double in the range 0 to 1.
     */
-    double   nextUniform() override;
+    double nextUniform() override;
 
     /**
         Generates the next random number as an unsigned 32-bit integer.
@@ -80,37 +79,36 @@ class MarsagliaRNG : public SST::RNG::Random {
     /**
         Generates the next number as a signed 64-bit integer.
     */
-    int64_t  generateNextInt64() override;
+    int64_t generateNextInt64() override;
 
     /**
         Generates the next number as a signed 32-bit integer.
     */
-    int32_t   generateNextInt32() override;
+    int32_t generateNextInt32() override;
 
     /**
         Seed the XOR RNG
     */
     void seed(uint64_t newSeed);
 
-    private:
+private:
     /**
         Generates the next random number
     */
-        unsigned int generateNext();
+    unsigned int generateNext();
 
     /**
         The Z seed of the Marsaglia generator
     */
-        unsigned int m_z;
+    unsigned int m_z;
 
     /**
         The W seed of the Marsaglia generator
     */
-        unsigned int m_w;
-
+    unsigned int m_w;
 };
 
-} //namespace RNG
-} //namespace SST
+} // namespace RNG
+} // namespace SST
 
-#endif //SST_CORE_RNG_MARSAGLIA_H
+#endif // SST_CORE_RNG_MARSAGLIA_H

--- a/src/sst/core/rng/mersenne.cc
+++ b/src/sst/core/rng/mersenne.cc
@@ -11,6 +11,7 @@
 
 #include "sst_config.h"
 
+#include "rng.h"
 #include "mersenne.h"
 
 #include <cstdlib>
@@ -22,7 +23,8 @@ using namespace SST::RNG;
     Generate a new random number generator with a random selection for the
     seed.
 */
-MersenneRNG::MersenneRNG() {
+MersenneRNG::MersenneRNG() :
+	SST::RNG::Random() {
     numbers = (uint32_t*) malloc(sizeof(uint32_t) * 624);
 
     struct timeval now;
@@ -40,7 +42,8 @@ MersenneRNG::MersenneRNG() {
 /*
     Seed the Mersenne and then make a group of numbers
 */
-MersenneRNG::MersenneRNG(unsigned int startSeed) {
+MersenneRNG::MersenneRNG(unsigned int startSeed) :
+	SST::RNG::Random() {
     seed(startSeed);
 }
 

--- a/src/sst/core/rng/mersenne.h
+++ b/src/sst/core/rng/mersenne.h
@@ -20,8 +20,8 @@
 
 #define MERSENNE_UINT32_MAX 4294967295U
 #define MERSENNE_UINT64_MAX 18446744073709551615ULL
-#define MERSENNE_INT32_MAX  2147483647L
-#define MERSENNE_INT64_MAX  9223372036854775807LL
+#define MERSENNE_INT32_MAX 2147483647L
+#define MERSENNE_INT64_MAX 9223372036854775807LL
 
 namespace SST {
 namespace RNG {
@@ -51,7 +51,7 @@ public:
     /**
        Generates the next random number as a double value between 0 and 1.
     */
-    double   nextUniform() override;
+    double nextUniform() override;
 
     /**
        Generates the next random number as an unsigned 32-bit integer
@@ -66,12 +66,12 @@ public:
     /**
        Generates the next random number as a signed 64-bit integer
     */
-    int64_t  generateNextInt64() override;
+    int64_t generateNextInt64() override;
 
     /**
        Generates the next random number as a signed 32-bit integer
     */
-    int32_t  generateNextInt32() override;
+    int32_t generateNextInt32() override;
 
     /**
        Seed the XOR RNG
@@ -83,11 +83,11 @@ public:
     */
     ~MersenneRNG();
 
-    private:
+private:
     /**
        Generates the next batch of random numbers
     */
-    void  generateNextBatch();
+    void generateNextBatch();
 
     /**
        Stores the next set of random numbers
@@ -98,10 +98,9 @@ public:
        Tells us what index of the random number list the next returnable number should come from
     */
     int index;
-
 };
 
-} //namespace RNG
-} //namespace SST
+} // namespace RNG
+} // namespace SST
 
-#endif //SST_CORE_RNG_MERSENNE_H
+#endif // SST_CORE_RNG_MERSENNE_H

--- a/src/sst/core/rng/poisson.cc
+++ b/src/sst/core/rng/poisson.cc
@@ -12,31 +12,32 @@
 
 #include "sst_config.h"
 
+#include "distrib.h"
 #include "poisson.h"
 
 using namespace SST::RNG;
 
-SSTPoissonDistribution::SSTPoissonDistribution(const double mn) :
-    SSTRandomDistribution(), lambda(mn) {
+PoissonDistribution::PoissonDistribution(const double mn) :
+    RandomDistribution(), lambda(mn) {
 
     baseDistrib = new MersenneRNG();
     deleteDistrib = true;
 }
 
-SSTPoissonDistribution::SSTPoissonDistribution(const double mn, SSTRandom* baseDist) :
-    SSTRandomDistribution(), lambda(mn) {
+PoissonDistribution::PoissonDistribution(const double mn, SST::RNG::Random* baseDist) :
+    RandomDistribution(), lambda(mn) {
 
     baseDistrib = baseDist;
     deleteDistrib = false;
 }
 
-SSTPoissonDistribution::~SSTPoissonDistribution() {
+PoissonDistribution::~PoissonDistribution() {
     if(deleteDistrib) {
         delete baseDistrib;
     }
 }
 
-double SSTPoissonDistribution::getNextDouble() {
+double PoissonDistribution::getNextDouble() {
     const double L = exp(-lambda);
           double p = 1.0;
           int k = 0;
@@ -49,6 +50,6 @@ double SSTPoissonDistribution::getNextDouble() {
     return k - 1;
 }
 
-double SSTPoissonDistribution::getLambda() {
+double PoissonDistribution::getLambda() {
     return lambda;
 }

--- a/src/sst/core/rng/poisson.h
+++ b/src/sst/core/rng/poisson.h
@@ -14,6 +14,7 @@
 
 #include "math.h"
 
+#include "rng.h"
 #include "distrib.h"
 #include "mersenne.h"
 
@@ -23,51 +24,49 @@ namespace SST {
 namespace RNG {
 
 /**
-    \class SSTPoissonDistribution poisson.h "sst/core/rng/poisson.h"
+    \class PoissonDistribution poisson.h "sst/core/rng/poisson.h"
 
     Creates an Poisson distribution for use within SST. This distribution is the same across
     platforms and compilers.
 */
-class SSTPoissonDistribution : public SSTRandomDistribution {
+class PoissonDistribution : public RandomDistribution {
 
-    public:
-        /**
-            Creates an Poisson distribution with a specific lambda
-            \param mn The lambda of the Poisson distribution
-        */
-    SSTPoissonDistribution(const double mn)  :
-    SSTRandomDistribution(), lambda(mn) {
+public:
+    /**
+        Creates an Poisson distribution with a specific lambda
+        \param mn The lambda of the Poisson distribution
+    */
+    PoissonDistribution(const double mn) : RandomDistribution(), lambda(mn) {
 
         baseDistrib = new MersenneRNG();
         deleteDistrib = true;
     }
 
-        /**
-            Creates an Poisson distribution with a specific lambda and a base random number generator
-            \param lambda The lambda of the Poisson distribution
-            \param baseDist The base random number generator to take the distribution from.
-        */
-    SSTPoissonDistribution(const double mn, SST::RNG::Random* baseDist)  :
-    SSTRandomDistribution(), lambda(mn) {
+    /**
+        Creates an Poisson distribution with a specific lambda and a base random number generator
+        \param lambda The lambda of the Poisson distribution
+        \param baseDist The base random number generator to take the distribution from.
+    */
+    PoissonDistribution(const double mn, SST::RNG::Random* baseDist) : RandomDistribution(), lambda(mn) {
 
         baseDistrib = baseDist;
         deleteDistrib = false;
     }
 
-        /**
-            Destroys the Poisson distribution
-        */
-    ~SSTPoissonDistribution()  {
-        if(deleteDistrib) {
+    /**
+        Destroys the Poisson distribution
+    */
+    ~PoissonDistribution() {
+        if (deleteDistrib) {
             delete baseDistrib;
         }
     }
 
-        /**
-            Gets the next (random) double value in the distribution
-            \return The next random double from the distribution
-        */
-     double getNextDouble() {
+    /**
+        Gets the next (random) double value in the distribution
+        \return The next random double from the distribution
+    */
+    double getNextDouble() {
         const double L = exp(-lambda);
         double p = 1.0;
         int k = 0;
@@ -75,37 +74,36 @@ class SSTPoissonDistribution : public SSTRandomDistribution {
         do {
             k++;
             p *= baseDistrib->nextUniform();
-        } while(p > L);
+        } while (p > L);
 
         return k - 1;
     }
 
-        /**
-            Gets the lambda with which the distribution was created
-            \return The lambda which the user created the distribution with
-        */
-    double getLambda()  {
-        return lambda;
-    }
+    /**
+        Gets the lambda with which the distribution was created
+        \return The lambda which the user created the distribution with
+    */
+    double getLambda() { return lambda; }
 
-    protected:
-        /**
-            Sets the lambda of the Poisson distribution.
-        */
-        const double lambda;
-        /**
-            Sets the base random number generator for the distribution.
-        */
-        SST::RNG::Random* baseDistrib;
+protected:
+    /**
+        Sets the lambda of the Poisson distribution.
+    */
+    const double lambda;
+    /**
+        Sets the base random number generator for the distribution.
+    */
+    SST::RNG::Random* baseDistrib;
 
-        /**
-            Controls whether the base distribution should be deleted when this class is destructed.
-        */
-        bool deleteDistrib;
-
+    /**
+        Controls whether the base distribution should be deleted when this class is destructed.
+    */
+    bool deleteDistrib;
 };
 
-}
-}
+using SSTPoissonDistribution = SST::RNG::PoissonDistribution;
+
+} // namespace RNG
+} // namespace SST
 
 #endif

--- a/src/sst/core/rng/uniform.h
+++ b/src/sst/core/rng/uniform.h
@@ -14,6 +14,7 @@
 
 #include "math.h"
 
+#include "rng.h"
 #include "distrib.h"
 #include "mersenne.h"
 
@@ -23,92 +24,93 @@ namespace SST {
 namespace RNG {
 
 /**
-    \class SSTUniformDistribution uniform.h "sst/core/rng/uniform.h"
+    \class UniformDistribution uniform.h "sst/core/rng/uniform.h"
 
     Creates a Uniform distribution for use within SST. This distribution is the same across
     platforms and compilers.
 */
-class SSTUniformDistribution : public SSTRandomDistribution {
+class UniformDistribution : public RandomDistribution {
 
-    public:
-        /**
-            Creates an uniform distribution with a specific number of bins
-            \param probsCount Number of probability bins in this distribution
-        */
-        SSTUniformDistribution(const uint32_t probsCount) :
-        	SSTRandomDistribution(), probCount(probsCount), deleteDistrib(true) {
+public:
+    /**
+        Creates an uniform distribution with a specific number of bins
+        \param probsCount Number of probability bins in this distribution
+    */
+    UniformDistribution(const uint32_t probsCount) : RandomDistribution(), probCount(probsCount), deleteDistrib(true) {
 
-		if( probCount > 0 ) {
-			probPerBin = 1.0 / static_cast<double>( probCount );
-		}
+        if (probCount > 0) {
+            probPerBin = 1.0 / static_cast<double>(probCount);
+        }
 
-        	baseDistrib = new MersenneRNG();
-    	}
+        baseDistrib = new MersenneRNG();
+    }
 
-    	/**
-	        Creates a Uniform distribution with a specific number of bins and user supplied
-	    	random number generator
-	        \param probsCount Number of probability bins in the distribution
-        	\param baseDist The base random number generator to take the distribution from.
-    	*/
-    	SSTUniformDistribution(const uint32_t probsCount, SST::RNG::Random* baseDist) :
-   		SSTRandomDistribution(), probCount(probsCount), deleteDistrib(false) {
+    /**
+            Creates a Uniform distribution with a specific number of bins and user supplied
+            random number generator
+            \param probsCount Number of probability bins in the distribution
+            \param baseDist The base random number generator to take the distribution from.
+    */
+    UniformDistribution(const uint32_t probsCount, SST::RNG::Random* baseDist)
+        : RandomDistribution(), probCount(probsCount), deleteDistrib(false) {
 
-		if( probCount > 0 ) {
-			probPerBin = 1.0 / static_cast<double>( probCount );
-		}
+        if (probCount > 0) {
+            probPerBin = 1.0 / static_cast<double>(probCount);
+        }
 
-        	baseDistrib = baseDist;
-    	}
+        baseDistrib = baseDist;
+    }
 
-        /**
-            Destroys the distribution and will delete locally allocated RNGs
-        */
-    	~SSTUniformDistribution() {
-        	if(deleteDistrib) {
-	            delete baseDistrib;
-        	}
-    	}
+    /**
+        Destroys the distribution and will delete locally allocated RNGs
+    */
+    ~UniformDistribution() {
+        if (deleteDistrib) {
+            delete baseDistrib;
+        }
+    }
 
-    	/**
-	    Gets the next (random) double value in the distribution
-	    \return The next random double from the distribution, this is the double converted of the index where the probability is located
-    	*/
-    	double getNextDouble() {
-        	const double nextD = baseDistrib->nextUniform();
-		uint32_t current_bin = 1;
+    /**
+        Gets the next (random) double value in the distribution
+        \return The next random double from the distribution, this is the double converted of the index where the
+       probability is located
+    */
+    double getNextDouble() {
+        const double nextD = baseDistrib->nextUniform();
+        uint32_t current_bin = 1;
 
-		while( nextD > ( static_cast<double>( current_bin ) * probPerBin ) ) {
-			current_bin++;
-		}
+        while (nextD > (static_cast<double>(current_bin) * probPerBin)) {
+            current_bin++;
+        }
 
-		return static_cast<double>( current_bin - 1 );
-    	}
+        return static_cast<double>(current_bin - 1);
+    }
 
-    protected:
-        /**
-            Sets the base random number generator for the distribution.
-        */
-        SST::RNG::Random* baseDistrib;
+protected:
+    /**
+        Sets the base random number generator for the distribution.
+    */
+    SST::RNG::Random* baseDistrib;
 
-        /**
-            Controls whether the base distribution should be deleted when this class is destructed.
-        */
-        const bool deleteDistrib;
+    /**
+        Controls whether the base distribution should be deleted when this class is destructed.
+    */
+    const bool deleteDistrib;
 
-        /**
-            Count of discrete probabilities
-        */
-        const uint32_t probCount;
+    /**
+        Count of discrete probabilities
+    */
+    const uint32_t probCount;
 
-	/**
-	    Range 0..1 split into discrete bins
-	*/
-	double probPerBin;
-
+    /**
+        Range 0..1 split into discrete bins
+    */
+    double probPerBin;
 };
 
-}
-}
+using SSTUniformDistribution = SST::RNG::UniformDistribution;
+
+} // namespace RNG
+} // namespace SST
 
 #endif

--- a/src/sst/core/rng/xorshift.cc
+++ b/src/sst/core/rng/xorshift.cc
@@ -11,6 +11,7 @@
 
 #include "sst_config.h"
 
+#include "rng.h"
 #include "xorshift.h"
 #include <cstdlib>
 #include <cassert>
@@ -21,7 +22,8 @@ using namespace SST::RNG;
     Generate a new random number generator with a random selection for the
     seed.
 */
-XORShiftRNG::XORShiftRNG() {
+XORShiftRNG::XORShiftRNG() :
+	SST::RNG::Random() {
     struct timeval now;
     gettimeofday(&now, nullptr);
 
@@ -34,7 +36,9 @@ XORShiftRNG::XORShiftRNG() {
 /*
     Seed the Mersenne and then make a group of numbers
 */
-XORShiftRNG::XORShiftRNG(unsigned int startSeed) {
+XORShiftRNG::XORShiftRNG(unsigned int startSeed) :
+	SST::RNG::Random() {
+
     assert(startSeed != 0);
 
     seed(startSeed);

--- a/src/sst/core/rng/xorshift.h
+++ b/src/sst/core/rng/xorshift.h
@@ -20,8 +20,8 @@
 
 #define XORSHIFT_UINT32_MAX 4294967295U
 #define XORSHIFT_UINT64_MAX 18446744073709551615ULL
-#define XORSHIFT_INT32_MAX  2147483647L
-#define XORSHIFT_INT64_MAX  9223372036854775807LL
+#define XORSHIFT_INT32_MAX 2147483647L
+#define XORSHIFT_INT64_MAX 9223372036854775807LL
 
 namespace SST {
 namespace RNG {
@@ -35,24 +35,24 @@ namespace RNG {
 */
 class XORShiftRNG : public SST::RNG::Random {
 
-    public:
+public:
     /**
         Create a new Mersenne RNG with a specified seed
         @param[in] seed The seed for this RNG
     */
-        XORShiftRNG(unsigned int seed);
+    XORShiftRNG(unsigned int seed);
 
     /**
         Creates a new Mersenne using a random seed which is obtained from the system
         clock. Note this will give different results on different platforms and between
         runs.
     */
-        XORShiftRNG();
+    XORShiftRNG();
 
     /**
         Generates the next random number as a double value between 0 and 1.
     */
-    double   nextUniform() override;
+    double nextUniform() override;
 
     /**
         Generates the next random number as an unsigned 32-bit integer
@@ -67,12 +67,12 @@ class XORShiftRNG : public SST::RNG::Random {
     /**
         Generates the next random number as a signed 64-bit integer
     */
-    int64_t  generateNextInt64() override;
+    int64_t generateNextInt64() override;
 
     /**
         Generates the next random number as a signed 32-bit integer
     */
-    int32_t  generateNextInt32() override;
+    int32_t generateNextInt32() override;
 
     /**
         Seed the XOR RNG
@@ -89,10 +89,9 @@ protected:
     uint32_t y;
     uint32_t z;
     uint32_t w;
-
 };
 
-} //namespace RNG
-} //namespace SST
+} // namespace RNG
+} // namespace SST
 
-#endif //SST_CORE_RNG_XORSHIFT_H
+#endif // SST_CORE_RNG_XORSHIFT_H


### PR DESCRIPTION
Renames distributions in the SST RNG core, removing SST prefixes from names. This has backwards compatibility until deprecation decisions are made. Addresses concerns identified in Issue #625.