### PR TITLE
adding fix for Issue #886; getSuccess would always return true

### DIFF
--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -157,7 +157,7 @@ public:
 
         void setSuccess() { unsetFail(); }
         void unsetSuccess() { setFail(); }
-        bool getSuccess() { return ~(flags & static_cast<int>(Flag::F_FAIL)); }
+        bool getSuccess() { return (flags & static_cast<int>(Flag::F_FAIL)) == 0; }
         bool getFail() { return flags & static_cast<int>(Flag::F_FAIL); }
         void setFail() { flags |= static_cast<int>(Flag::F_FAIL); }
         void unsetFail() { flags &= ~(static_cast<int>(Flag::F_FAIL)); }


### PR DESCRIPTION
This is a fix for Issue #886 whereby getSuccess always returns true.  Changing the logic for getSuccess such that it correctly returns true OR false.  Originally reported by @PhilippKasgen


