### PR TITLE
Add interface for accessing CustomReq/Resp data

### DIFF
--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -914,6 +914,8 @@ public:
             return str.str();
         }
 
+        CustomData* getData() { return data; }
+
         CustomData* data; /* Custom class that holds data for this event */
         Addr        iPtr; /* Instruction pointer */
         uint32_t    tid;  /* Thread ID */
@@ -951,6 +953,8 @@ public:
             str << ", InstPtr: 0x" << std::hex << iPtr << ", ThreadID: " << std::dec << tid;
             return str.str();
         }
+
+        CustomData* getData() { return data; }
 
         CustomData* data; /* Custom class that holds data for this event */
         Addr        iPtr; /* Instruction pointer */

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -913,31 +913,32 @@ public:
             str << ", InstPtr: 0x" << std::hex << iPtr << ", ThreadID: " << std::dec << tid;
             return str.str();
         }
-    
-        /** 
-         * Get the CustomData object associated with this request. 
+
+        /**
+         * Get the CustomData object associated with this request.
          * Ownership of the CustomData object is retained by this request.
          */
         CustomData& getData() { return *data; }
-    
-        /** 
-         * Get the CustomData object associated with this request. 
-         * Ownership of the CustomData object is retained by this request. 
+
+        /**
+         * Get the CustomData object associated with this request.
+         * Ownership of the CustomData object is retained by this request.
          * The returned data cannot be modified.
          */
         const CustomData& getData() const { return *data; }
-        
-        /** 
+
+        /**
          * Set the CustomData object associated with this request to a new
          * value.
          * This request takes ownership of the CustomData object.
          * The previous CustomData object is deleted.
          */
-        void setData(CustomData* d) { 
+        void setData(CustomData* d)
+        {
             delete data;
-            data = d; 
+            data = d;
         }
-        
+
         /**
          * Reset the CustomData object associated with this request to a new
          * value.
@@ -946,18 +947,14 @@ public:
          * This request assumes ownership of the passed in CustomData object.
          * If no CustomData object is passed in, the data member is set to nullptr.
          */
-        CustomData* resetData(CustomData* d = nullptr) {
-            return std::exchange(data,d);
-        }
+        CustomData* resetData(CustomData* d = nullptr) { return std::exchange(data, d); }
 
-        /** 
+        /**
          * Obtain the CustomData object associated with this request.
          * Ownership of the CustomData object is transferred to the caller.
          * The data member of this request is set to nullptr.
          */
-        CustomData* releaseData() {
-            return resetData();
-        }
+        CustomData* releaseData() { return resetData(); }
 
         CustomData* data; /* Custom class that holds data for this event */
         Addr        iPtr; /* Instruction pointer */
@@ -996,31 +993,32 @@ public:
             str << ", InstPtr: 0x" << std::hex << iPtr << ", ThreadID: " << std::dec << tid;
             return str.str();
         }
-       
-        /** 
-         * Get the CustomData object associated with this response. 
+
+        /**
+         * Get the CustomData object associated with this response.
          * Ownership of the CustomData object is retained by this response.
          */
         CustomData& getData() { return *data; }
-    
-        /** 
-         * Get the CustomData object associated with this response. 
-         * Ownership of the CustomData object is retained by this response. 
+
+        /**
+         * Get the CustomData object associated with this response.
+         * Ownership of the CustomData object is retained by this response.
          * The returned data cannot be modified.
          */
         const CustomData& getData() const { return *data; }
-        
-        /** 
+
+        /**
          * Set the CustomData object associated with this response to a new
          * value.
          * This response takes ownership of the CustomData object.
          * The previous CustomData object is deleted.
          */
-        void setData(CustomData* d) { 
+        void setData(CustomData* d)
+        {
             delete data;
-            data = d; 
+            data = d;
         }
-        
+
         /**
          * Reset the CustomData object associated with this response to a new
          * value.
@@ -1029,18 +1027,14 @@ public:
          * This response assumes ownership of the passed in CustomData object.
          * If no CustomData object is passed in, the data member is set to nullptr.
          */
-        CustomData* resetData(CustomData* d = nullptr) {
-            return std::exchange(data,d);
-        }
+        CustomData* resetData(CustomData* d = nullptr) { return std::exchange(data, d); }
 
-        /** 
+        /**
          * Obtain the CustomData object associated with this response.
          * Ownership of the CustomData object is transferred to the caller.
          * The data member of this response is set to nullptr.
          */
-        CustomData* releaseData() {
-            return resetData();
-        }
+        CustomData* releaseData() { return resetData(); }
 
         CustomData* data; /* Custom class that holds data for this event */
         Addr        iPtr; /* Instruction pointer */

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -916,6 +916,8 @@ public:
 
         CustomData* getData() { return data; }
 
+        void setData(CustomData* d) { data = d; }
+
         CustomData* data; /* Custom class that holds data for this event */
         Addr        iPtr; /* Instruction pointer */
         uint32_t    tid;  /* Thread ID */
@@ -932,7 +934,7 @@ public:
         {}
         CustomResp(CustomReq* req) :
             Request(req->getID(), req->getAllFlags()),
-            data(req->data->makeResponse()),
+            data(req->getData()->makeResponse()),
             iPtr(req->iPtr),
             tid(req->tid)
         {}
@@ -955,6 +957,8 @@ public:
         }
 
         CustomData* getData() { return data; }
