### PR TITLE
Handle zero-length string in UnitAlgebra::trim()

### DIFF
--- a/src/sst/core/unitAlgebra.cc
+++ b/src/sst/core/unitAlgebra.cc
@@ -321,6 +321,8 @@ Units::toString() const
 string
 UnitAlgebra::trim(const std::string& str)
 {
+    if ( !str.size() ) return str;
+
     // Find whitespace in front
     int front_index = 0;
     while ( isspace(str[front_index]) )


### PR DESCRIPTION
While turning on STL debugging flags, it was noticed that `UnitAlgebra::trim()` sometimes reads past the end of a `0`-length string:

```
$  /home/lkillough/sstcore-14.1.0/bin/sst   /home/lkillough/sst-core/tests/test_UnitAlgebra.py
...
Initialization from numeric arguments:
/usr/include/c++/12/bits/basic_string.h:1209: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::const_reference std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator[](size_type) const [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; const_reference = const char&; size_type = long unsigned int]: Assertion '__pos <= size()' failed.
Aborted (core dumped)
```
After this change:
```
$  /home/lkillough/sstcore-14.1.0/bin/sst   /home/lkillough/sst-core/tests/test_UnitAlgebra.py
...
Initialization from numeric arguments:
From int = 2: 2
From float = 9.443: 9.443

Printing:
1073741823 B = 1.07374e+09 B = 1.074e+09 B = 1.07374 GB = 1.1 GB = 1.073741823 GB

WARNING: No components are assigned to rank: 0.0
Simulation is complete, simulated time: 0 s
```

(Sorry if `clang-format` checks don't pass, but I ran it; every version is slightly different in its handling of formatting options.)
