### PR TITLE
Recurse subcomponents

### DIFF
--- a/src/sst/core/cfgoutput/dotConfigOutput.cc
+++ b/src/sst/core/cfgoutput/dotConfigOutput.cc
@@ -72,8 +72,15 @@ DotConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph)
 
 void
 DotConfigGraphOutput::generateDot(
+    const ConfigComponent* comp, const ConfigLinkMap_t& linkMap, const uint32_t dot_verbosity) const
+{
+    generateDot(comp, linkMap, dot_verbosity, nullptr);
+}
+
+void
+DotConfigGraphOutput::generateDot(
     const ConfigComponent* comp, const ConfigLinkMap_t& linkMap, const uint32_t dot_verbosity,
-    const ConfigComponent* parent = nullptr) const
+    const ConfigComponent* parent) const
 {
 
     // Display component type
@@ -106,7 +113,7 @@ DotConfigGraphOutput::generateDot(
     // Display subComponents
     if ( dot_verbosity >= 4 ) {
         for ( auto& sc : comp->subComponents ) {
-            generateDot(sc, sc->links, dot_verbosity, comp);
+            generateDot(sc, linkMap, dot_verbosity, comp);
         }
     }
 }

--- a/src/sst/core/cfgoutput/dotConfigOutput.cc
+++ b/src/sst/core/cfgoutput/dotConfigOutput.cc
@@ -72,15 +72,18 @@ DotConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph)
 
 void
 DotConfigGraphOutput::generateDot(
-    const ConfigComponent* comp, const ConfigLinkMap_t& linkMap, const uint32_t dot_verbosity) const
+    const ConfigComponent* comp, const ConfigLinkMap_t& linkMap, const uint32_t dot_verbosity,
+    const ConfigComponent* parent = nullptr) const
 {
 
     // Display component type
-    if ( dot_verbosity >= 2 ) {
-        fprintf(outputFile, "%" PRIu64 " [label=\"{<main> %s\\n%s", comp->id, comp->name.c_str(), comp->type.c_str());
-    }
+    if ( parent ) { fprintf(outputFile, "%" PRIu64 " [color=gray,label=\"{<main> ", comp->id); }
     else {
-        fprintf(outputFile, "%" PRIu64 " [label=\"{<main> %s", comp->id, comp->name.c_str());
+        fprintf(outputFile, "%" PRIu64 " [label=\"{<main> ", comp->id);
+    }
+    if ( dot_verbosity >= 2 ) { fprintf(outputFile, "%s\\n%s", comp->name.c_str(), comp->type.c_str()); }
+    else {
+        fprintf(outputFile, "%s", comp->name.c_str());
     }
 
     // Display ports
@@ -96,24 +99,14 @@ DotConfigGraphOutput::generateDot(
         }
     }
     fprintf(outputFile, "}\"];\n\n");
+    if ( parent ) {
+        fprintf(outputFile, "%" PRIu64 ":\"main\" -- %" PRIu64 ":\"main\" [style=dotted];\n\n", comp->id, parent->id);
+    }
 
     // Display subComponents
     if ( dot_verbosity >= 4 ) {
         for ( auto& sc : comp->subComponents ) {
-            fprintf(
-                outputFile, "%" PRIu64 " [color=gray,label=\"{<main> %s\\n%s", sc->id, sc->name.c_str(),
-                sc->type.c_str());
-            int j = sc->links.size();
-            if ( j != 0 ) { fprintf(outputFile, " |\n"); }
-            for ( LinkId_t i : sc->links ) {
-                const ConfigLink* link = linkMap[i];
-                const int         port = (link->component[0] == sc->id) ? 0 : 1;
-                fprintf(outputFile, "<%s> Port: %s", link->port[port].c_str(), link->port[port].c_str());
-                if ( j > 1 ) { fprintf(outputFile, " |\n"); }
-                j--;
-            }
-            fprintf(outputFile, "}\"];\n");
-            fprintf(outputFile, "%" PRIu64 ":\"main\" -- %" PRIu64 ":\"main\" [style=dotted];\n\n", comp->id, sc->id);
+            generateDot(sc, sc->links, dot_verbosity, comp);
         }
     }
 }

--- a/src/sst/core/cfgoutput/dotConfigOutput.h
+++ b/src/sst/core/cfgoutput/dotConfigOutput.h
@@ -26,7 +26,9 @@ public:
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 
 protected:
-    void generateDot(const ConfigComponent* comp, const ConfigLinkMap_t& linkMap, const uint32_t dot_verbosity) const;
+    void generateDot(
+        const ConfigComponent* comp, const ConfigLinkMap_t& linkMap, const uint32_t dot_verbosity,
+        const ConfigComponent* parent) const;
     void generateDot(const ConfigLink* link, const uint32_t dot_verbosity) const;
 };
 

--- a/src/sst/core/cfgoutput/dotConfigOutput.h
+++ b/src/sst/core/cfgoutput/dotConfigOutput.h
@@ -26,6 +26,7 @@ public:
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 
 protected:
+    void generateDot(const ConfigComponent* comp, const ConfigLinkMap_t& linkMap, const uint32_t dot_verbosity) const;
     void generateDot(
         const ConfigComponent* comp, const ConfigLinkMap_t& linkMap, const uint32_t dot_verbosity,
         const ConfigComponent* parent) const;


### PR DESCRIPTION
I noticed that the dot graph output was only handling first order subcomponents, and not displaying subcomponents of subcomponents or so on. Updated the code to be recursive for subcomponent dot graph output