### PR TITLE
Fixes for cmake-format GitHub Action

### DIFF
--- a/.github/workflows/PR_cmake-format_test.yml
+++ b/.github/workflows/PR_cmake-format_test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request_target:
     branches-ignore:
-    - master
+      - master
 # Push option may be used in the future for developers forks
 #  push:
 #    branches-ignore:
@@ -47,16 +47,16 @@ jobs:
 
 # Set the WIP label immediately before testing
     - name: SET WIP Label before testing
-      uses: actions/github-script@v6
+      uses: actions/github-script@v4
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.addLabels({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            labels: ['AT: WIP']
-          })
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['AT: WIP']
+            })
 
 #   Checkout this users SST-core repo/branch
     - name: Checkout Users SST-Core source
@@ -77,98 +77,98 @@ jobs:
 
 # Label the Results - FOR FAILURE
     - name: ADD FAIL + WIP Label Results for Failure
-      uses: actions/github-script@v6
+      uses: actions/github-script@v4
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.addLabels({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            labels: ['AT: CMAKE-FORMAT FAIL', 'AT: WIP']
-          })
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['AT: CMAKE-FORMAT FAIL', 'AT: WIP']
+            })
       if: ${{ failure() }}
 
     - name: REMOVE PASS Label Results for Failure
-      uses: actions/github-script@v6
+      uses: actions/github-script@v4
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.removeLabel({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            name: 'AT: CMAKE-FORMAT PASS'
-          })
+            github.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'AT: CMAKE-FORMAT PASS'
+            })
       if: ${{ failure() }}
       continue-on-error: true
 
     - name: ADD COMMENT ABOUT FAIL
-      uses: actions/github-script@v6
+      uses: actions/github-script@v4
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: '**CMAKE-FORMAT TEST - FAILED** (on last commit): <br>Run > ./scripts/cmake-format-test.sh using cmake-format to check formatting'
-          })
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '**CMAKE-FORMAT TEST - FAILED** (on last commit): <br>Run > ./scripts/cmake-format-test.sh using cmake-format to check formatting'
+            })
       if: ${{ failure() }}
 
 #############################
 
 # Label the Results - FOR SUCCESS
     - name: ADD PASS Label Results for Success
-      uses: actions/github-script@v6
+      uses: actions/github-script@v4
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.addLabels({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            labels: ['AT: CMAKE-FORMAT PASS']
-          })
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['AT: CMAKE-FORMAT PASS']
+            })
       if: ${{ success() }}
 
     - name: REMOVE WIP Label Results for Success
-      uses: actions/github-script@v6
+      uses: actions/github-script@v4
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.removeLabel({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            name: 'AT: WIP'
-          })
+            github.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'AT: WIP'
+            })
       if: ${{ success() }}
       continue-on-error: true
 
     - name: REMOVE FAIL Label Results for Success
-      uses: actions/github-script@v6
+      uses: actions/github-script@v4
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.removeLabel({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            name: 'AT: CMAKE-FORMAT FAIL'
-          })
+            github.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'AT: CMAKE-FORMAT FAIL'
+            })
       if: ${{ success() }}
       continue-on-error: true
 
     - name: ADD COMMENT ABOUT SUCCESS
-      uses: actions/github-script@v6
+      uses: actions/github-script@v4
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: '**CMAKE-FORMAT TEST - PASSED**'
-          })
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '**CMAKE-FORMAT TEST - PASSED**'
+            })
       if: ${{ success() }}

--- a/.github/workflows/PR_cmake-format_test.yml
+++ b/.github/workflows/PR_cmake-format_test.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Run cmake-format
       uses: PuneetMatharu/cmake-format-lint-action@a7e22edff1347b154dc1a0e8f900c450303efdf7 # v1.0.2
       with:
-        args: --config-files .cmake-format.yaml --check
+        args: --config-files experimental/.cmake-format.yaml --check
 
 
 #############################################


### PR DESCRIPTION
For #716, a follow-up to #963.  Apparently we are using an older form of the GitHub script language and I blindly updated the version for the CMake format checker.  The path also wasn't updated to the experimental location.

There is a non-syntax update that needs to be made, which is that the action only runs `cmake-format --check`, not the additional and different `cmake-lint`, but shouldn't be solved in this PR.