### PR TITLE
Lib order fix

### DIFF
--- a/src/sst/core/CMakeLists.txt
+++ b/src/sst/core/CMakeLists.txt
@@ -44,6 +44,8 @@ add_library(
   componentExtension.cc
   componentInfo.cc
   config.cc
+  configBase.cc
+  configShared.cc
   configGraph.cc
   cfgoutput/pythonConfigOutput.cc
   cfgoutput/dotConfigOutput.cc
@@ -119,6 +121,8 @@ set(SSTHeaders
     configGraph.h
     configGraphOutput.h
     config.h
+    configBase.h
+    configShared.h
     cputimer.h
     decimal_fixedpoint.h
     elemLoader.h

--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -26,6 +26,8 @@ nobase_dist_sst_HEADERS = \
 	componentExtension.h \
 	componentInfo.h \
 	config.h \
+	configBase.h \
+	configShared.h \
 	configGraph.h \
 	configGraphOutput.h \
 	cfgoutput/pythonConfigOutput.h \
@@ -165,6 +167,8 @@ sst_core_sources = \
 	componentExtension.cc \
 	componentInfo.cc \
 	config.cc \
+	configBase.cc \
+	configShared.cc \
 	configGraph.cc \
 	cfgoutput/pythonConfigOutput.cc \
 	cfgoutput/dotConfigOutput.cc \
@@ -242,6 +246,10 @@ sst_info_SOURCES = \
 	bootsstinfo.cc \
 	bootshared.cc \
 	bootshared.h \
+	configBase.h \
+	configBase.cc \
+	configShared.h \
+	configShared.cc \
 	env/envquery.h \
 	env/envconfig.h \
 	env/envquery.cc \
@@ -251,6 +259,10 @@ sst_SOURCES = \
 	bootsst.cc \
 	bootshared.cc \
 	bootshared.h \
+	configBase.h \
+	configBase.cc \
+	configShared.h \
+	configShared.cc \
 	env/envquery.h \
 	env/envconfig.h \
 	env/envquery.cc \

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -533,19 +533,19 @@ BaseComponent::getCompletePhaseElapsedRealTime() const
 bool
 BaseComponent::isSimulationRunModeInit() const
 {
-    return sim_->getSimulationMode() == Simulation::INIT;
+    return sim_->getSimulationMode() == SimulationRunMode::INIT;
 }
 
 bool
 BaseComponent::isSimulationRunModeRun() const
 {
-    return sim_->getSimulationMode() == Simulation::RUN;
+    return sim_->getSimulationMode() == SimulationRunMode::RUN;
 }
 
 bool
 BaseComponent::isSimulationRunModeBoth() const
 {
-    return sim_->getSimulationMode() == Simulation::BOTH;
+    return sim_->getSimulationMode() == SimulationRunMode::BOTH;
 }
 
 std::string&

--- a/src/sst/core/bootshared.h
+++ b/src/sst/core/bootshared.h
@@ -12,11 +12,12 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <string>
 #include <unistd.h>
 
 extern char** environ;
 
 void update_env_var(const char* name, const int verbose, char* argv[], const int argc);
-void boot_sst_configure_env(const int verbose, char* argv[], const int argc);
+// void boot_sst_configure_env(const SST::Config& cfg);
+void boot_sst_configure_env(const std::string& path);
 void boot_sst_executable(const char* binary, const int verbose, char* argv[], const int argc);

--- a/src/sst/core/bootsst.cc
+++ b/src/sst/core/bootsst.cc
@@ -15,6 +15,7 @@
 #include "sst/core/configShared.h"
 
 #include <cstdlib>
+#include <string.h>
 #include <unistd.h> // for opterr
 
 int

--- a/src/sst/core/bootsst.cc
+++ b/src/sst/core/bootsst.cc
@@ -12,8 +12,10 @@
 #include "sst_config.h"
 
 #include "sst/core/bootshared.h"
+#include "sst/core/configShared.h"
 
 #include <cstdlib>
+#include <unistd.h> // for opterr
 
 int
 main(int argc, char* argv[])
@@ -22,15 +24,24 @@ main(int argc, char* argv[])
     int print_env  = 0;
     int verbose    = 0;
 
+    // Create a ConfigShred object.  This object won't print any error
+    // messages about unknown command line options, that will be
+    // deferred to the actual sstsim.x executable.
+    SST::ConfigShared cfg(true, true, true, true, true);
+
+    // Make a copy of the argv array (shallow)
+    char* argv_copy[argc + 1];
     for ( int i = 0; i < argc; ++i ) {
-        if ( strcmp("--no-env-config", argv[i]) == 0 ) { config_env = 0; }
-        else if ( strcmp("--verbose", argv[i]) == 0 ) {
-            verbose = 1;
-        }
-        else if ( strcmp("--print-env", argv[i]) == 0 ) {
-            print_env = 1;
-        }
+        argv_copy[i] = argv[i];
     }
+    argv[argc] = nullptr;
+
+    // All ranks parse the command line
+    cfg.parseCmdLine(argc, argv_copy);
+
+    if ( cfg.no_env_config() ) config_env = 0;
+    if ( cfg.verbose() ) verbose = 1;
+    if ( cfg.print_env() ) print_env = 1;
 
     if ( print_env != 1 ) {
         const char* check_print_env   = std::getenv("SST_PRINT_ENV");
@@ -47,7 +58,7 @@ main(int argc, char* argv[])
 
     if ( verbose && config_env ) { printf("Launching SST with automatic environment processing enabled...\n"); }
 
-    if ( config_env ) { boot_sst_configure_env(verbose, argv, argc); }
+    if ( config_env ) { boot_sst_configure_env(cfg.getLibPath()); }
 
     if ( 1 == print_env ) {
         int next_index = 0;

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -22,6 +22,7 @@
 #include <string>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 using namespace std;
 

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -13,65 +13,30 @@
 
 #include "sst/core/config.h"
 
-#include "sst/core/build_info.h"
 #include "sst/core/env/envquery.h"
-#include "sst/core/output.h"
-#include "sst/core/part/sstpart.h"
 #include "sst/core/warnmacros.h"
 
-#ifdef SST_CONFIG_HAVE_MPI
-DISABLE_WARN_MISSING_OVERRIDE
-#include <mpi.h>
-REENABLE_WARNING
-#endif
-
 #include <cstdlib>
-#include <errno.h>
 #include <getopt.h>
 #include <iostream>
-#include <locale>
 #include <string>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-#ifndef E_OK
-#define E_OK 0
-#endif
 
 using namespace std;
 
 namespace SST {
 
-// Reserved name to indicate section header in program options
-static const char* SECTION_HEADER = "XSECTION_HEADERX";
-
 //// Helper class for setting options
 
 class ConfigHelper
 {
-private:
-    Config& cfg;
-
 public:
-    typedef bool (ConfigHelper::*flagFunction)(void);
-    typedef bool (ConfigHelper::*argFunction)(const std::string& arg);
-
-    // Used to determine what return code to use
-    bool clean_exit = false;
-
-    ConfigHelper(Config& cfg) : cfg(cfg) {}
-
     // Print usage
-    bool printHelp()
-    {
-        clean_exit = true;
-        return usage();
-    }
+    static int printHelp(Config* cfg, const std::string& UNUSED(arg)) { return cfg->printUsage(); }
 
     // Prints the SST version
-    bool printVersion()
+    static int printVersion(Config* UNUSED(cfg), const std::string& UNUSED(arg))
     {
         printf("SST-Core Version (" PACKAGE_VERSION);
         if ( strcmp(SSTCORE_GIT_HEADSHA, PACKAGE_VERSION) ) {
@@ -80,92 +45,64 @@ public:
         }
         printf(")\n");
 
-        clean_exit = true;
-        return false; /* Should not continue */
+        return 1; /* Should not continue, but clean exit */
     }
 
-    // Verbosity
-    bool incrVerbose()
-    {
-        cfg.verbose_++;
-        return true;
-    }
 
-    bool setVerbosity(const std::string& arg)
+    // num_threads
+    static int setNumThreads(Config* cfg, const std::string& arg)
     {
         try {
             unsigned long val = stoul(arg);
-            cfg.verbose_      = val;
-            return true;
-        }
-        catch ( std::invalid_argument& e ) {
-            fprintf(stderr, "Failed to parse '%s' as number for option --verbose\n", arg.c_str());
-            return false;
-        }
-    }
-
-    // num_threads
-    bool setNumThreads(const std::string& arg)
-    {
-        try {
-            unsigned long val      = stoul(arg);
-            cfg.world_size_.thread = val;
-            return true;
+            cfg->num_threads_ = val;
+            return 0;
         }
         catch ( std::invalid_argument& e ) {
             fprintf(stderr, "Failed to parse '%s' as number for option --num-threads\n", arg.c_str());
-            return false;
+            return -1;
         }
     }
 
     // SDL file
-    bool setConfigFile(const std::string& arg)
+    static int setConfigFile(Config* cfg, const std::string& arg)
     {
-        cfg.configFile_ = arg;
-        return true;
+        cfg->configFile_ = arg;
+        return 0;
     }
 
     // model_options
-    bool setModelOptions(const std::string& arg)
+    static int setModelOptions(Config* cfg, const std::string& arg)
     {
-        if ( cfg.model_options_.empty() )
-            cfg.model_options_ = arg;
+        if ( cfg->model_options_.empty() )
+            cfg->model_options_ = arg;
         else
-            cfg.model_options_ += std::string(" \"") + arg + std::string("\"");
-        return true;
+            cfg->model_options_ += std::string(" \"") + arg + std::string("\"");
+        return 0;
     }
 
     // print timing
-    bool enablePrintTiming()
+    static int setPrintTiming(Config* cfg, const std::string& arg)
     {
-        cfg.print_timing_ = true;
-        return true;
-    }
-
-    bool setPrintTiming(const std::string& arg)
-    {
-        bool success      = false;
-        cfg.print_timing_ = parseBoolean(arg, success, "enable-print-timing");
-        return success;
+        if ( arg == "" ) {
+            cfg->print_timing_ = true;
+            return 0;
+        }
+        bool success       = false;
+        cfg->print_timing_ = cfg->parseBoolean(arg, success, "enable-print-timing");
+        if ( success ) return 0;
+        return -1;
     }
 
     // stop-at
-    bool setStopAt(const std::string& arg)
+    static int setStopAt(Config* cfg, const std::string& arg)
     {
-        cfg.stop_at_ = arg;
-        return true;
+        cfg->stop_at_ = arg;
+        return 0;
     }
 
-    // stopAtCycle (deprecated)
-    bool setStopAtCycle(const std::string& arg)
-    {
-        // Uncomment this once all test files have been updated
-        // fprintf(stderr, "Program option 'stopAtCycle' has been deprecated.  Please use 'stop-at' instead");
-        return setStopAt(arg);
-    }
 
     // exit after
-    bool setExitAfter(const std::string& arg)
+    static int setExitAfter(Config* cfg, const std::string& arg)
     {
         /* TODO: Error checking */
         errno = 0;
@@ -185,10 +122,10 @@ public:
                 stderr, "**** [%s]  p = %p ; *p = '%c', %u:%u:%u\n", templates[i], p, (p) ? *p : '\0', res.tm_hour,
                 res.tm_min, res.tm_sec);
             if ( p != nullptr && *p == '\0' ) {
-                cfg.exit_after_ = res.tm_sec;
-                cfg.exit_after_ += res.tm_min * 60;
-                cfg.exit_after_ += res.tm_hour * 60 * 60;
-                return true;
+                cfg->exit_after_ = res.tm_sec;
+                cfg->exit_after_ += res.tm_min * 60;
+                cfg->exit_after_ += res.tm_hour * 60 * 60;
+                return 0;
             }
         }
 
@@ -201,93 +138,80 @@ public:
             fprintf(stderr, "\t%s\n", templates[i]);
         }
 
-        return false;
-    }
-
-    // stop after (deprecated)
-    bool setStopAfter(const std::string& arg)
-    {
-        // Uncomment this once all test files have been updated
-        // fprintf(stderr, "Program option 'stopAfter' has been deprecated.  Please use 'exit-after' instead");
-        return setExitAfter(arg);
+        return -1;
     }
 
 
     // partitioner
-    bool setPartitioner(const std::string& arg)
+    static int setPartitioner(Config* cfg, const std::string& arg)
     {
-        cfg.partitioner_ = arg;
-        if ( cfg.partitioner_.find('.') == cfg.partitioner_.npos ) { cfg.partitioner_ = "sst." + cfg.partitioner_; }
-        return true;
+        cfg->partitioner_ = arg;
+        if ( cfg->partitioner_.find('.') == cfg->partitioner_.npos ) { cfg->partitioner_ = "sst." + cfg->partitioner_; }
+        return 0;
     }
 
     // heart beat
-    bool setHeartbeat(const std::string& arg)
+    static int setHeartbeat(Config* cfg, const std::string& arg)
     {
         /* TODO: Error checking */
-        cfg.heartbeatPeriod_ = arg;
-        return true;
+        cfg->heartbeatPeriod_ = arg;
+        return 0;
     }
 
     // output directory
-    bool setOutputDir(const std::string& arg)
+    static int setOutputDir(Config* cfg, const std::string& arg)
     {
-        cfg.output_directory_ = arg;
-        return true;
+        cfg->output_directory_ = arg;
+        return 0;
     }
 
     // core output prefix
-    bool setOutputPrefix(const std::string& arg)
+    static int setOutputPrefix(Config* cfg, const std::string& arg)
     {
-        cfg.output_core_prefix_ = arg;
-        return true;
+        cfg->output_core_prefix_ = arg;
+        return 0;
     }
 
 
     // Configuration output
 
     // output config python
-    bool setWriteConfig(const std::string& arg)
+    static int setWriteConfig(Config* cfg, const std::string& arg)
     {
-        cfg.output_config_graph_ = arg;
-        return true;
+        cfg->output_config_graph_ = arg;
+        return 0;
     }
 
     // output config json
-    bool setWriteJSON(const std::string& arg)
+    static int setWriteJSON(Config* cfg, const std::string& arg)
     {
-        cfg.output_json_ = arg;
-        return true;
+        cfg->output_json_ = arg;
+        return 0;
     }
 
     // parallel output
 #ifdef SST_CONFIG_HAVE_MPI
-    bool enableParallelOutput()
+    static int enableParallelOutput(Config* cfg, const std::string& arg)
     {
         // If this is only a one rank job, then we can ignore
-        if ( cfg.world_size_.rank == 1 ) return true;
+        if ( cfg->num_ranks_ == 1 ) return 0;
 
-        cfg.parallel_output_  = true;
-        // For parallel output, we always need to output the partition
-        // info as well
-        cfg.output_partition_ = true;
-        return true;
-    }
+        bool state = true;
+        // If there's an arg, we need to parse it.  Otherwise, it will
+        // just get set to true.
+        if ( arg != "" ) {
+            bool success;
+            state = cfg->parseBoolean(arg, success, "parallel-output");
+            if ( !success ) return -1;
+        }
 
-    bool enableParallelOutputArg(const std::string& arg)
-    {
-        // If this is only a one rank job, then we can ignore, except
-        // that we will turn on output_partition
-        if ( cfg.world_size_.rank == 1 ) return true;
+        cfg->parallel_output_ = state;
 
-        bool success = false;
-
-        cfg.parallel_output_  = parseBoolean(arg, success, "parallel-output");
         // For parallel output, we always need to output the partition
         // info as well.  Also, if it was already set to true, don't
         // overwrite even if parallel_output was set to false.
-        cfg.output_partition_ = cfg.output_partition_ | cfg.parallel_output_;
-        return success;
+        cfg->output_partition_ = cfg->output_partition_ | cfg->parallel_output_;
+        return 0;
     }
 #endif
 
@@ -295,45 +219,47 @@ public:
     // Graph output
 
     // graph output dot
-    bool setWriteDot(const std::string& arg)
+    static int setWriteDot(Config* cfg, const std::string& arg)
     {
-        cfg.output_dot_ = arg;
-        return true;
+        cfg->output_dot_ = arg;
+        return 0;
     }
 
     // dot verbosity
-    bool setDotVerbosity(const std::string& arg)
+    static int setDotVerbosity(Config* cfg, const std::string& arg)
     {
         try {
-            unsigned long val  = stoul(arg);
-            cfg.dot_verbosity_ = val;
-            return true;
+            unsigned long val   = stoul(arg);
+            cfg->dot_verbosity_ = val;
+            return 0;
         }
         catch ( std::invalid_argument& e ) {
             fprintf(stderr, "Failed to parse '%s' as number for option --dot-verbosity\n", arg.c_str());
-            return false;
+            return -1;
         }
     }
 
     // output partition
-    bool setWritePartitionFile(const std::string& arg)
+    static int setWritePartitionFile(Config* cfg, const std::string& arg)
     {
-        cfg.component_partition_file_ = arg;
-        return true;
-    }
-
-    bool setWritePartition()
-    {
-        cfg.output_partition_ = true;
-        return true;
+        if ( arg == "" ) { cfg->output_partition_ = true; }
+        else {
+            cfg->component_partition_file_ = arg;
+        }
+        return 0;
     }
 
     // parallel load
 #ifdef SST_CONFIG_HAVE_MPI
-    bool enableParallelLoadMode(const std::string& arg)
+    static int enableParallelLoadMode(Config* cfg, const std::string& arg)
     {
         // If this is only a one rank job, then we can ignore
-        if ( cfg.world_size_.rank == 1 ) return true;
+        if ( cfg->num_ranks_ == 1 ) return 0;
+
+        if ( arg == "" ) {
+            cfg->parallel_load_ = true;
+            return 0;
+        }
 
         std::string arg_lower(arg);
         std::locale loc;
@@ -341,219 +267,138 @@ public:
             ch = std::tolower(ch, loc);
 
         if ( arg_lower == "none" ) {
-            cfg.parallel_load_ = false;
-            return true;
+            cfg->parallel_load_ = false;
+            return 0;
         }
         else
-            cfg.parallel_load_ = true;
+            cfg->parallel_load_ = true;
 
         if ( arg_lower == "single" )
-            cfg.parallel_load_mode_multi_ = false;
+            cfg->parallel_load_mode_multi_ = false;
         else if ( arg_lower == "multi" )
-            cfg.parallel_load_mode_multi_ = true;
+            cfg->parallel_load_mode_multi_ = true;
         else {
             fprintf(
                 stderr, "Invalid option '%s' passed to --parallel-load.  Valid options are NONE, SINGLE and MULTI.\n",
                 arg.c_str());
-            return false;
+            return -1;
         }
 
-        return true;
-    }
-
-    bool enableParallelLoad()
-    {
-        // If this is only a one rank job, then we can ignore
-        if ( cfg.world_size_.rank == 1 ) return true;
-
-        cfg.parallel_load_ = true;
-        return true;
+        return 0;
     }
 #endif
 
     // Advanced options
 
     // timebase
-    bool setTimebase(const std::string& arg)
+    static int setTimebase(Config* cfg, const std::string& arg)
     {
         // TODO: Error checking.  Need to wait until UnitAlgebra
         // switches to exceptions on errors instead of calling abort
-        cfg.timeBase_ = arg;
-        return true;
+        cfg->timeBase_ = arg;
+        return 0;
     }
 
     // timevortex
-    bool setTimeVortex(const std::string& arg)
+    static int setTimeVortex(Config* cfg, const std::string& arg)
     {
-        cfg.timeVortex_ = arg;
-        return true;
+        cfg->timeVortex_ = arg;
+        return 0;
     }
 
     // interthread links
-    bool setInterThreadLinks()
+    static int setInterThreadLinks(Config* cfg, const std::string& arg)
     {
-        cfg.interthread_links_ = true;
-        return true;
-    }
+        if ( arg == "" ) {
+            cfg->interthread_links_ = true;
+            return 0;
+        }
 
-    bool setInterThreadLinksArg(const std::string& arg)
-    {
-        bool success           = false;
-        cfg.interthread_links_ = parseBoolean(arg, success, "interthread-links");
-        return success;
+        bool success            = false;
+        cfg->interthread_links_ = cfg->parseBoolean(arg, success, "interthread-links");
+        return success ? 0 : -1;
     }
 
 #ifdef USE_MEMPOOL
     // cache align mempool allocations
-    bool setCacheAlignMempools()
+    static int setCacheAlignMempools(Config* cfg, const std::string& arg)
     {
-        cfg.cache_align_mempools_ = true;
-        return true;
-    }
-
-    bool setCacheAlignMempoolsArg(const std::string& arg)
-    {
-        bool success              = false;
-        cfg.cache_align_mempools_ = parseBoolean(arg, success, "cache-align-mempools");
-        return success;
+        if ( arg == "" ) {
+            cfg->cache_align_mempools_ = true;
+            return 0;
+        }
+        bool success               = false;
+        cfg->cache_align_mempools_ = cfg->parseBoolean(arg, success, "cache-align-mempools");
+        return success ? 0 : -1;
     }
 #endif
 
     // debug file
-    bool setDebugFile(const std::string& arg)
+    static int setDebugFile(Config* cfg, const std::string& arg)
     {
-        cfg.debugFile_ = arg;
-        return true;
+        cfg->debugFile_ = arg;
+        return 0;
     }
 
-    // lib path
-    bool setLibPath(const std::string& arg)
-    {
-        /* TODO: Error checking */
-        cfg.libpath_ = arg;
-        return true;
-    }
-
-    // add to lib path
-    bool addLibPath(const std::string& arg)
-    {
-        /* TODO: Error checking */
-        cfg.libpath_ += std::string(":") + arg;
-        return true;
-    }
 
     // Advanced options - profiling
-    bool enableProfiling(const std::string& arg)
+    static int enableProfiling(Config* cfg, const std::string& arg)
     {
-        cfg.enabled_profiling_ = arg;
-        return true;
+        cfg->enabled_profiling_ = arg;
+        return 0;
     }
 
-    bool setProfilingOutput(const std::string& arg)
+    static int setProfilingOutput(Config* cfg, const std::string& arg)
     {
-        cfg.profiling_output_ = arg;
-        return true;
+        cfg->profiling_output_ = arg;
+        return 0;
     }
 
 
     // Advanced options - debug
 
     // run mode
-    bool setRunMode(const std::string& arg)
+    static int setRunMode(Config* cfg, const std::string& arg)
     {
         if ( !arg.compare("init") )
-            cfg.runMode_ = Simulation::INIT;
+            cfg->runMode_ = SimulationRunMode::INIT;
         else if ( !arg.compare("run") )
-            cfg.runMode_ = Simulation::RUN;
+            cfg->runMode_ = SimulationRunMode::RUN;
         else if ( !arg.compare("both") )
-            cfg.runMode_ = Simulation::BOTH;
+            cfg->runMode_ = SimulationRunMode::BOTH;
         else {
             fprintf(stderr, "Unknown option for --run-mode: %s\n", arg.c_str());
-            cfg.runMode_ = Simulation::UNKNOWN;
+            cfg->runMode_ = SimulationRunMode::UNKNOWN;
         }
 
-        return cfg.runMode_ != Simulation::UNKNOWN;
+        return cfg->runMode_ != SimulationRunMode::UNKNOWN ? 0 : -1;
     }
 
     // dump undeleted events
 #ifdef USE_MEMPOOL
-    bool setWriteUndeleted(const std::string& arg)
+    static int setWriteUndeleted(Config* cfg, const std::string& arg)
     {
-        cfg.event_dump_file_ = arg;
-        return true;
+        cfg->event_dump_file_ = arg;
+        return 0;
     }
 #endif
 
     // rank sequentional startup
-    bool forceRankSeqStartup()
+    static int forceRankSeqStartup(Config* cfg, const std::string& UNUSED(arg))
     {
-        cfg.rank_seq_startup_ = true;
-        return true;
+        cfg->rank_seq_startup_ = true;
+        return 0;
     }
 
 
     // Advanced options - environment
 
-    // print environment
-    bool enablePrintEnv()
-    {
-        cfg.print_env_ = true;
-        return true;
-    }
-
     // Disable signal handlers
-    bool disableSigHandlers()
+    static int disableSigHandlers(Config* cfg, const std::string& UNUSED(arg))
     {
-        cfg.enable_sig_handling_ = false;
-        return true;
+        cfg->enable_sig_handling_ = false;
+        return 0;
     }
-
-    // Disable environment loader
-    bool disableEnvConfig()
-    {
-        cfg.no_env_config_ = true;
-        return true;
-    }
-
-    /**
-       Special function for catching the magic string indicating a
-       section header in the options array.  It will report that the
-       value is unknown.
-     */
-    bool sectionHeaderCatch()
-    {
-        // This will only ever get called, if, for some reason, someone
-        // tries to use the reserved section header name as an argument to
-        // sst.  In that case, make it look the same as any other unknown
-        // argument.
-        fprintf(stderr, "sst: unrecognized option --%s\n", SECTION_HEADER);
-        usage();
-        return false;
-    }
-
-    /**
-       Special function for catching the magic string indicating a
-       section header in the options array.  It will report that the
-       value is unknown.
-     */
-    bool sectionHeaderCatchArg(const std::string& UNUSED(arg))
-    {
-        // This will only ever get called, if, for some reason, someone
-        // tries to use the reserved section header name as an argument to
-        // sst.  In that case, make it look the same as any other unknown
-        // argument.
-        fprintf(stderr, "sst: unrecognized option --%s\n", SECTION_HEADER);
-        usage();
-        return false;
-    }
-
-
-    // Prints the usage information
-    bool usage();
-
-    // Function to uniformly parse boolean values for command line
-    // arguments
-    bool parseBoolean(const std::string& arg, bool& success, const std::string& option);
 };
 
 
@@ -563,8 +408,8 @@ void
 Config::print()
 {
     std::cout << "verbose = " << verbose_ << std::endl;
-    std::cout << "num_threads = " << world_size_.thread << std::endl;
-    std::cout << "num_ranks = " << world_size_.rank << std::endl;
+    std::cout << "num_threads = " << num_threads_ << std::endl;
+    std::cout << "num_ranks = " << num_ranks_ << std::endl;
     std::cout << "configFile = " << configFile_ << std::endl;
     std::cout << "model_options = " << model_options_ << std::endl;
     std::cout << "print_timing = " << print_timing_ << std::endl;
@@ -590,10 +435,25 @@ Config::print()
 #endif
     std::cout << "debugFile = " << debugFile_ << std::endl;
     std::cout << "libpath = " << libpath_ << std::endl;
-    std::cout << "addLlibPath = " << addLibPath_ << std::endl;
+    std::cout << "addLlibPath = " << addlibpath_ << std::endl;
     std::cout << "enabled_profiling = " << enabled_profiling_ << std::endl;
     std::cout << "profiling_output = " << profiling_output_ << std::endl;
-    std::cout << "runMode = " << runMode_ << std::endl;
+
+    switch ( runMode_ ) {
+    case SimulationRunMode::INIT:
+        std::cout << "runMode = INIT" << std::endl;
+        break;
+    case SimulationRunMode::RUN:
+        std::cout << "runMode = RUN" << std::endl;
+        break;
+    case SimulationRunMode::BOTH:
+        std::cout << "runMode = BOTH" << std::endl;
+        break;
+    default:
+        std::cout << "runMode = UNKNOWN" << std::endl;
+        break;
+    }
+
 #ifdef USE_MEMPOOL
     std::cout << "event_dump_file = " << event_dump_file_ << std::endl;
 #endif
@@ -604,19 +464,20 @@ Config::print()
 }
 
 
-Config::Config(RankInfo rank_info) : Config()
+Config::Config(uint32_t num_ranks, bool first_rank) : ConfigShared(!first_rank, false)
 {
     // Basic Options
-    verbose_           = 0;
-    world_size_.rank   = rank_info.rank;
-    world_size_.thread = 1;
-    configFile_        = "NONE";
-    model_options_     = "";
-    print_timing_      = false;
-    stop_at_           = "0 ns";
-    exit_after_        = 0;
-    partitioner_       = "sst.linear";
-    heartbeatPeriod_   = "";
+    first_rank_ = first_rank;
+
+    num_ranks_       = num_ranks;
+    num_threads_     = 1;
+    configFile_      = "NONE";
+    model_options_   = "";
+    print_timing_    = false;
+    stop_at_         = "0 ns";
+    exit_after_      = 0;
+    partitioner_     = "sst.linear";
+    heartbeatPeriod_ = "";
 
     char* wd_buf = (char*)malloc(sizeof(char) * PATH_MAX);
     getcwd(wd_buf, PATH_MAX);
@@ -650,25 +511,23 @@ Config::Config(RankInfo rank_info) : Config()
 #ifdef USE_MEMPOOL
     cache_align_mempools_ = false;
 #endif
-    debugFile_  = "/dev/null";
-    libpath_    = SST_INSTALL_PREFIX "/lib/sst";
-    addLibPath_ = "";
+    debugFile_ = "/dev/null";
 
     // Advance Options - Profiling
     enabled_profiling_ = "";
     profiling_output_  = "stdout";
 
     // Advanced Options - Debug
-    runMode_ = Simulation::BOTH;
+    runMode_ = SimulationRunMode::BOTH;
 #ifdef USE_MEMPOOL
     event_dump_file_ = "";
 #endif
     rank_seq_startup_ = false;
 
     // Advanced Options - environment
-    print_env_           = false;
     enable_sig_handling_ = true;
-    no_env_config_       = false;
+
+    insertOptions();
 }
 
 
@@ -701,218 +560,96 @@ Config::checkConfigFile()
     return true;
 }
 
-std::string
-Config::getLibPath(void) const
+void
+Config::insertOptions()
 {
-    char* envpath = getenv("SST_LIB_PATH");
-
-    // Get configuration options from the user config
-    std::vector<std::string>                          overrideConfigPaths;
-    SST::Core::Environment::EnvironmentConfiguration* envConfig =
-        SST::Core::Environment::getSSTEnvironmentConfiguration(overrideConfigPaths);
-
-    std::string           fullLibPath  = libpath_;
-    std::set<std::string> configGroups = envConfig->getGroupNames();
-
-    // iterate over groups of settings
-    for ( auto groupItr = configGroups.begin(); groupItr != configGroups.end(); groupItr++ ) {
-        SST::Core::Environment::EnvironmentConfigGroup* currentGroup = envConfig->getGroupByName(*groupItr);
-        std::set<std::string>                           groupKeys    = currentGroup->getKeys();
-
-        // find which keys have a LIBDIR at the END of the key
-        // we recognize these may house elements
-        for ( auto keyItr = groupKeys.begin(); keyItr != groupKeys.end(); keyItr++ ) {
-            const std::string& key   = *keyItr;
-            const std::string& value = currentGroup->getValue(key);
-
-            if ( key.size() > 6 ) {
-                if ( "LIBDIR" == key.substr(key.size() - 6) ) {
-                    fullLibPath.append(":");
-                    fullLibPath.append(value);
-                }
-            }
-        }
-    }
-
-    // Clean up and delete the configuration we just loaded up
-    delete envConfig;
-
-    if ( nullptr != envpath ) {
-        fullLibPath.clear();
-        fullLibPath.append(envpath);
-    }
-
-    if ( !addLibPath_.empty() ) {
-        fullLibPath.append(":");
-        fullLibPath.append(addLibPath_);
-    }
-
-    if ( verbose_ ) {
-        std::cout << "SST-Core: Configuration Library Path will read from: " << fullLibPath << std::endl;
-    }
-
-    return fullLibPath;
-}
-
-
-// Struct to hold the program option information
-struct sstLongOpts_s
-{
-    struct option              opt;
-    const char*                argName;
-    const char*                desc;
-    ConfigHelper::flagFunction flagFunc;
-    ConfigHelper::argFunction  argFunc;
-    bool                       sdl_avail;
-    // Unlike the other variables that hold the information about the
-    // option, this is used to keep track of options that are set on
-    // the command line.  We need this so we can ignore those when
-    // setting options from the sdl file.
-    mutable bool               set_cmdline;
-};
-
-
-// Macros to make defining options easier
-// Nomenaclature is:
-
-// FLAG - value is either true or false.  FLAG defaults to no arguments allowed
-// ARG - value is a string.  ARG defaults to required argument
-// OPTVAL - Takes an optional paramater
-
-// longName - multicharacter name referenced using --
-// shortName - single character name referenced using -
-// text - help text
-// func - function called if there is no value specified
-// valFunct - function called if there is a value specified
-// sdl_avail - determines whether option is avaialble to set in input files
-#define DEF_FLAG_OPTVAL(longName, shortName, text, func, valFunc, sdl_avail)                           \
-    {                                                                                                  \
-        { longName, optional_argument, 0, shortName }, "[BOOL]", text, func, valFunc, sdl_avail, false \
-    }
-
-#define DEF_FLAG(longName, shortName, text, func)                                           \
-    {                                                                                       \
-        { longName, no_argument, 0, shortName }, nullptr, text, func, nullptr, false, false \
-    }
-
-#define DEF_ARG(longName, shortName, argName, text, valFunc, sdl_avail)                                  \
-    {                                                                                                    \
-        { longName, required_argument, 0, shortName }, argName, text, nullptr, valFunc, sdl_avail, false \
-    }
-
-//#define DEF_ARGOPT(longName, argName, text, func) DEF_ARGOPT_SHORT(longName, 0, argName, text, func)
-
-#define DEF_ARG_OPTVAL(longName, shortName, argName, text, func, valFunc, sdl_avail)                          \
-    {                                                                                                         \
-        { longName, optional_argument, 0, shortName }, "[" argName "]", text, func, valFunc, sdl_avail, false \
-    }
-
-
-#define DEF_SECTION_HEADING(text)                                                                      \
-    {                                                                                                  \
-        { SECTION_HEADER, optional_argument, 0, 0 }, nullptr, text, &ConfigHelper::sectionHeaderCatch, \
-            &ConfigHelper::sectionHeaderCatchArg, false, false                                         \
-    }
-
-static const struct sstLongOpts_s sstOptions[] = {
+    using namespace std::placeholders;
     /* Informational options */
-    DEF_SECTION_HEADING("Informational Options"),
-    DEF_FLAG("help", 'h', "Print help message", &ConfigHelper::printHelp),
-    DEF_FLAG("version", 'V', "Print SST Release Version", &ConfigHelper::printVersion),
+    DEF_SECTION_HEADING("Informational Options");
+    DEF_FLAG("help", 'h', "Print help message", std::bind(&ConfigHelper::printHelp, this, _1));
+    DEF_FLAG("version", 'V', "Print SST Release Version", std::bind(&ConfigHelper::printVersion, this, _1));
 
     /* Basic Options */
-    DEF_SECTION_HEADING("Basic Options (most commonly used)"),
-    DEF_ARG_OPTVAL(
-        "verbose", 'v', "level", "Verbosity level to determine what information about core runtime is printed",
-        &ConfigHelper::incrVerbose, &ConfigHelper::setVerbosity, true),
+    DEF_SECTION_HEADING("Basic Options (most commonly used)");
+    addVerboseOptions(true);
     DEF_ARG(
-        "num-threads", 'n', "NUM", "Number of parallel threads to use per rank", &ConfigHelper::setNumThreads, true),
-    DEF_ARG(
-        "num_threads", 0, "NUM",
-        "[Deprecated] Number of parallel threads to use per rank (deprecated, please use --num-threads or -n instead)",
-        &ConfigHelper::setNumThreads, true),
+        "num-threads", 'n', "NUM", "Number of parallel threads to use per rank",
+        std::bind(&ConfigHelper::setNumThreads, this, _1), true);
     DEF_ARG(
         "sdl-file", 0, "FILE",
         "Specify SST Configuration file.  Note: this is most often done by just specifying the file without an option.",
-        &ConfigHelper::setConfigFile, false),
+        std::bind(&ConfigHelper::setConfigFile, this, _1), false);
     DEF_ARG(
         "model-options", 0, "STR",
         "Provide options to the python configuration script.  Additionally, any arguments provided after a final '-- ' "
         "will be "
         "appended to the model options (or used as the model options if --model-options was not specified).",
-        &ConfigHelper::setModelOptions, false),
+        std::bind(&ConfigHelper::setModelOptions, this, _1), false);
     DEF_FLAG_OPTVAL(
-        "print-timing-info", 0, "Print SST timing information", &ConfigHelper::enablePrintTiming,
-        &ConfigHelper::setPrintTiming, true),
-    DEF_ARG("stop-at", 0, "TIME", "Set time at which simulation will end execution", &ConfigHelper::setStopAt, true),
+        "print-timing-info", 0, "Print SST timing information", std::bind(&ConfigHelper::setPrintTiming, this, _1),
+        true);
     DEF_ARG(
-        "stopAtCycle", 0, "TIME",
-        "[DEPRECATED] Set time at which simulation will end execution (deprecated, please use --stop-at instead)",
-        &ConfigHelper::setStopAtCycle, true),
+        "stop-at", 0, "TIME", "Set time at which simulation will end execution",
+        std::bind(&ConfigHelper::setStopAt, this, _1), true);
     DEF_ARG(
         "exit-after", 0, "TIME",
         "Set the maximum wall time after which simulation will end execution.  Time is specified in hours, minutes and "
         "seconds, with the following formats supported: H:M:S, M:S, S, Hh, Mm, Ss (captital letters are the "
         "appropriate numbers for that value, lower case letters represent the units and are required for those "
         "formats).",
-        &ConfigHelper::setExitAfter, true),
-    DEF_ARG(
-        "stopAfter", 0, "TIME",
-        "[DEPRECATED] Set the maximum wall time after which simulation will exit (deprecatd, please use --exit-after "
-        "instead",
-        &ConfigHelper::setStopAfter, true),
+        std::bind(&ConfigHelper::setExitAfter, this, _1), true);
     DEF_ARG(
         "partitioner", 0, "PARTITIONER", "Select the partitioner to be used. <lib.partitionerName>",
-        &ConfigHelper::setPartitioner, true),
+        std::bind(&ConfigHelper::setPartitioner, this, _1), true);
     DEF_ARG(
         "heartbeat-period", 0, "PERIOD",
         "Set time for heartbeats to be published (these are approximate timings, published by the core, to update on "
         "progress)",
-        &ConfigHelper::setHeartbeat, true),
+        std::bind(&ConfigHelper::setHeartbeat, this, _1), true);
     DEF_ARG(
         "output-directory", 0, "DIR", "Directory into which all SST output files should reside",
-        &ConfigHelper::setOutputDir, true),
+        std::bind(&ConfigHelper::setOutputDir, this, _1), true);
     DEF_ARG(
-        "output-prefix-core", 0, "STR", "set the SST::Output prefix for the core", &ConfigHelper::setOutputPrefix,
-        true),
+        "output-prefix-core", 0, "STR", "set the SST::Output prefix for the core",
+        std::bind(&ConfigHelper::setOutputPrefix, this, _1), true);
 
     /* Configuration Output */
     DEF_SECTION_HEADING(
-        "Configuration Output Options (generates a file that can be used as input for reproducing a run)"),
+        "Configuration Output Options (generates a file that can be used as input for reproducing a run)");
     DEF_ARG(
-        "output-config", 0, "FILE", "File to write SST configuration (in Python format)", &ConfigHelper::setWriteConfig,
-        true),
+        "output-config", 0, "FILE", "File to write SST configuration (in Python format)",
+        std::bind(&ConfigHelper::setWriteConfig, this, _1), true);
     DEF_ARG(
-        "output-json", 0, "FILE", "File to write SST configuration graph (in JSON format)", &ConfigHelper::setWriteJSON,
-        true),
+        "output-json", 0, "FILE", "File to write SST configuration graph (in JSON format)",
+        std::bind(&ConfigHelper::setWriteJSON, this, _1), true);
 #ifdef SST_CONFIG_HAVE_MPI
     DEF_FLAG_OPTVAL(
         "parallel-output", 0,
         "Enable parallel output of configuration information.  This option is ignored for single rank jobs.  Must also "
         "specify an output type (--output-config "
         "and/or --output-json).  Note: this will also cause partition info to be output if set to true.",
-        &ConfigHelper::enableParallelOutput, &ConfigHelper::enableParallelOutputArg, true),
+        std::bind(&ConfigHelper::enableParallelOutput, this, _1), true);
 #endif
 
     /* Configuration Output */
