### PR TITLE
Realtime bug fix and other fixes

### DIFF
--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -588,7 +588,8 @@ public:
         catch ( UnitAlgebra::InvalidUnitType& e ) {
             fprintf(
                 stderr,
-                "Error parsing option: Argument passed to --checkpoint-sim-period has invalid units. Units must be time (s "
+                "Error parsing option: Argument passed to --checkpoint-sim-period has invalid units. Units must be "
+                "time (s "
                 "or Hz, SI prefix OK). Argument = [%s]\n",
                 arg.c_str());
             return -1;

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -588,7 +588,7 @@ public:
         catch ( UnitAlgebra::InvalidUnitType& e ) {
             fprintf(
                 stderr,
-                "Error parsing option: Argument passed to --checkpoint-period has invalid units. Units must be time (s "
+                "Error parsing option: Argument passed to --checkpoint-sim-period has invalid units. Units must be time (s "
                 "or Hz, SI prefix OK). Argument = [%s]\n",
                 arg.c_str());
             return -1;
@@ -977,6 +977,12 @@ Config::insertOptions()
         "the following formats supported: H:M:S, M:S, S, Hh, Mm, Ss (capital letters are the appropriate numbers for "
         "that value, lower case letters represent the units and are required for those formats.).",
         std::bind(&ConfigHelper::setCheckpointWallPeriod, this, _1), true);
+    DEF_ARG(
+        "checkpoint-period", 0, "PERIOD",
+        "Set approximate frequency for checkpoints to be generated in terms of simulated time. PERIOD must include "
+        "time units (s or Hz) and SI prefixes are accepted. This flag will eventually be removed in favor of "
+        "--checkpoint-sim-period",
+        std::bind(&ConfigHelper::setCheckpointSimPeriod, this, _1), true);
     DEF_ARG(
         "checkpoint-sim-period", 0, "PERIOD",
         "Set approximate frequency for checkpoints to be generated in terms of simulated time. PERIOD must include "

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -697,6 +697,8 @@ main(int argc, char* argv[])
         size_t size;
         char*  buffer;
 
+        if ( cfg.checkConfigFile() == false ) { return -1; /* checkConfigFile provides error message */ }
+
         SST::Core::Serialization::serializer ser;
         ser.enable_pointer_tracking();
         std::ifstream fs(cfg.configFile(), std::ios::binary);
@@ -768,14 +770,14 @@ main(int argc, char* argv[])
         Params::nextKeyID     = cpt_params_next_key_id;
     }
 
-    // Check to see if the config file exists
-    cfg.checkConfigFile();
-
     // If we are doing a parallel load with a file per rank, add the
     // rank number to the file name before the extension
     if ( cfg.parallel_load() && cfg.parallel_load_mode_multi() && world_size.rank != 1 ) {
         addRankToFileName(cfg.configFile_, myRank.rank);
     }
+
+    // Check to see if the config file exists
+    if ( cfg.checkConfigFile() == false ) { return -1; /* checkConfigFile provides error message */ }
 
     // Create the factory.  This may be needed to load an external model definition
     Factory* factory = new Factory(cfg.getLibPath());

--- a/src/sst/core/output.h
+++ b/src/sst/core/output.h
@@ -579,7 +579,7 @@ private:
  stable API (i.e. the class can change at any time).
 
  NOTE: Output for TraceFunction will only be turned on if the
- SST_TRACEFUNCTION_ACTIVIATE envirnoment variable is set.
+ SST_TRACEFUNCTION_ACTIVATE envirnoment variable is set.
 
  You can also control whether or not an "indent marker" will be used
  by setting SST_TRACEFUNCTION_INDENT_MARKER. If the environment

--- a/src/sst/core/realtime.cc
+++ b/src/sst/core/realtime.cc
@@ -463,7 +463,7 @@ AlrmSignalAction::begin(time_t UNUSED(scheduled_time))
     if ( rank_leader_ ) {
 #ifdef SST_CONFIG_HAVE_MPI
         // Broadcast elapsed time
-        MPI_Bcast(&last_time_, 1, MPI_UINT32_T, 0, MPI_COMM_WORLD);
+        MPI_Bcast(&last_time_, sizeof(last_time_), MPI_BYTE, 0, MPI_COMM_WORLD);
 #endif
     }
     if ( num_ranks.thread > 1 ) {
@@ -513,7 +513,6 @@ AlrmSignalAction::execute()
 }
 
 uint32_t                  AlrmSignalAction::elapsed_   = 0;
-time_t                    AlrmSignalAction::last_time_ = 0;
 Core::ThreadSafe::Barrier AlrmSignalAction::exchange_barrier_;
 
 

--- a/src/sst/core/realtime.cc
+++ b/src/sst/core/realtime.cc
@@ -512,7 +512,7 @@ AlrmSignalAction::execute()
     if ( alarm_manager_ && next_alarm_time != 0 ) { alarm(next_alarm_time); }
 }
 
