### PR TITLE
Add SSTConfigVersion.cmake to allow cmake find_package with version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,7 @@ AC_CONFIG_FILES([
   doc/Doxyfile
   share/Makefile
   share/SSTConfig.cmake
+  share/SSTConfigVersion.cmake
   src/sst/sstsimulator.conf:src/sst/sst.conf
   src/Makefile
   src/sst/Makefile

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -18,6 +18,12 @@ message(
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/SSTConfig.cmake.in
                ${CMAKE_CURRENT_BINARY_DIR}/SSTConfig.cmake)
 
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/SSTConfigVersion.cmake"
+  VERSION ${CMAKE_PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+
 install(
   DIRECTORY "."
   DESTINATION "lib/cmake/SST"

--- a/share/Makefile.am
+++ b/share/Makefile.am
@@ -1,2 +1,2 @@
 cmakedir=$(prefix)/lib/cmake/SST
-cmake_DATA=SSTConfig.cmake
+cmake_DATA=SSTConfig.cmake SSTConfigVersion.cmake

--- a/share/SSTConfigVersion.cmake.in
+++ b/share/SSTConfigVersion.cmake.in
@@ -1,0 +1,48 @@
+# This is a basic version file for the Config-mode of find_package().
+# It is used by write_basic_package_version_file() as input file for configure_file()
+# to create a version-file which can be installed along a config.cmake file.
+#
+# The created file sets PACKAGE_VERSION_EXACT if the current version string and
+# the requested version string are exactly the same and it sets
+# PACKAGE_VERSION_COMPATIBLE if the current version is >= requested version.
+# The variable CVF_VERSION must be set before calling configure_file().
+
+set(PACKAGE_VERSION "@VERSION@")
+
+if (PACKAGE_FIND_VERSION_RANGE)
+  # Package version must be in the requested version range
+  if ((PACKAGE_FIND_VERSION_RANGE_MIN STREQUAL "INCLUDE" AND PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION_MIN)
+      OR ((PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE" AND PACKAGE_VERSION VERSION_GREATER PACKAGE_FIND_VERSION_MAX)
+        OR (PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE" AND PACKAGE_VERSION VERSION_GREATER_EQUAL PACKAGE_FIND_VERSION_MAX)))
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  endif()
+else()
+  if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+  endif()
+endif()
+
+
+# if the installed project requested no architecture check, don't perform the check
+if("FALSE")
+  return()
+endif()
+
+# if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
+if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "" OR "8" STREQUAL "")
+  return()
+endif()
+
+# check that the installed version has the same 32/64bit-ness as the one which is currently searching:
+if(NOT CMAKE_SIZEOF_VOID_P STREQUAL "8")
+  math(EXPR installedBits "8 * 8")
+  set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
+  set(PACKAGE_VERSION_UNSUITABLE TRUE)
+endif()


### PR DESCRIPTION
With this commit SST can be found with version restrictions in CMake

    find_package(SST 13 REQUIRED)

Before this commit cmake would error with:

    Could not find a configuration file for package "SST" that is compatible
    with requested version "13".

    The following configuration files were considered but not accepted:

    /lib/cmake/SST/SSTConfig.cmake, version: unknown

(The code of this change was made by one of my colleagues, who allowed me to make a PR for this.)