### PR TITLE
Changed the max number of empty lines to 2 in .clang-format.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -107,7 +107,7 @@ JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
+MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2


### PR DESCRIPTION
Changing max number of empty lines to 2.  Also, this is the first PR to test the new clang-format test as part of the autotester.