### PR TITLE
deprecate initializeClass() method

### DIFF
--- a/src/sst/core/testingframework/sst_unittest.py
+++ b/src/sst/core/testingframework/sst_unittest.py
@@ -57,30 +57,8 @@ class SSTTestCase(unittest.TestCase):
         parent_module_path = os.path.dirname(sys.modules[self.__class__.__module__].__file__)
         self._testsuite_dirpath = parent_module_path
         #log_forced("SSTTestCase: __init__() - {0}".format(self.testname))
-        self.initializeClass(self.testname)
         self._start_test_time = time.time()
         self._stop_test_time = time.time()
-
-###
-
-    def initializeClass(self, testname):
-        """ The method is called by the Frameworks immediately before class is
-        initialized.
-
-        **NOTICE**:
-            If a derived class defines its own copy of this method, this
-            method (the parent method) MUST be called for proper operation
-            of the testing frameworks
-
-        **NOTE**:
-            (Single Thread Testing) - Called by frameworks.
-            (Concurrent Thread Testing) - Called by frameworks.
-
-        Args:
-            testname (str): Name of the test being initialized
-        """
-        # Placeholder method for overridden method in derived class
-        #log_forced("\nSSTTestCase: initializeClass() - {0}".format(testname))
 
 ###
 

--- a/src/sst/core/testingframework/sst_unittest.py
+++ b/src/sst/core/testingframework/sst_unittest.py
@@ -39,6 +39,11 @@ from test_engine_junit import JUnitTestSuite
 from test_engine_junit import junit_to_xml_report_file
 #from test_engine_junit import junit_to_xml_report_string
 
+if not sys.warnoptions:
+    import os, warnings
+    warnings.simplefilter("once") # Change the filter in this process
+    os.environ["PYTHONWARNINGS"] = "once" # Also affect subprocesses
+
 class SSTTestCase(unittest.TestCase):
     """ This class is main SSTTestCase class for the SST Testing Frameworks
 
@@ -57,8 +62,33 @@ class SSTTestCase(unittest.TestCase):
         parent_module_path = os.path.dirname(sys.modules[self.__class__.__module__].__file__)
         self._testsuite_dirpath = parent_module_path
         #log_forced("SSTTestCase: __init__() - {0}".format(self.testname))
+        self.initializeClass(self.testname)
         self._start_test_time = time.time()
         self._stop_test_time = time.time()
+
+###
+
+    def initializeClass(self, testname):
+        """ The method is called by the Frameworks immediately before class is
+        initialized.
+
+        **NOTICE**:
+            If a derived class defines its own copy of this method, this
+            method (the parent method) MUST be called for proper operation
+            of the testing frameworks
+
+        **NOTE**:
+            (Single Thread Testing) - Called by frameworks.
+            (Concurrent Thread Testing) - Called by frameworks.
+
+        Args:
+            testname (str): Name of the test being initialized
+        """
+        # Placeholder method for overridden method in derived class
+        #log_forced("\nSSTTestCase: initializeClass() - {0}".format(testname))
+        from warnings import warn
+        warn("initializeClass() is deprecated and will be removed in SST 15.",
+             DeprecationWarning, stacklevel=2)
 
 ###
 

--- a/tests/testsuite_default_Checkpoint.py
+++ b/tests/testsuite_default_Checkpoint.py
@@ -37,11 +37,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Checkpoint(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_Component.py
+++ b/tests/testsuite_default_Component.py
@@ -34,11 +34,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Component(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_Links.py
+++ b/tests/testsuite_default_Links.py
@@ -34,11 +34,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Links(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_MemPoolTest.py
+++ b/tests/testsuite_default_MemPoolTest.py
@@ -37,11 +37,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_StatisticComponent(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_Module.py
+++ b/tests/testsuite_default_Module.py
@@ -37,11 +37,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Module(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_Output.py
+++ b/tests/testsuite_default_Output.py
@@ -37,11 +37,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Output(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_ParamComponent.py
+++ b/tests/testsuite_default_ParamComponent.py
@@ -34,11 +34,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_ParamComponent(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_PerfComponent.py
+++ b/tests/testsuite_default_PerfComponent.py
@@ -35,11 +35,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_PerfComponent(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_RNGComponent.py
+++ b/tests/testsuite_default_RNGComponent.py
@@ -37,11 +37,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_RNGComponent(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_RealTime.py
+++ b/tests/testsuite_default_RealTime.py
@@ -44,11 +44,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Signals(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_Serialization.py
+++ b/tests/testsuite_default_Serialization.py
@@ -37,11 +37,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Serialization(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_SharedObject.py
+++ b/tests/testsuite_default_SharedObject.py
@@ -37,11 +37,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_SharedObject(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_StatisticsComponent.py
+++ b/tests/testsuite_default_StatisticsComponent.py
@@ -40,11 +40,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_StatisticComponent(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_SubComponent.py
+++ b/tests/testsuite_default_SubComponent.py
@@ -37,11 +37,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_SubComponent(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_UnitAlgebra.py
+++ b/tests/testsuite_default_UnitAlgebra.py
@@ -34,11 +34,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_UnitAlgebra(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_config_input_output.py
+++ b/tests/testsuite_default_config_input_output.py
@@ -39,11 +39,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Config_input_output(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_partitioner.py
+++ b/tests/testsuite_default_partitioner.py
@@ -37,11 +37,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Partitioners(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_default_sstinfo.py
+++ b/tests/testsuite_default_sstinfo.py
@@ -36,11 +36,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_sstinfo(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/tests/testsuite_testengine_testing.py
+++ b/tests/testsuite_testengine_testing.py
@@ -38,11 +38,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_testengine_testing_frameworks_operation(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)
@@ -119,11 +114,6 @@ class testcase_testengine_testing_support_functions(SSTTestCase):
         super(cls, cls).tearDownClass()
 
 #####
-
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
 
     def setUp(self):
         super(type(self), self).setUp()


### PR DESCRIPTION
`initializeClass()` is never used across any of our testing. Its functionality is replicated by `setUpClass()` which is a standard pattern used by unittest.
