### PR TITLE
Enforce Python type annotations in continuous integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,17 @@ repos:
     rev: "v0.9.4"
     hooks:
       - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v1.14.1"
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - blessings
+          - testtools
+          - types-Pygments
+        # Work around config file setting exclusion rules being bypassed when
+        # filenames are explicitly passed on the command line.  See
+        # https://github.com/python/mypy/pull/12373#issuecomment-1071662559
+        # for the idea.
+        args: [.]
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-hooks-apply
       - id: check-useless-excludes
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.6.0"
+    rev: "v5.0.0"
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
@@ -32,7 +32,7 @@ repos:
               external/
           )
   - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
-    rev: "v1.7.1.15"
+    rev: "v1.7.7.23"
     hooks:
       - id: actionlint
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,7 @@ repos:
     rev: "v1.7.1.15"
     hooks:
       - id: actionlint
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.9.4"
+    hooks:
+      - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,9 @@ repos:
     hooks:
       - id: ruff
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.14.1"
+    # This needs to match the last version that still supports the minimum
+    # required Python version
+    rev: "v1.5.1"
     hooks:
       - id: mypy
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,39 @@ module = [
     "testtools.testsuite",
 ]
 ignore_missing_imports = true
+
+[tool.ruff]
+cache-dir = "build/.ruff_cache"
+line-length = 100
+# This should be 3.6 but is not supported with the newest versions of ruff.
+target-version = "py37"
+
+[tool.ruff.lint]
+ignore = [
+    "E401",
+    "E402",
+    "E701",
+    "E703",
+    "E713",
+    "E722",
+    "E731",
+    "F401",
+    "F403",
+    "F405",
+    "F523",
+    "F841",
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["sst"]
+lines-after-imports = 2
+section-order = [
+    "future",
+    "standard-library",
+    "first-party",
+    "third-party",
+    "local-folder",
+]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,10 @@
 cache_dir = "build/.mypy_cache"
 explicit_package_bases = true
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src/sst/core/testingframework"
-# This should be 3.6 but is not supported with the newest versions of mypy.
-python_version = "3.8"
+python_version = "3.6"
 
 strict = true
+warn_unused_ignores = true
 
 exclude = [
     '^scripts/',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ module = [
 ]
 ignore_missing_imports = true
 
+[tool.pyright]
+pythonVersion = "3.6"
+
 [tool.ruff]
 cache-dir = "build/.ruff_cache"
 line-length = 100

--- a/src/sst/core/testingframework/sst_unittest_support.py
+++ b/src/sst/core/testingframework/sst_unittest_support.py
@@ -1191,7 +1191,7 @@ def testing_stat_output_diff(
 
 ### Built in LineFilters for filtering diffs
 class LineFilter:
-    def __init__(self):
+    def __init__(self) -> None:
         self.apply_to_ref_file = True
         self.apply_to_out_file = True
 
@@ -1883,7 +1883,7 @@ def os_extract_tar(tarfilepath: str, targetdir: str = ".") -> bool:
     try:
         this_tar = tarfile.open(tarfilepath)
         if sys.version_info.minor >= 12:
-            this_tar.extractall(targetdir, filter="data")
+            this_tar.extractall(targetdir, filter="data")  # type: ignore [call-arg]
         else:
             this_tar.extractall(targetdir)
         this_tar.close()

--- a/src/sst/core/testingframework/test_engine_unittest.py
+++ b/src/sst/core/testingframework/test_engine_unittest.py
@@ -25,6 +25,7 @@ from unittest import TestCase, TestResult, TestSuite, TextTestResult, TextTestRu
 
 if TYPE_CHECKING:
     from types import TracebackType
+    from unittest.runner import _WritelnDecorator  # type: ignore [attr-defined]
 
     from sst_unittest import SSTTestCase
     from test_engine import TestEngine
@@ -300,7 +301,7 @@ class SSTTextTestResult(TextTestResult):
         self._testcase_name = "undefined_testcasename"
         self._testsuite_name = "undefined_testsuitename"
         self._junit_test_case: JUnitTestCase = None  # type: ignore [assignment]
-        self.stream = stream
+        self.stream: _WritelnDecorator = stream
         self.showAll = verbosity > 1
         self.dots = verbosity == 1
         self.descriptions = descriptions

--- a/src/sst/core/testingframework/test_engine_unittest.py
+++ b/src/sst/core/testingframework/test_engine_unittest.py
@@ -587,7 +587,14 @@ class SSTTestSuite(TestSuiteBaseClass):  # type: ignore [misc, valid-type]
                          passed to ``run()``.  NOT USED IN TestSuite
 
         """
-        super().__init__(suite, make_tests=make_tests, wrap_result=wrap_result)
+        # This separation is required for the case when `testtools` is not
+        # installed, regardless of whether or not testing is performed
+        # concurrently.
+        if not test_engine_globals.TESTENGINE_CONCURRENTMODE:
+            # Ignore make_tests and wrap_results
+            super().__init__(suite)
+        else:
+            super().__init__(suite, make_tests, wrap_result)
 
 ####
 

--- a/src/sst/core/testingframework/test_engine_unittest.py
+++ b/src/sst/core/testingframework/test_engine_unittest.py
@@ -20,7 +20,7 @@ import traceback
 import threading
 import time
 import datetime
-from typing import Any, Callable, Dict, Iterable, List, Optional, TextIO, Tuple, Type, Union, TYPE_CHECKING
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, Union, TYPE_CHECKING
 from unittest import TestCase, TestResult, TestSuite, TextTestResult, TextTestRunner
 
 if TYPE_CHECKING:
@@ -125,7 +125,7 @@ class SSTTextTestRunner(TextTestRunner):
 
     def __init__(
         self,
-        stream: Optional[TextIO] = sys.stderr,
+        stream: Any = sys.stderr,
         descriptions: bool = True,
         verbosity: int = 1,
         failfast: bool = False,
@@ -149,7 +149,7 @@ class SSTTextTestRunner(TextTestRunner):
 
 ###
 
-    def run(self, test: Union[TestSuite, TestCase]) -> TextTestResult:
+    def run(self, test: Union[TestSuite, TestCase]) -> TestResult:
         """ Run the tests."""
         testing_start_time = time.time()
         runresults = super().run(test)
@@ -300,7 +300,6 @@ class SSTTextTestResult(TextTestResult):
         self._testcase_name = "undefined_testcasename"
         self._testsuite_name = "undefined_testsuitename"
         self._junit_test_case: JUnitTestCase = None  # type: ignore [assignment]
-        assert hasattr(stream, "writeln")
         self.stream = stream
         self.showAll = verbosity > 1
         self.dots = verbosity == 1
@@ -661,7 +660,7 @@ class SSTTestSuite(TestSuiteBaseClass):  # type: ignore [misc, valid-type]
         self,
         test: SSTTestCase,
         process_result: "testtools.testresult.real.ThreadsafeForwardingResult",
-        testqueue: Queue[TestCase],
+        testqueue: "Queue[TestCase]",
     ) -> None:
         """Support running a single test concurrently
 

--- a/tests/test_PortModule.py
+++ b/tests/test_PortModule.py
@@ -13,8 +13,9 @@
 
 import sst
 import argparse
+import sys
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Run PortModule test")
     parser.add_argument('--send', action='store_true', help="Install PortModule on send")
     parser.add_argument('--recv', action='store_true', help="Install PortModule on receive")


### PR DESCRIPTION
This is the last of the PRs that add type annotations to the test framework, this time adding some and fixing others in `test_engine_unittest.py`.

Since the type checker `mypy` now considers the type annotations to be valid and complete, I've enabled that they should be enforced during CI runs.  This only affects changes to the test framework itself, not core or elements tests, so most people are unlikely to encounter problems with it.