### PR TITLE
Add gitlab ci

### DIFF
--- a/experimental/.gitlab-ci.yml
+++ b/experimental/.gitlab-ci.yml
@@ -6,6 +6,6 @@ build:core:
   image: ${container_registry}/sst-centos8-base-env:0.1
   script:
     - cmake -B build experimental -DCMAKE_INSTALL_PREFIX=core-install -DMPI_ROOT=/usr/lib64/openmpi
-    - cmake --build core-build -j $(nproc)
-    - cmake --install core-build
+    - cmake --build build -j $(nproc)
+    - cmake --install build
     - core-install/bin/sst-test-core

--- a/experimental/.gitlab-ci.yml
+++ b/experimental/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+default:
+  tags:
+    - xlarge
+
+build:core:
+  image: ${container_registry}/sst-centos8-base-env:0.1
+  script:
+    - cmake -B build experimental -DCMAKE_INSTALL_PREFIX=core-install -DMPI_ROOT=/usr/lib64/openmpi
+    - cmake --build core-build -j $(nproc)
+    - cmake --install core-build
+    - core-install/bin/sst-test-core


### PR DESCRIPTION
Initial file for adding Gitlab CI.  This will build core in a centos 8 container with zlib and openmpi 4.0.5.  Feedback is welcome for more tests to add. 