### PR TITLE
Add a `[[maybe_unused]]` attribute to `__EliDerivedLevel` in `SST_ELI…

### DIFF
--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -406,7 +406,7 @@ SST_ELI_getTertiaryNumberFromVersion(SST_ELI_element_version_extraction ver)
 // information.  See comment for SST_ELI_DECLARE_BASE in elibase.h for
 // info on how __EliDerivedLevel is used.
 #define SST_ELI_REGISTER_DERIVED(base, cls, lib, name, version, desc)                                              \
-    static constexpr int __EliDerivedLevel = std::is_same<base, cls>::value ? __EliBaseLevel : __EliBaseLevel + 1; \
+    [[maybe_unused]] static constexpr int __EliDerivedLevel = std::is_same<base, cls>::value ? __EliBaseLevel : __EliBaseLevel + 1; \
     static bool          ELI_isLoaded()                                                                            \
     {                                                                                                              \
         return SST::ELI::InstantiateBuilder<base, cls>::isLoaded() &&                                              \


### PR DESCRIPTION
Add a `[[maybe_unused]]` attribute to `__EliDerivedLevel` in `SST_ELI_REGISTER_DERIVED`.

This is to address `clang`'s `-Wunused-const-variable` which is enabled by `-Wall` in the following case.

```c++
// Interface.hpp
namespace foo
{
    struct Interface : public SST::SubComponent
    {
        SST_ELI_REGISTER_SUBCOMPONENT_API(foo::Interface);
        using SubComponent::SubComponent;
    };
}

// Implementation.cpp
namespace
{
    struct Implementation final : foo::Interface
    {
        SST_ELI_REGISTER_SUBCOMPONENT
        (
                Implementation,
                "foo",
                "implemenation",
                SST_ELI_ELEMENT_VERSION(1,0,0),
                "An impementation",
                foo::Interface
        )

        Implementation(SST::ComponentId_t id, SST::Params&) : Interface(id)
        {
        }
    };
}
```

In this situation, `Implementation` is the concrete type of the interface that we are implementing, and we do so in an unnamed namespace to constrain its symbol visibility. Clang is smart enough to know that there is no use of the static variable allocated by the ELI macro and creates the warning.

Currently, our workaround it to add `std::ignore = __EliDerivedLevel;` in the `Implementation` constructor.