-uint32_t                  AlrmSignalAction::elapsed_   = 0;
+uint32_t                  AlrmSignalAction::elapsed_ = 0;
 Core::ThreadSafe::Barrier AlrmSignalAction::exchange_barrier_;
 
 

--- a/src/sst/core/realtime.h
+++ b/src/sst/core/realtime.h
@@ -140,7 +140,7 @@ private:
     std::vector<RealTimeIntervalAction> interval_actions_;
     bool                                alarm_manager_; /* The instance on thread 0/rank 0 is the manager */
     bool            rank_leader_; /* The instance on thread 0 of each rank participates in MPI exchanges */
-    static time_t   last_time_;   /* Last time a SIGALRM was received */
+    time_t          last_time_;   /* Last time a SIGALRM was received */
     static uint32_t elapsed_;     /* A static so that each threads' instance of this class share the same one */
     static Core::ThreadSafe::Barrier exchange_barrier_;
 };

--- a/src/sst/core/testingframework/sst_unittest.py
+++ b/src/sst/core/testingframework/sst_unittest.py
@@ -246,10 +246,10 @@ class SSTTestCase(unittest.TestCase):
                 sdl_file (str): The FilePath to the test SDL (python) file.
                 out_file (str): The FilePath to the finalized output file.
                 err_file (str): The FilePath to the finalized error file.
-                                Default = same directory as the output file.
+                                Default = same file as the output file.
                 mpi_out_files (str): The FilePath to the mpi run output files.
-                                     These will be merged into the out_file at
-                                     the end of a multi-rank run.
+                                     These will be merged into the out_file 
+                                     at the end of a multi-rank run.
                 other_args (str): Any other arguments used in the SST cmd
                                    that the caller wishes to use.
                 num_ranks (int): The number of ranks to run SST with.
@@ -336,10 +336,10 @@ class SSTTestCase(unittest.TestCase):
 
             numa_param = "-map-by numa:PE={0}".format(num_threads)
 
-            oscmd = "mpirun -np {0} {1} -output-filename {2} {3}".format(num_ranks,
-                                                                         numa_param,
-                                                                         mpiout_filename,
-                                                                         oscmd)
+            oscmd = "mpirun -np {0} {1} --output-filename {2} {3}".format(num_ranks,
+                                                                          numa_param,
+                                                                          mpiout_filename,
+                                                                          oscmd)
 
         # Identify the working directory that we are launching SST from
         final_wd = os.getcwd()
@@ -360,7 +360,8 @@ class SSTTestCase(unittest.TestCase):
                         error_file_path = err_file,
                         set_cwd = set_cwd).run(timeout_sec=timeout_sec, send_signal=send_signal, signal_sec=signal_sec)
         if num_ranks > 1:
-            testing_merge_mpi_files("{0}*".format(mpiout_filename), mpiout_filename, out_file)
+            testing_merge_mpi_files("{0}*".format(mpiout_filename), mpiout_filename, out_file, errorfilepath=err_file)
+
 
         # Look for runtime error conditions
         err_str = "SST Timed-Out ({0} secs) while running {1}".format(timeout_sec, oscmd)

