### PR TITLE
Remove libltdl directory creation

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -15,22 +15,8 @@ if [ -z $LIBTOOL ] || [ -z $LIBTOOLIZE ] ; then
     exit 1
 fi
 
-
-# Delete the old libtool output
-rm -rf libltdl src/sst/core/libltdl
-
 echo "Running ${LIBTOOLIZE}..."
-$LIBTOOLIZE --automake --copy --ltdl
-
-if test -d libltdl; then
-	echo "Moving libltdl to src .."
-	mv libltdl ./src/sst/core
-fi
-
-if test ! -d src/sst/core/libltdl ; then
-    echo "libltdl doesn't exist.  Aborting."
-    exit 1
-fi
+$LIBTOOLIZE --automake --copy
 
 aclocal -I config
 autoheader

--- a/configure.ac
+++ b/configure.ac
@@ -160,7 +160,6 @@ AC_CONFIG_FILES([
   src/sst/Makefile
   src/sst/SST-${PACKAGE_VERSION}.pc:src/sst/sst.pc.in
   src/sst/core/Makefile
-  src/sst/core/libltdl/Makefile
   src/sst/core/build_info.h:src/sst/core/build_info.h.in
 ])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -30,26 +30,7 @@ AC_CANONICAL_HOST
 
 AC_CACHE_SAVE
 
-LT_CONFIG_LTDL_DIR([src/sst/core/libltdl])
 LT_INIT([shared disable-static dlopen])
-LTDL_INIT([recursive])
-
-if test "x$with_included_ltdl" != "xyes"; then
-   save_CFLAGS="$CFLAGS"
-   save_LDFLAGS="$LDFLAGS"
-   save_LIBS="$LIBS"
-   CFLAGS="$CFLAGS $LTDLINCL"
-   LDFLAGS="$LDFLAGS $LIBLTDL"
-   AC_CHECK_LIB([ltdl], [lt_dladvise_init],
-                 [],
-                 [AC_MSG_ERROR([installed libltdl is too old])])
-   LIBS="$save_LIBS"
-   LDFLAGS="$save_LDFLAGS"
-   CFLAGS="$save_CFLAGS"
-fi
-
-AC_SUBST([LTDLINCL])
-AC_SUBST([LIBLTDL])
 
 dnl Work out the C++ standard which we are going to use
 AX_CXX_COMPILE_STDCXX_1Y

--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -13,8 +13,6 @@ AM_CPPFLAGS =  \
 	-I$(top_srcdir)/external \
 	$(LTDLINCL)
 
-DIST_SUBDIRS = libltdl .
-SUBDIRS = libltdl .
 EXTRA_DIST = mainpage.dox eli/README.md
 
 sstdir = $(includedir)/sst/core

--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -265,7 +265,6 @@ sstinfo_x_SOURCES = \
 	$(sst_xml_sources)
 
 sstsim_x_LDADD = \
-	$(LIBLTDL) \
 	$(PYTHON_LIBS) \
 	$(ZOLTAN_LIB) \
 	$(PARMETIS_LIB) \
@@ -282,7 +281,6 @@ sstsim_x_LDFLAGS = \
 	$(SST_LTLIBS_ELEMLIBS)
 
 sstinfo_x_LDADD = \
-	$(LIBLTDL) \
 	$(ZOLTAN_LIB) \
 	$(PARMETIS_LIB) \
 	$(MPILIBS) \


### PR DESCRIPTION
Removes `libltdl` generation and integration with SST core.