### PR TITLE
Fixes to the cmake build

### DIFF
--- a/experimental/cmake_configure_files/sst_config.h.in
+++ b/experimental/cmake_configure_files/sst_config.h.in
@@ -203,7 +203,7 @@
 #cmakedefine SST_COMPILE_MACOSX 1
 
 /* Define if you have the MPI library. */
-#cmakedefine SST_CONFIG_HAVE_MPI
+#cmakedefine SST_CONFIG_HAVE_MPI 1
 
 /* Set to 1 if Python was found */
 #cmakedefine SST_CONFIG_HAVE_PYTHON 1

--- a/src/sst/core/CMakeLists.txt
+++ b/src/sst/core/CMakeLists.txt
@@ -191,6 +191,7 @@ target_link_libraries(
           timeVortex
           modelCore
           modelpython
+          modeljson
           sync
           shared)
 set_target_properties(sstsim.x PROPERTIES ENABLE_EXPORTS ON)
@@ -204,6 +205,7 @@ target_link_libraries(
           timeVortex
           modelCore
           modelpython
+          modeljson
           sync
           shared
           tinyxml)

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -132,7 +132,7 @@ static const struct sstLongOpts_s sstOptions[] = {
     DEF_FLAGOPT("no-env-config", 0, "disable SST environment configuration", &Config::disableEnvConfig),
     DEF_FLAGOPT("print-timing-info", 0, "print SST timing information", &Config::enablePrintTiming),
     DEF_FLAGOPT("print-env", 0, "print SST environment vairable", &Config::enablePrintEnv),
-#if SST_CONFIG_HAVE_MPI
+#ifdef SST_CONFIG_HAVE_MPI
     DEF_FLAGOPT("parallel-load", 0, "Enable parallel loading of configuration", &Config::enableParallelLoad),
     DEF_FLAGOPT(
         "parallel-output", 0,

--- a/src/sst/core/testElements/CMakeLists.txt
+++ b/src/sst/core/testElements/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(
   coreTest_Module.cc
   coreTest_ParamComponent.cc)
 
+add_subdirectory(message_mesh)
+
 # NEED To double check this
 target_include_directories(coreTestElement PRIVATE ${SST_TOP_SRC_DIR}/src)
 target_link_libraries(coreTestElement PRIVATE sst-config-headers)
@@ -31,6 +33,7 @@ if(APPLE)
   target_link_options(coreTestElement PRIVATE
                       "LINKER:-undefined,dynamic_lookup")
 endif()
+
 
 # NEED To figure out how to deal with distributing the README
 

--- a/src/sst/core/testElements/message_mesh/CMakeLists.txt
+++ b/src/sst/core/testElements/message_mesh/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SST-CORE src/sst/core/testElements CMake
+#
+# Copyright 2009-2021 National Technology and Engineering Solutions of Sandia,
+# LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
+# retains certain rights in this software.
+#
+# See LICENSE for full license details
+#
+
+target_sources(coreTestElement PRIVATE enclosingComponent.cc)


### PR DESCRIPTION
- the json model wasn't linked into the exe
- one of the tests wasn't compiled in the cmake build
- changed config.cc to use ifdef for mpi detection to mirror the rest of
  the core
- changed the cmake generation of sst_config.h to define SST_HAVE_MPI 1
  just in case others try to do #if ... instead of #ifdef