-    DEF_SECTION_HEADING("Graph Output Options (for outputting graph information for visualization or inspection)"),
+    DEF_SECTION_HEADING("Graph Output Options (for outputting graph information for visualization or inspection)");
     DEF_ARG(
         "output-dot", 0, "FILE", "File to write SST configuration graph (in GraphViz format)",
-        &ConfigHelper::setWriteDot, true),
+        std::bind(&ConfigHelper::setWriteDot, this, _1), true);
     DEF_ARG(
         "dot-verbosity", 0, "INT", "Amount of detail to include in the dot graph output",
-        &ConfigHelper::setDotVerbosity, true),
+        std::bind(&ConfigHelper::setDotVerbosity, this, _1), true);
     DEF_ARG_OPTVAL(
         "output-partition", 0, "FILE",
         "File to write SST component partitioning information.  When used without an argument and in conjuction with "
         "--output-json or --output-config options, will cause paritition information to be added to graph output.",
-        &ConfigHelper::setWritePartition, &ConfigHelper::setWritePartitionFile, true),
+        std::bind(&ConfigHelper::setWritePartitionFile, this, _1), true);
 
     /* Advanced Features */
-    DEF_SECTION_HEADING("Advanced Options"),
+    DEF_SECTION_HEADING("Advanced Options");
     DEF_ARG(
         "timebase", 0, "TIMEBASE", "Set the base time step of the simulation (default: 1ps)",
-        &ConfigHelper::setTimebase, true),
+        std::bind(&ConfigHelper::setTimebase, this, _1), true);
 #ifdef SST_CONFIG_HAVE_MPI
     DEF_ARG_OPTVAL(
         "parallel-load", 0, "MODE",
@@ -921,312 +658,98 @@ static const struct sstLongOpts_s sstOptions[] = {
         "SINGLE is specified, the same file will be passed to all MPI "
         "ranks.  If MULTI is specified, each MPI rank is required to have it's own file to load. Note, not all input "
         "formats support both types of file loading.",
-        &ConfigHelper::enableParallelLoad, &ConfigHelper::enableParallelLoadMode, false),
+        std::bind(&ConfigHelper::enableParallelLoadMode, this, _1), false);
 #endif
     DEF_ARG(
-        "timeVortex", 0, "MODULE", "Select TimeVortex implementation <lib.timevortex>", &ConfigHelper::setTimeVortex,
-        true),
+        "timeVortex", 0, "MODULE", "Select TimeVortex implementation <lib.timevortex>",
+        std::bind(&ConfigHelper::setTimeVortex, this, _1), true);
     DEF_FLAG_OPTVAL(
         "interthread-links", 0, "[EXPERIMENTAL] Set whether or not interthread links should be used",
-        &ConfigHelper::setInterThreadLinks, &ConfigHelper::setInterThreadLinksArg, true),
+        std::bind(&ConfigHelper::setInterThreadLinks, this, _1), true);
 #ifdef USE_MEMPOOL
     DEF_FLAG_OPTVAL(
         "cache-align-mempools", 0, "[EXPERIMENTAL] Set whether mempool allocations are cache aligned",
-        &ConfigHelper::setCacheAlignMempools, &ConfigHelper::setCacheAlignMempoolsArg, true),
+        std::bind(&ConfigHelper::setCacheAlignMempools, this, _1), true);
 #endif
