### PR TITLE
Python: update logic between discover_and_run_tests and startup_and_run

### DIFF
--- a/src/sst/core/model/xmlToPython.py
+++ b/src/sst/core/model/xmlToPython.py
@@ -45,11 +45,11 @@ sstVarRE = re.compile("\\$([^{][a-zA-Z0-9_]+)", re.DOTALL)
 
 def processString(string: str) -> str:
     """Process a string, replacing variables and env. vars with their values"""
-    def replaceSSTVar(matchobj: re.Match) -> str:
+    def replaceSSTVar(matchobj: re.Match[str]) -> str:
         varname = matchobj.group(1)
         return sstVars[varname]
 
-    def replaceEnvVar(matchobj: re.Match) -> str:
+    def replaceEnvVar(matchobj: re.Match[str]) -> str:
         varname = matchobj.group(1)
         var = os.getenv(varname)
         assert var is not None

--- a/src/sst/core/testingframework/sst_test_engine_loader.py
+++ b/src/sst/core/testingframework/sst_test_engine_loader.py
@@ -72,7 +72,7 @@ def startup_and_run(sst_core_bin_dir: str, test_mode: int) -> None:
             sys.exit(1)
 
         t_e = test_engine.TestEngine(sst_core_bin_dir, test_mode)
-        t_e.discover_and_run_tests()
+        sys.exit(t_e.discover_and_run_tests())
 
     except Exception as exc_e:
         # NOTE: This is a generic catchall handler for any unhandled exception
@@ -80,7 +80,7 @@ def startup_and_run(sst_core_bin_dir: str, test_mode: int) -> None:
 
 ###############
 
-def _generic_exception_handler(exc_e):
+def _generic_exception_handler(exc_e: Exception) -> None:
 
     # Dump Exception info to the a log file
     log_filename = "./sst_test_frameworks_crashreport.log"
@@ -91,7 +91,7 @@ def _generic_exception_handler(exc_e):
         log_handler = RotatingFileHandler(log_filename, mode='a',
                                           maxBytes=10*1024*1024,
                                           backupCount=10,
-                                          encoding=None, delay=0)
+                                          encoding=None, delay=False)
         log_handler.setFormatter(log_formatter)
         crashlogger.addHandler(log_handler)
         crashlogger.setLevel(logging.DEBUG)

--- a/src/sst/core/testingframework/sst_unittest_parameterized.py
+++ b/src/sst/core/testingframework/sst_unittest_parameterized.py
@@ -1,3 +1,4 @@
+# type: ignore
 # -*- coding: utf-8 -*-
 ##
 ##Unless stated otherwise in the source files, all code is copyright 2010 David

--- a/src/sst/core/testingframework/test_engine.py
+++ b/src/sst/core/testingframework/test_engine.py
@@ -139,7 +139,7 @@ class TestEngine:
 
 ####
 
-    def discover_and_run_tests(self):
+    def discover_and_run_tests(self) -> int:
         """ Create the output directories, then discover the tests, and then
             run them using pythons unittest module
 
@@ -183,17 +183,17 @@ class TestEngine:
             sst_tests_results = test_runner.run(self._sst_full_test_suite)
 
             if not test_runner.did_tests_pass(sst_tests_results):
-                exit(1)
-            exit(0)
+                return 1
+            return 0
 
         # Handlers of unittest.TestRunner exceptions
         except KeyboardInterrupt:
             log_fatal("TESTING TERMINATED DUE TO KEYBOARD INTERRUPT...")
-        exit(2)
+        return 2
 
 ####
 
-    def _build_tests_list_helper(self, suite):
+    def _build_tests_list_helper(self, suite: SSTTestSuite) -> List[Any]:
         """
             A helper function to split the tests for the ConcurrentTestSuite into
             some number of concurrently executing sub-suites. _build_tests_list_helper


### PR DESCRIPTION
The docstring of `testingframework/test_engine.py/discover_and_run_tests()` states that it returns the status code to be used for exiting, and presumably `testingframework/sst_test_engine_loader.py/startup_and_run()` would use this when calling `sys.exit(...)`.  This was not the case, so it fixes that.

This should be safe since we don't consider these files to be part of the public testing API.

The other changes are small fixes for type annotations.