### PR TITLE
Fix for Issue #732; revising spelling of components

### DIFF
--- a/src/sst/core/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.cc
@@ -113,7 +113,7 @@ JSONConfigGraphOutput::generate(const Config* UNUSED(cfg), ConfigGraph* graph)
 
     json::json outputJson;
     for ( auto compItr : compMap ) {
-        outputJson["compenents"].emplace_back(CompLinkPair { compItr, linkMap });
+        outputJson["components"].emplace_back(CompLinkPair { compItr, linkMap });
     }
 
     for ( auto linkItr : linkMap ) {


### PR DESCRIPTION
This fixes a small spelling mistake noted in Issue #732.  This was found during initial testing for the forthcoming JSON graph reader.  I know its a nit, but we're using the current JSON output as the initial JSON format for the forthcoming reader implementation.  