### PR TITLE
Remove calls to deprecated functions

### DIFF
--- a/src/sst/core/testingframework/sst_unittest.py
+++ b/src/sst/core/testingframework/sst_unittest.py
@@ -304,7 +304,7 @@ class SSTTestCase(unittest.TestCase):
             mpiout_filename = mpi_out_files
 
         # Get the path to sst binary application
-        sst_app_path = sstsimulator_conf_get_value_str('SSTCore', 'bindir', default="UNDEFINED")
+        sst_app_path = sstsimulator_conf_get_value('SSTCore', 'bindir', str, default="UNDEFINED")
         err_str = "Path to SST {0}; does not exist...".format(sst_app_path)
         self.assertTrue(os.path.isdir(sst_app_path), err_str)
 
@@ -323,7 +323,7 @@ class SSTTestCase(unittest.TestCase):
                                                  sdl_file)
 
         # Update the os launch command if we are running multi-rank
-        num_cores = host_os_get_num_cores_on_system()
+        num_cores = multiprocessing.cpu_count()
 
         # Perform any multi-rank checks/setup
         mpi_avail = False

--- a/src/sst/core/testingframework/sst_unittest_support.py
+++ b/src/sst/core/testingframework/sst_unittest_support.py
@@ -402,7 +402,7 @@ def skip_on_sstsimulator_conf_empty_str(section, key, reason):
     check_param_type("section", section, str)
     check_param_type("key", key, str)
     check_param_type("reason", reason, str)
-    rtn_str = sstsimulator_conf_get_value_str(section, key, "")
+    rtn_str = sstsimulator_conf_get_value(section, key, str, "")
     if rtn_str != "":
         return lambda func: func
     return unittest.skip(reason)

--- a/src/sst/core/testingframework/test_engine.py
+++ b/src/sst/core/testingframework/test_engine.py
@@ -368,7 +368,7 @@ class TestEngine():
         sstcoreversion = rtn.output()
         sstcoreversion = sstcoreversion.replace("SST-Core Version ", "").rstrip()
 
-        num_cores = host_os_get_num_cores_on_system()
+        num_cores = multiprocessing.cpu_count()
 
         if test_engine_globals.TESTENGINE_CONCURRENTMODE:
             concurrent_txt = "[CONCURRENTLY ({0} Testing Threads)]".\
@@ -394,7 +394,7 @@ class TestEngine():
         # Check to see if we are using up all the cores on the system
         # in concurrent mode, warn user of possible failures
         if test_engine_globals.TESTENGINE_CONCURRENTMODE:
-            num_cores_avail = host_os_get_num_cores_on_system()
+            num_cores_avail = multiprocessing.cpu_count()
             threads_used = test_engine_globals.TESTENGINE_THREADLIMIT
             ranks_used = test_engine_globals.TESTENGINE_SSTRUN_NUMRANKS
             cores_used = threads_used * ranks_used
@@ -598,8 +598,9 @@ class TestEngine():
                 A dict object of defines from the sst_element_config.h file.
         """
         # ID the path to the sst element configuration file
-        build_root = sstsimulator_conf_get_value_str("SST_ELEMENT_LIBRARY",
+        build_root = sstsimulator_conf_get_value("SST_ELEMENT_LIBRARY",
                                                     "SST_ELEMENT_LIBRARY_BUILDDIR",
+                                                    str,
                                                     "undefined")
         # If the element root is not found, then elements have not yet been registerd
         if build_root == "undefined":


### PR DESCRIPTION
* sstsimulator_conf_get_value_str()
* host_os_get_num_cores_on_system()

Closes https://github.com/jmlapre/sst-core/issues/23
