### PR TITLE
Change Handling of Optimization and Profiling Flags in Configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,8 +142,8 @@ AC_DEFINE_UNQUOTED([SST_INSTALL_PREFIX], ["$prefix"], [Defines the location SST 
 AC_CACHE_SAVE
 
 dnl Remove flags like -g, -O, and -W, that are not needed by other elements
-SST_EXPORT_CXXFLAGS=`echo "$CXXFLAGS" | sed -E -e 's/ *-(g|O.|W@<:@^@<:@:space:@:>@@:>@+)//g'`
-SST_EXPORT_CFLAGS=`echo "$CFLAGS" | sed -E -e 's/ *-(g|O.|W@<:@^@<:@:space:@:>@@:>@+)//g'`
+SST_EXPORT_CXXFLAGS=`echo "$CXXFLAGS" | sed -E -e 's/ *-(g|O@<:@^@<:@:space:@:>@@:>?|W@<:@^@<:@:space:@:>@@:>@+)//g'`
+SST_EXPORT_CFLAGS=`echo "$CFLAGS" | sed -E -e 's/ *-(g|O@<:@^@<:@:space:@:>@@:>@?|W@<:@^@<:@:space:@:>@@:>@+)//g'`
 AC_SUBST(SST_EXPORT_CXXFLAGS)
 AC_SUBST(SST_EXPORT_CFLAGS)
 


### PR DESCRIPTION
Addresses issue in #679 where flags and compacted together without spaces, leading to errors.
