### PR TITLE
Utilize Python Detection to Populate SST Core/Element Test Loaders

### DIFF
--- a/src/sst/core/testingframework/Makefile.inc
+++ b/src/sst/core/testingframework/Makefile.inc
@@ -40,6 +40,8 @@ endif
 EXTRA_DIST += \
 	testingframework/__init__.py \
 	testingframework/readme.md \
+	testingframework/sst-test-core.in \
+   testingframework/sst-test-elements.in \
 	testingframework/sst_test_engine_loader.py \
 	testingframework/sst_unittest.py \
 	testingframework/sst_unittest_support.py \

--- a/src/sst/core/testingframework/Makefile.inc
+++ b/src/sst/core/testingframework/Makefile.inc
@@ -41,7 +41,7 @@ EXTRA_DIST += \
 	testingframework/__init__.py \
 	testingframework/readme.md \
 	testingframework/sst-test-core.in \
-   testingframework/sst-test-elements.in \
+	testingframework/sst-test-elements.in \
 	testingframework/sst_test_engine_loader.py \
 	testingframework/sst_unittest.py \
 	testingframework/sst_unittest_support.py \

--- a/src/sst/core/testingframework/Makefile.inc
+++ b/src/sst/core/testingframework/Makefile.inc
@@ -6,8 +6,8 @@
 if !SST_TESTFRAMEWORK_DEV
 # Install test frameworks by copy of files
 bin_SCRIPTS = \
-	testingframework/sst-test-core \
-	testingframework/sst-test-elements \
+	sst-test-core \
+	sst-test-elements \
 	testingframework/sst_test_engine_loader.py
 
 libexec_SCRIPTS += \
@@ -23,8 +23,8 @@ libexec_SCRIPTS += \
 else
 # Install test frameworks using symbolic links to the source (we can do development)
 install-exec-hook:
-	ln -s $(abs_srcdir)/testingframework/sst-test-core             $(bindir)/sst-test-core
-	ln -s $(abs_srcdir)/testingframework/sst-test-elements         $(bindir)/sst-test-elements
+	ln -s $(abs_builddir)/src/sst/core/sst-test-core   				$(bindir)/sst-test-core
+	ln -s $(abs_builddir)/src/sst/core/sst-test-elements				$(bindir)/sst-test-elements
 	ln -s $(abs_srcdir)/testingframework/sst_test_engine_loader.py $(bindir)/sst_test_engine_loader.py
 
 	ln -s $(abs_srcdir)/testingframework/sst_unittest.py           $(libexecdir)/sst_unittest.py
@@ -40,9 +40,6 @@ endif
 EXTRA_DIST += \
 	testingframework/__init__.py \
 	testingframework/readme.md \
-	testingframework/sst-test-core \
-	testingframework/sst-test-core \
-	testingframework/sst-test-elements \
 	testingframework/sst_test_engine_loader.py \
 	testingframework/sst_unittest.py \
 	testingframework/sst_unittest_support.py \
@@ -64,3 +61,19 @@ EXTRA_DIST += \
 	testingframework/pdoc_template/config.mako \
 	testingframework/pdoc_template/_lunr_search.inc.mako \
 	testingframework/pdoc_template/SSTLogo.png
+
+sst-test-core:
+	echo "#!$(PYTHON_EXE)" > $@; \
+   cat $(abs_srcdir)/testingframework/sst-test-core.in >> $@
+
+sst-test-elements:
+	echo "#!$(PYTHON_EXE)" > $@; \
+   cat $(abs_srcdir)/testingframework/sst-test-elements.in >> $@
+
+BUILT_SOURCES = \
+	sst-test-core \
+	sst-test-elements
+
+CLEANFILES = \
+	sst-test-core \
+   sst-test-elements

--- a/src/sst/core/testingframework/sst-test-core.in
+++ b/src/sst/core/testingframework/sst-test-core.in
@@ -1,18 +1,17 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-## Copyright 2009-2020 NTESS. Under the terms
+## Copyright 2009-2021 NTESS. Under the terms
 ## of Contract DE-NA0003525 with NTESS, the U.S.
 ## Government retains certain rights in this software.
 ##
-## Copyright (c) 2009-2020, NTESS
+## Copyright (c) 2009-2021, NTESS
 ## All rights reserved.
 ##
 ## This file is part of the SST software package. For license
 ## information, see the LICENSE file in the top level directory of the
 ## distribution.
 
-""" This module is the entry point for testing the SST Registered Elements
+""" This module is the entry point for testing the SST-Core
 """
 
 import sys
@@ -30,5 +29,5 @@ except ImportError as exc_e:
 if __name__ == "__main__":
     # Get the path of where this file is launched
     SSTCOREBINDIR = os.path.dirname(os.path.abspath(__file__))
-    # Run the test engine in Elements Mode
-    te_load.startup_and_run(SSTCOREBINDIR, te_load.TEST_ELEMENTS)
+    # Run the test engine in Core Mode
+    te_load.startup_and_run(SSTCOREBINDIR, te_load.TEST_SST_CORE)

--- a/src/sst/core/testingframework/sst-test-elements.in
+++ b/src/sst/core/testingframework/sst-test-elements.in
@@ -1,18 +1,17 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-## Copyright 2009-2021 NTESS. Under the terms
+## Copyright 2009-2020 NTESS. Under the terms
 ## of Contract DE-NA0003525 with NTESS, the U.S.
 ## Government retains certain rights in this software.
 ##
-## Copyright (c) 2009-2021, NTESS
+## Copyright (c) 2009-2020, NTESS
 ## All rights reserved.
 ##
 ## This file is part of the SST software package. For license
 ## information, see the LICENSE file in the top level directory of the
 ## distribution.
 
-""" This module is the entry point for testing the SST-Core
+""" This module is the entry point for testing the SST Registered Elements
 """
 
 import sys
@@ -30,5 +29,5 @@ except ImportError as exc_e:
 if __name__ == "__main__":
     # Get the path of where this file is launched
     SSTCOREBINDIR = os.path.dirname(os.path.abspath(__file__))
-    # Run the test engine in Core Mode
-    te_load.startup_and_run(SSTCOREBINDIR, te_load.TEST_SST_CORE)
+    # Run the test engine in Elements Mode
+    te_load.startup_and_run(SSTCOREBINDIR, te_load.TEST_ELEMENTS)


### PR DESCRIPTION
Uses SST's Python detection scripts to populate `sst-test-core` and `sst-test-elements` scripts (which are installed in `bin`).