### PR TITLE
String format specifiers for typedefs

### DIFF
--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -48,6 +48,7 @@ public:
 
     /** All Addresses can be 64-bit */
     typedef int64_t nid_t;
+#define PRI_NID PRIi64
 
     static const nid_t INIT_BROADCAST_ADDR;
 

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -104,6 +104,7 @@ public:
 
     /** All Addresses can be 64-bit */
     typedef uint64_t Addr;
+#define PRI_ADDR PRIx64
 
     /**
      * Base class for StandardMem commands

--- a/src/sst/core/sst_types.h
+++ b/src/sst/core/sst_types.h
@@ -25,6 +25,8 @@ typedef uint64_t Cycle_t;
 typedef uint64_t SimTime_t;
 typedef double   Time_t;
 
+#define PRI_SIMTIME PRIu64
+
 static constexpr StatisticId_t STATALL_ID = std::numeric_limits<StatisticId_t>::max();
 
 #define MAX_SIMTIME_T 0xFFFFFFFFFFFFFFFFl

--- a/src/sst/core/statapi/statgroup.cc
+++ b/src/sst/core/statapi/statgroup.cc
@@ -50,7 +50,7 @@ bool
 StatisticGroup::containsStatistic(const StatisticBase* stat) const
 {
     if ( isDefault ) return true;
-    std::find(stats.begin(), stats.end(), stat);
+    std::ignore = std::find(stats.begin(), stats.end(), stat);
     return false;
 }
 

--- a/src/sst/core/statapi/statgroup.cc
+++ b/src/sst/core/statapi/statgroup.cc
@@ -50,8 +50,7 @@ bool
 StatisticGroup::containsStatistic(const StatisticBase* stat) const
 {
     if ( isDefault ) return true;
-    std::ignore = std::find(stats.begin(), stats.end(), stat);
-    return false;
+    return std::find(stats.begin(), stats.end(), stat) != stats.end();
 }
 
 bool


### PR DESCRIPTION
These defines are used like `PRIu64` etc. for typedefs in elements.

There's also a fix for an unused return value.