### PR TITLE
Threading option fixes.

### DIFF
--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -798,7 +798,11 @@ static const struct sstLongOpts_s sstOptions[] = {
         "verbose", 'v', "level", "Verbosity level to determine what information about core runtime is printed",
         &ConfigHelper::incrVerbose, &ConfigHelper::setVerbosity, true),
     DEF_ARG(
-        "num_threads", 'n', "NUM", "Number of parallel threads to use per rank", &ConfigHelper::setNumThreads, true),
+        "num-threads", 'n', "NUM", "Number of parallel threads to use per rank", &ConfigHelper::setNumThreads, true),
+    DEF_ARG(
+        "num_threads", 0, "NUM",
+        "[Deprecated] Number of parallel threads to use per rank (deprecated, please use --num-threads or -n instead)",
+        &ConfigHelper::setNumThreads, true),
     DEF_ARG(
         "sdl-file", 0, "FILE",
         "Specify SST Configuration file.  Note: this is most often done by just specifying the file without an option.",

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -397,7 +397,7 @@ setSSTThreadCount(PyObject* UNUSED(self), PyObject* args)
     Config* cfg     = gModel->getConfig();
     long    oldNThr = cfg->num_threads();
     long    nThr    = SST_ConvertToCppLong(args);
-    if ( nThr > 0 && nThr <= oldNThr ) gModel->setConfigEntryFromModel("num_threads", std::to_string(nThr));
+    gModel->setConfigEntryFromModel("num_threads", std::to_string(nThr));
     return SST_ConvertToPythonLong(oldNThr);
 }
 


### PR DESCRIPTION
- Change command line option --num_threads to --num_threads.  Fixes #871
- Fix setting of threads in the Python input file.  Fixes #872