-    DEF_ARG("debug-file", 0, "FILE", "File where debug output will go", &ConfigHelper::setDebugFile, true),
-    DEF_ARG("lib-path", 0, "LIBPATH", "Component library path (overwrites default)", &ConfigHelper::setLibPath, true),
     DEF_ARG(
-        "add-lib-path", 0, "LIBPATH", "Component library path (appends to main path)", &ConfigHelper::addLibPath, true),
+        "debug-file", 0, "FILE", "File where debug output will go", std::bind(&ConfigHelper::setDebugFile, this, _1),
+        true);
+    addLibraryPathOptions();
 
     /* Advanced Features - Profiling */
-    DEF_SECTION_HEADING("Advanced Options - Profiling (EXPERIMENTAL)"),
+    DEF_SECTION_HEADING("Advanced Options - Profiling (EXPERIMENTAL)");
     DEF_ARG(
         "enable-profiling", 0, "POINTS",
         "Enables default profiling for the specified points.  Argument is a semicolon separated list specifying the "
         "points to enable.",
-        &ConfigHelper::enableProfiling, true),
+        std::bind(&ConfigHelper::enableProfiling, this, _1), true);
     DEF_ARG(
         "profiling-output", 0, "FILE", "Set output location for profiling data [stdout (default) or a filename]",
-        &ConfigHelper::setProfilingOutput, true),
+        std::bind(&ConfigHelper::setProfilingOutput, this, _1), true);
 
     /* Advanced Features - Debug */
