### PR TITLE
New perf manual rebase

### DIFF
--- a/config/sst_enable_perf_tracking.m4
+++ b/config/sst_enable_perf_tracking.m4
@@ -1,0 +1,21 @@
+AC_DEFUN([SST_ENABLE_PERF_TRACKING], [
+  enable_debug_perf_tracking="no"
+  AC_ARG_ENABLE([perf-tracking], [AS_HELP_STRING([--enable-perf-tracking],
+  [Enables tracking of simulator performance and component runtime. Options include component clock handler runtimes, openMPI synchronization overhead, and event handling. Communication sizes and information are also tracked. Tracking resolution can be implemented in nanosecond resolution or microsecond depening on individual workload. Slight performance penalties associated with enabling.])])
+   AS_IF([test "x$enable_perf_tracking" = "xyes" ], [enable_debug_perf_tracking="yes"]) 
+   AS_IF([test "$enable_debug_perf_tracking" = "yes"], [AC_DEFINE([SST_PERFORMANCE_INSTRUMENTING], [1],
+               [EXPERIMENTAL Required for all performance tracking. Enables file creation and final output])])
+   AS_IF([test "$enable_debug_perf_tracking" = "yes"], [AC_DEFINE([SST_HIGH_RESOLUTION_CLOCK], [0],
+               [EXPERIMENTAL Enables nanosecond resolution clock. Disable for gettimeofday microsecond resolution])])
+   AS_IF([test "$enable_debug_perf_tracking" = "yes"], [AC_DEFINE([SST_RUNTIME_PROFILING], [1],
+               [EXPERIMENTAL Tracks execution time for each rank.])])
+   AS_IF([test "$enable_debug_perf_tracking" = "yes"], [AC_DEFINE([SST_CLOCK_PROFILING], [1],
+               [EXPERIMENTAL Tracks clock handler execution time and counters])])
+   AS_IF([test "$enable_debug_perf_tracking" = "yes"], [AC_DEFINE([SST_EVENT_PROFILING], [1],
+               [EXPERIMENTAL Tracks event and communication time and counters])])
+   AS_IF([test "$enable_debug_perf_tracking" = "yes"], [AC_DEFINE([SST_PERIODIC_PRINT], [0],
+               [EXPERIMENTAL Periodically prints performance information to files])])
+   AS_IF([test "$enable_debug_perf_tracking" = "yes"], [AC_DEFINE([SST_PERIODIC_PRINT_THRESHOLD], [10000],
+               [EXPERIMENTAL Tune to affect how often files are written.])])
+])
+

--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,7 @@ SST_CHECK_MEM_POOL()
 
 SST_ENABLE_DEBUG_OUTPUT()
 SST_ENABLE_DEBUG_EVENT_TRACKING()
+SST_ENABLE_PERF_TRACKING()
 
 AS_IF([test "$use_mempool" = "no" -a "$enable_debug_event_tracking" = "yes"],
 [AC_MSG_ERROR([Event Tracking cannot be enabled with mem-pools disabled.])])

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -169,6 +169,12 @@ BaseComponent::unregisterClock(TimeConverter* tc, Clock::HandlerBase* handler)
     Simulation_impl::getSimulation()->unregisterClock(tc, handler, CLOCKPRIORITY);
 }
 
