### PR TITLE
cmake builds

### DIFF
--- a/src/sst/core/CMakeLists.txt
+++ b/src/sst/core/CMakeLists.txt
@@ -30,6 +30,7 @@ add_subdirectory(interfaces)
 add_subdirectory(interprocess)
 add_subdirectory(math)
 add_subdirectory(part)
+add_subdirectory(profile)
 add_subdirectory(rng)
 add_subdirectory(serialization)
 add_subdirectory(statapi)
@@ -58,6 +59,7 @@ add_library(
   initQueue.cc
   link.cc
   memuse.cc
+  mempool.cc
   namecheck.cc
   oneshot.cc
   output.cc
@@ -72,6 +74,13 @@ add_library(
   module.cc
   sstpart.cc
   timeVortex.cc
+
+  profile/clockHandlerProfileTool.cc
+  profile/componentProfileTool.cc
+  profile/eventHandlerProfileTool.cc
+  profile/syncProfileTool.cc
+  profile/profiletool.cc
+
   serialization/serializable.cc
   serialization/serialize_serializable.cc
   serialization/serializer.cc
@@ -94,6 +103,7 @@ add_library(
   statapi/statoutputcsv.cc
   statapi/statoutputjson.cc
   statapi/statbase.cc
+  stringize.cc
   cputimer.cc
   iouse.cc)
 

--- a/src/sst/core/profile/CMakeLists.txt
+++ b/src/sst/core/profile/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SST-CORE src/sst/core/eli CMake
+# SST-CORE src/sst/core/profile CMake
 #
 # Copyright 2009-2022 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.
@@ -12,21 +12,12 @@
 # distribution.
 #
 
-set(SSTELIHeaders
-    attributeInfo.h
-    categoryInfo.h
-    defaultInfo.h
-    elementbuilder.h
-    elementinfo.h
-    elibase.h
-    interfaceInfo.h
-    paramsInfo.h
-    portsInfo.h
-    profilePointInfo.h
-    statsInfo.h
-    simpleInfo.h
-    subcompSlotInfo.h)
+set(SSTprofileHeaders 
+    componentProfileTool.h
+    profiletool.h
 
-install(FILES ${SSTELIHeaders} DESTINATION "include/sst/core/eli")
+)
+
+install(FILES ${SSTprofileHeaders} DESTINATION "include/sst/core/profile")
 
 # EOF


### PR DESCRIPTION
git clone https://github.com/sstsimulator/sst-core.git
cd sst-core && mkdir build && cd build
cmake ../experimental
make -j32

OLD BEHAVIOR
sstsim.x and other targets fail to build with linking errors

NEW BEHAVIOR
build completes successfully 