### PR TITLE
Check that RNG never produce a value that equals 1.0

### DIFF
--- a/src/sst/core/rng/marsaglia.cc
+++ b/src/sst/core/rng/marsaglia.cc
@@ -10,6 +10,7 @@
 // distribution.
 
 #include "sst_config.h"
+#include "sst/core/sst_types.h"
 
 #include "rng.h"
 #include "marsaglia.h"
@@ -62,13 +63,18 @@ unsigned int MarsagliaRNG::generateNext() {
 
 /*
     Transform an unsigned integer into a uniform double from which other
-    distributed can be generated
+    distributions can be generated. Guarantees to produce random numbers
+    in the range of [0, 1).
 */
 double MarsagliaRNG::nextUniform() {
-    unsigned int next_uint = generateNext();
-        return (next_uint + 1) * 2.328306435454494e-10;
-}
+    double next_dbl = 1.0;
 
+    do {
+        next_dbl = static_cast<double>(generateNext() + 1) * 2.328306435454494e-10;
+    } while( UNLIKELY(next_dbl >= 1.0) );
+
+    return next_dbl;
+}
 
 uint64_t MarsagliaRNG::generateNextUInt64() {
     int64_t nextInt64 = generateNextInt64();

--- a/src/sst/core/rng/mersenne.cc
+++ b/src/sst/core/rng/mersenne.cc
@@ -10,6 +10,7 @@
 // distribution.
 
 #include "sst_config.h"
+#include "sst/core/sst_types.h"
 
 #include "rng.h"
 #include "mersenne.h"
@@ -63,24 +64,31 @@ void MersenneRNG::generateNextBatch() {
 
 /*
     Transform an unsigned integer into a uniform double from which other
-    distributed can be generated
+    distribution can be generated. Guarantees to select values in the
+    range [0,1).
 */
 double MersenneRNG::nextUniform() {
-    uint32_t temp = generateNextUInt32();
-    return ( (double) temp ) / (double) MERSENNE_UINT32_MAX;
+    double temp_dbl = 1.0;
+
+    do {
+        temp_dbl = static_cast<double>(generateNextUInt32()) / static_cast<double>(MERSENNE_UINT32_MAX);
+    } while( UNLIKELY(temp_dbl >= 1.0) );
+
+    return temp_dbl;
 }
 
 uint32_t MersenneRNG::generateNextUInt32() {
-    if(index == 0)
-                generateNextBatch();
+    if(index == 0) {
+        generateNextBatch();
+    }
 
-        uint32_t temp = numbers[index];
-        temp = temp ^ (temp >> 11);
-        temp = temp ^ ((temp << 7) & 2636928640UL);
-        temp = temp ^ ((temp << 15) & 4022730752UL);
-        temp = temp ^ (temp >> 18);
+    uint32_t temp = numbers[index];
+    temp = temp ^ (temp >> 11);
+    temp = temp ^ ((temp << 7) & 2636928640UL);
+    temp = temp ^ ((temp << 15) & 4022730752UL);
+    temp = temp ^ (temp >> 18);
 
-        index = (index + 1) % 624;
+    index = (index + 1) % 624;
     return (uint32_t) temp;
 }
 

--- a/src/sst/core/rng/rng.h
+++ b/src/sst/core/rng/rng.h
@@ -28,7 +28,7 @@ class Random {
 
 public:
     /**
-        Generates the next random number in the range 0 to 1.
+        Generates the next random number in the range [0,1).
     */
     virtual double nextUniform() = 0;
 

--- a/src/sst/core/rng/xorshift.cc
+++ b/src/sst/core/rng/xorshift.cc
@@ -10,6 +10,7 @@
 // distribution.
 
 #include "sst_config.h"
+#include "sst/core/sst_types.h"
 
 #include "rng.h"
 #include "xorshift.h"
@@ -40,17 +41,22 @@ XORShiftRNG::XORShiftRNG(unsigned int startSeed) :
 	SST::RNG::Random() {
 
     assert(startSeed != 0);
-
     seed(startSeed);
 }
 
 /*
     Transform an unsigned integer into a uniform double from which other
-    distributed can be generated
+    distribution can be generated. Guarantees to select values in the
+    range of [0, 1).
 */
 double XORShiftRNG::nextUniform() {
-    uint32_t temp = generateNextUInt32();
-    return ( (double) temp ) / (double) XORSHIFT_UINT32_MAX;
+    double temp_dbl = 1.0;
+
+    do {
+        temp_dbl = static_cast<double>(generateNextUInt32()) / static_cast<double>(XORSHIFT_UINT32_MAX);
+    } while( UNLIKELY(temp_dbl >= 1.0) );
+
+    return temp_dbl;
 }
 
 uint32_t XORShiftRNG::generateNextUInt32() {


### PR DESCRIPTION
This enforces that RNGs never produce a value that equals 1.0 during generation of a double. The range of values is [0,1) otherwise the code will loop and generate an alternative. This is requested in Issue #629 and is an extremely unlikely event.