+void
+BaseComponent::registerClockHandler(Clock::HandlerBase* handler)
+{
+    Simulation_impl::getSimulation()->registerClockHandler(my_info->id, handler->getId());
+}
+
 TimeConverter*
 BaseComponent::registerTimeBase(const std::string& base, bool regAll)
 {

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -253,6 +253,8 @@ protected:
     /** Returns the next Cycle that the TimeConverter would fire */
     Cycle_t getNextClockCycle(TimeConverter* freq);
 
+    void registerClockHandler(Clock::HandlerBase* handler);
+
     /** Registers a default time base for the component and optionally
         sets the the component's links to that timebase. Useful for
         components which do not have a clock, but would like a default

--- a/src/sst/core/clock.cc
+++ b/src/sst/core/clock.cc
@@ -13,10 +13,32 @@
 
 #include "sst/core/clock.h"
 
+#include "sst/core/factory.h"
 #include "sst/core/simulation_impl.h"
 #include "sst/core/timeConverter.h"
 
+#include <sys/time.h>
+
 namespace SST {
+
+#if SST_HIGH_RESOLUTION_CLOCK
+#define SST_CLOCK_PROFILE_START auto sst_clock_profile_start = std::chrono::high_resolution_clock::now();
+#define SST_CLOCK_PROFILE_STOP                                                                                   \
+    auto sst_clock_profile_finish = std::chrono::high_resolution_clock::now();                                   \
+    auto sst_clock_profile_it     = sim->clockHandlers.find(handler->getId());                                   \
+    sst_clock_profile_it->second +=                                                                              \
+        std::chrono::duration_cast<std::chrono::nanoseconds>(sst_clock_profile_finish - sst_clock_profile_start) \
+            .count();
+#else
+#define SST_CLOCK_PROFILE_START                     \
+    struct timeval clockStart, clockEnd, clockDiff; \
+    gettimeofday(&clockStart, NULL);
+#define SST_CLOCK_PROFILE_STOP                                             \
+    gettimeofday(&clockEnd, NULL);                                         \
+    timersub(&clockEnd, &clockStart, &clockDiff);                          \
+    auto sst_clock_profile_it = sim->clockHandlers.find(handler->getId()); \
+    sst_clock_profile_it->second += clockDiff.tv_usec + clockDiff.tv_sec * 1e6;
+#endif
 
 Clock::Clock(TimeConverter* period, int priority) : Action(), currentCycle(0), period(period), scheduled(false)
 {
@@ -82,10 +104,26 @@ Clock::execute(void)
     StaticHandlerMap_t::iterator sop_iter;
     for ( sop_iter = staticHandlerMap.begin(); sop_iter != staticHandlerMap.end(); ) {
         Clock::HandlerBase* handler = *sop_iter;
+
+
+#if SST_CLOCK_PROFILING
+        SST_CLOCK_PROFILE_START
+#endif
+
         if ( (*handler)(currentCycle) )
             sop_iter = staticHandlerMap.erase(sop_iter);
         else
             ++sop_iter;
+
+#if SST_CLOCK_PROFILING
+        SST_CLOCK_PROFILE_STOP
+
+        auto iter = sim->clockCounters.find(handler->getId());
+        if ( iter != sim->clockCounters.end() ) { iter->second++; }
+#endif
+
+        // (*handler)(currentCycle);
+        // ++sop_iter;
     }
 
     next = sim->getCurrentSimCycle() + period->getFactor();

--- a/src/sst/core/event.cc
+++ b/src/sst/core/event.cc
@@ -56,7 +56,8 @@ Event::execute(void)
     SST_EVENT_PROFILE_START
 #endif
 
-        (*functor)(this);
+        (*functor)
+    (this);
 
 #if SST_EVENT_PROFILING
     Simulation_impl* sim = Simulation_impl::getSimulation();

--- a/src/sst/core/event.cc
+++ b/src/sst/core/event.cc
@@ -14,19 +14,74 @@
 #include "sst/core/event.h"
 
 #include "sst/core/link.h"
-#include "sst/core/simulation.h"
+#include "sst/core/simulation_impl.h"
+
+#include <sys/time.h>
 
 namespace SST {
 
 std::atomic<uint64_t>     SST::Event::id_counter(0);
 const SST::Event::id_type SST::Event::NO_ID = std::make_pair(0, -1);
 
+#if SST_HIGH_RESOLUTION_CLOCK
+#define SST_EVENT_PROFILE_START auto event_profile_eventStart = std::chrono::high_resolution_clock::now();
+#define SST_EVENT_PROFILE_STOP                                                                                         \
+    auto event_profile_eventFinish  = std::chrono::high_resolution_clock::now();                                       \
+    auto event_profile_eventHandler = sim->eventHandlers.find(getLastComponentName());                                 \
+    if ( event_profile_eventHandler != sim->eventHandlers.end() ) {                                                    \
+        event_profile_eventHandler->second +=                                                                          \
+            std::chrono::duration_cast<std::chrono::nanoseconds>(event_profile_eventFinish - event_profile_eventStart) \
+                .count();                                                                                              \
+    }
+#else
+#define SST_EVENT_PROFILE_START                     \
+    struct timeval eventStart, eventEnd, eventDiff; \
+    gettimeofday(&eventStart, NULL);
+#define SST_EVENT_PROFILE_STOP                                                            \
+    gettimeofday(&eventEnd, NULL);                                                        \
+    timersub(&eventEnd, &eventStart, &eventDiff);                                         \
+    auto event_profile_eventHandler = sim->eventHandlers.find(getLastComponentName());    \
+    if ( event_profile_eventHandler != sim->eventHandlers.end() ) {                       \
+        event_profile_eventHandler->second += eventDiff.tv_usec + eventDiff.tv_sec * 1e6; \
+    }
+#endif
+
 Event::~Event() {}
 
 void
 Event::execute(void)
 {
-    (*functor)(this);
+
+#if SST_EVENT_PROFILING
+    SST_EVENT_PROFILE_START
+#endif
+
+        (*functor)(this);
+
+#if SST_EVENT_PROFILING
+    Simulation_impl* sim = Simulation_impl::getSimulation();
+
+    SST_EVENT_PROFILE_STOP
+
+    // Track sending and receiving counters
+    auto eventCount = sim->eventRecvCounters.find(getLastComponentName());
+    if ( eventCount != sim->eventRecvCounters.end() ) { eventCount->second++; }
+    else {
+        if ( getLastComponentName() != "" ) {
+            sim->eventRecvCounters.insert(std::pair<std::string, uint64_t>(getLastComponentName(), 1));
+            sim->eventHandlers.insert(std::pair<std::string, uint64_t>(getLastComponentName(), 0));
+        }
+    }
+    auto eventSend = sim->eventSendCounters.find(getFirstComponentName());
+    if ( eventSend != sim->eventSendCounters.end() ) { eventSend->second++; }
+    else {
+        // Insert handler and counter for the subcomponent so that all link traffic is monitored
+        if ( getFirstComponentName() != "" ) {
+            sim->eventSendCounters.insert(std::pair<std::string, uint64_t>(getFirstComponentName(), 1));
+            sim->eventHandlers.insert(std::pair<std::string, uint64_t>(getFirstComponentName(), 0));
+        }
+    }
+#endif
 }
 
 Event*

--- a/src/sst/core/event.h
+++ b/src/sst/core/event.h
@@ -148,7 +148,7 @@ public:
 
 #ifdef __SST_DEBUG_EVENT_TRACKING__
 
-    virtual void printTrackingInfo(const std::string& header, Output& out) const
+    virtual void printTrackingInfo(const std::string& header, Output& out) const override
     {
         out.output(
             "%s Event first sent from: %s:%s (type: %s) and last received by %s:%s (type: %s)\n", header.c_str(),

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -1130,8 +1130,7 @@ Simulation_impl::printPerformanceInfo()
 
     // Rank only information
     fprintf(fp, "Rank Statistics\n");
-    fprintf(fp, "Message size sent: %llu\n", messageSizeSent);
-    fprintf(fp, "Message size recv: %llu\n", messageSizeRecv);
+    fprintf(fp, "Message transfer size : %llu\n", messageXferSize);
     fprintf(fp, "Latency : %llu\n", rankLatency);
     fprintf(fp, "Counter : %llu\n", rankExchangeCounter);
     if ( rankExchangeCounter != 0 ) { fprintf(fp, "Avg : %lluns\n", rankLatency / rankExchangeCounter); }

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -400,8 +400,7 @@ public:
     std::map<std::string, uint64_t> eventHandlers;
     std::map<std::string, uint64_t> eventRecvCounters;
     std::map<std::string, uint64_t> eventSendCounters;
-    uint64_t                        messageSizeSent = 0;
-    uint64_t                        messageSizeRecv = 0;
+    uint64_t                        messageXferSize = 0;
 #endif
 
 #if SST_SYNC_PROFILING

--- a/src/sst/core/sync/rankSyncParallelSkip.cc
+++ b/src/sst/core/sync/rankSyncParallelSkip.cc
@@ -406,8 +406,8 @@ RankSyncParallelSkip::exchangeLinkUntimedData(int UNUSED_WO_MPI(thread), std::at
         SST_EVENT_PROFILE_STOP
 
         // Cast to Header so we can get/fill in data
-        SyncQueue::Header* hdr         = reinterpret_cast<SyncQueue::Header*>(send_buffer);
-        int                tag         = 2 * i->second.to_rank.thread;
+        SyncQueue::Header* hdr = reinterpret_cast<SyncQueue::Header*>(send_buffer);
+        int                tag = 2 * i->second.to_rank.thread;
         // Check to see if remote queue is big enough for data
         if ( i->second.remote_size < hdr->buffer_size ) {
             // not big enough, send message that will tell remote side to get larger buffer

--- a/src/sst/core/sync/rankSyncParallelSkip.cc
+++ b/src/sst/core/sync/rankSyncParallelSkip.cc
@@ -31,6 +31,19 @@
 
 namespace SST {
 
+#if SST_EVENT_PROFILING
+#define SST_EVENT_PROFILE_START auto event_profile_start = std::chrono::high_resolution_clock::now();
+#define SST_EVENT_PROFILE_STOP                                                                                    \
+    Simulation_impl* event_profile_simImpl = Simulation_impl::getSimulation();                                    \
+    auto             event_profile_finish  = std::chrono::high_resolution_clock::now();                           \
+    event_profile_simImpl->rankLatency +=                                                                         \
+        std::chrono::duration_cast<std::chrono::nanoseconds>(event_profile_finish - event_profile_start).count(); \
+    event_profile_simImpl->rankExchangeCounter++;
+#else
+#define SST_EVENT_PROFILE_START
+#define SST_EVENT_PROFILE_STOP
+#endif
+
 // Static Data Members
 SimTime_t RankSyncParallelSkip::myNextSyncTime = 0;
 
@@ -172,9 +185,16 @@ RankSyncParallelSkip::exchange_slave(int thread)
 
     // Check the serialize_queue for work.
     comm_send_pair* ser;
+
     while ( serialize_queue.try_remove(ser) ) {
         // Serialize the events
+        // Measures Latency
+        SST_EVENT_PROFILE_START
+
         ser->sbuf = ser->squeue->getData();
+
+        SST_EVENT_PROFILE_STOP
+
         // Send back to master to do MPI send
         send_queue.try_insert(ser);
     }
@@ -253,6 +273,7 @@ RankSyncParallelSkip::exchange_master(int UNUSED(thread))
     // with serialization
     int             my_send_count = send_count;
     comm_send_pair* send;
+
     while ( my_send_count != 0 ) {
         if ( send_queue.try_remove(send) ) {
             my_send_count--;
@@ -280,7 +301,10 @@ RankSyncParallelSkip::exchange_master(int UNUSED(thread))
         }
         else if ( serialize_queue.try_remove(send) ) {
             // Serialize the events
+            SST_EVENT_PROFILE_START
             send->sbuf = send->squeue->getData();
+            SST_EVENT_PROFILE_STOP
+
             // Send back to master to do MPI send
             send_queue.try_insert(send);
         }
@@ -377,7 +401,10 @@ RankSyncParallelSkip::exchangeLinkUntimedData(int UNUSED_WO_MPI(thread), std::at
 
         // Do all the sends
         // Get the buffer from the syncQueue
-        char*              send_buffer = i->second.squeue->getData();
+        SST_EVENT_PROFILE_START
+        char* send_buffer = i->second.squeue->getData();
+        SST_EVENT_PROFILE_STOP
+
         // Cast to Header so we can get/fill in data
         SyncQueue::Header* hdr         = reinterpret_cast<SyncQueue::Header*>(send_buffer);
         int                tag         = 2 * i->second.to_rank.thread;

--- a/src/sst/core/sync/rankSyncSerialSkip.cc
+++ b/src/sst/core/sync/rankSyncSerialSkip.cc
@@ -149,9 +149,9 @@ RankSyncSerialSkip::exchange(void)
         simImpl->rankExchangeCounter++;
 #endif
         // Cast to Header so we can get/fill in data
-        SyncQueue::Header* hdr         = reinterpret_cast<SyncQueue::Header*>(send_buffer);
+        SyncQueue::Header* hdr = reinterpret_cast<SyncQueue::Header*>(send_buffer);
         // Simulation_impl::getSimulation()->getSimulationOutput().output("Data size = %d\n", hdr->buffer_size);
-        int                tag         = 1;
+        int                tag = 1;
         // Check to see if remote queue is big enough for data
         if ( i->second.remote_size < hdr->buffer_size ) {
             // not big enough, send message that will tell remote side to get larger buffer

--- a/src/sst/core/sync/rankSyncSerialSkip.cc
+++ b/src/sst/core/sync/rankSyncSerialSkip.cc
@@ -130,11 +130,24 @@ RankSyncSerialSkip::exchange(void)
     int         sreq_count = 0;
     int         rreq_count = 0;
 
+#if SST_EVENT_PROFILING
+    Simulation_impl* simImpl = Simulation_impl::getSimulation();
+#endif
+
     for ( comm_map_t::iterator i = comm_map.begin(); i != comm_map.end(); ++i ) {
 
-        // Do all the sends
-        // Get the buffer from the syncQueue
-        char*              send_buffer = i->second.squeue->getData();
+// Do all the sends
+// Get the buffer from the syncQueue
+#if SST_EVENT_PROFILING
+        // Measures Latency
+        auto start = std::chrono::high_resolution_clock::now();
+#endif
+        char* send_buffer = i->second.squeue->getData();
+#if SST_EVENT_PROFILING
+        auto finish = std::chrono::high_resolution_clock::now();
+        simImpl->rankLatency += std::chrono::duration_cast<std::chrono::nanoseconds>(finish - start).count();
+        simImpl->rankExchangeCounter++;
+#endif
         // Cast to Header so we can get/fill in data
         SyncQueue::Header* hdr         = reinterpret_cast<SyncQueue::Header*>(send_buffer);
         // Simulation_impl::getSimulation()->getSimulationOutput().output("Data size = %d\n", hdr->buffer_size);

--- a/src/sst/core/sync/syncQueue.cc
+++ b/src/sst/core/sync/syncQueue.cc
@@ -57,7 +57,7 @@ SyncQueue::insert(Activity* activity)
 
     size_t size = ser.size();
 
-    sim->messageSizeSent += (uint64_t)size;
+    sim->messageXferSize += (uint64_t)size;
 #endif
 }
 
@@ -102,7 +102,7 @@ SyncQueue::getData()
 
 #if SST_EVENT_PROFILING
     Simulation_impl* sim = Simulation_impl::getSimulation();
-    sim->messageSizeRecv += (uint64_t)size;
+    sim->messageXferSize += (uint64_t)size;
 #endif
 
     if ( buf_size < (size + sizeof(SyncQueue::Header)) ) {

--- a/src/sst/core/testElements/Makefile.inc
+++ b/src/sst/core/testElements/Makefile.inc
@@ -33,6 +33,8 @@ libcoreTestElement_la_SOURCES = \
 	testElements/coreTest_Module.cc \
 	testElements/coreTest_ParamComponent.h \
 	testElements/coreTest_ParamComponent.cc \
+	testElements/coreTest_PerfComponent.h \
+	testElements/coreTest_PerfComponent.cc \
 	testElements/message_mesh/messageEvent.h \
 	testElements/message_mesh/enclosingComponent.h \
 	testElements/message_mesh/enclosingComponent.cc

--- a/src/sst/core/testElements/coreTest_PerfComponent.cc
+++ b/src/sst/core/testElements/coreTest_PerfComponent.cc
@@ -1,0 +1,180 @@
+// Copyright 2009-2021 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2021, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+
+#include "sst/core/testElements/coreTest_PerfComponent.h"
+
+#include "sst/core/testElements/coreTest_ComponentEvent.h"
+
+#include "sst/core/event.h"
+#include "sst/core/simulation.h"
+
+#include <assert.h>
+#include <math.h>
+
+using namespace SST;
+using namespace SST::CoreTestPerfComponent;
+
+coreTestPerfComponent::coreTestPerfComponent(SST::ComponentId_t id, SST::Params& params) :
+    coreTestPerfComponentBase2(id)
+{
+    bool found;
+
+    rng = new SST::RNG::MarsagliaRNG(11, 272727);
+
+    // get parameters
+    workPerCycle = params.find<int64_t>("workPerCycle", 0, found);
+    if ( !found ) {
+        Simulation::getSimulation()->getSimulationOutput().fatal(CALL_INFO, -1, "couldn't find work per cycle\n");
+    }
+
+    commFreq = params.find<int64_t>("commFreq", 0, found);
+    if ( !found ) {
+        Simulation::getSimulation()->getSimulationOutput().fatal(
+            CALL_INFO, -1, "couldn't find communication frequency\n");
+    }
+
+    commSize = params.find<int64_t>("commSize", 16);
+
+    // init randomness
+    srand(1);
+    neighbor = rng->generateNextInt32() % 4;
+
+    // tell the simulator not to end without us
+    registerAsPrimaryComponent();
+    primaryComponentDoNotEndSim();
+
+    // configure out links
+    N = configureLink("Nlink", new Event::Handler<coreTestPerfComponent>(this, &coreTestPerfComponent::handleEvent));
+    S = configureLink("Slink", new Event::Handler<coreTestPerfComponent>(this, &coreTestPerfComponent::handleEvent));
+    E = configureLink("Elink", new Event::Handler<coreTestPerfComponent>(this, &coreTestPerfComponent::handleEvent));
+    W = configureLink("Wlink", new Event::Handler<coreTestPerfComponent>(this, &coreTestPerfComponent::handleEvent));
+
+    countN = registerStatistic<int>("N");
+    countS = registerStatistic<int>("S");
+    countE = registerStatistic<int>("E");
+    countW = registerStatistic<int>("W");
+
+    assert(N);
+    assert(S);
+    assert(E);
+    assert(W);
+
+    // set our clock
+    auto clockHandler = new Clock::Handler<coreTestPerfComponent>(this, &coreTestPerfComponent::clockTic);
+    registerClock("1GHz", clockHandler);
+    registerClockHandler(clockHandler);
+}
+
+coreTestPerfComponent::~coreTestPerfComponent()
+{
+    delete rng;
+}
+
+coreTestPerfComponent::coreTestPerfComponent() : coreTestPerfComponentBase2(-1)
+{
+    // for serialization only
+}
+
+// incoming events are scanned and deleted
+void
+coreTestPerfComponent::handleEvent(Event* ev)
+{
+    // printf("recv\n");
+    SST::CoreTestComponent::coreTestComponentEvent* event =
+        dynamic_cast<SST::CoreTestComponent::coreTestComponentEvent*>(ev);
+    if ( event ) {
+        // scan through each element in the payload and do something to it
+        volatile int sum = 0;
+        for ( SST::CoreTestComponent::coreTestComponentEvent::dataVec::iterator i = event->payload.begin();
+              i != event->payload.end(); ++i ) {
+            sum += *i;
+        }
+        delete event;
+    }
+    else {
+        printf("Error! Bad Event Type!\n");
+    }
+}
+
+// each clock tick we do 'workPerCycle' iterations of a coreTest loop.
+// We have a 1/commFreq chance of sending an event of size commSize to
+// one of our neighbors.
+bool coreTestPerfComponent::clockTic(Cycle_t)
+{
+    // do work
+    // loop becomes:
+    /*  00001ab5        movl    0xe0(%ebp),%eax
+        00001ab8        incl    %eax
+        00001ab9        movl    %eax,0xe0(%ebp)
+        00001abc        incl    %edx
+        00001abd        cmpl    %ecx,%edx
+        00001abf        jne     0x00001ab5
+
+        6 instructions.
+    */
+
+    // As this is meant to test the performance counter infrastructure,
+    // we'll give this loop more to do - trig functions are typically
+    // quite slow so this should eat up some CPU cycles
+    volatile int    v   = 0;
+    volatile double sum = 0.0;
+    for ( int i = 0; i < workPerCycle; ++i ) {
+        sum = sum + sin(double(i));
+        v++;
+    }
+
+    // communicate?
+    if ( (rng->generateNextInt32() % commFreq) == 0 ) {
+        // yes, communicate
+        // create event
+        SST::CoreTestComponent::coreTestComponentEvent* e = new SST::CoreTestComponent::coreTestComponentEvent();
+        // fill payload with commSize bytes
+        for ( int i = 0; i < (commSize); ++i ) {
+            e->payload.push_back(1);
+        }
+        // find target
+        neighbor = neighbor + 1;
+        neighbor = neighbor % 4;
+        // send
+        switch ( neighbor ) {
+        case 0:
+            N->send(e);
+            countN->addData(1);
+            break;
+        case 1:
+            S->send(e);
+            countS->addData(1);
+            break;
+        case 2:
+            E->send(e);
+            countE->addData(1);
+            break;
+        case 3:
+            W->send(e);
+            countW->addData(1);
+            break;
+        default:
+            printf("bad neighbor\n");
+        }
+        // printf("sent\n");
+    }
+
+    // return false so we keep going
+    return false;
+}
+
+// Element Libarary / Serialization stuff