-    DEF_SECTION_HEADING("Advanced Options - Debug"),
-    DEF_ARG("run-mode", 0, "MODE", "Set run mode [ init | run | both (default)]", &ConfigHelper::setRunMode, true),
+    DEF_SECTION_HEADING("Advanced Options - Debug");
+    DEF_ARG(
+        "run-mode", 0, "MODE", "Set run mode [ init | run | both (default)]",
+        std::bind(&ConfigHelper::setRunMode, this, _1), true);
 #ifdef USE_MEMPOOL
     DEF_ARG(
         "output-undeleted-events", 0, "FILE",
         "file to write information about all undeleted events at the end of simulation (STDOUT and STDERR can be used "
         "to output to console)",
-        &ConfigHelper::setWriteUndeleted, true),
+        std::bind(&ConfigHelper::setWriteUndeleted, this, _1), true);
 #endif
     DEF_FLAG(
         "force-rank-seq-startup", 0,
         "Force startup phases of simulation to execute one rank at a time for debug purposes",
-        &ConfigHelper::forceRankSeqStartup),
+        std::bind(&ConfigHelper::forceRankSeqStartup, this, _1));
 
     /* Advanced Features - Environment Setup/Reporting */
-    DEF_SECTION_HEADING("Advanced Options - Environment Setup/Reporting"),
-    DEF_FLAG("print-env", 0, "Print environment variables SST will see", &ConfigHelper::enablePrintEnv),
-    DEF_FLAG("disable-signal-handlers", 0, "Disable signal handlers", &ConfigHelper::disableSigHandlers),
-    DEF_FLAG("no-env-config", 0, "Disable SST environment configuration", &ConfigHelper::disableEnvConfig),
-    { { nullptr, 0, nullptr, 0 }, nullptr, nullptr, nullptr, nullptr, false, false }
+    DEF_SECTION_HEADING("Advanced Options - Environment Setup/Reporting");
+    addEnvironmentOptions();
+    DEF_FLAG(
+        "disable-signal-handlers", 0, "Disable signal handlers",
+        std::bind(&ConfigHelper::disableSigHandlers, this, _1));
+
+    enableDashDashSupport(std::bind(&ConfigHelper::setModelOptions, this, _1));
+    addPositionalCallback(std::bind(&Config::positionalCallback, this, _1, _2));
 };
-static const size_t nLongOpts = (sizeof(sstOptions) / sizeof(sstLongOpts_s)) - 1;
 
-
-bool
-ConfigHelper::parseBoolean(const std::string& arg, bool& success, const std::string& option)
+std::string
+Config::getUsagePrelude()
 {
-    success = true;
-
-    std::string arg_lower(arg);
-    std::locale loc;
-    for ( auto& ch : arg_lower )
-        ch = std::tolower(ch, loc);
-
-    if ( arg_lower == "true" || arg_lower == "yes" || arg_lower == "1" || arg_lower == "on" )
-        return true;
-    else if ( arg_lower == "false" || arg_lower == "no" || arg_lower == "0" || arg_lower == "off" )
-        return false;
-    else {
-        fprintf(
-            stderr,
-            "ERROR: Failed to parse \"%s\" as a bool for option \"%s\", "
-            "please use true/false, yes/no or 1/0\n",
-            arg.c_str(), option.c_str());
-        exit(-1);
-        return false;
-    }
-}
-
-
-bool
-ConfigHelper::usage()
-{
-#ifdef SST_CONFIG_HAVE_MPI
-    int this_rank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &this_rank);
-    if ( this_rank != 0 ) return false;
-#endif
-
-    /* Determine screen / description widths */
-    uint32_t MAX_WIDTH = 80;
-
-    struct winsize size;
-    if ( ioctl(STDERR_FILENO, TIOCGWINSZ, &size) == 0 ) { MAX_WIDTH = size.ws_col; }
-
-    if ( getenv("COLUMNS") ) {
-        errno      = E_OK;
-        uint32_t x = strtoul(getenv("COLUMNS"), nullptr, 0);
-        if ( errno == E_OK ) MAX_WIDTH = x;
-    }
-
-    const char     sdl_indicator[] = "(S)";
-    const uint32_t sdl_start       = 34;
-    const uint32_t desc_start      = sdl_start + sizeof(sdl_indicator);
-    const uint32_t desc_width      = MAX_WIDTH - desc_start;
-
-    /* Print usage */
-    fprintf(
-        stderr, "Usage: sst [options] config-file\n"
-                "  Arguments to options contained in [] are optional\n"
-                "  Options available to be set in the sdl file (input configuration file) are denoted by (S)\n"
-                "   - Options set on the command line take precedence over options set in the SDL file\n"
-                "  Notes on flag options (options that take an optional BOOL value):\n"
-                "   - BOOL values can be expressed as true/false, yes/no, on/off or 1/0\n"
-                "   - Program default for flags is false\n"
-                "   - BOOL values default to true if flag is specified but no value is supplied\n");
-
-    for ( size_t i = 0; i < nLongOpts; i++ ) {
-        if ( !strcmp(sstOptions[i].opt.name, SECTION_HEADER) ) {
-            // Just a section heading
-            fprintf(stderr, "\n%s\n", sstOptions[i].desc);
-            continue;
-        }
-
-        uint32_t npos = 0;
-        if ( sstOptions[i].opt.val ) { npos += fprintf(stderr, "-%c ", (char)sstOptions[i].opt.val); }
-        else {
-            npos += fprintf(stderr, "   ");
-        }
-        npos += fprintf(stderr, "--%s", sstOptions[i].opt.name);
-        if ( sstOptions[i].opt.has_arg != no_argument ) { npos += fprintf(stderr, "=%s", sstOptions[i].argName); }
-        // If we have already gone beyond the description start,
-        // description starts on new line
-        if ( npos >= sdl_start ) {
-            fprintf(stderr, "\n");
-            npos = 0;
-        }
-
-        // If this can be set in the sdl file, start description with
-        // "(S)"
-        while ( npos < sdl_start ) {
-            npos += fprintf(stderr, " ");
-        }
-        if ( sstOptions[i].sdl_avail ) { npos += fprintf(stderr, sdl_indicator); }
-
-        const char* text = sstOptions[i].desc;
-        while ( text != nullptr && *text != '\0' ) {
-            /* Advance to offset */
-            while ( npos < desc_start )
-                npos += fprintf(stderr, " ");
-
-            if ( strlen(text) <= desc_width ) {
-                fprintf(stderr, "%s", text);
-                break;
-            }
-            else {
-                // Need to find the last space before we need to break
-                int index = desc_width - 1;
-                while ( index > 0 ) {
-                    if ( text[index] == ' ' ) break;
-                    index--;
-                }
-
-                int nwritten = fprintf(stderr, "%.*s\n", index, text);
-                text += (nwritten);
-                // Skip any extra spaces
-                while ( *text == ' ' )
-                    text++;
-                npos = 0;
-            }
-        }
-        fprintf(stderr, "\n");
-    }
-    fprintf(stderr, "\n");
-
-    return false; /* Should not continue */
+    std::string prelude = "Usage: sst [options] config-file\n";
+    prelude.append("  Arguments to options contained in [] are optional\n");
+    prelude.append("  Options available to be set in the sdl file (input configuration file) are denoted by (S)\n");
+    prelude.append("   - Options set on the command line take precedence over options set in the SDL file\n");
+    prelude.append("  Notes on flag options (options that take an optional BOOL value):\n");
+    prelude.append("   - BOOL values can be expressed as true/false, yes/no, on/off or 1/0\n");
+    prelude.append("   - Program default for flags is false\n");
+    prelude.append("   - BOOL values default to true if flag is specified but no value is supplied\n");
+    return prelude;
 }
 
 int
