### PR TITLE
Use exceptions for UnitAlgebra errors

### DIFF
--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -252,6 +252,31 @@ public:
         }
     }
     ImplementSerializable(SST::UnitAlgebra)
+
+public:
+    class UnitAlgebraException : public std::logic_error
+    {
+    public:
+        UnitAlgebraException(const std::string& msg);
+    };
+
+    class InvalidUnitType : public UnitAlgebraException
+    {
+    public:
+        InvalidUnitType(const std::string& type);
+    };
+
+    class InvalidNumberString : public UnitAlgebraException
+    {
+    public:
+        InvalidNumberString(const std::string& number);
+    };
+
+    class NonMatchingUnits : public UnitAlgebraException
+    {
+    public:
+        NonMatchingUnits(const std::string& lhs, const std::string& rhs, const std::string& operation);
+    };
 };
 
 // template <typename T>

--- a/tests/test_UnitAlgebra.py
+++ b/tests/test_UnitAlgebra.py
@@ -221,13 +221,28 @@ if not correct_throw:
     print("ERROR: did not get exception when checking not equals against invalid operand type as first argument")
 
 
-# Once expections are enabled in UnitAlgebra (instead of the fatal()
-# that is currently called), we need to test doing math and comparison
-# operations on this with mismatch units to make sure that they throw
-# exceptions in the proper instances (i.e. add, sub and compares other
-# than == and != will throw an exception if the units don't match.
+# Test doing math and comparison operations on this with mismatch units to make
+# sure that they throw exceptions in the proper instances (i.e. add, sub and
+# compares other than == and != will throw an exception if the units don't match.
+try:
+    UnitAlgebra("1 m")
+except ValueError as e:
+    assert str(e) == "Invalid unit type: "
 
-
+ua4 = UnitAlgebra("1s")
+ua5 = UnitAlgebra("4 events")
+try:
+    ua1 + ua4
+except TypeError as e:
+    assert str(e) == ""
+try:
+    ua1 + ua5
+except TypeError as e:
+    assert str(e) == "Attempting to add UnitAlgebra values with non-matching units: s, events"
+try:
+    ua1 < ua5
+except TypeError as e:
+    assert str(e) == "Attempting to compare UnitAlgebra values with non-matching units: s, events"
 
 #Check conversions to int (in which case it rounds to nearest integer)
 #and floats.  There are two ways to do it:


### PR DESCRIPTION
Closes #1037

Here is a proposal for adding exceptions to the core public API.  Doxygen is missing until we decide on the form of exceptions.

Thoughts:
- Since these exceptions are specific for `UnitAlgebra`, I've added them inside the `UnitAlgebra` class rather than just the header.
- There is a base `UnitAlgebraException` in case a consumer (elements, some other code) wants to catch a more generic exception type rather than one of the more specific types.
- The base `UnitAlgebraException` inherits from `logic_error` rather than `exception` since these are fundamentally not runtime errors.
- As a development guideline, it seems like reasons/messages given by C++ exceptions should be actionable directly Python side: the message passed to `PyErr_SetString` should always be `exception_instance.what()`.

For the tests, I used `assert` statements rather than the existing `correct_throw` idiom.