### PR TITLE
Remove redundant initializeTestModule_SingleInstance() methods

### DIFF
--- a/src/sst/core/testingframework/sst_unittest.py
+++ b/src/sst/core/testingframework/sst_unittest.py
@@ -53,15 +53,6 @@ class SSTTestCase(unittest.TestCase):
         This class is derived from Python's unittest.TestCase which provides an
         basic resource for how to develop tests for this frameworks.
     """
-    module_init = 0
-    module_sema = threading.Semaphore()
-
-    @classmethod
-    def initializeTestModule_SingleInstance(cls):
-        with cls.module_sema:
-            if cls.module_init != 1:
-                # Put your single instance Init Code Here
-                cls.module_init = 1
 
     def __init__(self, methodName):
         # NOTE: __init__ is called at startup for all tests before any

--- a/src/sst/core/testingframework/sst_unittest.py
+++ b/src/sst/core/testingframework/sst_unittest.py
@@ -53,6 +53,15 @@ class SSTTestCase(unittest.TestCase):
         This class is derived from Python's unittest.TestCase which provides an
         basic resource for how to develop tests for this frameworks.
     """
+    module_init = 0
+    module_sema = threading.Semaphore()
+
+    @classmethod
+    def initializeTestModule_SingleInstance(cls):
+        with cls.module_sema:
+            if cls.module_init != 1:
+                # Put your single instance Init Code Here
+                cls.module_init = 1
 
     def __init__(self, methodName):
         # NOTE: __init__ is called at startup for all tests before any