--- a/src/sst/core/testElements/coreTest_PerfComponent.h
+++ b/src/sst/core/testElements/coreTest_PerfComponent.h
@@ -1,0 +1,137 @@
+// Copyright 2009-2021 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2021, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_CORETEST_PERF_COMPONENT_H
+#define SST_CORE_CORETEST_PERF_COMPONENT_H
+
+#include <sst/core/component.h>
+#include <sst/core/link.h>
+#include <sst/core/rng/marsaglia.h>
+
+namespace SST {
+namespace CoreTestPerfComponent {
+
+// These first two classes are just base classes to test ELI
+// inheritance.  The definition of the ELI items are spread through 2
+// component base classes to make sure they get inherited in the
+// actual component that can be instanced.
+class coreTestPerfComponentBase : public SST::Component
+{
+public:
+    SST_ELI_REGISTER_COMPONENT_BASE(SST::CoreTestPerfComponent::coreTestPerfComponentBase)
+
+    SST_ELI_DOCUMENT_PARAMS(
+        { "workPerCycle", "Count of busy work to do during a clock tick.", NULL}
+    )
+
+    SST_ELI_DOCUMENT_STATISTICS(
+        { "N", "events sent on N link", "counts", 1 }
+    )
+
+    SST_ELI_DOCUMENT_PORTS(
+        {"Nlink", "Link to the coreTestComponent to the North", { "coreTestComponent.coreTestComponentEvent", "" } }
+    )
+
+    coreTestPerfComponentBase(ComponentId_t id) : SST::Component(id) {}
+    ~coreTestPerfComponentBase() {}
+};
+
+class coreTestPerfComponentBase2 : public coreTestPerfComponentBase
+{
+public:
+    SST_ELI_REGISTER_COMPONENT_DERIVED_BASE(
+        SST::CoreTestPerfComponent::coreTestPerfComponentBase2, SST::CoreTestPerfComponent::coreTestPerfComponentBase)
+
+    SST_ELI_DOCUMENT_PARAMS(
+        { "commFreq",     "Approximate frequency of sending an event during a clock tick.", NULL},
+    )
+
+    SST_ELI_DOCUMENT_STATISTICS(
+        { "S", "events sent on S link", "counts", 1 }
+    )
+
+    SST_ELI_DOCUMENT_PORTS(
+        {"Slink", "Link to the coreTestComponent to the South", { "coreTestComponent.coreTestComponentEvent", "" } }
+    )
+
+    coreTestPerfComponentBase2(ComponentId_t id) : coreTestPerfComponentBase(id) {}
+    ~coreTestPerfComponentBase2() {}
+};
+
+class coreTestPerfComponent : public coreTestPerfComponentBase2
+{
+public:
+    // REGISTER THIS COMPONENT INTO THE ELEMENT LIBRARY
+    SST_ELI_REGISTER_COMPONENT(
+        coreTestPerfComponent,
+        "coreTestElement",
+        "coreTestPerfComponent",
+        SST_ELI_ELEMENT_VERSION(1,0,0),
+        "CoreTest Test Perf Component",
+        COMPONENT_CATEGORY_PROCESSOR
+    )
+
+    SST_ELI_DOCUMENT_PARAMS(
+        { "commSize",     "Size of communication to send.", "16"}
+    )
+
+    SST_ELI_DOCUMENT_STATISTICS(
+        { "E", "events sent on E link", "counts", 1 },
+        { "W", "events sent on W link", "counts", 1 }
+    )
+
+    SST_ELI_DOCUMENT_PORTS(
+        {"Elink", "Link to the coreTestComponent to the East",  { "coreTestComponent.coreTestComponentEvent", "" } },
+        {"Wlink", "Link to the coreTestComponent to the West",  { "coreTestComponent.coreTestComponentEvent", "" } }
+    )
+
+    // Optional since there is nothing to document
+    SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
+    )
+
+    coreTestPerfComponent(SST::ComponentId_t id, SST::Params& params);
+    ~coreTestPerfComponent();
+
+    void setup() {}
+    void finish() { printf("Perf Test Component Finished.\n"); }
+
+private:
+    coreTestPerfComponent();                             // for serialization only
+    coreTestPerfComponent(const coreTestPerfComponent&); // do not implement
+    void operator=(const coreTestPerfComponent&);        // do not implement
+
+    void         handleEvent(SST::Event* ev);
+    virtual bool clockTic(SST::Cycle_t);
+
+    int workPerCycle;
+    int commFreq;
+    int commSize;
+    int neighbor;
+
+    SST::RNG::MarsagliaRNG*          rng;
+    SST::Link*                       N;
+    SST::Link*                       S;
+    SST::Link*                       E;
+    SST::Link*                       W;
+    SST::Statistics::Statistic<int>* countN;
+    SST::Statistics::Statistic<int>* countS;
+    SST::Statistics::Statistic<int>* countE;
+    SST::Statistics::Statistic<int>* countW;
+};
+
+} // namespace CoreTestPerfComponent
+} // namespace SST
+
+#endif // SST_CORE_CORETEST_PERF_COMPONENT_H