-Config::parseCmdLine(int argc, char* argv[])
+Config::positionalCallback(int num, const std::string& arg)
 {
-    ConfigHelper       helper(*this);
-    static const char* sst_short_options = "hv::Vn:";
-    struct option      sst_long_options[nLongOpts + 1];
-    for ( size_t i = 0; i < nLongOpts; i++ ) {
-        sst_long_options[i] = sstOptions[i].opt;
-    }
-    sst_long_options[nLongOpts] = { nullptr, 0, nullptr, 0 };
-
-    run_name = argv[0];
-
-    // Need to see if there are model-options specified after '--'.
-    // If there is, we will deal with it later and just tell getopt
-    // about everything before it.  getopt does not handle -- and
-    // positional arguments in a sane way.
-    int end_arg_index = 0;
-    for ( int i = 0; i < argc; ++i ) {
-        if ( !strcmp(argv[i], "--") ) {
-            end_arg_index = i;
-            break;
-        }
-    }
-    int my_argc = end_arg_index == 0 ? argc : end_arg_index;
-
-    bool ok           = true;
-    helper.clean_exit = false;
-    while ( ok ) {
-        int       option_index = 0;
-        const int intC         = getopt_long(my_argc, argv, sst_short_options, sst_long_options, &option_index);
-
-        if ( intC == -1 ) /* We're done */
-            break;
-
-        const char c = static_cast<char>(intC);
-
-        // Getopt is a bit strange it how it returns information.
-        // There are three cases:
-
-        // 1 - Unknown value:  c = '?' & option_index = 0
-        // 2 - long options:  c = first letter of option & option_index = index of option in sst_long_options
-        // 3 - short options: c = short option letter & option_index = 0
-
-        // This is a dumb combination of things.  They really should
-        // have return c = 0 in the long option case.  As it is,
-        // there's no way to differentiate a short value from the long
-        // value in index 0.  Thankfully, we have a "Section Header"
-        // in index 0 so we don't have to worry about that.
-
-        // If the character returned from getopt_long is '?', then it
-        // is an unknown command
-        if ( c == '?' ) {
-            // Unknown option
-            ok = helper.usage();
-        }
-        else if ( option_index != 0 ) {
-            // Long options
-            if ( optarg == nullptr ) {
-                ok = (helper.*sstOptions[option_index].flagFunc)();
-                if ( ok ) sstOptions[option_index].set_cmdline = true;
-            }
-            else {
-                ok = (helper.*sstOptions[option_index].argFunc)(optarg);
-                if ( ok ) sstOptions[option_index].set_cmdline = true;
-            }
-        }
-        else {
-            switch ( c ) {
-            case 0:
-                // This shouldn't happen, so we'll error if it does
-                fprintf(stderr, "INTERNAL ERROR: error parsing command line options\n");
-                exit(1);
-                break;
-
-            // Note, for these cases, we have to supply the
-            // option_index ourselves because it is set to 0 from
-            // getopt.  So, these need to be revisited if there is
-            // ever a new option put above any of these options.
-            case 'v':
-                if ( optarg == nullptr ) { ok = helper.incrVerbose(); }
-                else {
-                    ok = helper.setVerbosity(optarg);
-                }
-                if ( ok ) sstOptions[4].set_cmdline = true;
-                break;
-
-            case 'n':
-            {
-                ok = helper.setNumThreads(optarg);
-                if ( ok ) sstOptions[5].set_cmdline = true;
-                break;
-            }
-
-            case 'V':
-                ok                = helper.printVersion();
-                helper.clean_exit = true;
-                break;
-
-            case 'h':
-                helper.clean_exit = true;
-            /* fall through */
-            default:
-                ok = helper.usage();
-            }
-        }
-    }
-
-    if ( !ok ) {
-        if ( helper.clean_exit ) return 1;
-        return -1;
-    }
-
-    /* Handle positional arguments */
-    if ( optind < argc ) {
+    if ( num == 0 ) {
         // First positional argument is the sdl-file
-        ok = helper.setConfigFile(argv[optind++]);
-
+        configFile_ = arg;
+    }
+    else {
         // If there are additional position arguments, this is an
         // error
-        if ( optind == (my_argc - 1) ) {
-            fprintf(
-                stderr, "Error: sdl-file name is the only positional argument allowed.  See help for --model-options "
-                        "for more info on passing parameters to the input script.\n");
-            ok = false;
-        }
+        fprintf(
+            stderr, "Error: sdl-file name is the only positional argument allowed.  See help for --model-options "
+                    "for more info on passing parameters to the input script.\n");
+        return -1;
     }
+    return 0;
+}
 
+int
+Config::checkArgsAfterParsing()
+{
     // Check to make sure we had an sdl-file specified
     if ( configFile_ == "NONE" ) {
         fprintf(stderr, "ERROR: no sdl-file specified\n");
@@ -1234,19 +757,7 @@ Config::parseCmdLine(int argc, char* argv[])
         return -1;
     }
 
-    // Support further additional arguments specified after -- to be
-    // args to the model.
-    if ( end_arg_index != 0 ) {
-        for ( int i = end_arg_index + 1; i < argc; ++i ) {
-            helper.setModelOptions(argv[i]);
-        }
-    }
-
-    if ( !ok ) return -1;
-
     /* Sanity check, and other duties */
-    Output::setFileName(debugFile_ != "/dev/null" ? debugFile_ : "sst_output");
-
 
     // Ensure output directory ends with a directory separator
     if ( output_directory_.size() > 0 ) {
@@ -1263,7 +774,6 @@ Config::parseCmdLine(int argc, char* argv[])
     if ( output_json_.size() > 0 && isFileNameOnly(output_json_) ) { output_json_.insert(0, output_directory_); }
 
     if ( debugFile_.size() > 0 && isFileNameOnly(debugFile_) ) { debugFile_.insert(0, output_directory_); }
-
     return 0;
 }
 
@@ -1271,24 +781,7 @@ Config::parseCmdLine(int argc, char* argv[])
 bool
 Config::setOptionFromModel(const string& entryName, const string& value)
 {
-    ConfigHelper helper(*this);
-    for ( size_t i = 0; i < nLongOpts; i++ ) {
-        if ( !entryName.compare(sstOptions[i].opt.name) ) {
-            if ( sstOptions[i].sdl_avail ) {
-                // If this was set on the command line, skip it
-                if ( sstOptions[i].set_cmdline ) return false;
-                return (helper.*sstOptions[i].argFunc)(value);
-            }
-            else {
-                fprintf(stderr, "ERROR: Option \"%s\" is not available to be set in the SDL file\n", entryName.c_str());
-                exit(-1);
-                return false;
-            }
-        }
-    }
-    fprintf(stderr, "ERROR: Unknown configuration entry \"%s\"\n", entryName.c_str());
-    exit(-1);
-    return false;
+    return setOptionExternal(entryName, value);
 }
 
 

--- a/src/sst/core/configBase.cc
+++ b/src/sst/core/configBase.cc
@@ -22,6 +22,7 @@
 #include <string>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #ifndef E_OK
 #define E_OK 0

--- a/src/sst/core/configBase.cc
+++ b/src/sst/core/configBase.cc
@@ -1,0 +1,367 @@
+// Copyright 2009-2022 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2022, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+
+#include "sst/core/configBase.h"
+
+#include "sst/core/env/envquery.h"
+#include "sst/core/warnmacros.h"
+
+#include <cstdlib>
+#include <getopt.h>
+#include <iostream>
+#include <string>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+
+#ifndef E_OK
+#define E_OK 0
+#endif
+
+using namespace std;
+
+namespace SST {
+
+bool
+ConfigBase::parseBoolean(const std::string& arg, bool& success, const std::string& option)
+{
+    success = true;
+
+    std::string arg_lower(arg);
+    std::locale loc;
+    for ( auto& ch : arg_lower )
+        ch = std::tolower(ch, loc);
+
+    if ( arg_lower == "true" || arg_lower == "yes" || arg_lower == "1" || arg_lower == "on" )
+        return true;
+    else if ( arg_lower == "false" || arg_lower == "no" || arg_lower == "0" || arg_lower == "off" )
+        return false;
+    else {
+        fprintf(
+            stderr,
+            "ERROR: Failed to parse \"%s\" as a bool for option \"%s\", "
+            "please use true/false, yes/no or 1/0\n",
+            arg.c_str(), option.c_str());
+        exit(-1);
+        return false;
+    }
+}
+
+
+void
+ConfigBase::addOption(
+    struct option opt, const char* argname, const char* desc, std::function<int(const char* arg)> callback, bool header,
+    bool sdl_avail)
+{
+    // Put this into the options vector
+    options.emplace_back(opt, argname, desc, callback, header, sdl_avail, false);
+
+    LongOption& new_option = options.back();
+
+    // If this is a header, we're done
+    if ( new_option.header ) return;
+
+    // Increment the number of options
+    num_options++;
+
+    // See if this is the longest option
+    size_t size = 0;
+    if ( new_option.opt.name != nullptr ) { size = strlen(new_option.opt.name); }
+    if ( new_option.argname != "" ) { size += new_option.argname.size() + 1; }
+    if ( size > longest_option ) longest_option = size;
+
+    if ( new_option.opt.val != 0 ) {
+        // Put value in short option map with the index of where
+        // to find the optoin in options vector.
+        short_options[(char)new_option.opt.val] = options.size() - 1;
+
+        // short_options_string lists all the available short
+        // options.  If followed by a single colon, an argument is
+        // required.  If followed by two colons, an argument is
+        // optonsal.  No colon means no arguments.
+        short_options_string.push_back((char)new_option.opt.val);
+        if ( new_option.opt.has_arg == required_argument ) { short_options_string.push_back(':'); }
+        else if ( new_option.opt.has_arg == optional_argument ) {
+            short_options_string.append("::");
+        }
+    }
+}
+
+std::string
+ConfigBase::getUsagePrelude()
+{
+    return "";
+}
+
+int
+ConfigBase::checkArgsAfterParsing()
+{
+    return 0;
+}
+
+void
+ConfigBase::enableDashDashSupport(std::function<int(const char* arg)> callback)
+{
+    dashdash_callback = callback;
+}
+
+void
+ConfigBase::addPositionalCallback(std::function<int(int num, const char* arg)> callback)
+{
+    positional_args = callback;
+}
+
+int
+ConfigBase::printUsage()
+{
+    if ( suppress_print_ ) return 1;
+
+    /* Determine screen / description widths */
+    uint32_t MAX_WIDTH = 80;
+
+    struct winsize size;
+    if ( ioctl(STDERR_FILENO, TIOCGWINSZ, &size) == 0 ) { MAX_WIDTH = size.ws_col; }
+
+    if ( getenv("COLUMNS") ) {
+        errno      = E_OK;
+        uint32_t x = strtoul(getenv("COLUMNS"), nullptr, 0);
+        if ( errno == E_OK ) MAX_WIDTH = x;
+    }
+
+    const char*    sdl_indicator = suppress_sdl_ ? "" : "(S)";
+    const uint32_t sdl_start     = longest_option + 6;
+    const uint32_t desc_start    = sdl_start + strlen(sdl_indicator) + 1;
+    const uint32_t desc_width    = MAX_WIDTH - desc_start;
+
+    /* Print usage */
+    fprintf(stderr, "%s", getUsagePrelude().c_str());
+
+    for ( auto& option : options ) {
+        if ( option.header ) {
+            // Just a section heading
+            fprintf(stderr, "\n%s\n", option.desc.c_str());
+            continue;
+        }
+
+
+        uint32_t npos = 0;
+        // Check for short options
+        if ( option.opt.val ) { npos += fprintf(stderr, "-%c ", (char)option.opt.val); }
+        else {
+            npos += fprintf(stderr, "   ");
+        }
+        npos += fprintf(stderr, "--%s", option.opt.name);
+        if ( option.opt.has_arg != no_argument ) { npos += fprintf(stderr, "=%s", option.argname.c_str()); }
+        // If we have already gone beyond the description start,
+        // description starts on new line
+        if ( npos >= sdl_start ) {
+            fprintf(stderr, "\n");
+            npos = 0;
+        }
+
+        // If this can be set in the sdl file, start description with
+        // "(S)"
+        while ( npos < sdl_start ) {
+            npos += fprintf(stderr, " ");
+        }
+        if ( option.sdl_avail ) { npos += fprintf(stderr, "%s", sdl_indicator); }
+
+        const char* text = option.desc.c_str();
+        while ( text != nullptr && *text != '\0' ) {
+            /* Advance to offset */
+            while ( npos < desc_start )
+                npos += fprintf(stderr, " ");
+
+            if ( strlen(text) <= desc_width ) {
+                fprintf(stderr, "%s", text);
+                break;
+            }
+            else {
+                // Need to find the last space before we need to break
+                int index = desc_width - 1;
+                while ( index > 0 ) {
+                    if ( text[index] == ' ' ) break;
+                    index--;
+                }
+
+                int nwritten = fprintf(stderr, "%.*s\n", index, text);
+                text += (nwritten);
+                // Skip any extra spaces
+                while ( *text == ' ' )
+                    text++;
+                npos = 0;
+            }
+        }
+        fprintf(stderr, "\n");
+    }
+    fprintf(stderr, "\n");
+
+    return 1; /* Should not continue */
+}
+
+int
+ConfigBase::parseCmdLine(int argc, char* argv[], bool ignore_unknown)
+{
+    if ( suppress_print_ || ignore_unknown ) {
+        // Turn off printing of errors in getopt_long
+        opterr = 0;
+    }
+    struct option sst_long_options[num_options + 2];
+
+    // Because a zero index can mean two different things, we put in a
+    // dummy so we don't ever get a zero index
+    sst_long_options[0] = { "*DUMMY_ARGUMENT*", no_argument, nullptr, 0 };
+    int option_map[num_options + 1];
+    option_map[0] = 0;
+    {
+        int count = 1;
+
+        for ( size_t i = 0; i < options.size(); ++i ) {
+            LongOption& opt = options[i];
+            if ( opt.header ) continue;
+            option_map[count]         = i;
+            sst_long_options[count++] = opt.opt;
+        }
+        sst_long_options[count] = { nullptr, 0, nullptr, 0 };
+    }
+
+    run_name_ = argv[0];
+
+    int end_arg_index = 0;
+    int my_argc       = argc;
+
+    // Check to see if '--' support was requested
+    if ( dashdash_callback ) {
+        // Need to see if there are model-options specified after '--'.
+        // If there is, we will deal with it later and just tell getopt
+        // about everything before it.  getopt does not handle -- and
+        // positional arguments in a sane way.
+        for ( int i = 0; i < argc; ++i ) {
+            if ( !strcmp(argv[i], "--") ) {
+                end_arg_index = i;
+                break;
+            }
+        }
+        my_argc = end_arg_index == 0 ? argc : end_arg_index;
+    }
+
+    int ok = 0;
+    while ( 0 == ok ) {
+        int       option_index = 0;
+        const int intC = getopt_long(my_argc, argv, short_options_string.c_str(), sst_long_options, &option_index);
+
+        if ( intC == -1 ) /* We're done */
+            break;
+
+        const char c = static_cast<char>(intC);
+
+        // Getopt is a bit strange it how it returns information.
+        // There are three cases:
+
+        // 1 - Unknown value:  c = '?' & option_index = 0
+        // 2 - long options:  c = first letter of option & option_index = index of option in sst_long_options
+        // 3 - short options: c = short option letter & option_index = 0
+
+        // This is a dumb combination of things.  They really should
+        // have return c = 0 in the long option case.  As it is,
+        // there's no way to differentiate a short value from the long
+        // value in index 0.  So, we added a pad above.
+
+        // If the character returned from getopt_long is '?', then it
+        // is an unknown command
+        if ( c == '?' ) {
+            // Unknown option
+            if ( !ignore_unknown ) { ok = printUsage(); }
+        }
+        else if ( option_index != 0 ) {
+            // Long options
+            int real_index = option_map[option_index];
+            if ( optarg )
+                ok = options[real_index].callback(optarg);
+            else
+                ok = options[real_index].callback("");
+            if ( ok ) options[real_index].set_cmdline = true;
+        }
+        else {
+            // Short option
+            int real_index = short_options[c];
+            if ( optarg )
+                ok = options[real_index].callback(optarg);
+            else
+                ok = options[real_index].callback("");
+            if ( ok ) options[real_index].set_cmdline = true;
+        }
+    }
+
+    if ( ok != 0 ) { return ok; }
+
+    /* Handle positional arguments */
+    int    pos   = optind;
+    size_t count = 0;
+    while ( pos < my_argc ) {
+        // Make sure that we don't have too many positional arguments
+        if ( !positional_args && !suppress_print_ && !ignore_unknown ) {
+            fprintf(stderr, "Error: no positional arguments allowed: %s\n", argv[pos]);
+            return -1;
+        }
+
+        // If we aren't ignoring unknown arguments, we'll get an error
+        // above. Otherwise, just ignore all the positional arguments.
+        if ( positional_args )
+            ok = positional_args(count, argv[pos++]);
+        else
+            pos++;
+    }
+
+    // Support further additional arguments specified after -- to be
+    // args to the model.
+    if ( end_arg_index != 0 ) {
+        for ( int i = end_arg_index + 1; i < argc; ++i ) {
+            dashdash_callback(argv[i]);
+        }
+    }
+
+    if ( suppress_print_ ) {
+        // Turn on printing of errors in getopt_long
+        opterr = 1;
+    }
+
+    // If everything parsed okay, call the check function
+    if ( ok == 0 ) return checkArgsAfterParsing();
+    return ok;
+}
+
+
+bool
+ConfigBase::setOptionExternal(const string& entryName, const string& value)
+{
+    // NOTE: print outs in this function will not be suppressed
+    for ( auto& option : options ) {
+        if ( !entryName.compare(option.opt.name) ) {
+            if ( option.sdl_avail ) {
+                // If this was set on the command line, skip it
+                if ( option.set_cmdline ) return false;
+                return option.callback(value.c_str());
+            }
+            else {
+                fprintf(stderr, "ERROR: Option \"%s\" is not available to be set in the SDL file\n", entryName.c_str());
+                exit(-1);
+                return false;
+            }
+        }
+    }
+    fprintf(stderr, "ERROR: Unknown configuration entry \"%s\"\n", entryName.c_str());
+    exit(-1);
+    return false;
+}
+
+} // namespace SST

--- a/src/sst/core/configBase.h
+++ b/src/sst/core/configBase.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/sst_types.h"
 
+#include <functional>
 #include <getopt.h>
 #include <iostream>
 #include <map>

--- a/src/sst/core/configBase.h
+++ b/src/sst/core/configBase.h
@@ -1,0 +1,190 @@
+// Copyright 2009-2022 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2022, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_CONFIGBASE_H
+#define SST_CORE_CONFIGBASE_H
+
+#include "sst/core/sst_types.h"
+
+#include <getopt.h>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+/* Forward declare for Friendship */
+extern int main(int argc, char** argv);
+
+namespace SST {
+
+/**
+   Struct that holds all the getopt_long options along with the
+   docuementation for the option
+*/
+struct LongOption
+{
+    struct option                       opt;
+    std::string                         argname;
+    std::string                         desc;
+    std::function<int(const char* arg)> callback;
+    bool                                header; // if true, desc is actually the header
+    bool                                sdl_avail;
+    mutable bool                        set_cmdline;
+
+    LongOption(
+        struct option opt, const char* argname, const char* desc, const std::function<int(const char* arg)>& callback,
+        bool header, bool sdl_avail, bool set_cmdline) :
+        opt(opt),
+        argname(argname),
+        desc(desc),
+        callback(callback),
+        header(header),
+        sdl_avail(sdl_avail),
+        set_cmdline(set_cmdline)
+    {}
+};
+
+
+// Macros to make defining options easier.  These must be called
+// inside of a member function of a class inheriting from ConfigBase
+// Nomenaclature is:
+
+// FLAG - value is either true or false.  FLAG defaults to no arguments allowed
+// ARG - value is a string.  ARG defaults to required argument
+// OPTVAL - Takes an optional paramater
+
+// longName - multicharacter name referenced using --
+// shortName - single character name referenced using -
+// text - help text
+// func - function called if option is found
+#define DEF_FLAG_OPTVAL(longName, shortName, text, func, sdl_avail) \
+    addOption({ longName, optional_argument, 0, shortName }, "[BOOL]", text, func, false, sdl_avail);
+
+#define DEF_FLAG(longName, shortName, text, func) \
+    addOption({ longName, no_argument, 0, shortName }, "", text, func, false, false);
+
+#define DEF_ARG(longName, shortName, argName, text, func, sdl_avail) \
+    addOption({ longName, required_argument, 0, shortName }, argName, text, func, false, sdl_avail);
+
+#define DEF_ARG_OPTVAL(longName, shortName, argName, text, func, sdl_avail) \
+    addOption({ longName, optional_argument, 0, shortName }, "[" argName "]", text, func, false, sdl_avail);
+
+
+#define DEF_SECTION_HEADING(text) \
+    addOption({ "", optional_argument, 0, 0 }, "", text, std::function<int(const char* arg)>(), true, false);
+
+
+/**
+ * Base class to parse command line options for SST Simulation
+ * Configuration variables.
+ *
+ * NOTE: This class contains only state for parsing the command line.
+ * All options will be stored in classes derived from this class.
+ * This means that we don't need to be able to serialize anything in
+ * this class.
+ */
+class ConfigBase
+{
+protected:
+    /**
+       ConfigBase constructor.  Meant to only be created by main
+       function
+     */
+    ConfigBase(bool suppress_print, bool suppress_sdl) : suppress_print_(suppress_print), suppress_sdl_(suppress_sdl) {}
+
+    /**
+       Default constructor used for serialization.  After
+       serialization, the Config object is only used to get the values
+       of set options and it can no longer parse arguments.  Given
+       that, it will no longer print anything, so set suppress_print_
+       to true. None of this class needs to be serialized because it
+       it's state is only for parsing the arguments.
+     */
+    ConfigBase() : suppress_print_(true), suppress_sdl_(true) { options.reserve(100); }
+
+
+    /**
+       Called to print the help/usage message
+    */
+    int printUsage();
+
+
+    /**
+       Add options to the Config object.  The options will be added in
+       the order they are in the input array, and across calls to the
+       function.
+     */
+    void addOption(
+        struct option opt, const char* argname, const char* desc, std::function<int(const char* arg)> callback,
+        bool header, bool sdl_avail);
+
+    /**
+       Called to get the prelude for the help/usage message
+     */
+    virtual std::string getUsagePrelude();
+
+    // Function that will be called at the end of parsing so that
+    // error checking can be done
+    virtual int checkArgsAfterParsing();
+
+    // Enable support for everything after -- to be passed to a
+    // callback. Each arg will be passed independently to the callback
+    // function
+    void enableDashDashSupport(std::function<int(const char* arg)> callback);
+
+    // Add support for positional args.  Must be added in the order the
+    // args show up on the command line
+    void addPositionalCallback(std::function<int(int num, const char* arg)> callback);
+
+
+    /**
+       Get the name of the executable being run.  This is only
+       avaialable after parseCmdLine() is called.
+     */
+    std::string getRunName() { return run_name_; }
+
+    /** Set a configuration string to update configuration values */
+    bool setOptionExternal(const std::string& entryName, const std::string& value);
+
+public:
+    // Function to uniformly parse boolean values for command line
+    // arguments
+    static bool parseBoolean(const std::string& arg, bool& success, const std::string& option);
+
+    virtual ~ConfigBase() {}
+
+    /**
+       Parse command-line arguments to update configuration values.
+
+       @return Returns 0 if execution should continue.  Returns -1 if
+         there was an error.  Returns 1 if run command line only asked
+         for information to be print (e.g. --help or -V, for example).
+     */
+    int parseCmdLine(int argc, char* argv[], bool ignore_unknown = false);
+
+
+private:
+    std::vector<LongOption>                      options;
+    std::map<char, int>                          short_options;
+    std::string                                  short_options_string;
+    size_t                                       longest_option = 0;
+    size_t                                       num_options    = 0;
+    std::function<int(const char* arg)>          dashdash_callback;
+    std::function<int(int num, const char* arg)> positional_args;
+
+    std::string run_name_;
+    bool        suppress_print_;
+    bool        suppress_sdl_;
+};
+
+} // namespace SST
+
+#endif // SST_CORE_CONFIGBASE_H

--- a/src/sst/core/configShared.cc
+++ b/src/sst/core/configShared.cc
@@ -1,0 +1,158 @@
+// Copyright 2009-2022 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2022, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+
+#include "sst/core/configShared.h"
+
+#include "sst/core/env/envquery.h"
+
+#include <functional>
+
+using namespace std;
+
+namespace SST {
+
+ConfigShared::ConfigShared(
+    bool suppress_print, bool suppress_sdl, bool include_libpath, bool include_env, bool include_verbose) :
+    ConfigBase(suppress_print, suppress_sdl)
+{
+    if ( include_libpath ) addLibraryPathOptions();
+    if ( include_env ) addEnvironmentOptions();
+    if ( include_verbose ) addVerboseOptions(false);
+}
+
+
+ConfigShared::ConfigShared(bool suppress_print, bool suppress_sdl) : ConfigBase(suppress_print, suppress_sdl) {}
+
+void
+ConfigShared::addLibraryPathOptions()
+{
+    using namespace std::placeholders;
+    // Add the options
+    DEF_ARG(
+        "lib-path", 0, "LIBPATH", "Component library path (overwrites default)",
+        std::bind(&ConfigShared::setLibPath, this, _1), false);
+    DEF_ARG(
+        "add-lib-path", 0, "LIBPATH", "Component library path (appends to main path)",
+        std::bind(&ConfigShared::setAddLibPath, this, _1), false);
+}
+
+void
+ConfigShared::addEnvironmentOptions()
+{
+    using namespace std::placeholders;
+    // Add the options
+    DEF_FLAG(
+        "print-env", 0, "Print environment variables SST will see", std::bind(&ConfigShared::enablePrintEnv, this, _1));
+    DEF_FLAG(
+        "no-env-config", 0, "Disable SST environment configuration",
+        std::bind(&ConfigShared::disableEnvConfig, this, _1));
+}
+
+void
+ConfigShared::addVerboseOptions(bool sdl_avail)
+{
+    using namespace std::placeholders;
+    DEF_ARG_OPTVAL(
+        "verbose", 'v', "level",
+        "Verbosity level to determine what information about core runtime is printed.  If no argument is specified, it "
+        "will simply increment the verbosity level.",
+        std::bind(&ConfigShared::setVerbosity, this, _1), sdl_avail);
+}
+
+
+/**
+   Get the library path for loading element libraries.  There are
+   three places that paths can be specified and they are included in
+   the path in the following order:
+
+   1 - command line arguments set using --lib-path and --add-lib-path
+   2 - paths set in environment variable SST_LIB_PATH
+   3 - paths set in sstsimulator.conf file
+   4 - (only for bootsst, Factory will not search this) LD_LIBRARY_PATH environment variable
+
+ */
+std::string
+ConfigShared::getLibPath(void) const
+{
+    std::string fullLibPath;
+
+    // This creates the following search order:
+    //
+    // 1 - command line
+    // 2 - SST_LIB_PATH environment variable
+    // 3 - Path from configuration file
+    // 4 - User set LD_LIBRARY_PATH (only for final LD_LIBRARY_PATH)
+
+    // The --lib-path option overwrites everything that comes before
+    // (SST_LIB_PATH env variable and paths in sstsimulator.conf).
+    if ( "" == libpath_ ) {
+
+        // If the SST_LIB_PATH variable is set, put it into the final
+        // path
+        char* envpath = getenv("SST_LIB_PATH");
+        if ( nullptr != envpath ) {
+            fullLibPath.append(envpath);
+            // delete envpath;
+        }
+
+        // Get configuration options from the user config
+        std::vector<std::string>                          configPaths;
+        SST::Core::Environment::EnvironmentConfiguration* envConfig =
+            SST::Core::Environment::getSSTEnvironmentConfiguration(configPaths);
+
+        std::set<std::string> configGroups = envConfig->getGroupNames();
+
+        // iterate over groups of settings
+        for ( auto groupItr = configGroups.begin(); groupItr != configGroups.end(); groupItr++ ) {
+            SST::Core::Environment::EnvironmentConfigGroup* currentGroup = envConfig->getGroupByName(*groupItr);
+            std::set<std::string>                           groupKeys    = currentGroup->getKeys();
+
+            // find which keys have a LIBDIR at the END of the key we
+            // recognize these may house elements
+            for ( auto keyItr = groupKeys.begin(); keyItr != groupKeys.end(); keyItr++ ) {
+                const std::string& key   = *keyItr;
+                const std::string& value = currentGroup->getValue(key);
+
+                if ( key.size() > 6 ) {
+                    if ( "LIBDIR" == key.substr(key.size() - 6) ) {
+                        fullLibPath.append(":");
+                        fullLibPath.append(value);
+                    }
+                }
+            }
+        }
+
+        // Clean up and delete the configuration we just loaded up
+        delete envConfig;
+    }
+    else {
+        // --lib-path was set, so just use it as the base
+        fullLibPath = libpath_;
+    }
+
+    // NOw see if we need to prepend any paths from --add-lib-path
+    if ( !addlibpath_.empty() ) {
+        // fullLibPath.append(":");
+        // fullLibPath.append(addlibpath_);
+        fullLibPath.insert(0, ":");
+        fullLibPath.insert(0, addlibpath_);
+    }
+
+    // if ( verbose_ ) {
+    //     std::cout << "SST-Core: Configuration Library Path will read from: " << fullLibPath << std::endl;
+    // }
+
+    return fullLibPath;
+}
+
+} // namespace SST

--- a/src/sst/core/configShared.cc
+++ b/src/sst/core/configShared.cc
@@ -123,10 +123,15 @@ ConfigShared::getLibPath(void) const
                 const std::string& key   = *keyItr;
                 const std::string& value = currentGroup->getValue(key);
 
-                if ( key.size() > 6 ) {
+                if ( key.size() >= 6 ) {
                     if ( "LIBDIR" == key.substr(key.size() - 6) ) {
-                        fullLibPath.append(":");
-                        fullLibPath.append(value);
+                        // See if there is a value, if not, skip it
+                        if ( value.size() > 0 ) {
+                            // If this is the first one, we don't need
+                            // a colon
+                            if ( fullLibPath.size() > 0 ) fullLibPath.append(":");
+                            fullLibPath.append(value);
+                        }
                     }
                 }
             }

--- a/src/sst/core/configShared.h
+++ b/src/sst/core/configShared.h
@@ -1,0 +1,149 @@
+// Copyright 2009-2022 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2022, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_CONFIGSHARED_H
+#define SST_CORE_CONFIGSHARED_H
+
+#include "sst/core/configBase.h"
+#include "sst/core/sst_types.h"
+#include "sst/core/warnmacros.h"
+
+#include <iostream>
+
+
+namespace SST {
+
+/**
+ * Class to contain SST Simulation Configuration variables.
+ *
+ * NOTE: This class needs to be serialized for the sst.x executable,
+ * but not for the sst (wrapper compiled from the boot*.{h,cc} files)
+ * executable.  To avoid having to compile all the serialization code
+ * into the bootstrap executable, the Config class is serialized in
+ * serialization/serialize_config.h.
+ */
+class ConfigShared : public ConfigBase
+{
+public:
+    virtual ~ConfigShared() {}
+
+    /**
+       ConfigShared constructor that it meant to be used when needing
+       a stand only ConfigShared (i.e. for the bootstrap wrappers for
+       sst and sst-info
+    */
+    ConfigShared(bool suppress_print, bool suppress_sdl, bool include_libpath, bool include_env, bool include_verbose);
+
+protected:
+    void addLibraryPathOptions();
+    void addEnvironmentOptions();
+    void addVerboseOptions(bool sdl_avail);
+
+    /**
+       ConfigShared constructor for child classes
+     */
+    ConfigShared(bool suppress_print, bool suppress_sdl);
+
+    /**
+       Default constructor used for serialization.  At this point,
+       my_rank is no longer needed, so just initialize to 0,0.
+     */
+    ConfigShared() : ConfigBase() {}
+
+    // Variables that will need to be serialized by child class since
+    // this class does not serialize itself due to being used in the
+    // bootwrapper executables.
+
+    //// Libpath options
+    std::string libpath_    = "";
+    std::string addlibpath_ = "";
+
+    //// Environment Options
+    bool print_env_     = false;
+    bool no_env_config_ = false;
+
+    //// Verbose Option
+    int verbose_ = 0;
+
+private:
+    //// Libpath options
+
+    // lib path
+    int setLibPath(const std::string& arg)
+    {
+        libpath_ = arg;
+        return 0;
+    }
+
+    // add to lib path
+    int setAddLibPath(const std::string& arg)
+    {
+        if ( addlibpath_.length() > 0 ) addlibpath_ += std::string(":");
+        addlibpath_ += arg;
+        return 0;
+    }
+
+    //// Environment Options
+
+    int enablePrintEnv(const std::string& UNUSED(arg))
+    {
+        printf("enablePrintEnv()\n");
+        print_env_ = true;
+        return 0;
+    }
+
+    int disableEnvConfig(const std::string& UNUSED(arg))
+    {
+        printf("disableEnvConfig()\n");
+        no_env_config_ = true;
+        return 0;
+    }
+
+    //// Verbose Option
+
+    int setVerbosity(const std::string& arg)
+    {
+        if ( arg == "" ) {
+            verbose_++;
+            return 0;
+        }
+        try {
+            unsigned long val = stoul(arg);
+            verbose_          = val;
+            return 0;
+        }
+        catch ( std::invalid_argument& e ) {
+            fprintf(stderr, "Failed to parse '%s' as number for option --verbose\n", arg.c_str());
+            return -1;
+        }
+    }
+
+
+public:
+    /**
+       Controls whether the environment variables that SST sees are
+       printed out
+    */
+    bool print_env() const { return print_env_; }
+
+    bool no_env_config() const { return no_env_config_; }
+
+    int verbose() const { return verbose_; }
+
+    std::string libpath() const { return libpath_; }
+    std::string addLibPath() const { return addlibpath_; }
+
+    std::string getLibPath(void) const;
+};
+
+} // namespace SST
+
+#endif // SST_CORE_CONFIGBASE_H

--- a/src/sst/core/env/envquery.h
+++ b/src/sst/core/env/envquery.h
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <iostream>
 #include <string>
+#include <vector>
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/heartbeat.cc
+++ b/src/sst/core/heartbeat.cc
@@ -68,8 +68,8 @@ SimulatorHeartbeat::execute(void)
 
     uint64_t global_max_sync_data_size = 0, global_sync_data_size = 0;
 
-    uint64_t mempool_size      = 0;
-    uint64_t active_activities = 0;
+    int64_t mempool_size      = 0;
+    int64_t active_activities = 0;
     Core::MemPoolAccessor::getMemPoolUsage(mempool_size, active_activities);
     uint64_t max_mempool_size, global_mempool_size, global_active_activities;
 

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -389,7 +389,7 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
 
     barrier.wait();
 
-    if ( info.config->runMode() == Simulation::RUN || info.config->runMode() == Simulation::BOTH ) {
+    if ( info.config->runMode() == SimulationRunMode::RUN || info.config->runMode() == SimulationRunMode::BOTH ) {
         if ( info.config->verbose() && 0 == tid ) {
             g_output.verbose(CALL_INFO, 1, 0, "# Starting main event loop\n");
 
@@ -554,7 +554,7 @@ main(int argc, char* argv[])
     RankInfo world_size(1, 1);
     RankInfo myRank(0, 0);
 #endif
-    Config cfg(world_size);
+    Config cfg(world_size.rank, myrank == 0);
 
     // All ranks parse the command line
     auto ret_value = cfg.parseCmdLine(argc, argv);
@@ -566,6 +566,10 @@ main(int argc, char* argv[])
         // Just asked for info, clean exit
         return 0;
     }
+
+    // Set the debug output location
+    Output::setFileName(cfg.debugFile() != "/dev/null" ? cfg.debugFile() : "sst_output");
+
 
     if ( cfg.parallel_load() && cfg.parallel_load_mode_multi() && world_size.rank != 1 ) {
         addRankToFileName(cfg.configFile_, myRank.rank);

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -530,6 +530,9 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
         }
     }
 
+    // Put in info about sync memory usage
+    info.sync_data_size = sim->getSyncQueueDataSize();
+
     delete sim;
 }
 
@@ -967,8 +970,8 @@ main(int argc, char* argv[])
 
     uint64_t global_max_sync_data_size = 0, global_sync_data_size = 0;
 
-    uint64_t mempool_size = 0, max_mempool_size = 0, global_mempool_size = 0;
-    uint64_t active_activities = 0, global_active_activities = 0;
+    int64_t mempool_size = 0, max_mempool_size = 0, global_mempool_size = 0;
+    int64_t active_activities = 0, global_active_activities = 0;
     Core::MemPoolAccessor::getMemPoolUsage(mempool_size, active_activities);
 
 #ifdef SST_CONFIG_HAVE_MPI

--- a/src/sst/core/mempoolAccessor.h
+++ b/src/sst/core/mempoolAccessor.h
@@ -40,7 +40,7 @@ public:
     // bytes and the number of active entries.  Bytes and entries are
     // added to the value passed into the function.  If mempools
     // aren't enabled, then nothing will be counted.
-    static void getMemPoolUsage(uint64_t& bytes, uint64_t& active_entries);
+    static void getMemPoolUsage(int64_t& bytes, int64_t& active_entries);
 
     // Initialize the global mempool data structures
     static void initializeGlobalData(int num_threads, bool cache_align = false);

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -50,25 +50,6 @@ namespace SST {
 
 /**   Simulation functions **/
 
-/** Static functions **/
-Simulation*
-Simulation::getSimulation()
-{
-    return Simulation_impl::instanceMap.at(std::this_thread::get_id());
-}
-
-TimeLord*
-Simulation::getTimeLord()
-{
-    return &Simulation_impl::timeLord;
-}
-
-Output&
-Simulation::getSimulationOutput()
-{
-    return Simulation_impl::sim_output;
-}
-
 /** Non-static functions **/
 SimTime_t
 Simulation_impl::getCurrentSimCycle() const
@@ -105,8 +86,6 @@ Simulation_impl::getFinalSimTime() const
 {
     return timeLord.getTimeBase() * getEndSimCycle();
 }
-
-Simulation::~Simulation() {}
 
 /** Simulation_impl functions **/
 
@@ -195,8 +174,8 @@ Simulation_impl::Simulation_impl(Config* cfg, RankInfo my_rank, RankInfo num_ran
     wireUpFinished(false),
     runMode(cfg->runMode()),
     currentSimCycle(0),
-    endSimCycle(0),
     currentPriority(0),
+    endSimCycle(0),
     my_rank(my_rank),
     num_ranks(num_ranks),
     run_phase_start_time(0.0),

--- a/src/sst/core/simulation.h
+++ b/src/sst/core/simulation.h
@@ -34,36 +34,12 @@ class TimeLord;
 class Simulation
 {
 public:
-    /** Type of Run Modes */
-    typedef enum {
-        UNKNOWN, /*!< Unknown mode - Invalid for running */
-        INIT,    /*!< Initialize-only.  Useful for debugging initialization and graph generation */
-        RUN,     /*!< Run-only.  Useful when restoring from a checkpoint (not currently supported) */
-        BOTH     /*!< Default.  Both initialize and Run the simulation */
-    } Mode_t;
+    virtual ~Simulation() {}
 
-    virtual ~Simulation();
-
-    /********* Public Static API ************/
-
-    /** Return a pointer to the singleton instance of the Simulation */
-    static Simulation* getSimulation()
-        __attribute__((deprecated("Element facing Simulation class APIs are deprecated and have moved to the various "
-                                  "element base classes.  The APIs will be removed in SST 13.")));
-
-    /** Return the TimeLord associated with this Simulation */
-    static TimeLord* getTimeLord(void)
-        __attribute__((deprecated("Element facing Simulation class APIs are deprecated and have moved to the various "
-                                  "element base classes.  The APIs will be removed in SST 13.")));
-
-    /** Return the base simulation Output class instance */
-    static Output& getSimulationOutput()
-        __attribute__((deprecated("Element facing Simulation class APIs are deprecated and have moved to the various "
-                                  "element base classes.  The APIs will be removed in SST 13.")));
 
     /********* Public API ************/
     /** Get the run mode of the simulation (e.g. init, run, both etc) */
-    virtual Mode_t getSimulationMode() const = 0;
+    virtual SimulationRunMode getSimulationMode() const = 0;
 
     /** Return the current simulation time as a cycle count*/
     virtual SimTime_t getCurrentSimCycle() const = 0;

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -76,7 +76,7 @@ class Simulation_impl : public Simulation
 public:
     /********  Public API inherited from Simulation ********/
     /** Get the run mode of the simulation (e.g. init, run, both etc) */
-    Mode_t getSimulationMode() const override { return runMode; };
+    SimulationRunMode getSimulationMode() const override { return runMode; };
 
     /** Return the current simulation time as a cycle count*/
     SimTime_t getCurrentSimCycle() const override;
@@ -486,12 +486,17 @@ public:
     std::string clockResolution = "us";
 #endif
 
-    Mode_t    runMode;
+    // Run mode for the simulation
+    SimulationRunMode runMode;
+
+    // Track current simulated time
     SimTime_t currentSimCycle;
-    SimTime_t endSimCycle;
     int       currentPriority;
-    RankInfo  my_rank;
-    RankInfo  num_ranks;
+    SimTime_t endSimCycle;
+
+    // Rank information
+    RankInfo my_rank;
+    RankInfo num_ranks;
 
     std::string                 output_directory;
     static SharedRegionManager* sharedRegionManager;

--- a/src/sst/core/sst_types.h
+++ b/src/sst/core/sst_types.h
@@ -54,6 +54,13 @@ typedef double volts;
 #define UNLIKELY(x) __builtin_expect((int)(x), 0)
 #endif
 
+enum class SimulationRunMode {
+    UNKNOWN, /*!< Unknown mode - Invalid for running */
+    INIT,    /*!< Initialize-only.  Useful for debugging initialization and graph generation */
+    RUN,     /*!< Run-only.  Useful when restoring from a checkpoint (not currently supported) */
+    BOTH     /*!< Default.  Both initialize and Run the simulation */
+};
+
 } // namespace SST
 
 #endif // SST_CORE_SST_TYPES_H

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -41,7 +41,7 @@ using namespace SST::Core;
 static int                                                g_fileProcessedCount;
 static std::string                                        g_searchPath;
 static std::vector<SSTLibraryInfo>                        g_libInfoArray;
-static SSTInfoConfig                                      g_configuration;
+static SSTInfoConfig                                      g_configuration(false);
 static std::map<std::string, const ElementInfoGenerator*> g_foundGenerators;
 
 void
@@ -94,27 +94,13 @@ int
 main(int argc, char* argv[])
 {
     // Parse the Command Line and get the Configuration Settings
-    if ( g_configuration.parseCmdLine(argc, argv) ) { return -1; }
-
-    std::vector<std::string>               overridePaths;
-    Environment::EnvironmentConfiguration* sstEnv = Environment::getSSTEnvironmentConfiguration(overridePaths);
-    g_searchPath                                  = "";
-    std::set<std::string> groupNames              = sstEnv->getGroupNames();
-
-    for ( auto groupItr = groupNames.begin(); groupItr != groupNames.end(); groupItr++ ) {
-        SST::Core::Environment::EnvironmentConfigGroup* currentGroup = sstEnv->getGroupByName(*groupItr);
-        std::set<std::string>                           groupKeys    = currentGroup->getKeys();
-
-        for ( auto keyItr = groupKeys.begin(); keyItr != groupKeys.end(); keyItr++ ) {
-            const std::string key = *keyItr;
-
-            if ( key.size() > 6 && key.substr(key.size() - 6) == "LIBDIR" ) {
-                if ( g_searchPath.size() > 0 ) { g_searchPath.append(":"); }
-
-                g_searchPath.append(currentGroup->getValue(key));
-            }
-        }
+    int status = g_configuration.parseCmdLine(argc, argv);
+    if ( status ) {
+        if ( status == 1 ) return 0;
+        return 1;
     }
+
+    g_searchPath = g_configuration.getLibPath();
 
     // Read in the Element files and process them
     processSSTElementFiles();
@@ -250,7 +236,7 @@ OverallOutputter::outputXML()
     // XML Declaration
     TiXmlDeclaration* XMLDecl = new TiXmlDeclaration("1.0", "", "");
     XMLDocument.LinkEndChild(XMLDecl);
-    //
+
     // General Info on the Data
     xmlComment(&XMLDocument, "SSTInfo XML Data Generated on %s", TimeStamp);
     xmlComment(&XMLDocument, "%d .so FILES FOUND IN DIRECTORY(s) %s\n", g_fileProcessedCount, g_searchPath.c_str());
@@ -261,14 +247,55 @@ OverallOutputter::outputXML()
     XMLDocument.SaveFile(g_configuration.getXMLFilePath().c_str());
 }
 
-SSTInfoConfig::SSTInfoConfig()
+SSTInfoConfig::SSTInfoConfig(bool suppress_print) : ConfigShared(suppress_print, true)
 {
+    using namespace std::placeholders;
+
     m_optionBits   = CFG_OUTPUTHUMAN | CFG_VERBOSE; // Enable normal output by default
     m_XMLFilePath  = "./SSTInfo.xml";               // Default XML File Path
     m_debugEnabled = false;
+
+    // Add the options
+    DEF_SECTION_HEADING("Informational Options");
+    DEF_FLAG("help", 'h', "Print help message", std::bind(&SSTInfoConfig::printHelp, this, _1));
+    DEF_FLAG("version", 'V', "Print SST release version", std::bind(&SSTInfoConfig::outputVersion, this, _1));
+
+    DEF_SECTION_HEADING("Display Options");
+    addVerboseOptions(false);
+    DEF_FLAG("quiet", 'q', "Quiet/print summary only", std::bind(&SSTInfoConfig::setQuiet, this, _1));
+    DEF_FLAG("debug", 'd', "Enable debugging messages", std::bind(&SSTInfoConfig::setEnableDebug, this, _1));
+    DEF_FLAG(
+        "nodisplay", 'n', "Do not display output [default: off]", std::bind(&SSTInfoConfig::setNoDisplay, this, _1));
+    DEF_SECTION_HEADING("XML Options");
+    DEF_FLAG("xml", 'x', "Generate XML data [default:off]", std::bind(&SSTInfoConfig::setXML, this, _1));
+    DEF_ARG(
+        "outputxml", 'o', "FILE", "Filepath to XML file [default: SSTInfo.xml]",
+        std::bind(&SSTInfoConfig::setXMLOutput, this, _1), false);
+
+    DEF_SECTION_HEADING("Library and Path Options");
+    DEF_ARG(
+        "libs", 'l', "LIBS",
+        "Element libraries to process (all, <element>) [default: all]. <element> can be an element library, or it can "
+        "be a single element within the library.",
+        std::bind(&SSTInfoConfig::setLibs, this, _1), false);
+    addLibraryPathOptions();
+
+    DEF_SECTION_HEADING("Advanced Options - Environment");
+    addEnvironmentOptions();
+
+    addPositionalCallback(std::bind(&SSTInfoConfig::setPositionalArg, this, _1, _2));
 }
 
 SSTInfoConfig::~SSTInfoConfig() {}
+
+std::string
+SSTInfoConfig::getUsagePrelude()
+{
+    std::string prelude = "Usage: ";
+    prelude.append(getRunName());
+    prelude.append(" [options] [<element[.component|subcomponent]>]\n");
+    return prelude;
+}
 
 void
 SSTInfoConfig::outputUsage()
@@ -286,6 +313,7 @@ SSTInfoConfig::outputUsage()
     cout << endl;
 }
 
+#if 0
 void
 SSTInfoConfig::outputVersion()
 {
@@ -353,6 +381,7 @@ SSTInfoConfig::parseCmdLine(int argc, char* argv[])
 
     return 0;
 }
+#endif
 
 void
 SSTInfoConfig::addFilter(const std::string& name_str)
@@ -410,7 +439,7 @@ SSTLibraryInfo::outputHumanReadable(std::ostream& os, bool printAll)
                     if ( g_configuration.doVerbose() ) pair.second->toString(os);
                 }
                 ++idx;
-                os << std::endl;
+                if ( print ) os << std::endl;
             }
         }
     }

