### PR TITLE
Utilize basic dlopen functionality to work around needing libtldl

### DIFF
--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -19,9 +19,9 @@
 #include "sst/core/sstpart.h"
 #include "sst/core/subcomponent.h"
 
+#include <climits>
 #include <cstdio>
 #include <cstring>
-#include <climits>
 #include <dirent.h>
 #include <vector>
 
@@ -76,12 +76,10 @@ splitPath(const std::string& searchPaths)
 ElemLoader::ElemLoader(const std::string& searchPaths) : searchPaths(searchPaths)
 {
     preload_symbols();
-	verbose = false;
+    verbose = false;
 
-	const char* verbose_env = getenv("SST_CORE_DL_VERBOSE");
-	if(nullptr != verbose_env) {
-		verbose = atoi(verbose_env) > 0;
-	}
+    const char* verbose_env = getenv("SST_CORE_DL_VERBOSE");
+    if ( nullptr != verbose_env ) { verbose = atoi(verbose_env) > 0; }
 }
 
 ElemLoader::~ElemLoader() {}
@@ -96,9 +94,7 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
     bool  found_element = false;
 
     for ( std::string& next_path : paths ) {
-		  if(verbose) {
-				printf("SST-DL: Searching: %s\n", next_path.c_str());
-		  }
+        if ( verbose ) { printf("SST-DL: Searching: %s\n", next_path.c_str()); }
 
         DIR* current_dir = opendir(next_path.c_str());
 
@@ -106,24 +102,18 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
             struct dirent* dir_file;
 
             while ( (dir_file = readdir(current_dir)) != nullptr ) {
-					  if(verbose) {
-							printf("SST-DL: Checking file types: %s\n", dir_file->d_name);
-		  			  }
+                if ( verbose ) { printf("SST-DL: Checking file types: %s\n", dir_file->d_name); }
 
                 if ( (dir_file->d_type | DT_REG) || (dir_file->d_type | DT_LNK) ) {
                     if ( !strncmp("lib", dir_file->d_name, 3) ) {
                         sprintf(full_path, "%s/%s", next_path.c_str(), dir_file->d_name);
-								if(verbose) {
-									printf("SST-DL: Attempting dynamic load of %s\n", full_path);
-								}
+                        if ( verbose ) { printf("SST-DL: Attempting dynamic load of %s\n", full_path); }
                         void* handle = dlopen(full_path, RTLD_NOW | RTLD_GLOBAL);
 
                         if ( nullptr != handle ) {
                             found_element = true;
 
-									 if(verbose) {
-										printf("SST-DL: Load of %s was successful.\n", full_path);
-									 }
+                            if ( verbose ) { printf("SST-DL: Load of %s was successful.\n", full_path); }
 
                             // loading a library can "wipe" previously loaded libraries depending
                             // on how weak symbol resolution works in dlopen
@@ -137,11 +127,10 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
                                     }
                                 }
                             }
-                        } else {
-									if(verbose) {
-										printf("SST-DL: Load of %s failed, %s\n", full_path, dlerror());
-									}
-								}
+                        }
+                        else {
+                            if ( verbose ) { printf("SST-DL: Load of %s failed, %s\n", full_path, dlerror()); }
+                        }
                     }
                 }
             }

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -84,9 +84,7 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
     for ( std::string const& next_path : paths ) {
         if ( verbose ) { printf("SST-DL: Searching: %s\n", next_path.c_str()); }
 
-        if ( next_path.back() == '/' ) {
-            sprintf(full_path, "%slib%s.so", next_path.c_str(), elemlib.c_str());
-        }
+        if ( next_path.back() == '/' ) { sprintf(full_path, "%slib%s.so", next_path.c_str(), elemlib.c_str()); }
         else {
             sprintf(full_path, "%s/lib%s.so", next_path.c_str(), elemlib.c_str());
         }
@@ -103,9 +101,7 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
         // this implies ordering of .so before .dylib in priority.
 
         if ( nullptr == handle ) {
-            if ( next_path.back() == '/' ) {
-                sprintf(full_path, "%slib%s.dylib", next_path.c_str(), elemlib.c_str());
-            }
+            if ( next_path.back() == '/' ) { sprintf(full_path, "%slib%s.dylib", next_path.c_str(), elemlib.c_str()); }
             else {
                 sprintf(full_path, "%s/lib%s.dylib", next_path.c_str(), elemlib.c_str());
             }

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -84,7 +84,7 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
     for ( std::string const& next_path : paths ) {
         if ( verbose ) { printf("SST-DL: Searching: %s\n", next_path.c_str()); }
 
-        if ( next_path.at(next_path.size() - 1) == '/' ) {
+        if ( next_path.back() == '/' ) {
             sprintf(full_path, "%slib%s.so", next_path.c_str(), elemlib.c_str());
         }
         else {
@@ -103,7 +103,7 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
         // this implies ordering of .so before .dylib in priority.
 
         if ( nullptr == handle ) {
-            if ( next_path.at(next_path.size() - 1) == '/' ) {
+            if ( next_path.back() == '/' ) {
                 sprintf(full_path, "%slib%s.dylib", next_path.c_str(), elemlib.c_str());
             }
             else {

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -76,7 +76,7 @@ ElemLoader::~ElemLoader() {}
 void
 ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
 {
-    std::vector<std::string> paths   = splitPath(searchPaths);
+    std::vector<std::string> paths = splitPath(searchPaths);
 
     char* full_path     = new char[PATH_MAX];
     bool  found_element = false;
@@ -97,24 +97,24 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
         void* handle = dlopen(full_path, bindPolicy);
 
 #ifdef SST_COMPILE_MACOSX
-	// macOS will also allow files to use the dylib extension so this
-	// must also be checked. But only check this is the .so attempt
-	// failed first (because we may have had a successful load already)
-	// this implies ordering of .so before .dylib in priority.
+        // macOS will also allow files to use the dylib extension so this
+        // must also be checked. But only check this is the .so attempt
+        // failed first (because we may have had a successful load already)
+        // this implies ordering of .so before .dylib in priority.
 
-	if( nullptr == handle ) {
-	        if ( next_path.at(next_path.size() - 1) == '/' ) {
-	            sprintf(full_path, "%slib%s.dylib", next_path.c_str(), elemlib.c_str());
-	        }
-	        else {
-	            sprintf(full_path, "%s/lib%s.dylib", next_path.c_str(), elemlib.c_str());
-	        }
+        if ( nullptr == handle ) {
+            if ( next_path.at(next_path.size() - 1) == '/' ) {
+                sprintf(full_path, "%slib%s.dylib", next_path.c_str(), elemlib.c_str());
+            }
+            else {
+                sprintf(full_path, "%s/lib%s.dylib", next_path.c_str(), elemlib.c_str());
+            }
 
-	        if ( verbose ) { printf("SST-DL: Attempting to load %s\n", full_path); }
+            if ( verbose ) { printf("SST-DL: Attempting to load %s\n", full_path); }
 
-	        // use a global bind policy read from environment, default to RTLD_LAZY
-        	handle = dlopen(full_path, bindPolicy);
-	}
+            // use a global bind policy read from environment, default to RTLD_LAZY
+            handle = dlopen(full_path, bindPolicy);
+        }
 #endif
 
         if ( nullptr == handle ) {
@@ -135,8 +135,8 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
                 }
             }
 
-				// exit the search loop, we have found the library we tried to load
-				break;
+            // exit the search loop, we have found the library we tried to load
+            break;
         }
     }
 

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -19,7 +19,10 @@
 #include "sst/core/sstpart.h"
 #include "sst/core/subcomponent.h"
 
-#include <ltdl.h>
+#include <cstdio>
+#include <cstring>
+#include <dirent.h>
+#include <limits.h>
 #include <vector>
 
 #ifdef HAVE_DLFCN_H
@@ -34,9 +37,6 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-
-#include <cstring>
-#include <stdio.h>
 
 /* This needs to happen before lt_dlinit() and sets up the preload
    libraries properly.  The macro declares an extern symbol, so if we
@@ -57,68 +57,6 @@ preload_symbols(void)
 
 namespace SST {
 
-/** This structure exists so that we don't need to have any
-   libtool-specific code (and therefore need the libtool headers) in
-   factory.h */
-struct LoaderData
-{
-    /** Handle from Libtool */
-    lt_dladvise advise_handle;
-};
-
-ElemLoader::ElemLoader(const std::string& searchPaths) : searchPaths(searchPaths)
-{
-    loaderData = new LoaderData;
-    int ret    = 0;
-
-    preload_symbols();
-
-    ret = lt_dlinit();
-    if ( ret != 0 ) {
-        fprintf(stderr, "lt_dlinit returned %d, %s\n", ret, lt_dlerror());
-        delete loaderData;
-        abort();
-    }
-
-    ret = lt_dladvise_init(&loaderData->advise_handle);
-    if ( ret != 0 ) {
-        fprintf(stderr, "lt_dladvise_init returned %d, %s\n", ret, lt_dlerror());
-        delete loaderData;
-        abort();
-    }
-
-    ret = lt_dladvise_ext(&loaderData->advise_handle);
-    if ( ret != 0 ) {
-        fprintf(stderr, "lt_dladvise_ext returned %d, %s\n", ret, lt_dlerror());
-        delete loaderData;
-        abort();
-    }
-
-    ret = lt_dladvise_global(&loaderData->advise_handle);
-    if ( ret != 0 ) {
-        fprintf(stderr, "lt_dladvise_global returned %d, %s\n", ret, lt_dlerror());
-        delete loaderData;
-        abort();
-    }
-
-    ret = lt_dlsetsearchpath(searchPaths.c_str());
-    if ( ret != 0 ) {
-        fprintf(stderr, "lt_dlsetsearchpath returned %d, %s\n", ret, lt_dlerror());
-        delete loaderData;
-        abort();
-    }
-}
-
-ElemLoader::~ElemLoader()
-{
-    if ( loaderData ) {
-        lt_dladvise_destroy(&loaderData->advise_handle);
-        lt_dlexit();
-
-        delete loaderData;
-    }
-}
-
 static std::vector<std::string>
 splitPath(const std::string& searchPaths)
 {
@@ -135,92 +73,102 @@ splitPath(const std::string& searchPaths)
     return paths;
 }
 
-static void
-followError(
-    const std::string& libname, const std::string& elemlib, const std::string& searchPaths, std::ostream& err_os)
+ElemLoader::ElemLoader(const std::string& searchPaths) : searchPaths(searchPaths)
 {
-    std::string so_path = libname + ".so";
-    std::string fullpath;
-    void*       handle;
-
-    std::vector<std::string> paths = splitPath(searchPaths);
-
-    for ( std::string path : paths ) {
-        struct stat sbuf;
-        int         ret;
-
-        fullpath = path + "/" + so_path;
-        ret      = stat(fullpath.c_str(), &sbuf);
-        if ( ret == 0 ) break;
-    }
-
-    // This is a little weird, but always try the last path - if we
-    // didn't succeed in the stat, we'll get a file not found error
-    // from dlopen, which is a useful error message for the user.
-    handle = dlopen(fullpath.c_str(), RTLD_NOW | RTLD_GLOBAL);
-    if ( nullptr == handle ) {
-        std::vector<char> err_str(1e6); // make darn sure we fit the str
-        sprintf(
-            err_str.data(),
-            "Opening and resolving references for element library %s failed:\n"
-            "\t%s\n",
-            elemlib.c_str(), dlerror());
-        err_os << (const char*)err_str.data();
-    }
+    preload_symbols();
 }
+
+ElemLoader::~ElemLoader() {}
 
 void
 ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
 {
-    std::string libname = "lib" + elemlib;
-    lt_dlhandle lt_handle;
-    lt_handle = lt_dlopenadvise(libname.c_str(), loaderData->advise_handle);
-    if ( nullptr == lt_handle ) {
-        // The preopen module runs last and if the
-        // component was found earlier, but has a missing symbol or
-        // the like, we just get an amorphous "file not found" error,
-        // which is totally useless...
-        // Make darn sure we have enough space to hold the error message
-        std::vector<char> err_str(1e6);
-        sprintf(err_str.data(), "Opening element library %s failed: %s\n", elemlib.c_str(), lt_dlerror());
-        err_os << (const char*)err_str.data();
-        followError(libname, elemlib, searchPaths, err_os);
-    }
+    std::string              libname = "lib" + elemlib;
+    std::vector<std::string> paths   = splitPath(searchPaths);
 
-    // loading a library can "wipe" previously loaded libraries depending
-    // on how weak symbol resolution works in dlopen
-    // rerun the loaders to make sure everything is still registered
-    for ( auto& libpair : ELI::LoadedLibraries::getLoaders() ) {
-        // loop all the elements in the element lib
-        for ( auto& elempair : libpair.second ) {
-            // loop all the loaders in the element
-            for ( auto* loader : elempair.second ) {
-                loader->load();
+    char* full_path     = new char[PATH_MAX];
+    bool  found_element = false;
+
+    for ( std::string& next_path : paths ) {
+        DIR* current_dir = opendir(next_path.c_str());
+
+        if ( current_dir ) {
+            struct dirent* dir_file;
+
+            while ( (dir_file = readdir(current_dir)) != nullptr ) {
+                if ( (dir_file->d_type | DT_REG) || (dir_file->d_type | DT_LNK) ) {
+                    if ( !strncmp("lib", dir_file->d_name, 3) ) {
+                        sprintf(full_path, "%s/%s", next_path.c_str(), dir_file->d_name);
+                        void* handle = dlopen(full_path, RTLD_NOLOAD | RTLD_GLOBAL);
+
+                        if ( nullptr == handle ) {
+                            handle = dlopen(full_path, RTLD_NOW | RTLD_GLOBAL);
+
+                            if ( nullptr != handle ) {
+                                found_element = true;
+
+                                // loading a library can "wipe" previously loaded libraries depending
+                                // on how weak symbol resolution works in dlopen
+                                // rerun the loaders to make sure everything is still registered
+                                for ( auto& libpair : ELI::LoadedLibraries::getLoaders() ) {
+                                    // loop all the elements in the element lib
+                                    for ( auto& elempair : libpair.second ) {
+                                        // loop all the loaders in the element
+                                        for ( auto* loader : elempair.second ) {
+                                            loader->load();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }
+
+    delete[] full_path;
+
+    if ( !found_element ) { err_os << "Error: unable to find \"" << elemlib << "\" element library\n"; }
+
     return;
 }
 
-extern "C" {
-static int
-elemCB(const char* fname, void* vd)
+void
+ElemLoader::getPotentialElements(std::vector<std::string>& potential_elements)
 {
-    std::vector<std::string>* arr  = (std::vector<std::string>*)vd;
-    const char*               base = strrchr(fname, '/') + 1; /* +1 to go past the / */
-    if ( !strncmp("lib", base, 3) ) {                         /* Filter out directories and the like */
-        arr->push_back(base + 3);                             /* skip past "lib" */
-    }
-    return 0;
-}
-}
+    std::vector<std::string> paths = splitPath(searchPaths);
 
-std::vector<std::string>
-ElemLoader::getPotentialElements()
-{
-    std::vector<std::string> res;
-    lt_dlforeachfile(searchPaths.c_str(), elemCB, &res);
-    return res;
+    for ( std::string& next_path : paths ) {
+        DIR* current_dir = opendir(next_path.c_str());
+
+        if ( current_dir ) {
+            struct dirent* dir_file;
+            while ( (dir_file = readdir(current_dir)) != nullptr ) {
+                // ensure we are only processing normal files and nothing weird
+                if ( (dir_file->d_type | DT_REG) || (dir_file->d_type | DT_LNK) ) {
+                    char* current_file = new char[strlen(dir_file->d_name) + 1];
+                    std::strcpy(current_file, dir_file->d_name);
+
+                    // does the path start with "lib" required for SST
+                    if ( !strncmp("lib", current_file, 3) ) {
+                        // find out if we have an extension
+                        char* find_ext = strrchr(current_file, '.');
+
+                        if ( nullptr != find_ext ) {
+                            // need to strip the extension from the file name
+                            find_ext[0] = '\0';
+                            potential_elements.push_back(current_file + 3);
+                        }
+                    }
+
+                    delete[] current_file;
+                }
+            }
+
+            closedir(current_dir);
+        }
+    }
 }
 
 } // namespace SST

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -98,18 +98,23 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
 
 #ifdef SST_COMPILE_MACOSX
 	// macOS will also allow files to use the dylib extension so this
-	// must also be checked
-        if ( next_path.at(next_path.size() - 1) == '/' ) {
-            sprintf(full_path, "%slib%s.dylib", next_path.c_str(), elemlib.c_str());
-        }
-        else {
-            sprintf(full_path, "%s/lib%s.dylib", next_path.c_str(), elemlib.c_str());
-        }
+	// must also be checked. But only check this is the .so attempt
+	// failed first (because we may have had a successful load already)
+	// this implies ordering of .so before .dylib in priority.
 
-        if ( verbose ) { printf("SST-DL: Attempting to load %s\n", full_path); }
+	if( nullptr == handle ) {
+	        if ( next_path.at(next_path.size() - 1) == '/' ) {
+	            sprintf(full_path, "%slib%s.dylib", next_path.c_str(), elemlib.c_str());
+	        }
+	        else {
+	            sprintf(full_path, "%s/lib%s.dylib", next_path.c_str(), elemlib.c_str());
+	        }
 
-        // use a global bind policy read from environment, default to RTLD_LAZY
-        handle = dlopen(full_path, bindPolicy);
+	        if ( verbose ) { printf("SST-DL: Attempting to load %s\n", full_path); }
+
+	        // use a global bind policy read from environment, default to RTLD_LAZY
+        	handle = dlopen(full_path, bindPolicy);
+	}
 #endif
 
         if ( nullptr == handle ) {

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -56,17 +56,17 @@ splitPath(const std::string& searchPaths)
     return paths;
 }
 
-ElemLoader::ElemLoader(const std::string& searchPaths) : searchPaths(searchPaths), verbose(false)
+ElemLoader::ElemLoader(const std::string& searchPaths) :
+    searchPaths(searchPaths),
+    verbose(false),
+    bindPolicy(RTLD_LAZY | RTLD_GLOBAL)
 {
+
     const char* verbose_env = getenv("SST_CORE_DL_VERBOSE");
     if ( nullptr != verbose_env ) { verbose = atoi(verbose_env) > 0; }
 
     const char* bind_env = getenv("SST_CORE_DL_BIND_POLICY");
-    if ( nullptr == bind_env ) { bindPolicy = RTLD_LAZY | RTLD_GLOBAL; }
-    else if ( (!strcmp(bind_env, "lazy")) || (!strcmp(bind_env, "LAZY")) ) {
-        bindPolicy = RTLD_LAZY | RTLD_GLOBAL;
-    }
-    else if ( (!strcmp(bind_env, "now")) || (!strcmp(bind_env, "NOW")) ) {
+    if ( (nullptr != bind_env) && ((!strcmp(bind_env, "now")) || (!strcmp(bind_env, "NOW"))) ) {
         bindPolicy = RTLD_NOW | RTLD_GLOBAL;
     }
 }
@@ -81,7 +81,7 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
     char* full_path     = new char[PATH_MAX];
     bool  found_element = false;
 
-    for ( std::string& next_path : paths ) {
+    for ( std::string const& next_path : paths ) {
         if ( verbose ) { printf("SST-DL: Searching: %s\n", next_path.c_str()); }
 
         if ( next_path.at(next_path.size() - 1) == '/' ) {
@@ -152,7 +152,7 @@ ElemLoader::getPotentialElements(std::vector<std::string>& potential_elements)
 {
     std::vector<std::string> paths = splitPath(searchPaths);
 
-    for ( std::string& next_path : paths ) {
+    for ( std::string const& next_path : paths ) {
         DIR* current_dir = opendir(next_path.c_str());
 
         if ( current_dir ) {

--- a/src/sst/core/elemLoader.h
+++ b/src/sst/core/elemLoader.h
@@ -12,21 +12,16 @@
 #ifndef SST_CORE_ELEMLOADER_H
 #define SST_CORE_ELEMLOADER_H
 
-#include <map>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace SST {
 
-// struct LoaderData;
 struct ElementInfoGenerator;
 
 /** Class to load Element Libraries */
 class ElemLoader
 {
-    //    LoaderData* loaderData;
-
 public:
     /** Create a new ElementLoader with a given searchpath of directories */
     ElemLoader(const std::string& searchPaths);

--- a/src/sst/core/elemLoader.h
+++ b/src/sst/core/elemLoader.h
@@ -44,7 +44,7 @@ public:
 
 private:
     std::string searchPaths;
-    bool verbose;
+    bool        verbose;
 };
 
 } // namespace SST

--- a/src/sst/core/elemLoader.h
+++ b/src/sst/core/elemLoader.h
@@ -45,6 +45,7 @@ public:
 private:
     std::string searchPaths;
     bool        verbose;
+    int         bindPolicy;
 };
 
 } // namespace SST

--- a/src/sst/core/elemLoader.h
+++ b/src/sst/core/elemLoader.h
@@ -14,18 +14,18 @@
 
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace SST {
 
-struct LoaderData;
+// struct LoaderData;
 struct ElementInfoGenerator;
 
 /** Class to load Element Libraries */
 class ElemLoader
 {
-    LoaderData* loaderData;
-    std::string searchPaths;
+    //    LoaderData* loaderData;
 
 public:
     /** Create a new ElementLoader with a given searchpath of directories */
@@ -40,9 +40,15 @@ public:
     void loadLibrary(const std::string& elemlib, std::ostream& err_os);
 
     /**
-     * Returns a list of potential element libraries in the search path
+     * Search paths for potential elements and add them to the provided vector
+     *
+     * @param potElems - vector of potential elements that could contain elements
+     * @return void
      */
-    std::vector<std::string> getPotentialElements();
+    void getPotentialElements(std::vector<std::string>& potElems);
+
+private:
+    std::string searchPaths;
 };
 
 } // namespace SST

--- a/src/sst/core/elemLoader.h
+++ b/src/sst/core/elemLoader.h
@@ -44,6 +44,7 @@ public:
 
 private:
     std::string searchPaths;
+    bool verbose;
 };
 
 } // namespace SST

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -152,10 +152,10 @@ addELI(ElemLoader& loader, const std::string& lib, bool optional)
 static void
 processSSTElementFiles()
 {
-    std::vector<bool> EntryProcessedArray;
-    ElemLoader        loader(g_searchPath);
-
-    std::vector<std::string> potentialLibs = loader.getPotentialElements();
+    std::vector<bool>        EntryProcessedArray;
+    ElemLoader               loader(g_searchPath);
+    std::vector<std::string> potentialLibs;
+    loader.getPotentialElements(potentialLibs);
 
     // Which libraries should we (attempt) to process
     std::set<std::string> processLibs(g_configuration.getElementsToProcessArray());


### PR DESCRIPTION
Eliminates use of `lt_` functions for dynamic loading. This overhauls some basic capability and works with SST loading capabilities (at the cost of some generality).