### PR TITLE
Cmake block in-source builds. 

### DIFF
--- a/experimental/CMakeLists.txt
+++ b/experimental/CMakeLists.txt
@@ -14,6 +14,9 @@ project(
   DESCRIPTION "SSTCore"
   LANGUAGES C CXX)
 
+set(SST_TOP_SRC_DIR "${sst-core_SOURCE_DIR}/..")
+include(cmake/PreventInSourceBuilds.cmake)
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
   message(

--- a/experimental/cmake/PreventInSourceBuilds.cmake
+++ b/experimental/cmake/PreventInSourceBuilds.cmake
@@ -1,0 +1,17 @@
+# From cpp-best-practices/cpp_starter_project
+# This code is in the public domain
+# This function will prevent in-source builds
+function(AssureOutOfSourceBuilds)
+  # make sure the user doesn't play dirty with symlinks
+  get_filename_component(srcdir "${SST_TOP_SRC_DIR}" REALPATH)
+  get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+
+  # disallow in-source builds
+  if("${srcdir}" STREQUAL "${bindir}")
+    message(FATAL_ERROR "In-source builds are not allowed.
+      This process created the file `CMakeCache.txt' and the directory `CMakeFiles'.
+      Please delete them.")
+  endif()
+endfunction()
+
+assureoutofsourcebuilds()

--- a/experimental/cmake/PreventInSourceBuilds.cmake
+++ b/experimental/cmake/PreventInSourceBuilds.cmake
@@ -12,6 +12,10 @@ function(AssureOutOfSourceBuilds)
       This process created the file `CMakeCache.txt' and the directory `CMakeFiles'.
       Please delete them.")
   endif()
+
+  if(EXISTS ${SST_TOP_SRC_DIR}/src/sst/core/sst_config.h OR EXISTS ${SST_TOP_SRC_DIR}/src/sst/core/build_info.h)
+    message(FATAL_ERROR "Cannot run the cmake build if the autotools build was run in-source.")
+  endif()
 endfunction()
 
 assureoutofsourcebuilds()

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -13,7 +13,7 @@
 message(STATUS "SST: PREPROCESSING ${CMAKE_CURRENT_SOURCE_DIR}/SSTConfig.cmake.in")
 configure_file(
 ${CMAKE_CURRENT_SOURCE_DIR}/SSTConfig.cmake.in
-${CMAKE_CURRENT_SOURCE_DIR}/SSTConfig.cmake
+${CMAKE_CURRENT_BINARY_DIR}/SSTConfig.cmake
 )
 
 install(DIRECTORY "."


### PR DESCRIPTION
This will prevent the user from doing one of two things
1. The user can't invoke `cmake experimental/` in the top level source dir
2. The user can't use cmake if they have already run an in-source autotools build, which is detected by the presence of sst_config.h or build_info.h in the source folder. 

In both cases the cmake configure will quickly error. 

This should address #710 and #711