### PR TITLE
add MPI include directories and definitions

### DIFF
--- a/experimental/CMakeLists.txt
+++ b/experimental/CMakeLists.txt
@@ -54,6 +54,8 @@ endif()
 option(SST_DISABLE_MPI "Compile without MPI" OFF)
 if(NOT SST_DISABLE_MPI)
   find_package(MPI REQUIRED)
+  include_directories(SYSTEM ${MPI_INCLUDE_PATH})
+  add_definitions(-DSST_CONFIG_HAVE_MPI)
 endif()
 
 # sst sets all the variables needed for our *.in files


### PR DESCRIPTION
Experimental CMake config omits some important commands:

```
  include_directories(SYSTEM ${MPI_INCLUDE_PATH})
  add_definitions(-DSST_CONFIG_HAVE_MPI)
```