--- a/tests/Makefile.inc
+++ b/tests/Makefile.inc
@@ -4,6 +4,7 @@
 
 EXTRA_DIST += \
     tests/testsuite_default_Component.py \
+    tests/testsuite_default_PerfComponent.py \
     tests/testsuite_default_RNGComponent.py \
     tests/testsuite_default_Links.py \
     tests/testsuite_default_SharedObject.py \

--- a/tests/Makefile.inc
+++ b/tests/Makefile.inc
@@ -34,6 +34,7 @@ EXTRA_DIST += \
     tests/test_SubComponent.py \
     tests/test_SubComponent_2.py \
     tests/test_UnitAlgebra.py \
+    tests/test_PerfComponent.py \
     tests/refFiles/test_Component.out \
     tests/refFiles/test_PerfComponent.out \
     tests/refFiles/test_DistribComponent_discrete.out \

--- a/tests/Makefile.inc
+++ b/tests/Makefile.inc
@@ -35,6 +35,7 @@ EXTRA_DIST += \
     tests/test_SubComponent_2.py \
     tests/test_UnitAlgebra.py \
     tests/refFiles/test_Component.out \
+    tests/refFiles/test_PerfComponent.out \
     tests/refFiles/test_DistribComponent_discrete.out \
     tests/refFiles/test_DistribComponent_expon.out \
     tests/refFiles/test_DistribComponent_gaussian.out \

