### PR TITLE
Streamlining the interface to Perf counters by removing redundant registerClockHandler call

### DIFF
--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -142,6 +142,9 @@ BaseComponent::registerClock(TimeConverter* tc, Clock::HandlerBase* handler, boo
 {
     TimeConverter* tcRet = Simulation_impl::getSimulation()->registerClock(tc, handler, CLOCKPRIORITY);
 
+    // Register this clock handler with the performance counters
+    Simulation_impl::getSimulation()->registerClockHandler(my_info->id, handler->getId());
+
     // if regAll is true set tc as the default for the component and
     // for all the links
     if ( regAll ) {
@@ -167,12 +170,6 @@ void
 BaseComponent::unregisterClock(TimeConverter* tc, Clock::HandlerBase* handler)
 {
     Simulation_impl::getSimulation()->unregisterClock(tc, handler, CLOCKPRIORITY);
-}
-
-void
-BaseComponent::registerClockHandler(Clock::HandlerBase* handler)
-{
-    Simulation_impl::getSimulation()->registerClockHandler(my_info->id, handler->getId());
 }
 
 TimeConverter*

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -253,8 +253,6 @@ protected:
     /** Returns the next Cycle that the TimeConverter would fire */
     Cycle_t getNextClockCycle(TimeConverter* freq);
 
-    void registerClockHandler(Clock::HandlerBase* handler);
-
     /** Registers a default time base for the component and optionally
         sets the the component's links to that timebase. Useful for
         components which do not have a clock, but would like a default

--- a/src/sst/core/testElements/coreTest_PerfComponent.cc
+++ b/src/sst/core/testElements/coreTest_PerfComponent.cc
@@ -76,7 +76,6 @@ coreTestPerfComponent::coreTestPerfComponent(SST::ComponentId_t id, SST::Params&
     // set our clock
     auto clockHandler = new Clock::Handler<coreTestPerfComponent>(this, &coreTestPerfComponent::clockTic);
     registerClock("1GHz", clockHandler);
-    registerClockHandler(clockHandler);
 }
 
 coreTestPerfComponent::~coreTestPerfComponent()

--- a/tests/testsuite_default_PerfComponent.py
+++ b/tests/testsuite_default_PerfComponent.py
@@ -70,18 +70,24 @@ class testcase_PerfComponent(SSTTestCase):
                 self.assertTrue(False, "Output file {0} does not exist".format(perfdata_out))
             
             targetComponentFound = False
+            foundClockHandler = False
+            foundClockRuntime = False
             success = False
             with open(perfdata_sav, 'r') as file:
                 f = file.read()
 
             lines = f.split('\n')
             for line in lines:
-                if targetComponentFound and ("Clock Handler Runtime:" in line):
-                    if (float(line.split()[3].split('s')[0]) > 0):
-                        success = True
-                if "Component Name c0.0" in line:
+                if foundClockHandler:
+                    if (float(line.split()[2].split('s')[0]) > 0):
+                        foundClockRuntime = True
+                    foundClockHandler = False
+                if ("Clock Handlers" in line):
+                    foundClockHandler = True
+                if "Component c0_0" in line:
                     targetComponentFound = True
-                
+              
+            success = targetComponentFound and foundClockRuntime
             self.assertTrue(success, "Performance output file {0} does not contain expected value".format(perfdata_sav))
 
             


### PR DESCRIPTION
This removes the redundant registerClockHander() call that was once required to have performance counters track an element's activity. This functionality was merged into the existing registerClock() function.  

In addition, the test for the PerfCounters needed to be modified for build configurations that enable perf counters *only* Some component naming has changed (independent of this PR) and the test needed to know where to find the correct values