### PR TITLE
Add `typename` to some uses of std::conditional.

### DIFF
--- a/src/sst/core/eli/attributeInfo.h
+++ b/src/sst/core/eli/attributeInfo.h
@@ -79,7 +79,7 @@ private:
     {                                                                                                              \
         static std::vector<SST::ElementInfoAttribute> var  = { __VA_ARGS__ };                                      \
         auto parent = SST::ELI::GetAttributes<                                                                     \
-            std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
+            typename std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
         SST::ELI::combineEliInfo(var, parent);                                                                     \
         return var;                                                                                                \
     }

--- a/src/sst/core/eli/paramsInfo.h
+++ b/src/sst/core/eli/paramsInfo.h
@@ -87,7 +87,7 @@ private:
     {                                                                                                              \
         static std::vector<SST::ElementInfoParam> var    = { __VA_ARGS__ };                                        \
         auto parent = SST::ELI::GetParams<                                                                         \
-            std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
+            typename std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
         SST::ELI::combineEliInfo(var, parent);                                                                     \
         return var;                                                                                                \
     }

--- a/src/sst/core/eli/portsInfo.h
+++ b/src/sst/core/eli/portsInfo.h
@@ -82,7 +82,7 @@ private:
     {                                                                                                              \
         static std::vector<SST::ElementInfoPort> var    = { __VA_ARGS__ };                                         \
         auto parent = SST::ELI::InfoPorts<                                                                         \
-            std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
+            typename std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
         SST::ELI::combineEliInfo(var, parent);                                                                     \
         return var;                                                                                                \
     }

--- a/src/sst/core/eli/profilePointInfo.h
+++ b/src/sst/core/eli/profilePointInfo.h
@@ -76,7 +76,7 @@ private:
     {                                                                                                              \
         static std::vector<SST::ElementInfoProfilePoint> var = { __VA_ARGS__ };                                    \
         auto parent = SST::ELI::InfoProfilePoints<                                                                 \
-            std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
+            typename std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
         SST::ELI::combineEliInfo(var, parent);                                                                     \
         return var;                                                                                                \
     }

--- a/src/sst/core/eli/statsInfo.h
+++ b/src/sst/core/eli/statsInfo.h
@@ -90,7 +90,7 @@ public:
     {                                                                                                              \
         static std::vector<SST::ElementInfoStatistic> var    = { __VA_ARGS__ };                                    \
         auto parent = SST::ELI::InfoStats<                                                                         \
-            std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
+            typename std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
         SST::ELI::combineEliInfo(var, parent);                                                                     \
         return var;                                                                                                \
     }

--- a/src/sst/core/eli/subcompSlotInfo.h
+++ b/src/sst/core/eli/subcompSlotInfo.h
@@ -76,7 +76,7 @@ private:
     {                                                                                                              \
         static std::vector<SST::ElementInfoSubComponentSlot> var = { __VA_ARGS__ };                                \
         auto parent = SST::ELI::InfoSubs<                                                                          \
-            std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
+            typename std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
         SST::ELI::combineEliInfo(var, parent);                                                                     \
         return var;                                                                                                \
     }


### PR DESCRIPTION
This is needed when at least one of the two types is a dependent type. For example, while `std::conditional<true, int, float>::type` is fine, when `T` is a template parameter, `typename std::conditional<true, int, T>::type` is necessary.

These replacements are entirely inside of the ELI macros that use them, and allow us to use template classes in our element hierarchies.

Erase this information and put your Pull Request comments here
---
Instructions for Issuing a Pull Request to sst-core
---------------------------------------------------

1 - Verify that the Pull Request is targeted to the **devel** branch of sstsimulator/sst-core

2 - Verify that Source branch is up to date with the devel branch of sst-core

3 - After submitting your Pull Request:
   * Automatic Testing will commence in a short while 
      * Pull Requests will be tested with the devel branches of the sst-elements and sst-sqe repositories
         * These branches are syncronized with the devel branch of sst-core.  This is why is it important to keep your source branch up to date.
      * If testing passes, the SST Core developers will review your changes and merge them or contact you for more information
         * Pull Requests from forks will not be automatically tested until the code is inspected.
         * Pull Requests from forks will not be automatically merged into the devel branch.
      * If testing fails, You will be notified of the test results.  
         * The Pull Request will be retested on a regular basis - Changes to the source branch can be made to correct problems
         
----
