### PR TITLE
Deprecation cleanup

### DIFF
--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -491,7 +491,9 @@ protected:
      * @param params Parameters the module should use for configuration
      * @return handle to new instance of module, or nullptr on failure.
      */
-    Module* loadModule(const std::string& type, Params& params);
+    Module* loadModule(const std::string& type, Params& params)
+        __attribute__((deprecated("This version of loadModule() has been deprecated.  Please use the new templated "
+                                  "version that uses Module APIs")));
 
     /** Loads a module from an element Library
      * @param type Fully Qualified library.moduleName

--- a/src/sst/core/event.cc
+++ b/src/sst/core/event.cc
@@ -101,13 +101,6 @@ Event::generateUniqueId()
     return std::make_pair(id_counter++, Simulation_impl::getSimulation()->getRank().rank);
 }
 
-void
-NullEvent::execute(void)
-{
-    (*reinterpret_cast<HandlerBase*>(delivery_info))(nullptr);
-    delete this;
-}
-
 #ifdef USE_MEMPOOL
 std::mutex                        Activity::poolMutex;
 std::vector<Activity::PoolInfo_t> Activity::memPools;

--- a/src/sst/core/event.h
+++ b/src/sst/core/event.h
@@ -195,19 +195,18 @@ private:
 };
 
 /**
- * Null Event.  Does nothing.
+ * Empty Event.  Does nothing.
  */
-class NullEvent : public Event, public SST::Core::Serialization::serializable_type<NullEvent>
+class EmptyEvent : public Event
 {
 public:
-    NullEvent() : Event() {}
-    ~NullEvent() {}
-
-    void execute(void) override;
+    EmptyEvent() : Event() {}
+    ~EmptyEvent() {}
 
 private:
-    ImplementSerializable(SST::NullEvent)
+    ImplementSerializable(SST::EmptyEvent)
 };
+
 } // namespace SST
 
 #endif // SST_CORE_EVENT_H

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -27,6 +27,28 @@
 
 namespace SST {
 
+/**
+ * Null Event.  Used when nullptr is passed into any of the send
+ * functions.  On delivery, it will delete itself and return nullptr.
+ */
+
+class NullEvent : public Event
+{
+public:
+    NullEvent() : Event() {}
+    ~NullEvent() {}
+
+    void execute(void) override
+    {
+        (*reinterpret_cast<HandlerBase*>(delivery_info))(nullptr);
+        delete this;
+    }
+
+private:
+    ImplementSerializable(SST::NullEvent)
+};
+
+
 Link::Link(LinkId_t tag) :
     send_queue(nullptr),
     delivery_info(0),

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -292,6 +292,7 @@ public:
     }
 };
 
+
 } // namespace SST
 
 #endif // SST_CORE_LINK_H

--- a/src/sst/core/module.h
+++ b/src/sst/core/module.h
@@ -30,8 +30,22 @@ public:
 };
 } // namespace SST
 
-#define SST_ELI_REGISTER_MODULE(cls, lib, name, version, desc, interface)               \
-    SST_ELI_REGISTER_DERIVED(SST::Module,cls,lib,name,ELI_FORWARD_AS_ONE(version),desc) \
+// Very hackish way to get a deprecation warning for
+// SST_ELI_REGISTER_MODULE, but there are no standard ways to do this
+class sst_eli_fake_deprecated_class
+{
+public:
+    static constexpr int fake_deprecated_function()
+        __attribute__((deprecated("SST_ELI_REGISTER_MODULE is deprecated and will be removed in SST 13. Please use the "
+                                  "new SST_ELI_REGISTER_MODULE_API and SST_ELI_REGISTER_MODULE_DERIVED macros")))
+    {
+        return 0;
+    }
+};
+
+#define SST_ELI_REGISTER_MODULE(cls, lib, name, version, desc, interface)                            \
+    static const int SST_ELI_FAKE_VALUE = sst_eli_fake_deprecated_class::fake_deprecated_function(); \
+    SST_ELI_REGISTER_DERIVED(SST::Module,cls,lib,name,ELI_FORWARD_AS_ONE(version),desc)              \
     SST_ELI_INTERFACE_INFO(interface)
 
 // New way to register modules.  Must register an interface (API)

--- a/src/sst/core/testElements/coreTest_Module.h
+++ b/src/sst/core/testElements/coreTest_Module.h
@@ -31,13 +31,11 @@ class CoreTestModuleExample : public SST::Module
 public:
     CoreTestModuleExample(SST::Params& params);
 
-    SST_ELI_REGISTER_MODULE(
-        CoreTestModuleExample,
-        "coreTestElement",
-        "CoreTestModule",
-        SST_ELI_ELEMENT_VERSION(1, 0, 0),
-        "CoreTest module to demonstrate interface.",
-        "SST::CoreTestModule::CoreTestModuleInterface")
+    SST_ELI_REGISTER_MODULE_API(SST::CoreTestModule::CoreTestModuleExample)
+
+    SST_ELI_REGISTER_MODULE_DERIVED(
+        CoreTestModuleExample, "coreTestElement", "CoreTestModule", SST_ELI_ELEMENT_VERSION(1, 0, 0),
+        "CoreTest module to demonstrate interface.", SST::CoreTestModule::CoreTestModuleExample)
 
     SST_ELI_DOCUMENT_PARAMS(
         {"modulename", "Name to give this module", ""},


### PR DESCRIPTION
- Deprecated old module ELI in favor of using Module APIs
- Moved NullEvent into core private API and added EmptyEvent
