### PR TITLE
Fix for `SST_ELI_DECLARE_NEW_BASE` when `BuilderInfo` is a dependent name.

### DIFF
--- a/src/sst/core/eli/elibase.h
+++ b/src/sst/core/eli/elibase.h
@@ -187,6 +187,7 @@ private:
     template <class __TT>                                                       \
     static bool addDerivedInfo(const std::string& lib, const std::string& elem) \
     {                                                                           \
+        using BuilderInfo = typename __LocalEliBase::BuilderInfo;               \
         return addInfo(lib, elem, new BuilderInfo(lib, elem, (__TT*)nullptr));  \
     }
 


### PR DESCRIPTION
This resolves #1005.

Imagine the following code:

```c++
template <class Component>
struct MyComponentBase : public Component {
    SST_ELI_DECLARE_NEW_BASE(Component, MyComponentBase);
    // tools that help us with SST::Component interfaces
};

struct MyComponent : MyComponentBase<SST::Component> {
    // A custom component
};

struct MyRouter : MyComponentBase<SST::Merlin::Router> {
    // A merlin router implementation
};
```

In this context, inside the `SST_ELI_DECLARE_NEW_BASE`, the `BuilderInfo` is a dependent name in the `addDerivedInfo` template function, and can't be found without qualification. The qualified name is `__LocalEliBase::BuilderInfo` and it needs a `typename` pre-C++20.

This patch adds that typename to support this template pattern. This pattern allows us to write utility code that can be injected into _any_ component hierarchy.
