### PR TITLE
Python 3.11: Update datetime command for current UTC time

### DIFF
--- a/src/sst/core/testingframework/test_engine_unittest.py
+++ b/src/sst/core/testingframework/test_engine_unittest.py
@@ -20,7 +20,14 @@ import unittest
 import traceback
 import threading
 import time
-from datetime import datetime
+import datetime
+
+if sys.version_info.minor >= 11:
+    def get_current_time():
+        return datetime.datetime.now(datetime.UTC)
+else:
+    def get_current_time():
+        return datetime.datetime.utcnow()
 
 ################################################################################
 
@@ -324,7 +331,7 @@ class SSTTextTestResult(unittest.TestResult):
         else:
             self._testcase_name = "FailedTest"
             self._testsuite_name = "FailedTest"
-        timestamp = datetime.utcnow().strftime("%Y_%m%d_%H:%M:%S.%f utc")
+        timestamp = get_current_time().strftime("%Y_%m%d_%H:%M:%S.%f utc")
         self._junit_test_case = JUnitTestCase(self._test_name,
                                               self._testcase_name,
                                               timestamp=timestamp)


### PR DESCRIPTION
This fixes warnings like:
```
sst-core/bin/../libexec/test_engine_unittest.py:327: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```
The version conditional is because https://docs.python.org/3/library/datetime.html#datetime.UTC wasn't added until Python 3.11.