### PR TITLE
Didn't install a header needed by macro

### DIFF
--- a/src/sst/core/CMakeLists.txt
+++ b/src/sst/core/CMakeLists.txt
@@ -131,6 +131,7 @@ set(SSTHeaders
     sharedRegionImpl.h
     simulation.h
     sparseVectorMap.h
+	  ssthandler.h
     sstinfo.h
     sstpart.h
     sst_types.h

--- a/src/sst/core/CMakeLists.txt
+++ b/src/sst/core/CMakeLists.txt
@@ -131,7 +131,7 @@ set(SSTHeaders
     sharedRegionImpl.h
     simulation.h
     sparseVectorMap.h
-	  ssthandler.h
+    ssthandler.h
     sstinfo.h
     sstpart.h
     sst_types.h


### PR DESCRIPTION
This missing header stopped macro from compiling with the CMake build of core. 