### PR TITLE
Fix Python 3.12 issues

### DIFF
--- a/src/sst/core/testingframework/sst_unittest_support.py
+++ b/src/sst/core/testingframework/sst_unittest_support.py
@@ -904,7 +904,7 @@ def testing_parse_stat(line):
         Returns:
             (list) list of [component, sum, sumSq, count, min, max] or 'None' if not a statistic
     """
-    cons_accum = re.compile(' ([\w.]+)\.(\w+) : Accumulator : Sum.(\w+) = ([\d.]+); SumSQ.\w+ = ([\d.]+); Count.\w+ = ([\d.]+); Min.\w+ = ([\d.]+); Max.\w+ = ([\d.]+);')
+    cons_accum = re.compile(r' ([\w.]+)\.(\w+) : Accumulator : Sum.(\w+) = ([\d.]+); SumSQ.\w+ = ([\d.]+); Count.\w+ = ([\d.]+); Min.\w+ = ([\d.]+); Max.\w+ = ([\d.]+);')
     m = cons_accum.match(line)
     if m == None:
         return None

--- a/tests/test_UnitAlgebra.py
+++ b/tests/test_UnitAlgebra.py
@@ -96,7 +96,7 @@ ua4 = ua3
 ua3_id_before = id(ua3)
 ua3 /= ua2
 if id(ua3) == ua3_id_before:
-    print("ERROR: \= operator returned the same object")
+    print("ERROR: /= operator returned the same object")
 print(ua3.bestSI())
 print(ua4.bestSI())
 


### PR DESCRIPTION
Use raw strings with regex
Replace \= with /= inside string

Fixes #1002 