--- a/tests/subcomponent_tests/test_sc_2a.py
+++ b/tests/subcomponent_tests/test_sc_2a.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 
 # Set up senders using anonymous subcomponents

--- a/tests/subcomponent_tests/test_sc_2u.py
+++ b/tests/subcomponent_tests/test_sc_2u.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 # Set up senders using user subcomponents
 loader0 = sst.Component("Loader0", "coreTestElement.SubComponentLoader")

--- a/tests/subcomponent_tests/test_sc_2u2a.py
+++ b/tests/subcomponent_tests/test_sc_2u2a.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 
 # Set up senders using slots and anonymous subcomponents

--- a/tests/subcomponent_tests/test_sc_2u2u.py
+++ b/tests/subcomponent_tests/test_sc_2u2u.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 # Set up senders using slots and user subcomponents
 loader0 = sst.Component("Loader0", "coreTestElement.SubComponentLoader")

--- a/tests/subcomponent_tests/test_sc_2ua.py
+++ b/tests/subcomponent_tests/test_sc_2ua.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 
 # Set up senders using slots and anonymous subcomponent

--- a/tests/subcomponent_tests/test_sc_2uu.py
+++ b/tests/subcomponent_tests/test_sc_2uu.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 # Set up senders using slots and user subcomponent
 loader0 = sst.Component("Loader0", "coreTestElement.SubComponentLoader")

