### PR TITLE
Update checkpoint branch - statistics

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -99,6 +99,7 @@ nobase_dist_sst_HEADERS = \
 	serialization/serialize_list.h \
 	serialization/serialize_map.h \
 	serialization/serialize_multiset.h \
+	serialization/serialize_output.h \
 	serialization/serialize_packer.h \
 	serialization/serialize_priority_queue.h \
 	serialization/serialize_serializable.h \

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -1091,37 +1091,6 @@ public:
 namespace Core {
 namespace Serialization {
 
-template <class T>
-class serialize_impl<Statistic<T>*>
-{
-    template <class A>
-    friend class serialize;
-    void operator()(Statistic<T>*& s, serializer& ser)
-    {
-        // For sizer and pack, only need to get the information needed
-        // to create a NullStatistic on unpack.
-        switch ( ser.mode() ) {
-        case serializer::SIZER:
-        case serializer::PACK:
-        {
-            BaseComponent* comp = s->getComponent();
-            ser&           comp;
-            break;
-        }
-        case serializer::UNPACK:
-        {
-            Params         params;
-            BaseComponent* comp;
-            ser&           comp;
-            s = Factory::getFactory()->CreateWithParams<Statistic<T>>(
-                "sst.NullStatistic", params, comp, "", "", params);
-            break;
-        }
-        }
-    }
-};
-
-
 namespace pvt {
 
 void size_basecomponent(serializable_base* s, serializer& ser);

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -33,10 +33,6 @@ class ConfigStatistic;
 class Simulation_impl;
 class TimeConverter;
 
-namespace Statistics {
-class StatisticInfo;
-}
-
 class ComponentInfo
 {
 

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -765,12 +765,12 @@ main(int argc, char* argv[])
         buffer = new char[size];
         fs.read(buffer, size);
 
-        std::string cpt_lib_path, cpt_timebase, cpt_output_directory;
-        std::string cpt_output_core_prefix, cpt_debug_file, cpt_prefix;
-        int         cpt_output_verbose = 0;
+        std::string                     cpt_lib_path, cpt_timebase, cpt_output_directory;
+        std::string                     cpt_output_core_prefix, cpt_debug_file, cpt_prefix;
+        int                             cpt_output_verbose = 0;
         std::map<std::string, uint32_t> cpt_params_key_map;
-        std::vector<std::string> cpt_params_key_map_reverse;
-        uint32_t cpt_params_next_key_id;
+        std::vector<std::string>        cpt_params_key_map_reverse;
+        uint32_t                        cpt_params_next_key_id;
 
         ser.start_unpacking(buffer, size);
         ser& cpt_num_ranks;
@@ -807,9 +807,9 @@ main(int argc, char* argv[])
         g_output = Output::setDefaultObject(cfg.output_core_prefix(), cfg.verbose(), 0, Output::STDOUT);
         Simulation_impl::getTimeLord()->init(cfg.timeBase());
 
-        Params::keyMap = cpt_params_key_map;
+        Params::keyMap        = cpt_params_key_map;
         Params::keyMapReverse = cpt_params_key_map_reverse;
-        Params::nextKeyID = cpt_params_next_key_id;
+        Params::nextKeyID     = cpt_params_next_key_id;
     }
 
     // Check to see if the config file exists

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -768,6 +768,9 @@ main(int argc, char* argv[])
         std::string cpt_lib_path, cpt_timebase, cpt_output_directory;
         std::string cpt_output_core_prefix, cpt_debug_file, cpt_prefix;
         int         cpt_output_verbose = 0;
+        std::map<std::string, uint32_t> cpt_params_key_map;
+        std::vector<std::string> cpt_params_key_map_reverse;
+        uint32_t cpt_params_next_key_id;
 
         ser.start_unpacking(buffer, size);
         ser& cpt_num_ranks;
@@ -779,6 +782,9 @@ main(int argc, char* argv[])
         ser& cpt_output_verbose;
         ser& cpt_debug_file;
         ser& cpt_prefix;
+        ser& cpt_params_key_map;
+        ser& cpt_params_key_map_reverse;
+        ser& cpt_params_next_key_id;
 
         fs.close();
         delete[] buffer;
@@ -800,6 +806,10 @@ main(int argc, char* argv[])
         Output::setWorldSize(world_size.rank, world_size.thread, myrank);
         g_output = Output::setDefaultObject(cfg.output_core_prefix(), cfg.verbose(), 0, Output::STDOUT);
         Simulation_impl::getTimeLord()->init(cfg.timeBase());
+
+        Params::keyMap = cpt_params_key_map;
+        Params::keyMapReverse = cpt_params_key_map_reverse;
+        Params::nextKeyID = cpt_params_next_key_id;
     }
 
     // Check to see if the config file exists

--- a/src/sst/core/output.h
+++ b/src/sst/core/output.h
@@ -24,8 +24,6 @@
 #define __STDC_FORMAT_MACROS
 #endif
 
-#include "sst/core/serialization/serializable.h"
-
 #include <cinttypes>
 #include <cstdio>
 #include <stdarg.h>
@@ -45,12 +43,21 @@ namespace SST {
 #define CALL_INFO_LONG __LINE__, __FILE__, __FUNCTION__
 #endif
 
+namespace Core {
+namespace Serialization {
+
+class serializer;
+
+}
+}
+
+
 /**
  * Output object provides consistent method for outputting data to
  * stdout, stderr and/or sst debug file.  All components should
  * use this class to log any information.
  */
-class Output : public SST::Core::Serialization::serializable
+class Output
 {
 public:
     /** Choice of output location
@@ -477,9 +484,7 @@ public:
 
     static Output& getDefaultObject() { return m_defaultObject; }
 
-    void serialize_order(SST::Core::Serialization::serializer& ser) override;
-
-    ImplementSerializable(SST::Output)
+    void serialize_order(SST::Core::Serialization::serializer& ser);
 
 private:
     friend class TraceFunction;

--- a/src/sst/core/output.h
+++ b/src/sst/core/output.h
@@ -49,7 +49,7 @@ namespace Serialization {
 class serializer;
 
 }
-}
+} // namespace Core
 
 
 /**

--- a/src/sst/core/params.cc
+++ b/src/sst/core/params.cc
@@ -136,6 +136,29 @@ Params::print_all_params(Output& out, const std::string& prefix) const
     }
 }
 
+std::string
+Params::toString(const std::string& prefix) const
+{
+    std::stringstream str;
+    int level = 0;
+      for ( auto map : data ) {
+        if ( level == 0 ) {
+            if ( !map->empty() ) str << "Local params:" << std::endl;
+            level++;
+        }
+        else if ( level == 1 ) {
+            str << "Global params:" << std::endl;
+            level++;
+        }
+
+        for ( auto value : *map ) {
+            str << "  " << prefix << "key=" << keyMapReverse[value.first] << ", value=" << value.second << std::endl;
+        }
+    }
+    return str.str();
+}
+
+
 void
 Params::insert(const std::string& key, const std::string& value, bool overwrite)
 {

--- a/src/sst/core/params.cc
+++ b/src/sst/core/params.cc
@@ -140,8 +140,8 @@ std::string
 Params::toString(const std::string& prefix) const
 {
     std::stringstream str;
-    int level = 0;
-      for ( auto map : data ) {
+    int               level = 0;
+    for ( auto map : data ) {
         if ( level == 0 ) {
             if ( !map->empty() ) str << "Local params:" << std::endl;
             level++;

--- a/src/sst/core/params.h
+++ b/src/sst/core/params.h
@@ -772,9 +772,9 @@ public:
     }
 
     /** Print all key/value parameter pairs to specified ostream */
-    void print_all_params(std::ostream& os, const std::string& prefix = "") const;
+    void        print_all_params(std::ostream& os, const std::string& prefix = "") const;
     /** Print all key/value parameter pairs to specified ostream */
-    void print_all_params(Output& out, const std::string& prefix = "") const;
+    void        print_all_params(Output& out, const std::string& prefix = "") const;
     /** Return a string version of all key/value parameter pairs */
     std::string toString(const std::string& prefix = "") const;
 

--- a/src/sst/core/params.h
+++ b/src/sst/core/params.h
@@ -775,6 +775,8 @@ public:
     void print_all_params(std::ostream& os, const std::string& prefix = "") const;
     /** Print all key/value parameter pairs to specified ostream */
     void print_all_params(Output& out, const std::string& prefix = "") const;
+    /** Return a string version of all key/value parameter pairs */
+    std::string toString(const std::string& prefix = "") const;
 
     /**
      * Add a key/value pair into the param object.
@@ -946,6 +948,8 @@ private:
 
     /* Friend main() because it broadcasts the maps */
     friend int ::main(int argc, char* argv[]);
+    /* Friend simulation because it checkpoints the maps */
+    friend class Simulation_impl;
 
     static std::map<std::string, uint32_t> keyMap;
     static std::vector<std::string>        keyMapReverse;

--- a/src/sst/core/serialization/CMakeLists.txt
+++ b/src/sst/core/serialization/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SSTSerializationHeaders
     serialize_list.h
     serialize_map.h
     serialize_multiset.h
+    serialize_output.h
     serialize_packer.h
     serialize_priority_queue.h
     serializer_fwd.h

--- a/src/sst/core/serialization/serializable_base.h
+++ b/src/sst/core/serialization/serializable_base.h
@@ -138,38 +138,46 @@ template <class T>
 class serializable_type
 {};
 
-#define ImplementVirtualSerializable(obj)                                                                         \
-public:                                                                                                           \
-    static void throw_exc()                                                                                       \
-    {                                                                                                             \
-        ::SST::Core::Serialization::serializable_base::serializable_abort(__LINE__, __FILE__, __FUNCTION__, #obj);  \
-    }                                                                                                             \
-    virtual const char* cls_name() const override { return #obj; }                                                \
-    virtual uint32_t    cls_id() const { throw_exc(); return 0; }                                                 \
-    virtual std::string serialization_name() const { throw_exc(); return ""; }
+#define ImplementVirtualSerializable(obj)                                                                          \
+public:                                                                                                            \
+    static void throw_exc()                                                                                        \
+    {                                                                                                              \
+        ::SST::Core::Serialization::serializable_base::serializable_abort(__LINE__, __FILE__, __FUNCTION__, #obj); \
+    }                                                                                                              \
+    virtual const char* cls_name() const override { return #obj; }                                                 \
+    virtual uint32_t    cls_id() const                                                                             \
+    {                                                                                                              \
+        throw_exc();                                                                                               \
+        return 0;                                                                                                  \
+    }                                                                                                              \
+    virtual std::string serialization_name() const                                                                 \
+    {                                                                                                              \
+        throw_exc();                                                                                               \
+        return "";                                                                                                 \
+    }
 
-#define NotSerializable(obj)                                                                                      \
-public:                                                                                                           \
-    static void throw_exc()                                                                                       \
-    {                                                                                                             \
-        ::SST::Core::Serialization::serializable_base::serializable_abort(__LINE__, __FILE__, __FUNCTION__, #obj);  \
-    }                                                                                                             \
-    virtual void     serialize_order(SST::Core::Serialization::serializer& UNUSED(sst)) override { throw_exc(); } \
-    virtual uint32_t cls_id() const override                                                                      \
-    {                                                                                                             \
-        throw_exc();                                                                                              \
-        return ::SST::Core::Serialization::serializable_base::NullClsId;                                          \
-    }                                                                                                             \
-    static obj* construct_deserialize_stub()                                                                      \
-    {                                                                                                             \
-        throw_exc();                                                                                              \
-        return 0;                                                                                                 \
-    }                                                                                                             \
-    virtual std::string serialization_name() const override                                                       \
-    {                                                                                                             \
-        throw_exc();                                                                                              \
-        return "";                                                                                                \
-    }                                                                                                             \
+#define NotSerializable(obj)                                                                                       \
+public:                                                                                                            \
+    static void throw_exc()                                                                                        \
+    {                                                                                                              \
+        ::SST::Core::Serialization::serializable_base::serializable_abort(__LINE__, __FILE__, __FUNCTION__, #obj); \
+    }                                                                                                              \
+    virtual void     serialize_order(SST::Core::Serialization::serializer& UNUSED(sst)) override { throw_exc(); }  \
+    virtual uint32_t cls_id() const override                                                                       \
+    {                                                                                                              \
+        throw_exc();                                                                                               \
+        return ::SST::Core::Serialization::serializable_base::NullClsId;                                           \
+    }                                                                                                              \
+    static obj* construct_deserialize_stub()                                                                       \
+    {                                                                                                              \
+        throw_exc();                                                                                               \
+        return 0;                                                                                                  \
+    }                                                                                                              \
+    virtual std::string serialization_name() const override                                                        \
+    {                                                                                                              \
+        throw_exc();                                                                                               \
+        return "";                                                                                                 \
+    }                                                                                                              \
     virtual const char* cls_name() const override { return #obj; }
 
 //    virtual const char* cls_name() const override { return obj_str; }

--- a/src/sst/core/serialization/serializable_base.h
+++ b/src/sst/core/serialization/serializable_base.h
@@ -138,15 +138,21 @@ template <class T>
 class serializable_type
 {};
 
-#define ImplementVirtualSerializable(obj) \
-public:                                   \
-    virtual const char* cls_name() const override { return #obj; }
+#define ImplementVirtualSerializable(obj)                                                                         \
+public:                                                                                                           \
+    static void throw_exc()                                                                                       \
+    {                                                                                                             \
+        ::SST::Core::Serialization::serializable_base::serializable_abort(__LINE__, __FILE__, __FUNCTION__, #obj);  \
+    }                                                                                                             \
+    virtual const char* cls_name() const override { return #obj; }                                                \
+    virtual uint32_t    cls_id() const { throw_exc(); return 0; }                                                 \
+    virtual std::string serialization_name() const { throw_exc(); return ""; }
 
 #define NotSerializable(obj)                                                                                      \
 public:                                                                                                           \
     static void throw_exc()                                                                                       \
     {                                                                                                             \
-        ::SST::Core::Serialization::serializable_base::serializable_abort(CALL_INFO_LONG, #obj);                  \
+        ::SST::Core::Serialization::serializable_base::serializable_abort(__LINE__, __FILE__, __FUNCTION__, #obj);  \
     }                                                                                                             \
     virtual void     serialize_order(SST::Core::Serialization::serializer& UNUSED(sst)) override { throw_exc(); } \
     virtual uint32_t cls_id() const override                                                                      \

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -337,6 +337,7 @@ operator|(serializer& ser, T& t)
 #include "sst/core/serialization/serialize_deque.h"
 #include "sst/core/serialization/serialize_list.h"
 #include "sst/core/serialization/serialize_map.h"
+#include "sst/core/serialization/serialize_output.h"
 #include "sst/core/serialization/serialize_priority_queue.h"
 #include "sst/core/serialization/serialize_set.h"
 #include "sst/core/serialization/serialize_string.h"

--- a/src/sst/core/serialization/serialize_output.h
+++ b/src/sst/core/serialization/serialize_output.h
@@ -1,0 +1,33 @@
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_SERIALIZATION_SERIALIZE_OUTPUT_H
+#define SST_CORE_SERIALIZATION_SERIALIZE_OUTPUT_H
+
+#include "sst/core/serialization/serializer.h"
+#include "sst/core/output.h"
+
+namespace SST {
+namespace Core {
+namespace Serialization {
+
+template <>
+class serialize_impl<Output>
+{
+public:
+    void operator()(Output& out, serializer& ser) { out.serialize_order(ser); }
+};
+
+} // namespace Serialization
+} // namespace Core
+} // namespace SST
+
+#endif /* SST_CORE_SERIALIZATION_SERIALIZE_OUTPUT_H */

--- a/src/sst/core/serialization/serialize_output.h
+++ b/src/sst/core/serialization/serialize_output.h
@@ -12,8 +12,8 @@
 #ifndef SST_CORE_SERIALIZATION_SERIALIZE_OUTPUT_H
 #define SST_CORE_SERIALIZATION_SERIALIZE_OUTPUT_H
 
-#include "sst/core/serialization/serializer.h"
 #include "sst/core/output.h"
+#include "sst/core/serialization/serializer.h"
 
 namespace SST {
 namespace Core {

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -1297,9 +1297,9 @@ Simulation_impl::checkpoint()
     ser&        verbose;
     ser&        globalOutputFileName;
     ser&        checkpointPrefix;
-    ser& Params::keyMap;
-    ser& Params::keyMapReverse;
-    ser& Params::nextKeyID;
+    ser&        Params::keyMap;
+    ser&        Params::keyMapReverse;
+    ser&        Params::nextKeyID;
 
     size        = ser.size();
     buffer_size = size;
@@ -1466,7 +1466,7 @@ Simulation_impl::checkpoint()
 void
 Simulation_impl::restart(Config* cfg)
 {
-    TraceFunction trace(CALL_INFO, false, false);
+    TraceFunction                        trace(CALL_INFO, false, false);
     size_t                               size, buffer_size;
     char*                                buffer;
     SST::Core::Serialization::serializer ser;
@@ -1522,7 +1522,7 @@ Simulation_impl::restart(Config* cfg)
     ser& m_exit;
     ser& syncManager;
     ser& m_heartbeat;
-    
+
     trace.output("Getting statistics engine\n");
     // Get statistics engine
     ser& StatisticProcessingEngine::m_statOutputs;
@@ -1541,7 +1541,7 @@ Simulation_impl::restart(Config* cfg)
     timeLord.init(timeLord.timeBaseString);
 
     trace.output("Beginning component extraction\n");
-    
+
     /* Extract components */
     size_t compCount;
     fs.read(reinterpret_cast<char*>(&compCount), sizeof(compCount));
@@ -1570,9 +1570,7 @@ Simulation_impl::restart(Config* cfg)
     // Prepare stat engine for restart now that stats are registered
     trace.output("Calling startOfSimulation on StatEngine\n");
     stat_engine.finalizeInitialization();
-    if ( my_rank.thread == 0 ) {
-        StatisticProcessingEngine::stat_outputs_simulation_start();
-    }
+    if ( my_rank.thread == 0 ) { StatisticProcessingEngine::stat_outputs_simulation_start(); }
     stat_engine.startOfSimulation();
 }
 

--- a/src/sst/core/statapi/stataccumulator.h
+++ b/src/sst/core/statapi/stataccumulator.h
@@ -68,6 +68,18 @@ public:
 
     ~AccumulatorStatistic() {}
 
+    AccumulatorStatistic() : Statistic<NumberBase>() {} // For serialization only
+    
+    void serialize_order(SST::Core::Serialization::serializer& ser) override
+    {
+        SST::Statistics::Statistic<NumberBase>::serialize_order(ser);
+        ser& m_sum;
+        ser& m_sum_sq;
+        ser& m_min;
+        ser& m_max;
+        // Remaining fields will be reset by statistics output object
+    }
+    
 protected:
     /**
         Present a new value to the class to be included in the statistics.

--- a/src/sst/core/statapi/stataccumulator.h
+++ b/src/sst/core/statapi/stataccumulator.h
@@ -69,7 +69,7 @@ public:
     ~AccumulatorStatistic() {}
 
     AccumulatorStatistic() : Statistic<NumberBase>() {} // For serialization only
-    
+
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {
         SST::Statistics::Statistic<NumberBase>::serialize_order(ser);
@@ -79,7 +79,7 @@ public:
         ser& m_max;
         // Remaining fields will be reset by statistics output object
     }
-    
+
 protected:
     /**
         Present a new value to the class to be included in the statistics.

--- a/src/sst/core/statapi/statbase.cc
+++ b/src/sst/core/statapi/statbase.cc
@@ -28,13 +28,14 @@ namespace SST {
 namespace Stat {
 namespace pvt {
 
-void registerStatWithEngineOnRestart(SST::Statistics::StatisticBase* s)
+void
+registerStatWithEngineOnRestart(SST::Statistics::StatisticBase* s)
 {
-        Simulation_impl::getSimulation()->getStatisticsProcessingEngine()->registerStatisticWithEngine(s);
+    Simulation_impl::getSimulation()->getStatisticsProcessingEngine()->registerStatisticWithEngine(s);
 }
 
 } // namespace pvt
-} // namespace StatBase
+} // namespace Stat
 
 namespace Statistics {
 
@@ -178,8 +179,9 @@ StatisticBase::delayOutput(const char* delayTime)
         m_outputEnabled      = false;
         m_outputDelayed      = true;
 
-        Simulation_impl::getSimulation()->registerOneShot(delayTime, 
-            new OneShot::Handler<StatisticBase>(this, &StatisticBase::delayOutputExpiredHandler), STATISTICCLOCKPRIORITY);
+        Simulation_impl::getSimulation()->registerOneShot(
+            delayTime, new OneShot::Handler<StatisticBase>(this, &StatisticBase::delayOutputExpiredHandler),
+            STATISTICCLOCKPRIORITY);
     }
 }
 
@@ -194,9 +196,9 @@ StatisticBase::delayCollection(const char* delayTime)
         m_savedStatEnabled  = m_statEnabled;
         m_statEnabled       = false;
         m_collectionDelayed = true;
-        
+
         Simulation_impl::getSimulation()->registerOneShot(
-            delayTime, new OneShot::Handler<StatisticBase>(this, &StatisticBase::delayCollectionExpiredHandler), 
+            delayTime, new OneShot::Handler<StatisticBase>(this, &StatisticBase::delayCollectionExpiredHandler),
             STATISTICCLOCKPRIORITY);
     }
 }
@@ -220,16 +222,17 @@ StatisticBase::delayCollectionExpiredHandler()
 void
 StatisticBase::serialize_order(SST::Core::Serialization::serializer& ser)
 {
-    ser& m_component;   // BaseComponent*
+    ser& m_component; // BaseComponent*
     ser& m_statName;
     ser& m_statSubId;
     ser& m_statFullName;
-    ser& m_statParams;  // OPTIMIZATION: Don't need all of these for recreation
+    ser& m_statParams; // OPTIMIZATION: Don't need all of these for recreation
     ser& m_registeredCollectionMode;
     ser& m_currentCollectionCount;
     ser& m_outputCollectionCount;
     ser& m_collectionCountLimit;
-    ser& m_statDataType;    // TODO: Need to store type name instead & lookup ID on return -> may differ if custom types exist
+    ser& m_statDataType; // TODO: Need to store type name instead & lookup ID on return -> may differ if custom types
+                         // exist
     ser& m_statEnabled;
     ser& m_outputEnabled;
     ser& m_resetCountOnOutput;
@@ -238,8 +241,7 @@ StatisticBase::serialize_order(SST::Core::Serialization::serializer& ser)
     ser& m_outputDelayed;
     ser& m_savedStatEnabled;
     ser& m_savedOutputEnabled;
-    //ser& m_group; // This will get re-created on restart
-    
+    // ser& m_group; // This will get re-created on restart
 }
 SST_ELI_INSTANTIATE_STATISTIC(AccumulatorStatistic, int32_t);
 SST_ELI_INSTANTIATE_STATISTIC(AccumulatorStatistic, uint32_t);

--- a/src/sst/core/statapi/statbase.cc
+++ b/src/sst/core/statapi/statbase.cc
@@ -24,7 +24,20 @@
 #include "sst/core/statapi/statuniquecount.h"
 
 namespace SST {
+
+namespace Stat {
+namespace pvt {
+
+void registerStatWithEngineOnRestart(SST::Statistics::StatisticBase* s)
+{
+        Simulation_impl::getSimulation()->getStatisticsProcessingEngine()->registerStatisticWithEngine(s);
+}
+
+} // namespace pvt
+} // namespace StatBase
+
 namespace Statistics {
+
 
 StatisticBase::StatisticBase(
     BaseComponent* comp, const std::string& statName, const std::string& statSubId, Params& statParams)
@@ -135,9 +148,6 @@ StatisticBase::initializeProperties()
     m_collectionDelayed        = false;
     m_savedStatEnabled         = true;
     m_savedOutputEnabled       = true;
-    m_outputDelayedHandler     = new OneShot::Handler<StatisticBase>(this, &StatisticBase::delayOutputExpiredHandler);
-    m_collectionDelayedHandler =
-        new OneShot::Handler<StatisticBase>(this, &StatisticBase::delayCollectionExpiredHandler);
 }
 
 void
@@ -156,6 +166,7 @@ StatisticBase::operator==(StatisticBase& checkStat)
     return (getFullStatName() == checkStat.getFullStatName());
 }
 
+// GV_TODO: Potentially remove this. It doesn't work as intended and delays should be user-set, not component-set
 void
 StatisticBase::delayOutput(const char* delayTime)
 {
@@ -167,10 +178,12 @@ StatisticBase::delayOutput(const char* delayTime)
         m_outputEnabled      = false;
         m_outputDelayed      = true;
 
-        Simulation_impl::getSimulation()->registerOneShot(delayTime, m_outputDelayedHandler, STATISTICCLOCKPRIORITY);
+        Simulation_impl::getSimulation()->registerOneShot(delayTime, 
+            new OneShot::Handler<StatisticBase>(this, &StatisticBase::delayOutputExpiredHandler), STATISTICCLOCKPRIORITY);
     }
 }
 
+// GV_TODO: Potentially remove this. It doesn't work as intended and delays should be user-set, not component-set
 void
 StatisticBase::delayCollection(const char* delayTime)
 {
@@ -181,9 +194,10 @@ StatisticBase::delayCollection(const char* delayTime)
         m_savedStatEnabled  = m_statEnabled;
         m_statEnabled       = false;
         m_collectionDelayed = true;
-
+        
         Simulation_impl::getSimulation()->registerOneShot(
-            delayTime, m_collectionDelayedHandler, STATISTICCLOCKPRIORITY);
+            delayTime, new OneShot::Handler<StatisticBase>(this, &StatisticBase::delayCollectionExpiredHandler), 
+            STATISTICCLOCKPRIORITY);
     }
 }
 
@@ -203,6 +217,30 @@ StatisticBase::delayCollectionExpiredHandler()
     m_collectionDelayed = false;
 }
 
+void
+StatisticBase::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    ser& m_component;   // BaseComponent*
+    ser& m_statName;
+    ser& m_statSubId;
+    ser& m_statFullName;
+    ser& m_statParams;  // OPTIMIZATION: Don't need all of these for recreation
+    ser& m_registeredCollectionMode;
+    ser& m_currentCollectionCount;
+    ser& m_outputCollectionCount;
+    ser& m_collectionCountLimit;
+    ser& m_statDataType;    // TODO: Need to store type name instead & lookup ID on return -> may differ if custom types exist
+    ser& m_statEnabled;
+    ser& m_outputEnabled;
+    ser& m_resetCountOnOutput;
+    ser& m_clearDataOnOutput;
+    ser& m_outputAtEndOfSim;
+    ser& m_outputDelayed;
+    ser& m_savedStatEnabled;
+    ser& m_savedOutputEnabled;
+    //ser& m_group; // This will get re-created on restart
+    
+}
 SST_ELI_INSTANTIATE_STATISTIC(AccumulatorStatistic, int32_t);
 SST_ELI_INSTANTIATE_STATISTIC(AccumulatorStatistic, uint32_t);
 SST_ELI_INSTANTIATE_STATISTIC(AccumulatorStatistic, int64_t);

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -166,10 +166,10 @@ public:
     /** Indicate if the Statistic is a NullStatistic */
     virtual bool isNullStatistic() const { return false; }
 
-    /** Return the Statistic Parameters 
+    /** Return the Statistic Parameters
      * NOTE: This must be public so that it is accessible to the serialize_impl
      * class for statistics.
-    */
+     */
     Params& getParams() { return m_statParams; }
 
     /** Serialization */
@@ -615,10 +615,12 @@ class serialize_impl<Statistics::Statistic<T>*>
         case serializer::SIZER:
         case serializer::PACK:
         {
-            Params params = s->getParams();
-            std::string    stattype = s->getStatTypeName();
-            if (stattype == "NULL") stattype = "sst.NullStatistic";
-            else stattype = params.find<std::string>("type", "sst.AccumulatorStatistic");
+            Params      params   = s->getParams();
+            std::string stattype = s->getStatTypeName();
+            if ( stattype == "NULL" )
+                stattype = "sst.NullStatistic";
+            else
+                stattype = params.find<std::string>("type", "sst.AccumulatorStatistic");
             BaseComponent* comp = s->getComponent();
             ser&           stattype;
             ser&           comp;
@@ -637,9 +639,7 @@ class serialize_impl<Statistics::Statistic<T>*>
             s = Factory::getFactory()->CreateWithParams<Statistics::Statistic<T>>(
                 stattype, params, comp, "", "", params);
             s->serialize_order(ser);
-            if (stattype != "sst.NullStatistic") {
-                SST::Stat::pvt::registerStatWithEngineOnRestart(s);
-            }
+            if ( stattype != "sst.NullStatistic" ) { SST::Stat::pvt::registerStatWithEngineOnRestart(s); }
             break;
         }
         }
@@ -648,7 +648,6 @@ class serialize_impl<Statistics::Statistic<T>*>
 
 } // namespace Serialization
 } // namespace Core
-
 
 
 } // namespace SST

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -16,7 +16,7 @@
 #include "sst/core/factory.h"
 #include "sst/core/oneshot.h"
 #include "sst/core/params.h"
-#include "sst/core/serialization/serializable.h"
+#include "sst/core/serialization/serialize_impl_fwd.h"
 #include "sst/core/sst_types.h"
 #include "sst/core/statapi/statfieldinfo.h"
 #include "sst/core/warnmacros.h"
@@ -32,25 +32,6 @@ class StatisticOutput;
 class StatisticFieldsOutput;
 class StatisticProcessingEngine;
 class StatisticGroup;
-
-class StatisticInfo : public SST::Core::Serialization::serializable
-{
-public:
-    std::string name;
-    Params      params;
-
-    StatisticInfo(const std::string& name) : name(name) {}
-    StatisticInfo(const std::string& name, const Params& params) : name(name), params(params) {}
-    StatisticInfo() {} /* DO NOT USE:  For serialization */
-
-    void serialize_order(SST::Core::Serialization::serializer& ser) override
-    {
-        ser& name;
-        ser& params;
-    }
-
-    ImplementSerializable(SST::Statistics::StatisticInfo)
-};
 
 /**
     \class StatisticBase
@@ -185,6 +166,15 @@ public:
     /** Indicate if the Statistic is a NullStatistic */
     virtual bool isNullStatistic() const { return false; }
 
+    /** Return the Statistic Parameters 
+     * NOTE: This must be public so that it is accessible to the serialize_impl
+     * class for statistics.
+    */
+    Params& getParams() { return m_statParams; }
+
+    /** Serialization */
+    virtual void serialize_order(SST::Core::Serialization::serializer& ser);
+
 protected:
     friend class SST::Statistics::StatisticProcessingEngine;
     friend class SST::Statistics::StatisticOutput;
@@ -204,9 +194,7 @@ protected:
     // Destructor
     virtual ~StatisticBase() {}
 
-    /** Return the Statistic Parameters */
-    Params& getParams() { return m_statParams; }
-
+protected:
     /** Set the Statistic Data Type */
     void setStatisticDataType(const StatisticFieldInfo::fieldType_t dataType) { m_statDataType = dataType; }
 
@@ -288,10 +276,9 @@ private:
     bool                  m_collectionDelayed;
     bool                  m_savedStatEnabled;
     bool                  m_savedOutputEnabled;
-    OneShot::HandlerBase* m_outputDelayedHandler;
-    OneShot::HandlerBase* m_collectionDelayedHandler;
     const StatisticGroup* m_group;
 };
+
 
 /**
  \class StatisticCollector
@@ -399,6 +386,11 @@ public:
 
     static fieldType_t fieldId() { return StatisticFieldType<T>::id(); }
 
+    virtual void serialize_order(SST::Core::Serialization::serializer& ser) override
+    {
+        StatisticBase::serialize_order(ser);
+    }
+
 protected:
     friend class SST::Factory;
     friend class SST::BaseComponent;
@@ -490,6 +482,7 @@ private:
     const char*             short_name_;
     Statistics::fieldType_t field_;
 };
+
 
 #define SST_ELI_DECLARE_STATISTIC_TEMPLATE(cls, lib, name, version, desc, interface) \
     SST_ELI_DEFAULT_INFO(lib, name, ELI_FORWARD_AS_ONE(version), desc)               \
@@ -596,6 +589,68 @@ private:
     MAKE_MULTI_STATISTIC(cls, STAT_GLUE_NAME(cls, __VA_ARGS__), STAT_TUPLE(__VA_ARGS__), __VA_ARGS__)
 
 } // namespace Statistics
+
+namespace Stat {
+namespace pvt {
+
+/** Helper function for re-registering statistics during simulation restart */
+void registerStatWithEngineOnRestart(SST::Statistics::StatisticBase* s);
+
+} // namespace pvt
+} // namespace Stat
+
+namespace Core {
+namespace Serialization {
+
+template <class T>
+class serialize_impl<Statistics::Statistic<T>*>
+{
+    template <class A>
+    friend class serialize;
+    void operator()(Statistics::Statistic<T>*& s, serializer& ser)
+    {
+        // For sizer and pack, need to get the information needed
+        // to create a new statistic of the correct type on unpack.
+        switch ( ser.mode() ) {
+        case serializer::SIZER:
+        case serializer::PACK:
+        {
+            Params params = s->getParams();
+            std::string    stattype = s->getStatTypeName();
+            if (stattype == "NULL") stattype = "sst.NullStatistic";
+            else stattype = params.find<std::string>("type", "sst.AccumulatorStatistic");
+            BaseComponent* comp = s->getComponent();
+            ser&           stattype;
+            ser&           comp;
+            ser&           params;
+            s->serialize_order(ser);
+            break;
+        }
+        case serializer::UNPACK:
+        {
+            Params         params;
+            std::string    stattype;
+            BaseComponent* comp;
+            ser&           stattype;
+            ser&           comp;
+            ser&           params;
+            s = Factory::getFactory()->CreateWithParams<Statistics::Statistic<T>>(
+                stattype, params, comp, "", "", params);
+            s->serialize_order(ser);
+            if (stattype != "sst.NullStatistic") {
+                SST::Stat::pvt::registerStatWithEngineOnRestart(s);
+            }
+            break;
+        }
+        }
+    }
+};
+
+} // namespace Serialization
+} // namespace Core
+
+
+
 } // namespace SST
 
 // we need to make sure null stats are instantiated for whatever types we use

--- a/src/sst/core/statapi/statengine.cc
+++ b/src/sst/core/statapi/statengine.cc
@@ -76,6 +76,17 @@ StatisticProcessingEngine::setup(Simulation_impl* sim, ConfigGraph* graph)
     }
 }
 
+void
+StatisticProcessingEngine::restart(Simulation_impl* sim)
+{
+    m_sim = sim;
+    m_SimulationStarted = false;
+    m_defaultGroup.output = m_statOutputs[0];
+    for ( std::vector<StatisticGroup>::iterator it = m_statGroups.begin(); it != m_statGroups.end(); it++ ) {
+        it->restartGroup(this);
+    }
+}
+
 StatisticProcessingEngine::~StatisticProcessingEngine()
 {
     StatArray_t*   statArray;
@@ -102,7 +113,7 @@ StatisticProcessingEngine::registerStatisticCore(StatisticBase* stat)
     auto* comp = stat->getComponent();
     if ( comp == nullptr ) {
         m_output.verbose(
-            CALL_INFO, 1, 0, " Error: Statistc %s hasn't any associated component .\n",
+            CALL_INFO, 1, 0, " Error: Statistic %s hasn't any associated component .\n",
             stat->getFullStatName().c_str());
         return false;
     }
@@ -297,7 +308,6 @@ StatisticProcessingEngine::addPeriodicBasedStatistic(const UnitAlgebra& freq, St
 
     // See if the map contains an entry for this factor
     if ( m_PeriodicStatisticMap.find(tcFactor) == m_PeriodicStatisticMap.end() ) {
-
         // Check to see if the freq is zero.  Only add a new clock if the freq is non zero
         if ( 0 != freq.getValue() ) {
 
@@ -623,6 +633,32 @@ StatisticProcessingEngine::addStatisticToCompStatMap(
 
     // Add the statistic to the lists of statistics registered to this component
     statArray->push_back(Stat);
+}
+
+void
+StatisticProcessingEngine::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    ser& m_SimulationStarted;
+    ser& m_statLoadLevel;
+    ser& m_statGroups; // Going to have to revisit if changing partitioning - will stat groups need to be global? Are they global already?
+
+    // Maybe save
+    //typedef std::vector<StatisticBase*>           StatArray_t;   /*!< Array of Statistics */
+    //typedef std::map<SimTime_t, StatArray_t*>     StatMap_t;     /*!< Map of simtimes to Statistic Arrays */
+    //typedef std::map<ComponentId_t, StatArray_t*> CompStatMap_t; /*!< Map of ComponentId's to StatInfo Arrays */
+
+    //StatArray_t   m_EventStatisticArray;  /*!< Array of Event Based Statistics */
+    //StatMap_t     m_PeriodicStatisticMap; /*!< Map of Array's of Periodic Based Statistics */
+    //StatMap_t     m_StartTimeMap;         /*!< Map of Array's of Statistics that are started at a sim time */
+    //StatMap_t     m_StopTimeMap;          /*!< Map of Array's of Statistics that are stopped at a sim time */
+    //CompStatMap_t m_CompStatMap;          /*!< Map of Arrays of Statistics tied to Component Id's */
+
+    // Don't save
+    // m_output         Reset to default output in default constructor so don't need to save
+    // m_sim            Reset on restart
+    // m_defaultGroup   Reset on restart
+    // m_statOutputs    Saved & recreated by simulation object
+
 }
 
 } // namespace Statistics

--- a/src/sst/core/statapi/statengine.cc
+++ b/src/sst/core/statapi/statengine.cc
@@ -79,8 +79,8 @@ StatisticProcessingEngine::setup(Simulation_impl* sim, ConfigGraph* graph)
 void
 StatisticProcessingEngine::restart(Simulation_impl* sim)
 {
-    m_sim = sim;
-    m_SimulationStarted = false;
+    m_sim                 = sim;
+    m_SimulationStarted   = false;
     m_defaultGroup.output = m_statOutputs[0];
     for ( std::vector<StatisticGroup>::iterator it = m_statGroups.begin(); it != m_statGroups.end(); it++ ) {
         it->restartGroup(this);
@@ -640,25 +640,25 @@ StatisticProcessingEngine::serialize_order(SST::Core::Serialization::serializer&
 {
     ser& m_SimulationStarted;
     ser& m_statLoadLevel;
-    ser& m_statGroups; // Going to have to revisit if changing partitioning - will stat groups need to be global? Are they global already?
+    ser& m_statGroups; // Going to have to revisit if changing partitioning - will stat groups need to be global? Are
+                       // they global already?
 
     // Maybe save
-    //typedef std::vector<StatisticBase*>           StatArray_t;   /*!< Array of Statistics */
-    //typedef std::map<SimTime_t, StatArray_t*>     StatMap_t;     /*!< Map of simtimes to Statistic Arrays */
-    //typedef std::map<ComponentId_t, StatArray_t*> CompStatMap_t; /*!< Map of ComponentId's to StatInfo Arrays */
+    // typedef std::vector<StatisticBase*>           StatArray_t;   /*!< Array of Statistics */
+    // typedef std::map<SimTime_t, StatArray_t*>     StatMap_t;     /*!< Map of simtimes to Statistic Arrays */
+    // typedef std::map<ComponentId_t, StatArray_t*> CompStatMap_t; /*!< Map of ComponentId's to StatInfo Arrays */
 
-    //StatArray_t   m_EventStatisticArray;  /*!< Array of Event Based Statistics */
-    //StatMap_t     m_PeriodicStatisticMap; /*!< Map of Array's of Periodic Based Statistics */
-    //StatMap_t     m_StartTimeMap;         /*!< Map of Array's of Statistics that are started at a sim time */
-    //StatMap_t     m_StopTimeMap;          /*!< Map of Array's of Statistics that are stopped at a sim time */
-    //CompStatMap_t m_CompStatMap;          /*!< Map of Arrays of Statistics tied to Component Id's */
+    // StatArray_t   m_EventStatisticArray;  /*!< Array of Event Based Statistics */
+    // StatMap_t     m_PeriodicStatisticMap; /*!< Map of Array's of Periodic Based Statistics */
+    // StatMap_t     m_StartTimeMap;         /*!< Map of Array's of Statistics that are started at a sim time */
+    // StatMap_t     m_StopTimeMap;          /*!< Map of Array's of Statistics that are stopped at a sim time */
+    // CompStatMap_t m_CompStatMap;          /*!< Map of Arrays of Statistics tied to Component Id's */
 
     // Don't save
     // m_output         Reset to default output in default constructor so don't need to save
     // m_sim            Reset on restart
     // m_defaultGroup   Reset on restart
     // m_statOutputs    Saved & recreated by simulation object
-
 }
 
 } // namespace Statistics

--- a/src/sst/core/statapi/statengine.h
+++ b/src/sst/core/statapi/statengine.h
@@ -15,6 +15,7 @@
 #include "sst/core/clock.h"
 #include "sst/core/factory.h"
 #include "sst/core/oneshot.h"
+#include "sst/core/serialization/serializable.h"
 #include "sst/core/sst_types.h"
 #include "sst/core/statapi/statbase.h"
 #include "sst/core/statapi/statfieldinfo.h"
@@ -48,7 +49,7 @@ class StatisticOutput;
     all registered Statistics to generate their outputs at desired rates.
 */
 
-class StatisticProcessingEngine
+class StatisticProcessingEngine : public SST::Core::Serialization::serializable
 {
 
 public:
@@ -94,6 +95,8 @@ public:
      */
     static void stat_outputs_simulation_end();
 
+    void serialize_order(SST::Core::Serialization::serializer& ser);
+    ImplementSerializable(SST::Statistics::StatisticProcessingEngine)
 private:
     friend class SST::Simulation_impl;
     friend int ::main(int argc, char** argv);
@@ -101,6 +104,7 @@ private:
 
     StatisticProcessingEngine();
     void setup(Simulation_impl* sim, ConfigGraph* graph);
+    void restart(Simulation_impl* sim);
     ~StatisticProcessingEngine();
 
     static StatisticOutput* createStatisticOutput(const ConfigStatOutput& cfg);

--- a/src/sst/core/statapi/statgroup.cc
+++ b/src/sst/core/statapi/statgroup.cc
@@ -31,6 +31,7 @@ StatisticGroup::StatisticGroup(const ConfigStatGroup& csg, StatisticProcessingEn
     name(csg.name),
     output(const_cast<StatisticOutput*>(engine->getStatOutputs()[csg.outputID])),
     outputFreq(csg.outputFrequency),
+    outputId(csg.outputID),
     components(csg.components)
 {
 
@@ -45,6 +46,18 @@ StatisticGroup::StatisticGroup(const ConfigStatGroup& csg, StatisticProcessingEn
         statNames.push_back(kv.first);
     }
 }
+
+void
+StatisticGroup::restartGroup(StatisticProcessingEngine* engine)
+{
+    output = const_cast<StatisticOutput*>(engine->getStatOutputs()[outputId]);
+    if ( !output->acceptsGroups() ) {
+        Output::getDefaultObject().fatal(
+            CALL_INFO, 1, "Statistic Output type %s cannot handle Statistic Groups\n",
+            output->getStatisticOutputName().c_str());
+    }
+}
+
 
 bool
 StatisticGroup::containsStatistic(const StatisticBase* stat) const
@@ -70,6 +83,17 @@ StatisticGroup::addStatistic(StatisticBase* stat)
 {
     stats.push_back(stat);
     stat->setGroup(this);
+}
+
+void
+StatisticGroup::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    ser& isDefault;
+    ser& name;
+    ser& outputFreq;
+    ser& outputId;
+    ser& components;
+    ser& statNames;
 }
 
 } // namespace Statistics

--- a/src/sst/core/statapi/statgroup.h
+++ b/src/sst/core/statapi/statgroup.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/sst_types.h"
 #include "sst/core/unitAlgebra.h"
+#include "sst/core/serialization/serializer.h"
 
 #include <string>
 #include <vector>
@@ -39,10 +40,14 @@ public:
     std::string      name;
     StatisticOutput* output;
     UnitAlgebra      outputFreq;
+    size_t           outputId;
 
     std::vector<ComponentId_t>  components;
     std::vector<std::string>    statNames;
     std::vector<StatisticBase*> stats;
+
+    void restartGroup(StatisticProcessingEngine* engine);
+    void serialize_order(SST::Core::Serialization::serializer& ser);
 };
 
 } // namespace Statistics

--- a/src/sst/core/statapi/statgroup.h
+++ b/src/sst/core/statapi/statgroup.h
@@ -12,9 +12,9 @@
 #ifndef SST_CORE_STATAPI_STATGROUP_H
 #define SST_CORE_STATAPI_STATGROUP_H
 
+#include "sst/core/serialization/serializer.h"
 #include "sst/core/sst_types.h"
 #include "sst/core/unitAlgebra.h"
-#include "sst/core/serialization/serializer.h"
 
 #include <string>
 #include <vector>

--- a/src/sst/core/statapi/stathistogram.h
+++ b/src/sst/core/statapi/stathistogram.h
@@ -83,6 +83,25 @@ public:
 
     ~HistogramStatistic() {}
 
+    HistogramStatistic() : Statistic<BinDataType>() {} // For serialization ONLY
+    
+    void serialize_order(SST::Core::Serialization::serializer& ser) override
+    {
+        SST::Statistics::Statistic<BinDataType>::serialize_order(ser);
+        ser& m_minValue;
+        ser& m_binWidth;
+        ser& m_numBins;
+        ser& m_OOBMinCount;
+        ser& m_OOBMaxCount;
+        ser& m_itemsBinnedCount;
+        ser& m_totalSummed;
+        ser& m_totalSummedSqr;
+        ser& m_binsMap;
+        ser& m_dumpBinsOnOutput;
+        ser& m_includeOutOfBounds;
+        //ser& m_Fields; // Rebuilt by stat output object
+    }
+
 protected:
     /**
         Adds a new value to the histogram. The correct bin is identified and then incremented. If no bin can be found
@@ -260,7 +279,7 @@ private:
 
     void outputStatisticFields(StatisticFieldsOutput* statOutput, bool UNUSED(EndOfSimFlag)) override
     {
-        uint32_t x = 0;
+        StatisticOutput::fieldHandle_t x = 0;
         statOutput->outputField(m_Fields[x++], getBinsMinValue());
         statOutput->outputField(m_Fields[x++], getBinsMaxValue());
         statOutput->outputField(m_Fields[x++], getBinWidth());
@@ -336,7 +355,7 @@ private:
     HistoMap_t m_binsMap;
 
     // Support
-    std::vector<uint32_t> m_Fields;
+    std::vector<StatisticOutput::fieldHandle_t> m_Fields;
     bool                  m_dumpBinsOnOutput;
     bool                  m_includeOutOfBounds;
 };

--- a/src/sst/core/statapi/stathistogram.h
+++ b/src/sst/core/statapi/stathistogram.h
@@ -84,7 +84,7 @@ public:
     ~HistogramStatistic() {}
 
     HistogramStatistic() : Statistic<BinDataType>() {} // For serialization ONLY
-    
+
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {
         SST::Statistics::Statistic<BinDataType>::serialize_order(ser);
@@ -99,7 +99,7 @@ public:
         ser& m_binsMap;
         ser& m_dumpBinsOnOutput;
         ser& m_includeOutOfBounds;
-        //ser& m_Fields; // Rebuilt by stat output object
+        // ser& m_Fields; // Rebuilt by stat output object
     }
 
 protected:
@@ -356,8 +356,8 @@ private:
 
     // Support
     std::vector<StatisticOutput::fieldHandle_t> m_Fields;
-    bool                  m_dumpBinsOnOutput;
-    bool                  m_includeOutOfBounds;
+    bool                                        m_dumpBinsOnOutput;
+    bool                                        m_includeOutOfBounds;
 };
 
 } // namespace Statistics

--- a/src/sst/core/statapi/statoutput.cc
+++ b/src/sst/core/statapi/statoutput.cc
@@ -35,6 +35,13 @@ SST_ELI_DEFINE_INFO_EXTERN(StatisticOutput)
 StatisticOutput::~StatisticOutput() {}
 
 void
+StatisticOutput::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    ser& m_statOutputName;
+    ser& m_outputParameters;
+}
+
+void
 StatisticOutput::outputGroup(StatisticGroup* group, bool endOfSimFlag)
 {
     this->lock();
@@ -250,6 +257,11 @@ StatisticFieldsOutput::stopRegisterFields()
     m_currentFieldStatName = "";
 }
 
+void
+StatisticFieldsOutput::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    StatisticOutput::serialize_order(ser);
+}
 
 } // namespace Statistics
 } // namespace SST

--- a/src/sst/core/statapi/statoutput.h
+++ b/src/sst/core/statapi/statoutput.h
@@ -15,6 +15,7 @@
 #include "sst/core/eli/elementinfo.h"
 #include "sst/core/module.h"
 #include "sst/core/params.h"
+#include "sst/core/serialization/serializable.h"
 #include "sst/core/sst_types.h"
 #include "sst/core/statapi/statbase.h"
 #include "sst/core/statapi/statfieldinfo.h"
@@ -46,7 +47,7 @@ class StatisticGroup;
   the end of the simulation.  A single statistic output will be created by the
   simulation (per node) and will collect the data per its design.
 */
-class StatisticOutput
+class StatisticOutput : public SST::Core::Serialization::serializable
 {
 public:
     SST_ELI_DECLARE_BASE(StatisticOutput)
@@ -73,6 +74,10 @@ public:
     virtual void output(StatisticBase* statistic, bool endOfSimFlag) = 0;
 
     virtual bool supportsDynamicRegistration() const { return false; }
+  
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    
+    ImplementVirtualSerializable(SST::Statistics::StatisticOutput)
 
     /////////////////
     // Methods for Registering Fields (Called by Statistic Objects)
@@ -266,6 +271,9 @@ public:
      * @return String name of the field type.
      */
     const char* getFieldTypeShortName(fieldType_t type);
+    
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementVirtualSerializable(SST::Statistics::StatisticFieldsOutput)
 
 protected:
     /** Construct a base StatisticOutput
@@ -274,7 +282,7 @@ protected:
     StatisticFieldsOutput(Params& outputParameters);
 
     // For Serialization
-    StatisticFieldsOutput() {}
+    StatisticFieldsOutput() : m_highestFieldHandle(0), m_currentFieldStatName("") {}
 
 private:
     // Other support functions

--- a/src/sst/core/statapi/statoutput.h
+++ b/src/sst/core/statapi/statoutput.h
@@ -74,16 +74,16 @@ public:
     virtual void output(StatisticBase* statistic, bool endOfSimFlag) = 0;
 
     virtual bool supportsDynamicRegistration() const { return false; }
-  
+
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
-    
+
     ImplementVirtualSerializable(SST::Statistics::StatisticOutput)
 
-    /////////////////
-    // Methods for Registering Fields (Called by Statistic Objects)
-public:
-    // by default, no params to return
-    static const std::vector<SST::ElementInfoParam>& ELI_getParams()
+        /////////////////
+        // Methods for Registering Fields (Called by Statistic Objects)
+        public :
+        // by default, no params to return
+        static const std::vector<SST::ElementInfoParam>& ELI_getParams()
     {
         static std::vector<SST::ElementInfoParam> var {};
         return var;
@@ -271,15 +271,15 @@ public:
      * @return String name of the field type.
      */
     const char* getFieldTypeShortName(fieldType_t type);
-    
+
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementVirtualSerializable(SST::Statistics::StatisticFieldsOutput)
 
-protected:
-    /** Construct a base StatisticOutput
-     * @param outputParameters - The parameters for the statistic Output.
-     */
-    StatisticFieldsOutput(Params& outputParameters);
+        protected :
+        /** Construct a base StatisticOutput
+         * @param outputParameters - The parameters for the statistic Output.
+         */
+        StatisticFieldsOutput(Params& outputParameters);
 
     // For Serialization
     StatisticFieldsOutput() : m_highestFieldHandle(0), m_currentFieldStatName("") {}

--- a/src/sst/core/statapi/statoutputcsv.cc
+++ b/src/sst/core/statapi/statoutputcsv.cc
@@ -30,7 +30,7 @@ StatisticOutputCSV::StatisticOutputCSV(Params& outputParameters) : StatisticFiel
 bool
 StatisticOutputCSV::checkOutputParameters()
 {
-    bool        foundKey;
+    bool foundKey;
 
     // Review the output parameters and make sure they are correct, and
     // also setup internal variables

--- a/src/sst/core/statapi/statoutputcsv.cc
+++ b/src/sst/core/statapi/statoutputcsv.cc
@@ -31,9 +31,6 @@ bool
 StatisticOutputCSV::checkOutputParameters()
 {
     bool        foundKey;
-    std::string topHeaderFlag;
-    std::string simTimeFlag;
-    std::string rankFlag;
 
     // Review the output parameters and make sure they are correct, and
     // also setup internal variables
@@ -45,12 +42,9 @@ StatisticOutputCSV::checkOutputParameters()
     // Get the parameters
     m_Separator       = getOutputParameters().find<std::string>("separator", ", ");
     m_FilePath        = getOutputParameters().find<std::string>("filepath", "./StatisticOutput.csv");
-    topHeaderFlag     = getOutputParameters().find<std::string>("outputtopheader", "1");
-    simTimeFlag       = getOutputParameters().find<std::string>("outputsimtime", "1");
-    rankFlag          = getOutputParameters().find<std::string>("outputrank", "1");
-    m_outputTopHeader = ("1" == topHeaderFlag);
-    m_outputSimTime   = ("1" == simTimeFlag);
-    m_outputRank      = ("1" == rankFlag);
+    m_outputTopHeader = getOutputParameters().find<bool>("outputtopheader", true);
+    m_outputSimTime   = getOutputParameters().find<bool>("outputsimtime", true);
+    m_outputRank      = getOutputParameters().find<bool>("outputrank", true);
 
     // Perform some checking on the parameters
     if ( 0 == m_Separator.length() ) {
@@ -362,6 +356,18 @@ StatisticOutputCSV::print(const char* fmt, ...)
         va_end(args);
     }
     return res;
+}
+
+void
+StatisticOutputCSV::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    StatisticFieldsOutput::serialize_order(ser);
+    ser& m_Separator;
+    ser& m_FilePath;
+    ser& m_outputRank;
+    ser& m_outputSimTime;
+    ser& m_outputTopHeader;
+    ser& m_useCompression;
 }
 
 } // namespace Statistics

--- a/src/sst/core/statapi/statoutputcsv.h
+++ b/src/sst/core/statapi/statoutputcsv.h
@@ -44,6 +44,8 @@ public:
      */
     StatisticOutputCSV(Params& outputParameters);
 
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(SST::Statistics::StatisticOutputCSV)
 protected:
     /** Perform a check of provided parameters
      * @return True if all required parameters and options are acceptable

--- a/src/sst/core/statapi/statoutputhdf5.cc
+++ b/src/sst/core/statapi/statoutputhdf5.cc
@@ -621,5 +621,16 @@ StatisticOutputHDF5::GroupInfo::GroupStat::finishGroupEntry()
     dataset->write(currentData.data(), *memType, memSpace, fspace);
 }
 
+void 
+StatisticOutputHDF5::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    StatisticFieldsOutput::serialize_order(ser);
+    // H5::H5File*                              m_hFile;
+    // DataSet*                                 m_currentDataSet;
+    // std::map<StatisticBase*, StatisticInfo*> m_statistics;
+    // std::map<std::string, GroupInfo>         m_statGroups;
+}
+
+
 } // namespace Statistics
 } // namespace SST

--- a/src/sst/core/statapi/statoutputhdf5.cc
+++ b/src/sst/core/statapi/statoutputhdf5.cc
@@ -621,7 +621,7 @@ StatisticOutputHDF5::GroupInfo::GroupStat::finishGroupEntry()
     dataset->write(currentData.data(), *memType, memSpace, fspace);
 }
 
-void 
+void
 StatisticOutputHDF5::serialize_order(SST::Core::Serialization::serializer& ser)
 {
     StatisticFieldsOutput::serialize_order(ser);

--- a/src/sst/core/statapi/statoutputhdf5.h
+++ b/src/sst/core/statapi/statoutputhdf5.h
@@ -48,6 +48,9 @@ public:
     StatisticOutputHDF5(Params& outputParameters);
 
     bool acceptsGroups() const override { return true; }
+    
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    NotSerializable(SST::Statistics::StatisticOutputHDF5)
 
 private:
     /** Perform a check of provided parameters

--- a/src/sst/core/statapi/statoutputhdf5.h
+++ b/src/sst/core/statapi/statoutputhdf5.h
@@ -48,15 +48,15 @@ public:
     StatisticOutputHDF5(Params& outputParameters);
 
     bool acceptsGroups() const override { return true; }
-    
+
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     NotSerializable(SST::Statistics::StatisticOutputHDF5)
 
-private:
-    /** Perform a check of provided parameters
-     * @return True if all required parameters and options are acceptable
-     */
-    bool checkOutputParameters() override;
+        private :
+        /** Perform a check of provided parameters
+         * @return True if all required parameters and options are acceptable
+         */
+        bool checkOutputParameters() override;
 
     /** Print out usage for this Statistic Output */
     void printUsage() override;

--- a/src/sst/core/statapi/statoutputjson.cc
+++ b/src/sst/core/statapi/statoutputjson.cc
@@ -29,6 +29,7 @@ StatisticOutputJSON::StatisticOutputJSON(Params& outputParameters) : StatisticFi
     m_currentComponentName = "";
     m_firstEntry           = false;
     m_processedAnyStats    = false;
+    m_curIndentLevel       = 0;
 }
 
 bool
@@ -47,12 +48,9 @@ StatisticOutputJSON::checkOutputParameters()
     if ( true == foundKey ) { return false; }
 
     // Get the parameters
-    m_FilePath  = getOutputParameters().find<std::string>("filepath", "./StatisticOutput.json");
-    simTimeFlag = getOutputParameters().find<std::string>("outputsimtime", "1");
-    rankFlag    = getOutputParameters().find<std::string>("outputrank", "1");
-
-    m_outputSimTime = ("1" == simTimeFlag);
-    m_outputRank    = ("1" == rankFlag);
+    m_FilePath      = getOutputParameters().find<std::string>("filepath", "./StatisticOutput.json");
+    m_outputSimTime = getOutputParameters().find<bool>("outputsimtime", true);
+    m_outputRank    = getOutputParameters().find<bool>("outputrank", true);
 
     if ( 0 == m_FilePath.length() ) {
         // Filepath is zero length
@@ -138,6 +136,10 @@ StatisticOutputJSON::implStartOutputEntries(StatisticBase* statistic)
         m_curIndentLevel++;
         printIndent();
         fprintf(m_hFile, "\"name\" : \"%s\",\n", statistic->getCompName().c_str());
+        printIndent();
+        if (m_outputSimTime) {
+            fprintf(m_hFile, "\"simtime\" : %" PRIu64 ",\n", getCurrentSimCycle());
+        }
 
         printIndent();
         fprintf(m_hFile, "\"statistics\" : [\n");
@@ -259,6 +261,18 @@ StatisticOutputJSON::printIndent()
     for ( int i = 0; i < m_curIndentLevel; ++i ) {
         fprintf(m_hFile, "   ");
     }
+}
+
+void
+StatisticOutputJSON::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    StatisticFieldsOutput::serialize_order(ser);
+    ser& m_FilePath;
+    ser& m_outputSimTime;
+    ser& m_outputRank;
+    ser& m_firstEntry;
+    ser& m_firstField;
+    ser& m_processedAnyStats;
 }
 
 } // namespace Statistics

--- a/src/sst/core/statapi/statoutputjson.cc
+++ b/src/sst/core/statapi/statoutputjson.cc
@@ -137,9 +137,7 @@ StatisticOutputJSON::implStartOutputEntries(StatisticBase* statistic)
         printIndent();
         fprintf(m_hFile, "\"name\" : \"%s\",\n", statistic->getCompName().c_str());
         printIndent();
-        if (m_outputSimTime) {
-            fprintf(m_hFile, "\"simtime\" : %" PRIu64 ",\n", getCurrentSimCycle());
-        }
+        if ( m_outputSimTime ) { fprintf(m_hFile, "\"simtime\" : %" PRIu64 ",\n", getCurrentSimCycle()); }
 
         printIndent();
         fprintf(m_hFile, "\"statistics\" : [\n");

--- a/src/sst/core/statapi/statoutputjson.h
+++ b/src/sst/core/statapi/statoutputjson.h
@@ -39,6 +39,9 @@ public:
      */
     StatisticOutputJSON(Params& outputParameters);
 
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(SST::Statistics::StatisticOutputJSON)
+
 protected:
     /** Perform a check of provided parameters
      * @return True if all required parameters and options are acceptable
@@ -89,7 +92,7 @@ protected:
     void printIndent();
 
 protected:
-    StatisticOutputJSON() { ; } // For serialization
+    StatisticOutputJSON() : m_currentComponentName(""), m_firstEntry(false), m_processedAnyStats(false), m_curIndentLevel(0) { ; } // For serialization
 
 private:
     bool openFile();

--- a/src/sst/core/statapi/statoutputjson.h
+++ b/src/sst/core/statapi/statoutputjson.h
@@ -92,7 +92,14 @@ protected:
     void printIndent();
 
 protected:
-    StatisticOutputJSON() : m_currentComponentName(""), m_firstEntry(false), m_processedAnyStats(false), m_curIndentLevel(0) { ; } // For serialization
+    StatisticOutputJSON() :
+        m_currentComponentName(""),
+        m_firstEntry(false),
+        m_processedAnyStats(false),
+        m_curIndentLevel(0)
+    {
+        ;
+    } // For serialization
 
 private:
     bool openFile();

--- a/src/sst/core/statapi/statoutputtxt.cc
+++ b/src/sst/core/statapi/statoutputtxt.cc
@@ -416,7 +416,7 @@ StatisticOutputTextBase::serialize_order(SST::Core::Serialization::serializer& s
     ser& m_outputRank;
     ser& m_outputSimTime;
     ser& m_useCompression;
-    //ser& m_outputBuffer; // Rebuild during restart
+    // ser& m_outputBuffer; // Rebuild during restart
     ser& m_FilePath;
 }
 

--- a/src/sst/core/statapi/statoutputtxt.cc
+++ b/src/sst/core/statapi/statoutputtxt.cc
@@ -407,6 +407,19 @@ StatisticOutputTextBase::print(const char* fmt, ...)
     return res;
 }
 
+void
+StatisticOutputTextBase::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    StatisticOutput::serialize_order(ser);
+    ser& m_outputTopHeader;
+    ser& m_outputInlineHeader;
+    ser& m_outputRank;
+    ser& m_outputSimTime;
+    ser& m_useCompression;
+    //ser& m_outputBuffer; // Rebuild during restart
+    ser& m_FilePath;
+}
+
 StatisticOutputTxt::StatisticOutputTxt(Params& outputParameters) : StatisticOutputTextBase(outputParameters)
 {
     // Announce this output object's name
@@ -415,6 +428,11 @@ StatisticOutputTxt::StatisticOutputTxt(Params& outputParameters) : StatisticOutp
     setStatisticOutputName(m_useCompression ? "StatisticOutputCompressedTxt" : "StatisticOutputTxt");
 }
 
+void
+StatisticOutputTxt::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    StatisticOutputTextBase::serialize_order(ser);
+}
 
 StatisticOutputConsole::StatisticOutputConsole(Params& outputParameters) : StatisticOutputTextBase(outputParameters)
 {
@@ -424,6 +442,11 @@ StatisticOutputConsole::StatisticOutputConsole(Params& outputParameters) : Stati
     setStatisticOutputName("StatisticOutputConsole");
 }
 
+void
+StatisticOutputConsole::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    StatisticOutputTextBase::serialize_order(ser);
+}
 
 } // namespace Statistics
 } // namespace SST

--- a/src/sst/core/statapi/statoutputtxt.h
+++ b/src/sst/core/statapi/statoutputtxt.h
@@ -31,6 +31,8 @@ public:
      */
     StatisticOutputTextBase(Params& outputParameters);
 
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementVirtualSerializable(SST::Statistics::StatisticOutputTextBase)
 protected:
     /** Perform a check of provided parameters
      * @return True if all required parameters and options are acceptable
@@ -160,6 +162,10 @@ public:
      */
     StatisticOutputTxt(Params& outputParameters);
 
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(SST::Statistics::StatisticOutputTxt)
+
+
 protected:
     StatisticOutputTxt() { ; } // For serialization
 
@@ -226,6 +232,9 @@ public:
      * @param outputParameters - Parameters used for this Statistic Output
      */
     StatisticOutputConsole(Params& outputParameters);
+
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(SST::Statistics::StatisticOutputConsole)
 
 protected:
     StatisticOutputConsole() { ; } // For serialization

--- a/src/sst/core/statapi/statoutputtxt.h
+++ b/src/sst/core/statapi/statoutputtxt.h
@@ -32,12 +32,11 @@ public:
     StatisticOutputTextBase(Params& outputParameters);
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
-    ImplementVirtualSerializable(SST::Statistics::StatisticOutputTextBase)
-protected:
-    /** Perform a check of provided parameters
-     * @return True if all required parameters and options are acceptable
-     */
-    bool checkOutputParameters() override;
+    ImplementVirtualSerializable(SST::Statistics::StatisticOutputTextBase) protected :
+        /** Perform a check of provided parameters
+         * @return True if all required parameters and options are acceptable
+         */
+        bool checkOutputParameters() override;
 
     /** Print out usage for this Statistic Output */
     void printUsage() override;

--- a/src/sst/core/statapi/statuniquecount.h
+++ b/src/sst/core/statapi/statuniquecount.h
@@ -50,6 +50,15 @@ public:
 
     ~UniqueCountStatistic() {};
 
+    UniqueCountStatistic() : Statistic<T>() {}
+
+    void serialize_order(SST::Core::Serialization::serializer& ser)
+    {
+        SST::Statistics::Statistic<T>::serialize_order(ser);
+        ser& uniqueSet;
+        // uniqueCountField will be reset by statistics output object
+    }
+
 protected:
     /**
     Present a new value to the Statistic to be included in the unique set

--- a/src/sst/core/testElements/coreTest_Checkpoint.cc
+++ b/src/sst/core/testElements/coreTest_Checkpoint.cc
@@ -66,7 +66,7 @@ coreTestCheckpoint::coreTestCheckpoint(ComponentId_t id, Params& params) : Compo
         new RNG::MarsagliaRNG(params.find<unsigned int>("rng_seed_w", 7), params.find<unsigned int>("rng_seed_z", 5));
     mersenne = new RNG::MersenneRNG(params.find<unsigned int>("rng_seed", 11));
     xorshift = new RNG::XORShiftRNG(params.find<unsigned int>("rng_seed", 11));
-    
+
     dist_const = new RNG::ConstantDistribution(params.find<double>("dist_const", 1.5));
 
     std::vector<double> discrete_probs;
@@ -85,8 +85,8 @@ coreTestCheckpoint::coreTestCheckpoint(ComponentId_t id, Params& params) : Compo
     dist_uniform = new RNG::UniformDistribution(params.find<uint32_t>("dist_uni_bins", 4));
 
     stat_eventcount = registerStatistic<uint32_t>("eventcount");
-    stat_rng = registerStatistic<uint32_t>("rngvals");
-    stat_dist = registerStatistic<double>("distvals");
+    stat_rng        = registerStatistic<uint32_t>("rngvals");
+    stat_dist       = registerStatistic<double>("distvals");
 }
 
 coreTestCheckpoint::~coreTestCheckpoint() {}
@@ -129,17 +129,16 @@ coreTestCheckpoint::handleClock(Cycle_t cycle)
 {
     getSimulationOutput().output("Clock cycle count = %" PRIu64 "\n", cycle);
 
-    double distval = dist_gauss->getNextDouble();
-    uint32_t rngval = mersenne->generateNextUInt32();
+    double   distval = dist_gauss->getNextDouble();
+    uint32_t rngval  = mersenne->generateNextUInt32();
 
     output->output(
         "RNG: %" PRIu32 ", %" PRIu32 ", %" PRIu32 "\n", marsaglia->generateNextUInt32(), rngval,
         xorshift->generateNextUInt32());
     output->output(
         "Distributions: %f, %f, %f, %f, %f, %f\n", dist_const->getNextDouble(), dist_discrete->getNextDouble(),
-        dist_expon->getNextDouble(), distval, dist_poisson->getNextDouble(),
-        dist_uniform->getNextDouble());
-    
+        dist_expon->getNextDouble(), distval, dist_poisson->getNextDouble(), dist_uniform->getNextDouble());
+
     stat_dist->addData(distval);
     stat_rng->addData(rngval);
 

--- a/src/sst/core/testElements/coreTest_Checkpoint.cc
+++ b/src/sst/core/testElements/coreTest_Checkpoint.cc
@@ -66,7 +66,7 @@ coreTestCheckpoint::coreTestCheckpoint(ComponentId_t id, Params& params) : Compo
         new RNG::MarsagliaRNG(params.find<unsigned int>("rng_seed_w", 7), params.find<unsigned int>("rng_seed_z", 5));
     mersenne = new RNG::MersenneRNG(params.find<unsigned int>("rng_seed", 11));
     xorshift = new RNG::XORShiftRNG(params.find<unsigned int>("rng_seed", 11));
-
+    
     dist_const = new RNG::ConstantDistribution(params.find<double>("dist_const", 1.5));
 
     std::vector<double> discrete_probs;
@@ -83,6 +83,10 @@ coreTestCheckpoint::coreTestCheckpoint(ComponentId_t id, Params& params) : Compo
     dist_poisson = new RNG::PoissonDistribution(params.find<double>("dist_poisson_lambda", 1.0));
 
     dist_uniform = new RNG::UniformDistribution(params.find<uint32_t>("dist_uni_bins", 4));
+
+    stat_eventcount = registerStatistic<uint32_t>("eventcount");
+    stat_rng = registerStatistic<uint32_t>("rngvals");
+    stat_dist = registerStatistic<double>("distvals");
 }
 
 coreTestCheckpoint::~coreTestCheckpoint() {}
@@ -116,6 +120,7 @@ coreTestCheckpoint::handleEvent(Event* ev)
     getSimulationOutput().output(
         "%s, bounce %d, t=%" PRIu64 "\n", getName().c_str(), event->getCount(), getCurrentSimCycle());
     link->send(event);
+    stat_eventcount->addData(1);
 }
 
 // clock hander just prints
@@ -123,13 +128,21 @@ bool
 coreTestCheckpoint::handleClock(Cycle_t cycle)
 {
     getSimulationOutput().output("Clock cycle count = %" PRIu64 "\n", cycle);
+
+    double distval = dist_gauss->getNextDouble();
+    uint32_t rngval = mersenne->generateNextUInt32();
+
     output->output(
-        "RNG: %" PRIu32 ", %" PRIu32 ", %" PRIu32 "\n", marsaglia->generateNextUInt32(), mersenne->generateNextUInt32(),
+        "RNG: %" PRIu32 ", %" PRIu32 ", %" PRIu32 "\n", marsaglia->generateNextUInt32(), rngval,
         xorshift->generateNextUInt32());
     output->output(
         "Distributions: %f, %f, %f, %f, %f, %f\n", dist_const->getNextDouble(), dist_discrete->getNextDouble(),
-        dist_expon->getNextDouble(), dist_gauss->getNextDouble(), dist_poisson->getNextDouble(),
+        dist_expon->getNextDouble(), distval, dist_poisson->getNextDouble(),
         dist_uniform->getNextDouble());
+    
+    stat_dist->addData(distval);
+    stat_rng->addData(rngval);
+
     duty_cycle_count--;
     if ( duty_cycle_count == 0 ) {
         duty_cycle_count = duty_cycle;
@@ -180,6 +193,9 @@ coreTestCheckpoint::serialize_order(SST::Core::Serialization::serializer& ser)
     SST_SER(dist_gauss)
     SST_SER(dist_poisson)
     SST_SER(dist_uniform)
+    SST_SER(stat_eventcount)
+    SST_SER(stat_rng)
+    SST_SER(stat_dist)
 }
 
 

--- a/src/sst/core/testElements/coreTest_Checkpoint.h
+++ b/src/sst/core/testElements/coreTest_Checkpoint.h
@@ -138,9 +138,9 @@ private:
     RNG::RandomDistribution* dist_poisson;
     RNG::RandomDistribution* dist_uniform;
 
-    Statistic<uint32_t> * stat_eventcount;
-    Statistic<uint32_t> * stat_rng;
-    Statistic<double> * stat_dist;
+    Statistic<uint32_t>* stat_eventcount;
+    Statistic<uint32_t>* stat_rng;
+    Statistic<double>*   stat_dist;
 };
 
 } // namespace CoreTestCheckpoint

--- a/src/sst/core/testElements/coreTest_Checkpoint.h
+++ b/src/sst/core/testElements/coreTest_Checkpoint.h
@@ -93,6 +93,12 @@ public:
         {"port", "Link to the other coreTestCheckpoint", { "coreTestElement.coreTestCheckpointEvent", "" } }
     )
 
+    SST_ELI_DOCUMENT_STATISTICS(
+        {"eventcount", "Total number of events received", "events", 1},
+        {"rngvals", "Numbers from RNG", "number", 2},
+        {"distvals", "Numbers from distribution", "number", 3}
+    )
+
     coreTestCheckpoint(ComponentId_t id, SST::Params& params);
     ~coreTestCheckpoint();
 
@@ -131,6 +137,10 @@ private:
     RNG::RandomDistribution* dist_gauss;
     RNG::RandomDistribution* dist_poisson;
     RNG::RandomDistribution* dist_uniform;
+
+    Statistic<uint32_t> * stat_eventcount;
+    Statistic<uint32_t> * stat_rng;
+    Statistic<double> * stat_dist;
 };
 
 } // namespace CoreTestCheckpoint

--- a/src/sst/core/timeLord.cc
+++ b/src/sst/core/timeLord.cc
@@ -181,7 +181,6 @@ TimeLord::serialize_order(SST::Core::Serialization::serializer& ser)
 {
     ser& timeBaseString;
     ser& timeBase;
-    ser& tcMap;
 }
 
 UnitAlgebra

--- a/tests/test_Checkpoint.py
+++ b/tests/test_Checkpoint.py
@@ -26,3 +26,20 @@ comp_c1.addParams({
 # Connect the components
 link = sst.Link("link")
 link.connect( (comp_c0, "port", "1us"), (comp_c1, "port", "1us") )
+
+# Stats config
+sst.setStatisticLoadLevel(3)
+sst.setStatisticOutput("sst.statOutputConsole")
+#sst.setStatisticOutput("sst.statOutputJSON", {"outputsimtime" : "1"})
+#sst.setStatisticOutput("sst.statOutputTxt")
+#sst.setStatisticOutput("sst.statOutputCSV", {
+#    "filepath" : "test_Checkpoint_stats.csv",
+#    "separator" : "; " })
+sst.enableStatisticForComponentName("c0", "rngvals",
+    {"type":"sst.HistogramStatistic",
+     "minvalue" : 0,
+     "binwidth" : 400000000,
+     "numbins" : 10,
+     "IncludeOutOfBounds" : "T"
+})
+sst.enableAllStatisticsForAllComponents({ "rate" : "100us" })


### PR DESCRIPTION
- Add checkpoint support for statistics 
 - HDF5 not supported yet
- NotSerializable macro no longer required for classes that inherit from a class that uses ImplementVirtualSerializable
- Output no longer inherits from serializable
- Minor general clean up in statapi classes
- Fixed issue in JSON statistic output where the outputsimtime parameter had no effect
- Fixed issue where params were serializable but not checkpointable due to missing keysets in checkpoint