### PR TITLE
Add missing cstdint include for GCC 13

### DIFF
--- a/src/sst/core/decimal_fixedpoint.h
+++ b/src/sst/core/decimal_fixedpoint.h
@@ -16,6 +16,7 @@
 
 #include "sst/core/from_string.h"
 
+#include <cstdint>
 #include <iomanip>
 #include <limits>
 #include <sstream>


### PR DESCRIPTION
Closes #972 