### PR TITLE
Remove use of sprintf

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -183,6 +183,7 @@ sst_core_sources = \
 	params.cc \
 	pollingLinkQueue.cc \
 	simulation.cc \
+	stringize.cc \
 	subcomponent.cc \
 	timeLord.cc \
 	uninitializedQueue.cc \

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -20,6 +20,7 @@
 #include "sst/core/linkMap.h"
 #include "sst/core/simulation_impl.h"
 #include "sst/core/statapi/statoutput.h"
+#include "sst/core/stringize.h"
 #include "sst/core/subcomponent.h"
 #include "sst/core/timeConverter.h"
 #include "sst/core/timeLord.h"
@@ -530,15 +531,15 @@ BaseComponent::vfatal(
         parent    = parent->parent_info;
     }
 
-    char new_format[256];
+    std::string new_format;
 
-    snprintf(
-        new_format, 256, "\nElement name: %s,  type: %s (full type tree: %s)\n%s", name.c_str(), type.c_str(),
-        type_tree.c_str(), format);
+    new_format = format_string(
+        "\nElement name: %s,  type: %s (full type tree: %s)\n%s", name.c_str(), type.c_str(), type_tree.c_str(),
+        format);
 
-    char buf[512];
-    vsnprintf(buf, 512, new_format, arg);
-    abort.fatal(line, file, func, exit_code, "%s", buf);
+    std::string buf;
+    buf = format_string(new_format.c_str(), arg);
+    abort.fatal(line, file, func, exit_code, "%s", buf.c_str());
 }
 
 void

--- a/src/sst/core/bootshared.cc
+++ b/src/sst/core/bootshared.cc
@@ -33,7 +33,7 @@ update_env_var(const char* name, const int UNUSED(verbose), char* UNUSED(argv[])
         new_ld_path_copy[i] = '\0';
     }
 
-    if ( nullptr != current_ld_path ) { sprintf(new_ld_path, "%s", current_ld_path); }
+    if ( nullptr != current_ld_path ) { snprintf(new_ld_path, 32768, "%s", current_ld_path); }
     std::vector<std::string>                          configFiles;
     SST::Core::Environment::EnvironmentConfiguration* envConfig =
         SST::Core::Environment::getSSTEnvironmentConfiguration(configFiles);
@@ -53,7 +53,7 @@ update_env_var(const char* name, const int UNUSED(verbose), char* UNUSED(argv[])
 
                 if ( strcmp(&paramNameEnding[paramName.size() - 6], "LIBDIR") == 0 ) {
                     strcpy(new_ld_path_copy, new_ld_path);
-                    sprintf(new_ld_path, "%s:%s", value.c_str(), new_ld_path_copy);
+                    snprintf(new_ld_path, 32768, "%s:%s", value.c_str(), new_ld_path_copy);
                 }
             }
         }