+
+        void setData(CustomData* d) { data = d; }
 
         CustomData* data; /* Custom class that holds data for this event */
         Addr        iPtr; /* Instruction pointer */

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -913,10 +913,51 @@ public:
             str << ", InstPtr: 0x" << std::hex << iPtr << ", ThreadID: " << std::dec << tid;
             return str.str();
         }
+    
+        /** 
+         * Get the CustomData object associated with this request. 
+         * Ownership of the CustomData object is retained by this request.
+         */
+        CustomData& getData() { return *data; }
+    
+        /** 
+         * Get the CustomData object associated with this request. 
+         * Ownership of the CustomData object is retained by this request. 
+         * The returned data cannot be modified.
+         */
+        const CustomData& getData() const { return *data; }
+        
+        /** 
+         * Set the CustomData object associated with this request to a new
+         * value.
+         * This request takes ownership of the CustomData object.
+         * The previous CustomData object is deleted.
+         */
+        void setData(CustomData* d) { 
+            delete data;
+            data = d; 
+        }
+        
+        /**
+         * Reset the CustomData object associated with this request to a new
+         * value.
+         * The previous CustomData object is returned and ownership is
+         * transferred to the caller.
+         * This request assumes ownership of the passed in CustomData object.
+         * If no CustomData object is passed in, the data member is set to nullptr.
+         */
+        CustomData* resetData(CustomData* d = nullptr) {
+            return std::exchange(data,d);
+        }
 
-        CustomData* getData() { return data; }
-
-        void setData(CustomData* d) { data = d; }
+        /** 
+         * Obtain the CustomData object associated with this request.
+         * Ownership of the CustomData object is transferred to the caller.
+         * The data member of this request is set to nullptr.
+         */
+        CustomData* releaseData() {
+            return resetData();
+        }
 
         CustomData* data; /* Custom class that holds data for this event */
         Addr        iPtr; /* Instruction pointer */
@@ -934,7 +975,7 @@ public:
         {}
         CustomResp(CustomReq* req) :
             Request(req->getID(), req->getAllFlags()),
-            data(req->getData()->makeResponse()),
+            data(req->getData().makeResponse()),
             iPtr(req->iPtr),
             tid(req->tid)
         {}
@@ -955,10 +996,51 @@ public:
             str << ", InstPtr: 0x" << std::hex << iPtr << ", ThreadID: " << std::dec << tid;
             return str.str();
         }
+       
+        /** 
+         * Get the CustomData object associated with this response. 
+         * Ownership of the CustomData object is retained by this response.
+         */
+        CustomData& getData() { return *data; }
+    
+        /** 
+         * Get the CustomData object associated with this response. 
+         * Ownership of the CustomData object is retained by this response. 
+         * The returned data cannot be modified.
+         */
+        const CustomData& getData() const { return *data; }
+        
+        /** 
+         * Set the CustomData object associated with this response to a new
+         * value.
+         * This response takes ownership of the CustomData object.
+         * The previous CustomData object is deleted.
+         */
+        void setData(CustomData* d) { 
+            delete data;
+            data = d; 
+        }
+        
+        /**
+         * Reset the CustomData object associated with this response to a new
+         * value.
+         * The previous CustomData object is returned and ownership is
+         * transferred to the caller.
+         * This response assumes ownership of the passed in CustomData object.
+         * If no CustomData object is passed in, the data member is set to nullptr.
+         */
+        CustomData* resetData(CustomData* d = nullptr) {
+            return std::exchange(data,d);
+        }
 
-        CustomData* getData() { return data; }
-
-        void setData(CustomData* d) { data = d; }
+        /** 
+         * Obtain the CustomData object associated with this response.
+         * Ownership of the CustomData object is transferred to the caller.
+         * The data member of this response is set to nullptr.
+         */
+        CustomData* releaseData() {
+            return resetData();
+        }
 
         CustomData* data; /* Custom class that holds data for this event */
         Addr        iPtr; /* Instruction pointer */


### PR DESCRIPTION
This is related to #1001. Introduces an interface so we can leapfrog sst-core and sst-elements to ensure builds continue to pass as we deal with this pernicious memory leak.
