### PR TITLE
Replace MethodDetect<...> with std::void_t<...>

### DIFF
--- a/src/sst/core/eli/attributeInfo.h
+++ b/src/sst/core/eli/attributeInfo.h
@@ -21,7 +21,7 @@
 namespace SST {
 namespace ELI {
 
-template <class T, class Enable = void>
+template <typename, typename = void>
 struct GetAttributes
 {
     static const std::vector<SST::ElementInfoAttribute>& get()
@@ -31,8 +31,8 @@ struct GetAttributes
     }
 };
 
-template <class T>
-struct GetAttributes<T, typename MethodDetect<decltype(T::ELI_getAttributes())>::type>
+template <typename T>
+struct GetAttributes<T, std::void_t<decltype(T::ELI_getAttributes())>>
 {
     static const std::vector<SST::ElementInfoAttribute>& get() { return T::ELI_getAttributes(); }
 };

--- a/src/sst/core/eli/elibase.h
+++ b/src/sst/core/eli/elibase.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 // Component Category Definitions
@@ -125,12 +126,6 @@ combineEliInfo(std::vector<T>& base, std::vector<T>& add)
 // field
 void combineEliInfo(std::vector<ElementInfoAttribute>& base, std::vector<ElementInfoAttribute>& add);
 
-template <class T>
-struct MethodDetect
-{
-    using type = void;
-};
-
 struct LibraryLoader
 {
     virtual void load() = 0;
@@ -159,14 +154,14 @@ private:
 
 // Template used to get aliases.  Needed because the ELI_getAlias()
 // function may not exist.
-template <class T, class Enable = void>
+template <typename, typename = void>
 struct GetAlias
 {
     static std::string get() { return ""; }
 };
 
-template <class T>
-struct GetAlias<T, typename MethodDetect<decltype(T::ELI_getAlias())>::type>
+template <typename T>
+struct GetAlias<T, std::void_t<decltype(T::ELI_getAlias())>>
 {
     static std::string get() { return T::ELI_getAlias(); }
 };

--- a/src/sst/core/eli/paramsInfo.h
+++ b/src/sst/core/eli/paramsInfo.h
@@ -20,7 +20,7 @@
 namespace SST {
 namespace ELI {
 
-template <class T, class Enable = void>
+template <typename, typename = void>
 struct GetParams
 {
     static const std::vector<SST::ElementInfoParam>& get()
@@ -31,7 +31,7 @@ struct GetParams
 };
 
 template <class T>
-struct GetParams<T, typename MethodDetect<decltype(T::ELI_getParams())>::type>
+struct GetParams<T, std::void_t<decltype(T::ELI_getParams())>>
 {
     static const std::vector<SST::ElementInfoParam>& get() { return T::ELI_getParams(); }
 };

--- a/src/sst/core/eli/portsInfo.h
+++ b/src/sst/core/eli/portsInfo.h
@@ -20,7 +20,7 @@
 namespace SST {
 namespace ELI {
 
-template <class T, class Enable = void>
+template <typename, typename = void>
 struct InfoPorts
 {
     static const std::vector<SST::ElementInfoPort>& get()
@@ -30,8 +30,8 @@ struct InfoPorts
     }
 };
 
-template <class T>
-struct InfoPorts<T, typename MethodDetect<decltype(T::ELI_getPorts())>::type>
+template <typename T>
+struct InfoPorts<T, std::void_t<decltype(T::ELI_getPorts())>>
 {
     static const std::vector<SST::ElementInfoPort>& get() { return T::ELI_getPorts(); }
 };

--- a/src/sst/core/eli/profilePointInfo.h
+++ b/src/sst/core/eli/profilePointInfo.h
@@ -20,7 +20,7 @@
 namespace SST {
 namespace ELI {
 
-template <class T, class Enable = void>
+template <typename T, typename = void>
 struct InfoProfilePoints
 {
     static const std::vector<SST::ElementInfoProfilePoint>& get()
@@ -31,7 +31,7 @@ struct InfoProfilePoints
 };
 
 template <class T>
-struct InfoProfilePoints<T, typename MethodDetect<decltype(T::ELI_getProfilePoints())>::type>
+struct InfoProfilePoints<T, std::void_t<decltype(T::ELI_getProfilePoints())>>
 {
     static const std::vector<SST::ElementInfoProfilePoint>& get() { return T::ELI_getProfilePoints(); }
 };

--- a/src/sst/core/eli/simpleInfo.h
+++ b/src/sst/core/eli/simpleInfo.h
@@ -28,9 +28,9 @@ template <int num, typename InfoType>
 struct SimpleInfoPlaceHolder
 {};
 
-//  Class to check for an ELI_getSimpleInfo Function.  The
-//  MethodDetect way to detect a member function doesn't seem to work
-//  for functions with specific type signatures and we need to
+//  Class to check for an ELI_getSimpleInfo Function. The std::void_t<
+//  decltype()> way to detect a member function's type doesn't seem to
+//  work for functions with specific type signatures and we need to
 //  differentiate between the various versions using the first
 //  parameter to the function (index + type).
 template <class T, int index, class InfoType>

--- a/src/sst/core/eli/statsInfo.h
+++ b/src/sst/core/eli/statsInfo.h
@@ -20,7 +20,7 @@
 namespace SST {
 namespace ELI {
 
-template <class T, class Enable = void>
+template <typename, typename = void>
 struct InfoStats
 {
     static const std::vector<SST::ElementInfoStatistic>& get()
@@ -30,8 +30,8 @@ struct InfoStats
     }
 };
 
-template <class T>
-struct InfoStats<T, typename MethodDetect<decltype(T::ELI_getStatistics())>::type>
+template <typename T>
+struct InfoStats<T, std::void_t<decltype(T::ELI_getStatistics())>>
 {
     static const std::vector<SST::ElementInfoStatistic>& get() { return T::ELI_getStatistics(); }
 };

--- a/src/sst/core/eli/subcompSlotInfo.h
+++ b/src/sst/core/eli/subcompSlotInfo.h
@@ -20,7 +20,7 @@
 namespace SST {
 namespace ELI {
 
-template <class T, class Enable = void>
+template <typename, typename = void>
 struct InfoSubs
 {
     static const std::vector<SST::ElementInfoSubComponentSlot>& get()
@@ -31,7 +31,7 @@ struct InfoSubs
 };
 
 template <class T>
-struct InfoSubs<T, typename MethodDetect<decltype(T::ELI_getSubComponentSlots())>::type>
+struct InfoSubs<T, std::void_t<decltype(T::ELI_getSubComponentSlots())>>
 {
     static const std::vector<SST::ElementInfoSubComponentSlot>& get() { return T::ELI_getSubComponentSlots(); }
 };


### PR DESCRIPTION
This replaces the `MethodDetect` class template with C++17's [`std::void_t`](https://en.cppreference.com/w/cpp/types/void_t) for [SFINAE](https://en.cppreference.com/w/cpp/language/sfinae).

It also uses `typename` instead of `class` in the relevant `template` definitions, as well as removes unused template parameter names.
