### PR TITLE
Outputting empty components and links for ranks that do not have components and/or links

### DIFF
--- a/src/sst/core/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.cc
@@ -168,9 +168,15 @@ JSONConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph)
         }
     }
 
+    // no components exist in this rank
+    if ( const_cast<ConfigComponentMap_t&>(compMap).size() == 0 ) { outputJson["components"]; }
+
     for ( const auto& compItr : compMap ) {
         outputJson["components"].emplace_back(CompWrapper { compItr, cfg->output_partition() });
     }
+
+    // no links exist in this rank
+    if ( const_cast<ConfigLinkMap_t&>(linkMap).size() == 0 ) { outputJson["links"]; }
 
     for ( const auto& linkItr : linkMap ) {
         outputJson["links"].push_back(LinkConfPair { linkItr, graph });


### PR DESCRIPTION
Fix for Issue #777 

The fix inserts two tests into the `jsonConfigOutput.cc`.  When outputting parallel configurations where individual ranks do not have links and/or components, the modification outputs empty objects in order for the JSON model parser to correctly ingest the parallel configuration.  

This was tested against the `test_ParamComponent.py` using the following: 

Model output:
```
mpirun --hostfile output.txt -n 7 sst --run-mode=init --output-json=foo.json --parallel-output=1 test_ParamComponent.py
```

Model input:
```
mpirun --hostfile output.txt -n 7 sst --run-mode=init --parallel-load foo.json
```