--- a/tests/subcomponent_tests/test_sc_a.py
+++ b/tests/subcomponent_tests/test_sc_a.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 
 # Set up sender using anonymous subcomponent

--- a/tests/subcomponent_tests/test_sc_u.py
+++ b/tests/subcomponent_tests/test_sc_u.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 # Set up sender using user subcomponent
 loader0 = sst.Component("Loader0", "coreTestElement.SubComponentLoader")

--- a/tests/subcomponent_tests/test_sc_u2a.py
+++ b/tests/subcomponent_tests/test_sc_u2a.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 
 # Set up senders using slot and user subcomponents

--- a/tests/subcomponent_tests/test_sc_u2u.py
+++ b/tests/subcomponent_tests/test_sc_u2u.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 # Set up sender using slot and user subcomponents
 loader0 = sst.Component("Loader0", "coreTestElement.SubComponentLoader")

--- a/tests/subcomponent_tests/test_sc_ua.py
+++ b/tests/subcomponent_tests/test_sc_ua.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 
 # Set up sender using slot and anonymous subcomponent

--- a/tests/subcomponent_tests/test_sc_uu.py
+++ b/tests/subcomponent_tests/test_sc_uu.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 
 # Set up sender using slot and user subcomponent

--- a/tests/test_ClockerComponent.py
+++ b/tests/test_ClockerComponent.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10000s")
+sst.setProgramOption("stop-at", "10000s")
 
 # Define the simulation components
 comp_clocker0 = sst.Component("clocker0", "coreTestElement.simpleClockerComponent")

