### PR TITLE
Remove libltdl Header from SST Info

### DIFF
--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -31,7 +31,6 @@
 #include <dlfcn.h>
 #include <getopt.h>
 #include <list>
-#include <ltdl.h>
 #include <sys/stat.h>
 
 using namespace std;


### PR DESCRIPTION
Removes libltdl header from SST Info.
