### PR TITLE
adding requirement for C++ 17 in SST-Core CMake infrastructure

### DIFF
--- a/experimental/CMAKE_README.md
+++ b/experimental/CMAKE_README.md
@@ -2,7 +2,7 @@
 
 # Structural Simulation Toolkit (SST)
 
-#### Copyright (c) 2009-2022, National Technology and Engineering Solutions of Sandia, LLC (NTESS)
+#### Copyright (c) 2009-2023, National Technology and Engineering Solutions of Sandia, LLC (NTESS)
 
 ---
 

--- a/experimental/CMakeLists.txt
+++ b/experimental/CMakeLists.txt
@@ -18,13 +18,13 @@ set(SST_TOP_SRC_DIR "${sst-core_SOURCE_DIR}/..")
 include(cmake/PreventInSourceBuilds.cmake)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 17)
   message(
-    STATUS "CMAKE_CXX_STANDARD was not set, defaulting the cmake standard to 11"
+    STATUS "CMAKE_CXX_STANDARD was not set, defaulting the cmake standard to 17"
   )
 else()
-  if(CMAKE_CXX_STANDARD LESS 11)
-    message(FATAL_ERROR "We require the c++ standard to be at least 11")
+  if(CMAKE_CXX_STANDARD LESS 17)
+    message(FATAL_ERROR "We require the c++ standard to be at least 17")
   endif()
 endif()
 


### PR DESCRIPTION
This bumps the c++ version requirements up to C++ 17 to match the recent bump in the traditional makefiles.  This is a fix for Issue #922.  We also bump the date on the copyright notice in the README.