### PR TITLE
CMake update grabbag

### DIFF
--- a/experimental/CMakeLists.txt
+++ b/experimental/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(
   sst-core
-  VERSION 11.1.0
+  VERSION 13.0.0
   DESCRIPTION "SSTCore"
   LANGUAGES C CXX)
 
@@ -40,7 +40,7 @@ endif()
 # Don't change this path to SST_TOP_SRC_DIR cmake lives in experimental for now.
 list(APPEND CMAKE_MODULE_PATH ${sst-core_SOURCE_DIR}/cmake)
 
-find_package(Python 3.5 REQUIRED COMPONENTS Interpreter Development)
+find_package(Python 3.6 REQUIRED COMPONENTS Interpreter Development)
 find_package(Threads)
 
 option(SST_DISABLE_ZLIB "Use zlib compression library" OFF)

--- a/experimental/CMakeLists.txt
+++ b/experimental/CMakeLists.txt
@@ -23,16 +23,23 @@ project(
 set(SST_TOP_SRC_DIR "${sst-core_SOURCE_DIR}/..")
 include(cmake/PreventInSourceBuilds.cmake)
 
+# cmake-lint: disable=C0103
+set(_REQUIRED_CXX_STANDARD 17)
+# cmake-lint: disable=C0301
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD ${_REQUIRED_CXX_STANDARD})
   message(
-    STATUS "CMAKE_CXX_STANDARD was not set, defaulting the cmake standard to 17"
+    STATUS
+      "CMAKE_CXX_STANDARD was not set, defaulting the cmake standard to ${_REQUIRED_CXX_STANDARD}"
   )
 else()
-  if(CMAKE_CXX_STANDARD LESS 17)
-    message(FATAL_ERROR "We require the c++ standard to be at least 17")
+  if(CMAKE_CXX_STANDARD LESS ${_REQUIRED_CXX_STANDARD})
+    message(
+      FATAL_ERROR
+        "We require the c++ standard to be at least ${_REQUIRED_CXX_STANDARD}")
   endif()
 endif()
+unset(_REQUIRED_CXX_STANDARD)
 
 # ------------------------------------------------------------------------
 # -- EXTERNAL CMAKE SCRIPTS

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -13,8 +13,6 @@
 # distribution.
 # ~~~
 
-# TODO Remove this set set(prefix ${CMAKE_INSTALL_PREFIX})
-
 message(
   STATUS "SST: PREPROCESSING ${CMAKE_CURRENT_SOURCE_DIR}/SSTConfig.cmake.in")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/SSTConfig.cmake.in


### PR DESCRIPTION
* Bump CMake project version to 13.0.0
* Minimum required version of Python now matches autotools build
* Set C++ standard in a single location