### PR TITLE
Bug fixes for parallel checkpointing.

### DIFF
--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -1616,7 +1616,6 @@ Simulation_impl::checkpoint(const std::string& checkpoint_filename)
     // Actions that may also be in TV
     ser& real_time_;
     if ( my_rank.thread == 0 ) { ser& m_exit; }
-    initBarrier.wait();
     ser& m_heartbeat;
 
     // Add shared StatisticOutput vector
@@ -1751,6 +1750,7 @@ Simulation_impl::restart(Config* cfg)
     // Actions that may also be in TV
     ser& real_time_;
     if ( my_rank.thread == 0 ) { ser& m_exit; }
+    initBarrier.wait();
 
     // Create new checkpoint object.  Needs to be done before SyncManager is reinitialized
     if ( cfg->checkpoint_sim_period() != "" ) {

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -495,7 +495,10 @@ SyncManager::finalizeLinkConfigurations()
     // Need to figure out what sync comes first and insert object into
     // TimeVortex
     if ( num_ranks_.rank == 1 && num_ranks_.thread == 1 ) return;
-    computeNextInsert();
+    if ( checkpoint_ )
+        computeNextInsert(checkpoint_->getNextCheckpointSimTime());
+    else
+        computeNextInsert();
 }
 
 /** Prepare for complete() phase */

--- a/src/sst/core/testElements/coreTest_Component.h
+++ b/src/sst/core/testElements/coreTest_Component.h
@@ -116,8 +116,8 @@ public:
     coreTestComponent(SST::ComponentId_t id, SST::Params& params);
     ~coreTestComponent();
 
-    void setup() {}
-    void finish() { printf("Component Finished.\n"); }
+    void setup() override {}
+    void finish() override { printf("Component Finished.\n"); }
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::CoreTestComponent::coreTestComponent)


### PR DESCRIPTION
- Fixes #1156 - Initial Sync interval needed to take Checkpoint time into account.
- Fixes #1157 - Moved barrier for Exit restart to the proper place.