--- a/tests/testsuite_default_Checkpoint.py
+++ b/tests/testsuite_default_Checkpoint.py
@@ -163,7 +163,7 @@ class testcase_Checkpoint(SSTTestCase):
             sdlfile_generate = "{0}/subcomponent_tests/test_{1}.py".format(testsuitedir, testtype)
         else:
             sdlfile_generate = "{0}/test_{1}.py".format(testsuitedir,testtype)
-        outfile_generate = "{0}/test_Checkpoint_{1}_generate.out".format(outdir, outstr)
+        outfile_generate = "{0}/test_Checkpoint_{1}_generate.out".format(outdir,teststr)
         options_checkpoint="--checkpoint-sim-period={0} --checkpoint-prefix={1} --model-options='{2}'".format(cptfreq,teststr,modelparams)
         self.run_sst(sdlfile_generate, outfile_generate, other_args=options_checkpoint)
 

--- a/tests/testsuite_default_RealTime.py
+++ b/tests/testsuite_default_RealTime.py
@@ -19,22 +19,6 @@ from sst_unittest import *
 from sst_unittest_support import *
 
 ################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 # These tests test the RealTime features of SST including:
 # - SIGUSR1 / SIGUSR2
 # - SIGINT / SIGTERM
@@ -43,15 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 ################################################################################
 
 class testcase_Signals(SSTTestCase):
-
-    def setUp(self):
-        super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
-        # Put test based setup code here. it is called once before every test
-
-    def tearDown(self):
-        # Put test based teardown code here. it is called once after every test
-        super(type(self), self).tearDown()
 
 #####
     def test_RealTime_SIGUSR1(self):
@@ -80,7 +55,7 @@ class testcase_Signals(SSTTestCase):
         num_lines = 101 + (threads * ranks) * 3
         self.assertTrue(sig_found, "Output file is missing SIGUSR1 triggered output message")
         self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(num_para,exit_count,outfile))
-        self.assertTrue(line_count == num_lines, "Line count incorrect, should be {0}, found {1} in {2}".format(num_lines,line_count,outfile))
+        self.assertTrue(line_count >= num_lines, "Line count incorrect, should be at least {0}, found {1} in {2}".format(num_lines,line_count,outfile))
 
     
     def test_RealTime_SIGUSR2(self):
@@ -108,7 +83,7 @@ class testcase_Signals(SSTTestCase):
         num_para = threads * ranks
         num_lines = 101 + (threads * ranks) * 5
         self.assertTrue(sig_found, "Output file is missing SIGUSR2 triggered output message")
-        self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(exit_count,num_para,outfile))
+        self.assertTrue(exit_count >= num_para, "Exit message count incorrect, should be at least {0}, found {1} in {2}".format(exit_count,num_para,outfile))
         self.assertTrue(line_count == num_lines, "Line count incorrect, should be {0}, found {1} in {2}".format(num_lines,line_count,outfile))
     
     #@unittest.skipIf(testing_check_get_num_ranks() > 1, "This test does not run with MPI")

--- a/tests/testsuite_default_RealTime.py
+++ b/tests/testsuite_default_RealTime.py
@@ -54,7 +54,6 @@ class testcase_Signals(SSTTestCase):
         super(type(self), self).tearDown()
 
 #####
-    @unittest.skipIf(testing_check_get_num_ranks() > 1, "This test does not run with MPI")
     def test_RealTime_SIGUSR1(self):
         testsuitedir = self.get_testsuite_dir()
         outdir = test_output_get_run_dir()
@@ -80,11 +79,10 @@ class testcase_Signals(SSTTestCase):
         num_para = threads * ranks
         num_lines = 101 + (threads * ranks) * 3
         self.assertTrue(sig_found, "Output file is missing SIGUSR1 triggered output message")
-        self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(exit_count,num_para,outfile))
+        self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(num_para,exit_count,outfile))
         self.assertTrue(line_count == num_lines, "Line count incorrect, should be {0}, found {1} in {2}".format(num_lines,line_count,outfile))
 
     
-    @unittest.skipIf(testing_check_get_num_ranks() > 1, "This test does not run with MPI")
     def test_RealTime_SIGUSR2(self):
         testsuitedir = self.get_testsuite_dir()
         outdir = test_output_get_run_dir()
