### PR TITLE
Update tar extraction command for Python 3.12 and newer

### DIFF
--- a/src/sst/core/testingframework/sst_unittest_support.py
+++ b/src/sst/core/testingframework/sst_unittest_support.py
@@ -1670,7 +1670,7 @@ def os_extract_tar(tarfilepath, targetdir="."):
             targetdir (str): Where to extract to [.]
 
         Returns:
-            (bool) True if wget is successful.
+            (bool) True if untar is successful.
     """
     if not os.path.isfile(tarfilepath):
         errmsg = "tar file{0} does not exist".format(tarfilepath)
@@ -1678,7 +1678,10 @@ def os_extract_tar(tarfilepath, targetdir="."):
         return False
     try:
         this_tar = tarfile.open(tarfilepath)
-        this_tar.extractall(targetdir)
+        if sys.version_info.minor >= 12:
+            this_tar.extractall(targetdir, filter="data")
+        else:
+            this_tar.extractall(targetdir)
         this_tar.close()
         return True
     except tarfile.TarError as exc_e:


### PR DESCRIPTION
See https://docs.python.org/3/library/tarfile.html#tarfile-extraction-filter for more information.

This silences the warning:
```
/usr/lib/python3.12/tarfile.py:2221: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
```