### PR TITLE
Fixed some python issues

### DIFF
--- a/src/sst/core/cfgoutput/pythonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.cc
@@ -53,14 +53,13 @@ PythonConfigGraphOutput::generateParams(const Params& params)
 }
 
 const std::string&
-PythonConfigGraphOutput::getLinkObject(LinkId_t id, bool no_cut)
+PythonConfigGraphOutput::getLinkObject(LinkId_t id, const std::string& name, bool no_cut)
 {
     if ( linkMap.find(id) == linkMap.end() ) {
-        char tmp[8 + 8 + 1];
-        snprintf(tmp, 8 + 8 + 1, "link_id_%08" PRIx32, id);
-        fprintf(outputFile, "%s = sst.Link(\"%s\")\n", tmp, tmp);
-        if ( no_cut ) fprintf(outputFile, "%s.setNoCut()\n", tmp);
-        linkMap[id] = tmp;
+        char* pyLinkName = makePythonSafeWithPrefix(name.c_str(), "link_");
+        fprintf(outputFile, "%s = sst.Link(\"%s\")\n", pyLinkName, name.c_str());
+        if ( no_cut ) fprintf(outputFile, "%s.setNoCut()\n", pyLinkName);
+        linkMap[id] = pyLinkName;
     }
     return linkMap[id];
 }
@@ -114,7 +113,7 @@ PythonConfigGraphOutput::generateCommonComponent(const char* objName, const Conf
         std::string       latencyStr = link->latency_str[idx];
         char*             esPortName = makeEscapeSafe(link->port[idx].c_str());
 
-        const std::string& linkName = getLinkObject(linkID, link->no_cut);
+        const std::string& linkName = getLinkObject(linkID, link->name, link->no_cut);
         fprintf(
             outputFile, "%s.addLink(%s, \"%s\", \"%s\")\n", objName, linkName.c_str(), esPortName,
             tmp.toStringBestSI().c_str());

--- a/src/sst/core/cfgoutput/pythonConfigOutput.h
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.h
@@ -36,7 +36,7 @@ protected:
     void         generateComponent(const ConfigComponent* comp, bool output_parition_info);
     void         generateStatGroup(const ConfigGraph* graph, const ConfigStatGroup& grp);
 
-    const std::string& getLinkObject(LinkId_t id, bool no_cut);
+    const std::string& getLinkObject(LinkId_t id, const std::string& name, bool no_cut);
 
     char* makePythonSafeWithPrefix(const std::string& name, const std::string& prefix) const;
     void  makeBufferPythonSafe(char* buffer) const;

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -1221,7 +1221,7 @@ SSTPythonModelDefinition::pushNamePrefix(const char* name)
         namePrefixLen *= 2;
     }
 
-    if ( origLen > 0 ) {
+    if ( origLen > 0 && newLen > 0 ) {
         namePrefix[origLen]     = '.';
         namePrefix[origLen + 1] = '\0';
     }
@@ -1241,7 +1241,7 @@ SSTPythonModelDefinition::popNamePrefix(void)
 char*
 SSTPythonModelDefinition::addNamePrefix(const char* name) const
 {
-    if ( nameStack.empty() ) { return strdup(name); }
+    if ( nameStack.empty() || strlen(namePrefix) == 0 ) { return strdup(name); }
     size_t prefixLen = strlen(namePrefix);
     char*  buf       = (char*)malloc(prefixLen + 2 + strlen(name));
 


### PR DESCRIPTION
- Fixed issue when using pushNamePrefix() with empty string; function will no longer add . to name for empty string prefixes
- Changed python config output so that it now uses the actual Link name in the python instead of name based on link ID