@@ -113,6 +111,7 @@ class testcase_Signals(SSTTestCase):
         self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(exit_count,num_para,outfile))
         self.assertTrue(line_count == num_lines, "Line count incorrect, should be {0}, found {1} in {2}".format(num_lines,line_count,outfile))
     
+    #@unittest.skipIf(testing_check_get_num_ranks() > 1, "This test does not run with MPI")
     def test_RealTime_SIGINT(self):
         testsuitedir = self.get_testsuite_dir()
         outdir = test_output_get_run_dir()
@@ -138,9 +137,10 @@ class testcase_Signals(SSTTestCase):
         num_para = threads * ranks
         num_lines = 101 + (threads * ranks) * 3
         self.assertTrue(sig_found, "Output file is missing SIGINT triggered output message")
-        self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(exit_count,num_para,outfile))
+        self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(num_para,exit_count,outfile))
         self.assertTrue(line_count == num_lines, "Line count incorrect, should be {0}, found {1} in {2}".format(num_lines,line_count,outfile))        
 
+    #@unittest.skipIf(testing_check_get_num_ranks() > 1, "This test does not run with MPI")
     def test_RealTime_SIGTERM(self):
         testsuitedir = self.get_testsuite_dir()
         outdir = test_output_get_run_dir()
@@ -166,7 +166,7 @@ class testcase_Signals(SSTTestCase):
         num_para = threads * ranks
         num_lines = 101 + (threads * ranks) * 3
         self.assertTrue(sig_found, "Output file is missing SIGTERM triggered output message")
-        self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(exit_count,num_para,outfile))
+        self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(num_para,exit_count,outfile))
         self.assertTrue(line_count == num_lines, "Line count incorrect, should be {0}, found {1} in {2}".format(num_lines,line_count,outfile))  
     
     def test_RealTime_SIGALRM(self):
@@ -200,5 +200,5 @@ class testcase_Signals(SSTTestCase):
         if ranks > 1:
             num_lines += 12 # Extra heartbeat output for MPI
         self.assertTrue(hb_count == 6, "Heartbeat count incorrect, should be 6, found {0} in {1}".format(hb_count,outfile))
-        self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(exit_count,num_para,outfile))
+        self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(num_para,exit_count,outfile))
         self.assertTrue(line_count == num_lines, "Line count incorrect, should be {0}, found {1} in {2}".format(num_lines,line_count,outfile))

--- a/tests/testsuite_default_RealTime.py
+++ b/tests/testsuite_default_RealTime.py
@@ -86,7 +86,7 @@ class testcase_Signals(SSTTestCase):
         self.assertTrue(exit_count >= num_para, "Exit message count incorrect, should be at least {0}, found {1} in {2}".format(exit_count,num_para,outfile))
         self.assertTrue(line_count == num_lines, "Line count incorrect, should be {0}, found {1} in {2}".format(num_lines,line_count,outfile))
     
-    #@unittest.skipIf(testing_check_get_num_ranks() > 1, "This test does not run with MPI")
+    @unittest.skipIf(testing_check_get_num_ranks() > 1, "This test does not run reliably with mpirun")
     def test_RealTime_SIGINT(self):
         testsuitedir = self.get_testsuite_dir()
         outdir = test_output_get_run_dir()
@@ -115,7 +115,7 @@ class testcase_Signals(SSTTestCase):
         self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(num_para,exit_count,outfile))
         self.assertTrue(line_count == num_lines, "Line count incorrect, should be {0}, found {1} in {2}".format(num_lines,line_count,outfile))        
 
-    #@unittest.skipIf(testing_check_get_num_ranks() > 1, "This test does not run with MPI")
+    @unittest.skipIf(testing_check_get_num_ranks() > 1, "This test does not run reliably with mpirun")
     def test_RealTime_SIGTERM(self):
         testsuitedir = self.get_testsuite_dir()
         outdir = test_output_get_run_dir()


### PR DESCRIPTION
Fix bug in real time interval tracking
Fix so sdl file is checked after its name is changed in parallel load
Change MPI test utility to include stderr output as they do in serial tests
Exit simulation if the check for the SDL file fails
Add --checkpoint-period back in