--- a/tests/refFiles/test_PerfComponent.out
+++ b/tests/refFiles/test_PerfComponent.out
@@ -1,0 +1,17 @@
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Simulation is complete, simulated time: 10 us

--- a/tests/test_PerfComponent.py
+++ b/tests/test_PerfComponent.py
@@ -8,97 +8,97 @@ sst.setProgramOption("stopAtCycle", "10us")
 # Define the simulation components
 comp_c0_0 = sst.Component("c0.0", "coreTestElement.coreTestPerfComponent")
 comp_c0_0.addParams({
-      "workPerCycle" : """50000""",
+      "workPerCycle" : """5000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c1_0 = sst.Component("c1.0", "coreTestElement.coreTestPerfComponent")
 comp_c1_0.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c2_0 = sst.Component("c2.0", "coreTestElement.coreTestPerfComponent")
 comp_c2_0.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c3_0 = sst.Component("c3.0", "coreTestElement.coreTestPerfComponent")
 comp_c3_0.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c0_1 = sst.Component("c0.1", "coreTestElement.coreTestPerfComponent")
 comp_c0_1.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c1_1 = sst.Component("c1.1", "coreTestElement.coreTestPerfComponent")
 comp_c1_1.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c2_1 = sst.Component("c2.1", "coreTestElement.coreTestPerfComponent")
 comp_c2_1.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c3_1 = sst.Component("c3.1", "coreTestElement.coreTestPerfComponent")
 comp_c3_1.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c0_2 = sst.Component("c0.2", "coreTestElement.coreTestPerfComponent")
 comp_c0_2.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c1_2 = sst.Component("c1.2", "coreTestElement.coreTestPerfComponent")
 comp_c1_2.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c2_2 = sst.Component("c2.2", "coreTestElement.coreTestPerfComponent")
 comp_c2_2.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c3_2 = sst.Component("c3.2", "coreTestElement.coreTestPerfComponent")
 comp_c3_2.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c0_3 = sst.Component("c0.3", "coreTestElement.coreTestPerfComponent")
 comp_c0_3.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c1_3 = sst.Component("c1.3", "coreTestElement.coreTestPerfComponent")
 comp_c1_3.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c2_3 = sst.Component("c2.3", "coreTestElement.coreTestPerfComponent")
 comp_c2_3.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })
 comp_c3_3 = sst.Component("c3.3", "coreTestElement.coreTestPerfComponent")
 comp_c3_3.addParams({
-      "workPerCycle" : """10000""",
+      "workPerCycle" : """1000""",
       "commSize" : """100""",
       "commFreq" : """1000"""
 })

--- a/tests/test_PerfComponent.py
+++ b/tests/test_PerfComponent.py
@@ -1,0 +1,171 @@
+# Automatically generated SST Python input
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1 ps")
+sst.setProgramOption("stopAtCycle", "10us")
+
+# Define the simulation components
+comp_c0_0 = sst.Component("c0.0", "coreTestElement.coreTestPerfComponent")
+comp_c0_0.addParams({
+      "workPerCycle" : """50000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c1_0 = sst.Component("c1.0", "coreTestElement.coreTestPerfComponent")
+comp_c1_0.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c2_0 = sst.Component("c2.0", "coreTestElement.coreTestPerfComponent")
+comp_c2_0.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c3_0 = sst.Component("c3.0", "coreTestElement.coreTestPerfComponent")
+comp_c3_0.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c0_1 = sst.Component("c0.1", "coreTestElement.coreTestPerfComponent")
+comp_c0_1.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c1_1 = sst.Component("c1.1", "coreTestElement.coreTestPerfComponent")
+comp_c1_1.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c2_1 = sst.Component("c2.1", "coreTestElement.coreTestPerfComponent")
+comp_c2_1.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c3_1 = sst.Component("c3.1", "coreTestElement.coreTestPerfComponent")
+comp_c3_1.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c0_2 = sst.Component("c0.2", "coreTestElement.coreTestPerfComponent")
+comp_c0_2.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c1_2 = sst.Component("c1.2", "coreTestElement.coreTestPerfComponent")
+comp_c1_2.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c2_2 = sst.Component("c2.2", "coreTestElement.coreTestPerfComponent")
+comp_c2_2.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c3_2 = sst.Component("c3.2", "coreTestElement.coreTestPerfComponent")
+comp_c3_2.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c0_3 = sst.Component("c0.3", "coreTestElement.coreTestPerfComponent")
+comp_c0_3.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c1_3 = sst.Component("c1.3", "coreTestElement.coreTestPerfComponent")
+comp_c1_3.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c2_3 = sst.Component("c2.3", "coreTestElement.coreTestPerfComponent")
+comp_c2_3.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+comp_c3_3 = sst.Component("c3.3", "coreTestElement.coreTestPerfComponent")
+comp_c3_3.addParams({
+      "workPerCycle" : """10000""",
+      "commSize" : """100""",
+      "commFreq" : """1000"""
+})
+
+# Define the simulation links
+link_s_0_10 = sst.Link("link_s_0_10")
+link_s_0_10.connect( (comp_c0_0, "Nlink", "10000ps"), (comp_c0_1, "Slink", "10000ps") )
+link_s_0_90 = sst.Link("link_s_0_90")
+link_s_0_90.connect( (comp_c0_0, "Slink", "10000ps"), (comp_c0_3, "Nlink", "10000ps") )
+link_s_0_1 = sst.Link("link_s_0_1")
+link_s_0_1.connect( (comp_c0_0, "Elink", "10000ps"), (comp_c1_0, "Wlink", "10000ps") )
+link_s_0_9 = sst.Link("link_s_0_9")
+link_s_0_9.connect( (comp_c0_0, "Wlink", "10000ps"), (comp_c3_0, "Elink", "10000ps") )
+link_s_1_11 = sst.Link("link_s_1_11")
+link_s_1_11.connect( (comp_c1_0, "Nlink", "10000ps"), (comp_c1_1, "Slink", "10000ps") )
+link_s_1_91 = sst.Link("link_s_1_91")
+link_s_1_91.connect( (comp_c1_0, "Slink", "10000ps"), (comp_c1_3, "Nlink", "10000ps") )
+link_s_1_2 = sst.Link("link_s_1_2")
+link_s_1_2.connect( (comp_c1_0, "Elink", "10000ps"), (comp_c2_0, "Wlink", "10000ps") )
+link_s_2_12 = sst.Link("link_s_2_12")
+link_s_2_12.connect( (comp_c2_0, "Nlink", "10000ps"), (comp_c2_1, "Slink", "10000ps") )
+link_s_2_92 = sst.Link("link_s_2_92")
+link_s_2_92.connect( (comp_c2_0, "Slink", "10000ps"), (comp_c2_3, "Nlink", "10000ps") )
+link_s_2_3 = sst.Link("link_s_2_3")
+link_s_2_3.connect( (comp_c2_0, "Elink", "10000ps"), (comp_c3_0, "Wlink", "10000ps") )
+link_s_3_13 = sst.Link("link_s_3_13")
+link_s_3_13.connect( (comp_c3_0, "Nlink", "10000ps"), (comp_c3_1, "Slink", "10000ps") )
+link_s_3_93 = sst.Link("link_s_3_93")
+link_s_3_93.connect( (comp_c3_0, "Slink", "10000ps"), (comp_c3_3, "Nlink", "10000ps") )
+link_s_10_20 = sst.Link("link_s_10_20")
+link_s_10_20.connect( (comp_c0_1, "Nlink", "10000ps"), (comp_c0_2, "Slink", "10000ps") )
+link_s_10_11 = sst.Link("link_s_10_11")
+link_s_10_11.connect( (comp_c0_1, "Elink", "10000ps"), (comp_c1_1, "Wlink", "10000ps") )
+link_s_10_19 = sst.Link("link_s_10_19")
+link_s_10_19.connect( (comp_c0_1, "Wlink", "10000ps"), (comp_c3_1, "Elink", "10000ps") )
+link_s_11_21 = sst.Link("link_s_11_21")
+link_s_11_21.connect( (comp_c1_1, "Nlink", "10000ps"), (comp_c1_2, "Slink", "10000ps") )
+link_s_11_12 = sst.Link("link_s_11_12")
+link_s_11_12.connect( (comp_c1_1, "Elink", "10000ps"), (comp_c2_1, "Wlink", "10000ps") )
+link_s_12_22 = sst.Link("link_s_12_22")
+link_s_12_22.connect( (comp_c2_1, "Nlink", "10000ps"), (comp_c2_2, "Slink", "10000ps") )
+link_s_12_13 = sst.Link("link_s_12_13")
+link_s_12_13.connect( (comp_c2_1, "Elink", "10000ps"), (comp_c3_1, "Wlink", "10000ps") )
+link_s_13_23 = sst.Link("link_s_13_23")
+link_s_13_23.connect( (comp_c3_1, "Nlink", "10000ps"), (comp_c3_2, "Slink", "10000ps") )
+link_s_20_30 = sst.Link("link_s_20_30")
+link_s_20_30.connect( (comp_c0_2, "Nlink", "10000ps"), (comp_c0_3, "Slink", "10000ps") )
+link_s_20_21 = sst.Link("link_s_20_21")
+link_s_20_21.connect( (comp_c0_2, "Elink", "10000ps"), (comp_c1_2, "Wlink", "10000ps") )
+link_s_20_29 = sst.Link("link_s_20_29")
+link_s_20_29.connect( (comp_c0_2, "Wlink", "10000ps"), (comp_c3_2, "Elink", "10000ps") )
+link_s_21_31 = sst.Link("link_s_21_31")
+link_s_21_31.connect( (comp_c1_2, "Nlink", "10000ps"), (comp_c1_3, "Slink", "10000ps") )
+link_s_21_22 = sst.Link("link_s_21_22")
+link_s_21_22.connect( (comp_c1_2, "Elink", "10000ps"), (comp_c2_2, "Wlink", "10000ps") )
+link_s_22_32 = sst.Link("link_s_22_32")
+link_s_22_32.connect( (comp_c2_2, "Nlink", "10000ps"), (comp_c2_3, "Slink", "10000ps") )
+link_s_22_23 = sst.Link("link_s_22_23")
+link_s_22_23.connect( (comp_c2_2, "Elink", "10000ps"), (comp_c3_2, "Wlink", "10000ps") )
+link_s_23_33 = sst.Link("link_s_23_33")
+link_s_23_33.connect( (comp_c3_2, "Nlink", "10000ps"), (comp_c3_3, "Slink", "10000ps") )
+link_s_30_31 = sst.Link("link_s_30_31")
+link_s_30_31.connect( (comp_c0_3, "Elink", "10000ps"), (comp_c1_3, "Wlink", "10000ps") )
+link_s_30_39 = sst.Link("link_s_30_39")
+link_s_30_39.connect( (comp_c0_3, "Wlink", "10000ps"), (comp_c3_3, "Elink", "10000ps") )
+link_s_31_32 = sst.Link("link_s_31_32")
+link_s_31_32.connect( (comp_c1_3, "Elink", "10000ps"), (comp_c2_3, "Wlink", "10000ps") )
+link_s_32_33 = sst.Link("link_s_32_33")
+link_s_32_33.connect( (comp_c2_3, "Elink", "10000ps"), (comp_c3_3, "Wlink", "10000ps") )
+# End of generated output.

--- a/tests/testsuite_default_PerfComponent.py
+++ b/tests/testsuite_default_PerfComponent.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+import os
+from sst_unittest import *
+from sst_unittest_support import *
+
+################################################################################
+# Code to support a single instance module initialize, must be called setUp method
+
+module_init = 0
+module_sema = threading.Semaphore()
+
+def initializeTestModule_SingleInstance(class_inst):
+    global module_init
+    global module_sema
+
+    module_sema.acquire()
+    if module_init != 1:
+        # Put your single instance Init Code Here
+        module_init = 1
+    module_sema.release()
+
+################################################################################
+
+class testcase_PerfComponent(SSTTestCase):
+
+    def initializeClass(self, testName):
+        super(type(self), self).initializeClass(testName)
+        # Put test based setup code here. it is called before testing starts
+        # NOTE: This method is called once for every test
+
+    def setUp(self):
+        super(type(self), self).setUp()
+        initializeTestModule_SingleInstance(self)
+        # Put test based setup code here. it is called once before every test
+
+    def tearDown(self):
+        # Put test based teardown code here. it is called once after every test
+        super(type(self), self).tearDown()
+
+#####
+
+    def test_PerfComponent(self):
+        self.perf_component_test_template("PerfComponent")
+
+#####
+
+    def perf_component_test_template(self, testtype):
+        testsuitedir = self.get_testsuite_dir()
+        outdir = test_output_get_run_dir()
+
+        sdlfile = "{0}/test_PerfComponent.py".format(testsuitedir)
+        reffile = "{0}/refFiles/test_PerfComponent.out".format(testsuitedir)
+        outfile = "{0}/test_PerfComponent.out".format(outdir)
+
+        self.run_sst(sdlfile, outfile)
+        
+        # Perform the test of the standard simulation output
+        cmp_result = testing_compare_sorted_diff(testtype, outfile, reffile)
+        self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))
+
+        #save off the performance data
+        perfdata_out = "{0}/rank_0_thread_0".format(outdir)
+        perfdata_sav = "{0}/PerfComponent_PerfData.out".format(outdir)
+
+        #if SST was built with SST_PERFORMANCE_INSTRUMENTING enabled, then we will also check that the counters are sane
+        if(sst_core_config_include_file_get_value_int(define="SST_PERFORMANCE_INSTRUMENTING", default=0, disable_warning=True) > 0):
+            if os.path.isfile(perfdata_out):
+                os.system("mv {0} {1}".format(perfdata_out, perfdata_sav))
+            else:
+                self.assertTrue(False, "Output file {0} does not exist".format(perfdata_out))
+            
+            targetComponentFound = False
+            success = False
+            with open(perfdata_sav, 'r') as file:
+                f = file.read()
+
+            lines = f.split('\n')
+            for line in lines:
+                if targetComponentFound and ("Clock Handler Runtime:" in line):
+                    if (float(line.split()[3].split('s')[0]) > 0):
+                        success = True
+                if "Component Name c0.0" in line:
+                    targetComponentFound = True
+                
+            self.assertTrue(success, "Performance output file {0} does not contain expected value".format(perfdata_sav))
+
+            
+
+
+


### PR DESCRIPTION
This is a manual rebase to remove extra commits from PR #734 In addition, the naming for message size accounting has been simplified to just be called `messageXferSize`   Original PR comments reproduced below for convenience:

---------------------------------------
Adds a significant amount of performance and event tracking data. These features are DISABLED by default and only enabled via the --enable-perf-tracking option for the configure script. 

Enables tracking of simulator performance and component runtime. Options include component clock handler runtimes, openMPI synchronization overhead, and event handling. Communication sizes and information are also tracked. Tracking resolution can be implemented in nanosecond resolution or microsecond depending on individual workload. Slight performance penalties associated with enabling.

Documentation regarding the metrics and features can be found here:
https://github.com/tactcomplabs/sst-tutorials/blob/tcl-tutorial/performanceGuide.md

The documentation will eventually be modified and sent upstream to the sst-docs repo.