### PR TITLE
Update and pin version of clang-format-lint-action

### DIFF
--- a/.github/workflows/PR_clang-format_test.yml
+++ b/.github/workflows/PR_clang-format_test.yml
@@ -67,7 +67,7 @@ jobs:
 
 #   Running the github action for clang format
     - name: Run Action clang-format-lint
-      uses: DoozyX/clang-format-lint-action@v0.12
+      uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 # v0.18.2
       with:
         source: './sst-core_source/'
         exclude: './sst-core_source/src/sst/core/libltdl ./sst-core_source/external ./sst-core_source/build'


### PR DESCRIPTION
This fixes the error in the `clang-format` part of CI:
```
Traceback (most recent call last):
  File "/run-clang-format.py", line 25, in <module>
    from distutils.util import strtobool
ModuleNotFoundError: No module named 'distutils'
```
See https://github.com/kokkos/kokkos/pull/7295 for another example.

This is not the version of `clang-format` used, which is specified by `clangFormatVersion: 12` (see line 75).

All PRs on core will fail until this is merged.

Redo of https://github.com/sstsimulator/sst-core/pull/1126