@@ -82,9 +82,11 @@ boot_sst_executable(const char* binary, const int verbose, char* argv[], const i
 {
     char* real_binary_path = (char*)malloc(sizeof(char) * PATH_MAX);
 
-    if ( strcmp(SST_INSTALL_PREFIX, "NONE") == 0 ) { sprintf(real_binary_path, "/usr/local/libexec/%s", binary); }
+    if ( strcmp(SST_INSTALL_PREFIX, "NONE") == 0 ) {
+        snprintf(real_binary_path, PATH_MAX, "/usr/local/libexec/%s", binary);
+    }
     else {
-        sprintf(real_binary_path, "%s/libexec/%s", SST_INSTALL_PREFIX, binary);
+        snprintf(real_binary_path, PATH_MAX, "%s/libexec/%s", SST_INSTALL_PREFIX, binary);
     }
 
     if ( verbose ) {

--- a/src/sst/core/cfgoutput/pythonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.cc
@@ -57,7 +57,7 @@ PythonConfigGraphOutput::getLinkObject(LinkId_t id, bool no_cut)
 {
     if ( linkMap.find(id) == linkMap.end() ) {
         char tmp[8 + 8 + 1];
-        sprintf(tmp, "link_id_%08" PRIx32, id);
+        snprintf(tmp, 8 + 8 + 1, "link_id_%08" PRIx32, id);
         fprintf(outputFile, "%s = sst.Link(\"%s\")\n", tmp, tmp);
         if ( no_cut ) fprintf(outputFile, "%s.setNoCut()\n", tmp);
         linkMap[id] = tmp;
@@ -130,8 +130,9 @@ PythonConfigGraphOutput::generateCommonComponent(const char* objName, const Conf
 void
 PythonConfigGraphOutput::generateSubComponent(const char* owner, const ConfigComponent* comp)
 {
-    char* combName = (char*)calloc(1, strlen(owner) + strlen("_subcomp_") + 1);
-    sprintf(combName, "%s%s", owner, "_subcomp_");
+    size_t slen     = strlen(owner) + strlen("_subcomp_") + 1;
+    char*  combName = (char*)calloc(1, slen);
+    snprintf(combName, slen, "%s%s", owner, "_subcomp_");
     char* pyCompName = makePythonSafeWithPrefix(comp->name.c_str(), combName);
     char* esCompName = makeEscapeSafe(comp->name.c_str());
 
@@ -333,33 +334,39 @@ PythonConfigGraphOutput::makePythonSafeWithPrefix(const std::string& name, const
     if ( nameLength > 0 && isdigit(name.at(0)) ) {
         if ( name.size() > prefix.size() ) {
             if ( name.substr(0, prefix.size()) == prefix ) {
-                buffer = (char*)malloc(sizeof(char) * (name.size() + 3));
-                sprintf(buffer, "s_%s", name.c_str());
+                size_t slen = name.size() + 3;
+                buffer      = (char*)malloc(sizeof(char) * slen);
+                snprintf(buffer, slen, "s_%s", name.c_str());
             }
             else {
-                buffer = (char*)malloc(sizeof(char) * (name.size() + prefix.size() + 3));
-                sprintf(buffer, "%ss_%s", prefix.c_str(), name.c_str());
+                size_t slen = name.size() + prefix.size() + 3;
+                buffer      = (char*)malloc(sizeof(char) * slen);
+                snprintf(buffer, slen, "%ss_%s", prefix.c_str(), name.c_str());
             }
         }
         else {
-            buffer = (char*)malloc(sizeof(char) * (name.size() + prefix.size() + 3));
-            sprintf(buffer, "%ss_%s", prefix.c_str(), name.c_str());
+            size_t slen = name.size() + prefix.size() + 3;
+            buffer      = (char*)malloc(sizeof(char) * slen);
+            snprintf(buffer, slen, "%ss_%s", prefix.c_str(), name.c_str());
         }
     }
     else {
         if ( name.size() > prefix.size() ) {
             if ( name.substr(0, prefix.size()) == prefix ) {
-                buffer = (char*)malloc(sizeof(char) * (name.size() + 3));
-                sprintf(buffer, "%s", name.c_str());
+                size_t slen = name.size() + 3;
+                buffer      = (char*)malloc(sizeof(char) * slen);
+                snprintf(buffer, slen, "%s", name.c_str());
             }
             else {
-                buffer = (char*)malloc(sizeof(char) * (prefix.size() + name.size() + 1));
-                sprintf(buffer, "%s%s", prefix.c_str(), name.c_str());
+                size_t slen = prefix.size() + name.size() + 1;
+                buffer      = (char*)malloc(sizeof(char) * slen);
+                snprintf(buffer, slen, "%s%s", prefix.c_str(), name.c_str());
             }
         }
         else {
-            buffer = (char*)malloc(sizeof(char) * (prefix.size() + name.size() + 1));
-            sprintf(buffer, "%s%s", prefix.c_str(), name.c_str());
+            size_t slen = prefix.size() + name.size() + 1;
+            buffer      = (char*)malloc(sizeof(char) * slen);
+            snprintf(buffer, slen, "%s%s", prefix.c_str(), name.c_str());
         }
     }
 
@@ -435,8 +442,9 @@ PythonConfigGraphOutput::makeEscapeSafe(const std::string& input) const
         }
     }
 
-    char* escapedBuffer = (char*)malloc(sizeof(char) * (1 + escapedInput.size()));
-    sprintf(escapedBuffer, "%s", escapedInput.c_str());
+    size_t slen          = 1 + escapedInput.size();
+    char*  escapedBuffer = (char*)malloc(sizeof(char) * slen);
+    snprintf(escapedBuffer, slen, "%s", escapedInput.c_str());
 
     return escapedBuffer;
 }

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -160,9 +160,11 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
     for ( std::string const& next_path : paths ) {
         if ( verbose ) { printf("SST-DL: Searching: %s\n", next_path.c_str()); }
 
-        if ( next_path.back() == '/' ) { sprintf(full_path, "%slib%s.so", next_path.c_str(), elemlib.c_str()); }
+        if ( next_path.back() == '/' ) {
+            snprintf(full_path, PATH_MAX, "%slib%s.so", next_path.c_str(), elemlib.c_str());
+        }
         else {
-            sprintf(full_path, "%s/lib%s.so", next_path.c_str(), elemlib.c_str());
+            snprintf(full_path, PATH_MAX, "%s/lib%s.so", next_path.c_str(), elemlib.c_str());
         }
 
         if ( verbose ) { printf("SST-DL: Attempting to load %s\n", full_path); }
@@ -192,9 +194,11 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
         // this implies ordering of .so before .dylib in priority.
 
         if ( nullptr == handle ) {
-            if ( next_path.back() == '/' ) { sprintf(full_path, "%slib%s.dylib", next_path.c_str(), elemlib.c_str()); }
+            if ( next_path.back() == '/' ) {
+                snprintf(full_path, PATH_MAX, "%slib%s.dylib", next_path.c_str(), elemlib.c_str());
+            }
             else {
-                sprintf(full_path, "%s/lib%s.dylib", next_path.c_str(), elemlib.c_str());
+                snprintf(full_path, PATH_MAX, "%s/lib%s.dylib", next_path.c_str(), elemlib.c_str());
             }
 
             if ( verbose ) { printf("SST-DL: Attempting to load %s\n", full_path); }

--- a/src/sst/core/env/envquery.cc
+++ b/src/sst/core/env/envquery.cc
@@ -158,9 +158,9 @@ SST::Core::Environment::getSSTEnvironmentConfiguration(const std::vector<std::st
     char* homeConfigPath = (char*)malloc(sizeof(char) * PATH_MAX);
     char* userHome       = getenv("HOME");
 
-    if ( nullptr == userHome ) { sprintf(homeConfigPath, "~/.sst/sstsimulator.conf"); }
+    if ( nullptr == userHome ) { snprintf(homeConfigPath, PATH_MAX, "~/.sst/sstsimulator.conf"); }
     else {
-        sprintf(homeConfigPath, "%s/.sst/sstsimulator.conf", userHome);
+        snprintf(homeConfigPath, PATH_MAX, "%s/.sst/sstsimulator.conf", userHome);
     }
 
     const std::string homeConfigPathStr(homeConfigPath);

--- a/src/sst/core/heartbeat.cc
+++ b/src/sst/core/heartbeat.cc
@@ -15,6 +15,7 @@
 
 #include "sst/core/component.h"
 #include "sst/core/simulation_impl.h"
+#include "sst/core/stringize.h"
 #include "sst/core/timeConverter.h"
 #include "sst/core/warnmacros.h"
 
@@ -92,19 +93,19 @@ SimulatorHeartbeat::execute(void)
 #endif
 
     if ( rank == 0 ) {
-        char ua_buffer[256];
+        std::string ua_str;
 
-        sprintf(ua_buffer, "%" PRIu64 "B", global_max_sync_data_size);
-        UnitAlgebra global_max_sync_data_size_ua(ua_buffer);
+        ua_str = format_string("%" PRIu64 "B", global_max_sync_data_size);
+        UnitAlgebra global_max_sync_data_size_ua(ua_str);
 
-        sprintf(ua_buffer, "%" PRIu64 "B", global_sync_data_size);
-        UnitAlgebra global_sync_data_size_ua(ua_buffer);
+        ua_str = format_string("%" PRIu64 "B", global_sync_data_size);
+        UnitAlgebra global_sync_data_size_ua(ua_str);
 
-        sprintf(ua_buffer, "%" PRIu64 "B", max_mempool_size);
-        UnitAlgebra max_mempool_size_ua(ua_buffer);
+        ua_str = format_string("%" PRIu64 "B", max_mempool_size);
+        UnitAlgebra max_mempool_size_ua(ua_str);
 
-        sprintf(ua_buffer, "%" PRIu64 "B", global_mempool_size);
-        UnitAlgebra global_mempool_size_ua(ua_buffer);
+        ua_str = format_string("%" PRIu64 "B", global_mempool_size);
+        UnitAlgebra global_mempool_size_ua(ua_str);
 
         sim_output.output("\tMax mempool usage:               %s\n", max_mempool_size_ua.toStringBestSI().c_str());
         sim_output.output("\tGlobal mempool usage:            %s\n", global_mempool_size_ua.toStringBestSI().c_str());

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -37,6 +37,7 @@ REENABLE_WARNING
 #include "sst/core/rankInfo.h"
 #include "sst/core/simulation_impl.h"
 #include "sst/core/statapi/statengine.h"
+#include "sst/core/stringize.h"
 #include "sst/core/threadsafe.h"
 #include "sst/core/timeLord.h"
 #include "sst/core/timeVortex.h"
@@ -889,23 +890,23 @@ main(int argc, char* argv[])
     const uint64_t global_max_io_out = maxOutputOperations();
 
     if ( myRank.rank == 0 && (cfg.verbose() || cfg.print_timing()) ) {
-        char ua_buffer[256];
-        sprintf(ua_buffer, "%" PRIu64 "KB", local_max_rss);
+        std::string ua_buffer;
+        ua_buffer = format_string("%" PRIu64 "KB", local_max_rss);
         UnitAlgebra max_rss_ua(ua_buffer);
 
-        sprintf(ua_buffer, "%" PRIu64 "KB", global_max_rss);
+        ua_buffer = format_string("%" PRIu64 "KB", global_max_rss);
         UnitAlgebra global_rss_ua(ua_buffer);
 
-        sprintf(ua_buffer, "%" PRIu64 "B", global_max_sync_data_size);
+        ua_buffer = format_string("%" PRIu64 "B", global_max_sync_data_size);
         UnitAlgebra global_max_sync_data_size_ua(ua_buffer);
 
-        sprintf(ua_buffer, "%" PRIu64 "B", global_sync_data_size);
+        ua_buffer = format_string("%" PRIu64 "B", global_sync_data_size);
         UnitAlgebra global_sync_data_size_ua(ua_buffer);
 
-        sprintf(ua_buffer, "%" PRIu64 "B", max_mempool_size);
+        ua_buffer = format_string("%" PRIu64 "B", max_mempool_size);
         UnitAlgebra max_mempool_size_ua(ua_buffer);
 
-        sprintf(ua_buffer, "%" PRIu64 "B", global_mempool_size);
+        ua_buffer = format_string("%" PRIu64 "B", global_mempool_size);
         UnitAlgebra global_mempool_size_ua(ua_buffer);
 
         g_output.output("\n");

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -1081,8 +1081,9 @@ SSTPythonModelDefinition::SSTPythonModelDefinition(
     const int argc = argv_vector.size();
 
     for ( int i = 0; i < argc; ++i ) {
-        argv[i] = (char*)malloc(sizeof(char) * argv_vector[i].size() + 1);
-        sprintf(argv[i], "%s", argv_vector[i].c_str());
+        size_t slen = argv_vector[i].size() + 1;
+        argv[i]     = (char*)malloc(sizeof(char) * slen);
+        snprintf(argv[i], slen, "%s", argv_vector[i].c_str());
     }
 
     // Init the model

--- a/src/sst/core/model/python/pymodel_comp.cc
+++ b/src/sst/core/model/python/pymodel_comp.cc
@@ -24,6 +24,7 @@
 #include "sst/core/model/python/pymodel_stat.h"
 #include "sst/core/simulation.h"
 #include "sst/core/sst_types.h"
+#include "sst/core/stringize.h"
 #include "sst/core/subcomponent.h"
 #include "sst/core/warnmacros.h"
 
@@ -279,12 +280,11 @@ compSetSubComponent(PyObject* self, PyObject* args)
         return subObj;
     }
 
-    char errMsg[1024] = { 0 };
-    snprintf(
-        errMsg, sizeof(errMsg) - 1,
+    std::string errMsg = format_string(
         "Failed to create subcomponent %s on %s.  Already attached a subcomponent at that slot name and number?\n",
         name, c->name.c_str());
-    PyErr_SetString(PyExc_RuntimeError, errMsg);
+
+    PyErr_SetString(PyExc_RuntimeError, errMsg.c_str());
     return nullptr;
 }
 
@@ -495,9 +495,8 @@ compCreateStatistic(PyObject* self, PyObject* args)
 
     ConfigStatistic* cs = comp->createStatistic();
     if ( cs == nullptr ) {
-        char errMsg[1024] = { 0 };
-        snprintf(errMsg, sizeof(errMsg) - 1, "Failed to create statistic '%s' on '%s'", name, comp->name.c_str());
-        PyErr_SetString(PyExc_RuntimeError, errMsg);
+        std::string errMsg = format_string("Failed to create statistic '%s' on '%s'", name, comp->name.c_str());
+        PyErr_SetString(PyExc_RuntimeError, errMsg.c_str());
         return nullptr;
     }
 

--- a/src/sst/core/output.cc
+++ b/src/sst/core/output.cc
@@ -300,7 +300,7 @@ Output::openSSTTargetFile() const
 
                 // Append the rank to file name if MPI_COMM_WORLD is GT 1
                 if ( getMPIWorldSize() > 1 ) {
-                    sprintf(tempBuf, "%d", getMPIWorldRank());
+                    snprintf(tempBuf, 256, "%d", getMPIWorldRank());
                     tempFileName += tempBuf;
                 }
 
@@ -360,7 +360,7 @@ Output::buildPrefixString(uint32_t line, const std::string& file, const std::str
                 startindex = findindex + 2;
                 break;
             case 'l':
-                sprintf(tempBuf, "%d", line);
+                snprintf(tempBuf, 256, "%d", line);
                 rtnstring += tempBuf;
                 startindex = findindex + 2;
                 break;
@@ -371,7 +371,7 @@ Output::buildPrefixString(uint32_t line, const std::string& file, const std::str
             case 'r':
                 if ( 1 == getMPIWorldSize() ) { rtnstring += ""; }
                 else {
-                    sprintf(tempBuf, "%d", getMPIWorldRank());
+                    snprintf(tempBuf, 256, "%d", getMPIWorldRank());
                     rtnstring += tempBuf;
                 }
                 startindex = findindex + 2;
@@ -379,7 +379,7 @@ Output::buildPrefixString(uint32_t line, const std::string& file, const std::str
             case 'R':
                 if ( 1 == getMPIWorldSize() ) { rtnstring += "0"; }
                 else {
-                    sprintf(tempBuf, "%d", getMPIWorldRank());
+                    snprintf(tempBuf, 256, "%d", getMPIWorldRank());
                     rtnstring += tempBuf;
                 }
                 startindex = findindex + 2;
@@ -387,30 +387,30 @@ Output::buildPrefixString(uint32_t line, const std::string& file, const std::str
             case 'i':
                 if ( 1 == getNumThreads() ) { rtnstring += ""; }
                 else {
-                    sprintf(tempBuf, "%u", getThreadRank());
+                    snprintf(tempBuf, 256, "%u", getThreadRank());
                     rtnstring += tempBuf;
                 }
                 startindex = findindex + 2;
                 break;
             case 'I':
-                sprintf(tempBuf, "%u", getThreadRank());
+                snprintf(tempBuf, 256, "%u", getThreadRank());
                 rtnstring += tempBuf;
                 startindex = findindex + 2;
                 break;
             case 'x':
                 if ( getMPIWorldSize() != 1 || getNumThreads() != 1 ) {
-                    sprintf(tempBuf, "[%d:%u]", getMPIWorldRank(), getThreadRank());
+                    snprintf(tempBuf, 256, "[%d:%u]", getMPIWorldRank(), getThreadRank());
                     rtnstring += tempBuf;
                 }
                 startindex = findindex + 2;
                 break;
             case 'X':
-                sprintf(tempBuf, "[%d:%u]", getMPIWorldRank(), getThreadRank());
+                snprintf(tempBuf, 256, "[%d:%u]", getMPIWorldRank(), getThreadRank());
                 rtnstring += tempBuf;
                 startindex = findindex + 2;
                 break;
             case 't':
-                sprintf(tempBuf, "%" PRIu64, Simulation_impl::getSimulation()->getCurrentSimCycle());
+                snprintf(tempBuf, 256, "%" PRIu64, Simulation_impl::getSimulation()->getCurrentSimCycle());
                 rtnstring += tempBuf;
                 startindex = findindex + 2;
                 break;
@@ -536,7 +536,7 @@ TraceFunction::output(const char* format, ...) const
 
     int indent           = trace_level * indent_length;
     indent_array[indent] = '\0';
-    sprintf(buf, "%s%s", indent_array.data(), format);
+    snprintf(buf, 200, "%s%s", indent_array.data(), format);
     indent_array[indent] = ' ';
 
     va_list arg;

--- a/src/sst/core/rng/marsaglia.h
+++ b/src/sst/core/rng/marsaglia.h
@@ -19,8 +19,6 @@
 #include <stdint.h>
 #include <sys/time.h>
 
-#include "sstrng.h"
-
 #define MARSAGLIA_UINT32_MAX 4294967295U
 #define MARSAGLIA_UINT64_MAX 18446744073709551615ULL
 #define MARSAGLIA_INT32_MAX  2147483647L

--- a/src/sst/core/rng/mersenne.h
+++ b/src/sst/core/rng/mersenne.h
@@ -17,8 +17,6 @@
 #include <stdint.h>
 #include <sys/time.h>
 
-#include "sstrng.h"
-
 #define MERSENNE_UINT32_MAX 4294967295U
 #define MERSENNE_UINT64_MAX 18446744073709551615ULL
 #define MERSENNE_INT32_MAX  2147483647L

--- a/src/sst/core/rng/sstrng.h
+++ b/src/sst/core/rng/sstrng.h
@@ -12,6 +12,9 @@
 #ifndef SST_CORE_RNG_SSTRNG_H
 #define SST_CORE_RNG_SSTRNG_H
 
+#warning \
+    "sst/core/rng/sstrng.h is deprecated and will be removed in SST 13.  Please use the equivalent functionality in sst/core/rng/rng.h"
+
 #include "sst/core/rng/rng.h"
 
 #include <stdint.h>

--- a/src/sst/core/rng/xorshift.h
+++ b/src/sst/core/rng/xorshift.h
@@ -17,8 +17,6 @@
 #include <stdint.h>
 #include <sys/time.h>
 
-#include "sstrng.h"
-
 #define XORSHIFT_UINT32_MAX 4294967295U
 #define XORSHIFT_UINT64_MAX 18446744073709551615ULL
 #define XORSHIFT_INT32_MAX  2147483647L

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -650,14 +650,14 @@ Simulation_impl::run()
     // Tell the Statistics Engine that the simulation is beginning
     if ( my_rank.thread == 0 ) StatisticProcessingEngine::getInstance()->startOfSimulation();
 
-    std::string header = SST::to_string(my_rank.rank);
+    std::string header = std::to_string(my_rank.rank);
     header += ", ";
-    header += SST::to_string(my_rank.thread);
+    header += std::to_string(my_rank.thread);
     header += ":  ";
 
 #if SST_PERFORMANCE_INSTRUMENTING
-    std::string filename = "rank_" + SST::to_string(my_rank.rank);
-    filename += "_thread_" + SST::to_string(my_rank.thread);
+    std::string filename = "rank_" + std::to_string(my_rank.rank);
+    filename += "_thread_" + std::to_string(my_rank.thread);
     fp = fopen(filename.c_str(), "w");
 #endif
 

--- a/src/sst/core/sstregistertool.cc
+++ b/src/sst/core/sstregistertool.cc
@@ -54,14 +54,14 @@ main(int argc, char* argv[])
     }
 
     // Check for configuration file
-    sprintf(cfgPath, SST_INSTALL_PREFIX "/etc/sst/sstsimulator.conf");
+    snprintf(cfgPath, PATH_MAX, SST_INSTALL_PREFIX "/etc/sst/sstsimulator.conf");
     FILE* cfgFile = fopen(cfgPath, "r+");
     if ( nullptr == cfgFile ) {
         char* envHome = getenv("HOME");
 
-        if ( nullptr == envHome ) { sprintf(cfgPath, "~/.sst/sstsimulator.conf"); }
+        if ( nullptr == envHome ) { snprintf(cfgPath, PATH_MAX, "~/.sst/sstsimulator.conf"); }
         else {
-            sprintf(cfgPath, "%s/.sst/sstsimulator.conf", envHome);
+            snprintf(cfgPath, PATH_MAX, "%s/.sst/sstsimulator.conf", envHome);
         }
 
         cfgFile = fopen(cfgPath, "r+");

--- a/src/sst/core/statapi/statfieldinfo.cc
+++ b/src/sst/core/statapi/statfieldinfo.cc
@@ -42,7 +42,7 @@ StatisticFieldInfo::getFieldUniqueName() const
 {
     std::string strRtn;
     strRtn = getFieldName() + ".";
-    strRtn += SST::to_string(getFieldType());
+    strRtn += std::to_string(getFieldType());
     return strRtn;
 }
 

--- a/src/sst/core/statapi/statoutputcsv.cc
+++ b/src/sst/core/statapi/statoutputcsv.cc
@@ -91,7 +91,7 @@ StatisticOutputCSV::startOfSimulation()
     // Set Filename with Rank if Num Ranks > 1
     if ( 1 < Simulation_impl::getSimulation()->getNumRanks().rank ) {
         int         rank    = Simulation_impl::getSimulation()->getRank().rank;
-        std::string rankstr = "_" + SST::to_string(rank);
+        std::string rankstr = "_" + std::to_string(rank);
 
         // Search for any extension
         size_t index = m_FilePath.find_last_of(".");
@@ -229,48 +229,48 @@ StatisticOutputCSV::implStopOutputEntries()
 void
 StatisticOutputCSV::outputField(fieldHandle_t fieldHandle, int32_t data)
 {
-    char buffer[256];
-    sprintf(buffer, "%" PRId32, data);
+    std::string buffer;
+    buffer                           = format_string("%" PRId32, data);
     m_OutputBufferArray[fieldHandle] = buffer;
 }
 
 void
 StatisticOutputCSV::outputField(fieldHandle_t fieldHandle, uint32_t data)
 {
-    char buffer[256];
-    sprintf(buffer, "%" PRIu32, data);
+    std::string buffer;
+    buffer                           = format_string("%" PRIu32, data);
     m_OutputBufferArray[fieldHandle] = buffer;
 }
 
 void
 StatisticOutputCSV::outputField(fieldHandle_t fieldHandle, int64_t data)
 {
-    char buffer[256];
-    sprintf(buffer, "%" PRId64, data);
+    std::string buffer;
+    buffer                           = format_string("%" PRId64, data);
     m_OutputBufferArray[fieldHandle] = buffer;
 }
 
 void
 StatisticOutputCSV::outputField(fieldHandle_t fieldHandle, uint64_t data)
 {
-    char buffer[256];
-    sprintf(buffer, "%" PRIu64, data);
+    std::string buffer;
+    buffer                           = format_string("%" PRIu64, data);
     m_OutputBufferArray[fieldHandle] = buffer;
 }
 
 void
 StatisticOutputCSV::outputField(fieldHandle_t fieldHandle, float data)
 {
-    char buffer[256];
-    sprintf(buffer, "%f", data);
+    std::string buffer;
+    buffer                           = format_string("%f", data);
     m_OutputBufferArray[fieldHandle] = buffer;
 }
 
 void
 StatisticOutputCSV::outputField(fieldHandle_t fieldHandle, double data)
 {
-    char buffer[256];
-    sprintf(buffer, "%f", data);
+    std::string buffer;
+    buffer                           = format_string("%f", data);
     m_OutputBufferArray[fieldHandle] = buffer;
 }
 

--- a/src/sst/core/statapi/statoutputtxt.cc
+++ b/src/sst/core/statapi/statoutputtxt.cc
@@ -85,7 +85,7 @@ StatisticOutputTextBase::startOfSimulation()
     // Set Filename with Rank if Num Ranks > 1
     if ( 1 < Simulation_impl::getSimulation()->getNumRanks().rank ) {
         int         rank    = Simulation_impl::getSimulation()->getRank().rank;
-        std::string rankstr = "_" + SST::to_string(rank);
+        std::string rankstr = "_" + std::to_string(rank);
 
         // Search for any extension
         size_t index = m_FilePath.find_last_of(".");
@@ -149,7 +149,7 @@ StatisticOutputTextBase::endOfSimulation()
 void
 StatisticOutputTextBase::implStartOutputEntries(StatisticBase* statistic)
 {
-    char buffer[256];
+    std::string buffer;
 
     // Starting Output
     // m_outputBuffer.clear();
@@ -162,10 +162,10 @@ StatisticOutputTextBase::implStartOutputEntries(StatisticBase* statistic)
     if ( true == m_outputSimTime ) {
         // Add the Simulation Time to the front
         if ( true == m_outputInlineHeader ) {
-            sprintf(buffer, "SimTime = %" PRIu64, Simulation_impl::getSimulation()->getCurrentSimCycle());
+            buffer = format_string("SimTime = %" PRIu64, Simulation_impl::getSimulation()->getCurrentSimCycle());
         }
         else {
-            sprintf(buffer, "%" PRIu64, Simulation_impl::getSimulation()->getCurrentSimCycle());
+            buffer = format_string("%" PRIu64, Simulation_impl::getSimulation()->getCurrentSimCycle());
         }
 
         m_outputBuffer += buffer;
@@ -175,10 +175,10 @@ StatisticOutputTextBase::implStartOutputEntries(StatisticBase* statistic)
     if ( true == m_outputRank ) {
         // Add the Rank to the front
         if ( true == m_outputInlineHeader ) {
-            sprintf(buffer, "Rank = %d", Simulation_impl::getSimulation()->getRank().rank);
+            buffer = format_string("Rank = %d", Simulation_impl::getSimulation()->getRank().rank);
         }
         else {
-            sprintf(buffer, "%d", Simulation_impl::getSimulation()->getRank().rank);
+            buffer = format_string("%d", Simulation_impl::getSimulation()->getRank().rank);
         }
 
         m_outputBuffer += buffer;
@@ -197,17 +197,17 @@ StatisticOutputTextBase::implStopOutputEntries()
 void
 StatisticOutputTextBase::outputField(fieldHandle_t fieldHandle, int32_t data)
 {
-    char                buffer[256];
+    std::string         buffer;
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
     if ( nullptr != FieldInfo ) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
 
         if ( true == m_outputInlineHeader ) {
-            sprintf(buffer, "%s.%s = %" PRId32, FieldInfo->getFieldName().c_str(), typeName, data);
+            buffer = format_string("%s.%s = %" PRId32, FieldInfo->getFieldName().c_str(), typeName, data);
         }
         else {
-            sprintf(buffer, "%" PRId32, data);
+            buffer = format_string("%" PRId32, data);
         }
         m_outputBuffer += buffer;
         m_outputBuffer += "; ";
@@ -217,17 +217,17 @@ StatisticOutputTextBase::outputField(fieldHandle_t fieldHandle, int32_t data)
 void
 StatisticOutputTextBase::outputField(fieldHandle_t fieldHandle, uint32_t data)
 {
-    char                buffer[256];
+    std::string         buffer;
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
     if ( nullptr != FieldInfo ) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
 
         if ( true == m_outputInlineHeader ) {
-            sprintf(buffer, "%s.%s = %" PRIu32, FieldInfo->getFieldName().c_str(), typeName, data);
+            buffer = format_string("%s.%s = %" PRIu32, FieldInfo->getFieldName().c_str(), typeName, data);
         }
         else {
-            sprintf(buffer, "%" PRIu32, data);
+            buffer = format_string("%" PRIu32, data);
         }
         m_outputBuffer += buffer;
         m_outputBuffer += "; ";
@@ -237,17 +237,17 @@ StatisticOutputTextBase::outputField(fieldHandle_t fieldHandle, uint32_t data)
 void
 StatisticOutputTextBase::outputField(fieldHandle_t fieldHandle, int64_t data)
 {
-    char                buffer[256];
+    std::string         buffer;
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
     if ( nullptr != FieldInfo ) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
 
         if ( true == m_outputInlineHeader ) {
-            sprintf(buffer, "%s.%s = %" PRId64, FieldInfo->getFieldName().c_str(), typeName, data);
+            buffer = format_string("%s.%s = %" PRId64, FieldInfo->getFieldName().c_str(), typeName, data);
         }
         else {
-            sprintf(buffer, "%" PRId64, data);
+            buffer = format_string("%" PRId64, data);
         }
         m_outputBuffer += buffer;
         m_outputBuffer += "; ";
@@ -257,17 +257,17 @@ StatisticOutputTextBase::outputField(fieldHandle_t fieldHandle, int64_t data)
 void
 StatisticOutputTextBase::outputField(fieldHandle_t fieldHandle, uint64_t data)
 {
-    char                buffer[256];
+    std::string         buffer;
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
     if ( nullptr != FieldInfo ) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
 
         if ( true == m_outputInlineHeader ) {
-            sprintf(buffer, "%s.%s = %" PRIu64, FieldInfo->getFieldName().c_str(), typeName, data);
+            buffer = format_string("%s.%s = %" PRIu64, FieldInfo->getFieldName().c_str(), typeName, data);
         }
         else {
-            sprintf(buffer, "%" PRIu64, data);
+            buffer = format_string("%" PRIu64, data);
         }
         m_outputBuffer += buffer;
         m_outputBuffer += "; ";
@@ -277,17 +277,17 @@ StatisticOutputTextBase::outputField(fieldHandle_t fieldHandle, uint64_t data)
 void
 StatisticOutputTextBase::outputField(fieldHandle_t fieldHandle, float data)
 {
-    char                buffer[256];
+    std::string         buffer;
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
     if ( nullptr != FieldInfo ) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
 
         if ( true == m_outputInlineHeader ) {
-            sprintf(buffer, "%s.%s = %f", FieldInfo->getFieldName().c_str(), typeName, data);
+            buffer = format_string("%s.%s = %f", FieldInfo->getFieldName().c_str(), typeName, data);
         }
         else {
-            sprintf(buffer, "%f", data);
+            buffer = format_string("%f", data);
         }
         m_outputBuffer += buffer;
         m_outputBuffer += "; ";
@@ -297,17 +297,17 @@ StatisticOutputTextBase::outputField(fieldHandle_t fieldHandle, float data)
 void
 StatisticOutputTextBase::outputField(fieldHandle_t fieldHandle, double data)
 {
-    char                buffer[256];
+    std::string         buffer;
     StatisticFieldInfo* FieldInfo = getRegisteredField(fieldHandle);
 
     if ( nullptr != FieldInfo ) {
         const char* typeName = getFieldTypeShortName(FieldInfo->getFieldType());
 
         if ( true == m_outputInlineHeader ) {
-            sprintf(buffer, "%s.%s = %f", FieldInfo->getFieldName().c_str(), typeName, data);
+            buffer = format_string("%s.%s = %f", FieldInfo->getFieldName().c_str(), typeName, data);
         }
         else {
-            sprintf(buffer, "%f", data);
+            buffer = format_string("%f", data);
         }
         m_outputBuffer += buffer;
         m_outputBuffer += "; ";

--- a/src/sst/core/stringize.cc
+++ b/src/sst/core/stringize.cc
@@ -1,0 +1,73 @@
+// Copyright 2009-2022 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2022, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+#include "stringize.h"
+
+#include <cstdarg>
+#include <cstdio>
+
+namespace SST {
+
+std::string
+vformat_string(size_t max_length, const char* format, va_list args)
+{
+    char* buf = new char[max_length];
+
+    vsnprintf(buf, max_length, format, args);
+
+    std::string ret(buf);
+    delete[] buf;
+    return ret;
+}
+
+std::string
+vformat_string(const char* format, va_list args)
+{
+    char buf[256];
+
+    va_list args_copy;
+    va_copy(args_copy, args);
+    size_t length = vsnprintf(buf, 256, format, args_copy);
+
+    if ( length < 256 ) return std::string(buf);
+
+    // Buffer was too small, create a bigger one and try again
+    char* large_buf = new char[length + 1];
+    vsnprintf(buf, length + 1, format, args);
+
+    std::string ret(buf);
+    delete[] large_buf;
+
+    return ret;
+}
+
+std::string
+format_string(size_t max_length, const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    std::string ret = vformat_string(max_length, format, args);
+    va_end(args);
+    return ret;
+}
+
+std::string
+format_string(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    std::string ret = vformat_string(format, args);
+    va_end(args);
+    return ret;
+}
+
+} // namespace SST

--- a/src/sst/core/stringize.h
+++ b/src/sst/core/stringize.h
@@ -14,69 +14,59 @@
 
 #include <cctype>
 #include <cinttypes>
+#include <cstdarg>
+#include <cstdio>
 #include <string>
 #include <strings.h>
 
 namespace SST {
 
-inline std::string
-to_string(double val)
+__attribute__((deprecated(
+    "SST::to_string() is deprecated and will be removed in SST 13.  Please use std::to_string() instead"))) inline std::
+    string
+    to_string(double val)
 {
-    char buffer[256];
-    sprintf(buffer, "%f", val);
-
-    std::string buffer_str(buffer);
-    return buffer_str;
+    return std::to_string(val);
 };
 
-inline std::string
-to_string(float val)
+__attribute__((deprecated(
+    "SST::to_string() is deprecated and will be removed in SST 13.  Please use std::to_string() instead"))) inline std::
+    string
+    to_string(float val)
 {
-    char buffer[256];
-    sprintf(buffer, "%f", val);
-
-    std::string buffer_str(buffer);
-    return buffer_str;
+    return std::to_string(val);
 };
 
-inline std::string
-to_string(int32_t val)
+__attribute__((deprecated(
+    "SST::to_string() is deprecated and will be removed in SST 13.  Please use std::to_string() instead"))) inline std::
+    string
+    to_string(int32_t val)
 {
-    char buffer[256];
-    sprintf(buffer, "%" PRId32, val);
-
-    std::string buffer_str(buffer);
-    return buffer_str;
+    return std::to_string(val);
 };
 
-inline std::string
-to_string(int64_t val)
+__attribute__((deprecated(
+    "SST::to_string() is deprecated and will be removed in SST 13.  Please use std::to_string() instead"))) inline std::
+    string
+    to_string(int64_t val)
 {
-    char buffer[256];
-    sprintf(buffer, "%" PRId64, val);
-
-    std::string buffer_str(buffer);
-    return buffer_str;
+    return std::to_string(val);
 };
 
-inline std::string
-to_string(uint32_t val)
+__attribute__((deprecated(
+    "SST::to_string() is deprecated and will be removed in SST 13.  Please use std::to_string() instead"))) inline std::
+    string
+    to_string(uint32_t val)
 {
-    char buffer[256];
-    sprintf(buffer, "%" PRIu32, val);
-
-    std::string buffer_str(buffer);
-    return buffer_str;
+    return std::to_string(val);
 };
 
-inline std::string
-to_string(uint64_t val)
+__attribute__((deprecated(
+    "SST::to_string() is deprecated and will be removed in SST 13.  Please use std::to_string() instead"))) inline std::
+    string
+    to_string(uint64_t val)
 {
-    char buffer[256];
-    sprintf(buffer, "%" PRIu64, val);
-
-    std::string buffer_str(buffer);
-    return buffer_str;
+    return std::to_string(val);
 };
 
 inline bool
@@ -227,6 +217,73 @@ private:
     std::string::const_iterator first, last;
     TokenizerFunc               f;
 };
+
+
+/**
+   Creates a string using a vprintf like function call.  This function
+   uses a dynamically allocated char array of size max_length to
+   create the buffer to intialize the string.
+
+   @param max_length Maximum length of string.  Anything past
+   max_length will be truncated (null terminator is included in the
+   length)
+
+   @param format printf-like format string
+
+   @param args va_list containing variable length argument list
+
+   @return formatted string, potentially truncated at length max_length - 1
+ */
+std::string vformat_string(size_t max_length, const char* format, va_list args);
+
+/**
+   Creates a string using a printf like function call.  This function
+   uses a compile time allocated char array of length 256 to create
+   the buffer to intialize the string.  If this is not long enough, it
+   will dynamically allocate an array that is just big enough to
+   create the buffer to initialize the string.  No truncation will
+   occur.
+
+   @param format printf-like format string
+
+   @param args va_list containing variable length argument list
+
+   @return formatted string
+ */
+std::string vformat_string(const char* format, va_list args);
+
+/**
+   Creates a string using a printf like function call.  This function
+   uses a dynamically allocated char array of size max_length to
+   create the buffer to intialize the string.
+
+   @param max_length Maximum length of string.  Anything past
+   max_length will be truncated (null terminator is included in the
+   length)
+
+   @param format printf-like format string
+
+   @param ... arguments for format string
+
+   @return formatted string, potentially truncated at length max_length - 1
+ */
+std::string format_string(size_t max_length, const char* format, ...) __attribute__((format(printf, 2, 3)));
+
+/**
+   Creates a string using a printf like function call.  This function
+   uses a compile time allocated char array of length 256 to create
+   the buffer to intialize the string.  If this is not long enough, it
+   will dynamically allocate an array that is just big enough to
+   create the buffer to initialize the string.  No truncation will
+   occur.
+
+   @param format printf-like format string
+
+   @param ... arguments for format string
+
+   @return formatted string
+ */
+std::string format_string(const char* format, ...) __attribute__((format(printf, 1, 2)));
 
 } // namespace SST
 

--- a/src/sst/core/testElements/coreTest_DistribComponent.cc
+++ b/src/sst/core/testElements/coreTest_DistribComponent.cc
@@ -23,6 +23,7 @@
 #include "sst/core/rng/expon.h"
 #include "sst/core/rng/gaussian.h"
 #include "sst/core/rng/poisson.h"
+#include "sst/core/stringize.h"
 
 using namespace SST;
 using namespace SST::RNG;
@@ -83,18 +84,17 @@ coreTestDistribComponent::coreTestDistribComponent(ComponentId_t id, Params& par
 
         if ( 1 == prob_count ) { probs[0] = 1.0; }
         else {
-            char* prob_name = (char*)malloc(sizeof(char) * 64);
+            std::string prob_name;
+
 
             for ( uint32_t i = 0; i < prob_count; i++ ) {
-                sprintf(prob_name, "prob%" PRIu32, i);
+                prob_name       = format_string("prob%" PRIu32, i);
                 double prob_tmp = (double)params.find<double>(prob_name, 1.0 / (double)(prob_count));
 
                 // printf("Probability at %" PRIu32 " : %f\n", i, prob_tmp);
 
                 probs[i] = prob_tmp;
             }
-
-            free(prob_name);
 
             probs[prob_count - 1] = 1.0;
         }

--- a/src/sst/core/testElements/coreTest_LookupTableComponent.cc
+++ b/src/sst/core/testElements/coreTest_LookupTableComponent.cc
@@ -90,13 +90,14 @@ bool coreTestLookupTableComponent::tick(SST::Cycle_t)
     bool                done    = false;
     static const size_t nPerRow = 8;
     if ( tableSize > 0 ) {
-        char   buffer[nPerRow * 5 + 1] = { 0 };
-        size_t nitems                  = std::min(nPerRow, tableSize);
+        size_t slen         = nPerRow * 5 + 1;
+        char   buffer[slen] = { 0 };
+        size_t nitems       = std::min(nPerRow, tableSize);
         for ( size_t i = 0; i < nitems; i++ ) {
             char tbuf[6] = { 0 };
-            sprintf(tbuf, "0x%02x ", *table++);
+            snprintf(tbuf, 6, "0x%02x ", *table++);
             tableSize--;
-            strcat(buffer, tbuf);
+            strncat(buffer, tbuf, slen);
         }
         out.output(CALL_INFO, "%s\n", buffer);
     }

--- a/src/sst/core/testElements/coreTest_RNGComponent.h
+++ b/src/sst/core/testElements/coreTest_RNGComponent.h
@@ -17,7 +17,7 @@
 #define SST_CORE_CORETEST_RNGCOMPONENT_H
 
 #include "sst/core/component.h"
-#include "sst/core/rng/sstrng.h"
+#include "sst/core/rng/rng.h"
 
 using namespace SST;
 using namespace SST::RNG;
@@ -72,7 +72,7 @@ private:
     virtual bool tick(SST::Cycle_t);
 
     Output*     output;
-    SSTRandom*  rng;
+    Random*     rng;
     std::string rng_type;
     int         rng_max_count;
     int         rng_count;

--- a/src/sst/core/testElements/coreTest_StatisticsComponent.h
+++ b/src/sst/core/testElements/coreTest_StatisticsComponent.h
@@ -17,7 +17,7 @@
 #define SST_CORE_CORETEST_STATISTICSCOMPONENT_H
 
 #include "sst/core/component.h"
-#include "sst/core/rng/sstrng.h"
+#include "sst/core/rng/rng.h"
 
 using namespace SST;
 using namespace SST::RNG;
@@ -75,7 +75,7 @@ private:
 
     virtual bool Clock1Tick(SST::Cycle_t);
 
-    SSTRandom*  rng;
+    Random*     rng;
     std::string rng_type;
     int         rng_max_count;
     int         rng_count;
@@ -134,7 +134,7 @@ private:
 
     virtual bool Clock1Tick(SST::Cycle_t);
 
-    SSTRandom*  rng;
+    Random*     rng;
     std::string rng_type;
     int         rng_max_count;
     int         rng_count;


### PR DESCRIPTION
Added format_string() function and changed all sprintf() call to use either format_string() or snprintf().  Also marked sstrng.h deprecated.