--- a/tests/test_Component.py
+++ b/tests/test_Component.py
@@ -1,7 +1,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "25us")
+sst.setProgramOption("stop-at", "25us")
 
 # Define the simulation components
 comp_c0_0 = sst.Component("c0_0", "coreTestElement.coreTestComponent")

--- a/tests/test_Component_createStats.py
+++ b/tests/test_Component_createStats.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "25us")
+sst.setProgramOption("stop-at", "25us")
 
 # Define the simulation components
 size = 2

--- a/tests/test_Component_enableAllStats.py
+++ b/tests/test_Component_enableAllStats.py
@@ -10,7 +10,7 @@
 # distribution.
 import sst
 
-sst.setProgramOption("stopAtCycle", "25us")
+sst.setProgramOption("stop-at", "25us")
 
 # Define the simulation components
 size = 2

--- a/tests/test_Component_setStats.py
+++ b/tests/test_Component_setStats.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "25us")
+sst.setProgramOption("stop-at", "25us")
 
 # Define the simulation components
 size = 2

--- a/tests/test_MemPool_overflow.py
+++ b/tests/test_MemPool_overflow.py
@@ -1,7 +1,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10000ns")
+sst.setProgramOption("stop-at", "10000ns")
 sst.setProgramOption("num-threads", "4")
 sst.setProgramOption("partitioner", "self")
 

--- a/tests/test_MemPool_undeleted_items.py
+++ b/tests/test_MemPool_undeleted_items.py
@@ -1,7 +1,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10000ns")
+sst.setProgramOption("stop-at", "10000ns")
 sst.setProgramOption("output-undeleted-events", "STDOUT")
 
 # Define the simulation components

--- a/tests/test_MessageGeneratorComponent.py
+++ b/tests/test_MessageGeneratorComponent.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10000s")
+sst.setProgramOption("stop-at", "10000s")
 
 # Define the simulation components
 comp_msgGen0 = sst.Component("msgGen0", "coreTestElement.simpleMessageGeneratorComponent")

--- a/tests/test_MessageMesh.py
+++ b/tests/test_MessageMesh.py
@@ -12,9 +12,8 @@ import sst
 import sys
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 #sst.setProgramOption("verbose", "3")
-#sst.setProgramOptions({"stopAtCycle" : "10us", "verbose" : "3"})
 
 x_size = int(sys.argv[1])
 y_size = int(sys.argv[2])

--- a/tests/test_ParallelLoad.py
+++ b/tests/test_ParallelLoad.py
@@ -2,7 +2,7 @@ import sst
 import sys
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner", "self")
 
 # Size per rank.  They will be tiled linearly in the x dimension

--- a/tests/test_ParamComponent.py
+++ b/tests/test_ParamComponent.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "25us")
+sst.setProgramOption("stop-at", "25us")
 
 global_params = {
     "bool_true_param" : "yes",

--- a/tests/test_PerfComponent.py
+++ b/tests/test_PerfComponent.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 # Define the simulation components
 comp_c0_0 = sst.Component("c0_0", "coreTestElement.coreTestPerfComponent")

--- a/tests/test_RNGComponent_marsaglia.py
+++ b/tests/test_RNGComponent_marsaglia.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10000s")
+sst.setProgramOption("stop-at", "10000s")
 
 # Define the simulation components
 comp_clocker0 = sst.Component("clocker0", "coreTestElement.coreTestRNGComponent")

--- a/tests/test_RNGComponent_mersenne.py
+++ b/tests/test_RNGComponent_mersenne.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10000s")
+sst.setProgramOption("stop-at", "10000s")
 
 # Define the simulation components
 comp_clocker0 = sst.Component("clocker0", "coreTestElement.coreTestRNGComponent")

--- a/tests/test_RNGComponent_xorshift.py
+++ b/tests/test_RNGComponent_xorshift.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10000s")
+sst.setProgramOption("stop-at", "10000s")
 
 # Define the simulation components
 comp_clocker0 = sst.Component("clocker0", "coreTestElement.coreTestRNGComponent")

--- a/tests/test_SubComponent.py
+++ b/tests/test_SubComponent.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 loader0 = sst.Component("Loader0", "coreTestElement.SubComponentLoader")
 loader0.addParam("clock", "1.5GHz")

--- a/tests/test_SubComponent_2.py
+++ b/tests/test_SubComponent_2.py
@@ -11,7 +11,7 @@
 import sst
 
 # Define SST core options
-sst.setProgramOption("stopAtCycle", "10us")
+sst.setProgramOption("stop-at", "10us")
 
 loader0 = sst.Component("Loader0", "coreTestElement.SubComponentLoader")
 loader0.addParam("clock", "1.5GHz")


### PR DESCRIPTION
Library search path ordering now matches between the bootloader code and the Factory.  Also added a change to made things compatible with Py3.11.