--- a/tests/testsuite_default_Checkpoint.py
+++ b/tests/testsuite_default_Checkpoint.py
@@ -17,29 +17,12 @@ import filecmp
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_Checkpoint(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_Checkpoint.py
+++ b/tests/testsuite_default_Checkpoint.py
@@ -22,7 +22,6 @@ class testcase_Checkpoint(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_Component.py
+++ b/tests/testsuite_default_Component.py
@@ -14,29 +14,12 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_Component(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_Component.py
+++ b/tests/testsuite_default_Component.py
@@ -19,7 +19,6 @@ class testcase_Component(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_Links.py
+++ b/tests/testsuite_default_Links.py
@@ -14,29 +14,12 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_Links(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_Links.py
+++ b/tests/testsuite_default_Links.py
@@ -19,7 +19,6 @@ class testcase_Links(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_MemPoolTest.py
+++ b/tests/testsuite_default_MemPoolTest.py
@@ -17,29 +17,12 @@ import filecmp
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_StatisticComponent(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_MemPoolTest.py
+++ b/tests/testsuite_default_MemPoolTest.py
@@ -22,7 +22,6 @@ class testcase_StatisticComponent(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_Module.py
+++ b/tests/testsuite_default_Module.py
@@ -22,7 +22,6 @@ class testcase_Module(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_Module.py
+++ b/tests/testsuite_default_Module.py
@@ -17,29 +17,12 @@ import filecmp
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_Module(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_Output.py
+++ b/tests/testsuite_default_Output.py
@@ -22,7 +22,6 @@ class testcase_Output(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_Output.py
+++ b/tests/testsuite_default_Output.py
@@ -17,29 +17,12 @@ import filecmp
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_Output(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_ParamComponent.py
+++ b/tests/testsuite_default_ParamComponent.py
@@ -19,7 +19,6 @@ class testcase_ParamComponent(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_ParamComponent.py
+++ b/tests/testsuite_default_ParamComponent.py
@@ -14,29 +14,12 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_ParamComponent(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_PerfComponent.py
+++ b/tests/testsuite_default_PerfComponent.py
@@ -15,29 +15,12 @@ import os
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_PerfComponent(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_PerfComponent.py
+++ b/tests/testsuite_default_PerfComponent.py
@@ -20,7 +20,6 @@ class testcase_PerfComponent(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_RNGComponent.py
+++ b/tests/testsuite_default_RNGComponent.py
@@ -22,7 +22,6 @@ class testcase_RNGComponent(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_RNGComponent.py
+++ b/tests/testsuite_default_RNGComponent.py
@@ -17,29 +17,12 @@ import filecmp
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_RNGComponent(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_RealTime.py
+++ b/tests/testsuite_default_RealTime.py
@@ -36,7 +36,6 @@ class testcase_Signals(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_RealTime.py
+++ b/tests/testsuite_default_RealTime.py
@@ -18,6 +18,7 @@ import signal
 from sst_unittest import *
 from sst_unittest_support import *
 
+
 ################################################################################
 # These tests test the RealTime features of SST including:
 # - SIGUSR1 / SIGUSR2
@@ -27,6 +28,20 @@ from sst_unittest_support import *
 ################################################################################
 
 class testcase_Signals(SSTTestCase):
+
+    def initializeClass(self, testName):
+        super(type(self), self).initializeClass(testName)
+        # Put test based setup code here. it is called before testing starts
+        # NOTE: This method is called once for every test
+
+    def setUp(self):
+        super(type(self), self).setUp()
+        type(self).initializeTestModule_SingleInstance()
+        # Put test based setup code here. it is called once before every test
+
+    def tearDown(self):
+        # Put test based teardown code here. it is called once after every test
+        super(type(self), self).tearDown()
 
 #####
     def test_RealTime_SIGUSR1(self):

--- a/tests/testsuite_default_Serialization.py
+++ b/tests/testsuite_default_Serialization.py
@@ -22,7 +22,6 @@ class testcase_Serialization(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_Serialization.py
+++ b/tests/testsuite_default_Serialization.py
@@ -17,29 +17,12 @@ import filecmp
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_Serialization(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_SharedObject.py
+++ b/tests/testsuite_default_SharedObject.py
@@ -22,7 +22,6 @@ class testcase_SharedObject(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_SharedObject.py
+++ b/tests/testsuite_default_SharedObject.py
@@ -17,29 +17,12 @@ import sys
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_SharedObject(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_StatisticsComponent.py
+++ b/tests/testsuite_default_StatisticsComponent.py
@@ -26,7 +26,6 @@ class testcase_StatisticComponent(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_StatisticsComponent.py
+++ b/tests/testsuite_default_StatisticsComponent.py
@@ -18,31 +18,15 @@ import subprocess
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
 
 have_h5 = sst_core_config_include_file_get_value_int("HAVE_HDF5", default=0, disable_warning=True) == 1
 
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_StatisticComponent(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_SubComponent.py
+++ b/tests/testsuite_default_SubComponent.py
@@ -22,7 +22,6 @@ class testcase_SubComponent(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_SubComponent.py
+++ b/tests/testsuite_default_SubComponent.py
@@ -17,29 +17,12 @@ import sys
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_SubComponent(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_UnitAlgebra.py
+++ b/tests/testsuite_default_UnitAlgebra.py
@@ -19,7 +19,6 @@ class testcase_UnitAlgebra(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_UnitAlgebra.py
+++ b/tests/testsuite_default_UnitAlgebra.py
@@ -14,29 +14,12 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_UnitAlgebra(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_config_input_output.py
+++ b/tests/testsuite_default_config_input_output.py
@@ -17,31 +17,15 @@ import sys
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
 
 have_mpi = sst_core_config_include_file_get_value_int("SST_CONFIG_HAVE_MPI", default=0, disable_warning=True) == 1
 
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_Config_input_output(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_config_input_output.py
+++ b/tests/testsuite_default_config_input_output.py
@@ -25,7 +25,6 @@ class testcase_Config_input_output(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_partitioner.py
+++ b/tests/testsuite_default_partitioner.py
@@ -17,29 +17,12 @@ import sys
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_Partitioners(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_partitioner.py
+++ b/tests/testsuite_default_partitioner.py
@@ -22,7 +22,6 @@ class testcase_Partitioners(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_sstinfo.py
+++ b/tests/testsuite_default_sstinfo.py
@@ -14,31 +14,15 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
 
 have_curses = sst_core_config_include_file_get_value_int("HAVE_CURSES", default=0, disable_warning=True) == 1
 
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_sstinfo(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_default_sstinfo.py
+++ b/tests/testsuite_default_sstinfo.py
@@ -22,7 +22,6 @@ class testcase_sstinfo(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_testengine_testing.py
+++ b/tests/testsuite_testengine_testing.py
@@ -23,7 +23,6 @@ class testcase_testengine_testing_frameworks_operation(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/tests/testsuite_testengine_testing.py
+++ b/tests/testsuite_testengine_testing.py
@@ -14,23 +14,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 ####################################################################
 # These tests verify general operation of the SST Testing Frameworks
@@ -40,7 +23,7 @@ class testcase_testengine_testing_frameworks_operation(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        type(self).initializeTestModule_SingleInstance()
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):


### PR DESCRIPTION
The implementation of `initializeTestModule_SingleInstance()` is essentially the same across all of the `SSTTestCase` subclasses.  There's no need to re-implement them in each class.  We can cut ~15 lines from each of the 19 `testsuite_default_*.py` files.
