### PR TITLE
Require verbose level 1 for checkpoint info output to stdout

### DIFF
--- a/src/sst/core/checkpointAction.cc
+++ b/src/sst/core/checkpointAction.cc
@@ -87,7 +87,8 @@ CheckpointAction::createCheckpoint(Simulation_impl* sim)
 {
     if ( 0 == rank_.rank ) {
         const double now = sst_get_cpu_time();
-        sim->getSimulationOutput().output(
+        sim->getSimulationOutput().verbose(
+            CALL_INFO, 0, 1,
             "# Simulation Checkpoint: Simulated Time %s (Real CPU time since last checkpoint %.5f seconds)\n",
             sim->getElapsedSimTime().toStringBestSI().c_str(), (now - last_cpu_time_));
 

--- a/src/sst/core/realtime.cc
+++ b/src/sst/core/realtime.cc
@@ -263,7 +263,8 @@ CheckpointRealTimeAction::execute()
     Output   sim_output = getSimulationOutput();
     RankInfo rank       = getRank();
 
-    sim_output.output(
+    sim_output.verbose(
+        CALL_INFO, 1, 0,
         "Creating checkpoint at simulated time %s (rank=%u,thread=%u).\n", getElapsedSimTime().toStringBestSI().c_str(),
         rank.rank, rank.thread);
     simulationCheckpoint();

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -229,7 +229,8 @@ Simulation_impl::Simulation_impl(Config* cfg, RankInfo my_rank, RankInfo num_ran
         }
 
         if ( cfg->checkpoint_sim_period() != "" ) {
-            sim_output.output(
+            sim_output.verbose(
+                CALL_INFO, 1, 0,
                 "# Creating simulation checkpoint at simulated time period of %s.\n",
                 cfg->checkpoint_sim_period().c_str());
             checkpoint_action_ =
@@ -1829,7 +1830,8 @@ Simulation_impl::restart(Config* cfg)
 
     // Create new checkpoint object.  Needs to be done before SyncManager is reinitialized
     if ( cfg->checkpoint_sim_period() != "" ) {
-        sim_output.output(
+        sim_output.verbose(
+            CALL_INFO, 1, 0,
             "# Creating simulation checkpoint at simulated time period of %s.\n", cfg->checkpoint_sim_period().c_str());
         checkpoint_action_ =
             new CheckpointAction(cfg, my_rank, this, timeLord.getTimeConverter(cfg->checkpoint_sim_period()));


### PR DESCRIPTION
Currently informational messages for checkpointing are sent unqualified to stdout. During testing we would like to silence output to improve simulation throughput and avoid blowing up log files. Even though the typical use case is to have infrequent checkpoints we are generating them with a high frequency to stress the functionality and performance.
