### PR TITLE
Fix compiler error when calling addDataNTimes

### DIFF
--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -368,6 +368,8 @@ public:
 
     using Datum = T;
     using StatisticCollector<T>::addData_impl;
+    using StatisticCollector<T>::addData_impl_Ntimes;
+
     // The main method to add data to the statistic
     /** Add data to the Statistic
      * This will call the addData_impl() routine in the derived Statistic.


### PR DESCRIPTION
I get a compiler error when trying to call `addDataNTimes` from anywhere:

```
In file included from /opt/sst/include/sst/core/baseComponent.h:23,
                 from /opt/sst/include/sst/core/component.h:15,
                 from ../../../../../src/sst/elements/memHierarchy/cacheController.h:26,
                 from ../../../../../src/sst/elements/memHierarchy/cacheController.cc:21:
/opt/sst/include/sst/core/statapi/statbase.h: In instantiation of 'void SST::Statistics::Statistic<T>::addDataNTimes(uint64_t, InArgs&& ...) [with InArgs = {int}; T = long unsigned int; uint64_t = long unsigned int]':
../../../../../src/sst/elements/memHierarchy/cacheController.cc:207:37:   required from here
/opt/sst/include/sst/core/statapi/statbase.h:392:32: error: 'addData_impl_Ntimes' was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
  392 |             addData_impl_Ntimes(N, std::forward<InArgs>(args)...);
      |             ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/sst/include/sst/core/statapi/statbase.h:392:32: note: declarations in dependent base 'SST::Statistics::StatisticCollector<long unsigned int, true>' are not found by unqualified lookup
/opt/sst/include/sst/core/statapi/statbase.h:392:32: note: use 'this->addData_impl_Ntimes' instead
```

 I don't really understand the message (hooray C++) but this is the suggested fix, and it works.
