### PR TITLE
Simplify SST_ELI_COMPILED_VERSION

### DIFF
--- a/src/sst/core/eli/elementinfo.cc
+++ b/src/sst/core/eli/elementinfo.cc
@@ -15,7 +15,7 @@
 
 #include "sst/core/eli/elibase.h"
 
-#include <sstream>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -35,16 +35,14 @@ static const std::vector<int> SST_ELI_COMPILED_VERSION = { 0, 9, 0 };
 std::string
 ProvidesDefaultInfo::getELIVersionString() const
 {
-    std::stringstream stream;
-    bool              first = true;
-    for ( int item : SST_ELI_COMPILED_VERSION ) {
-        if ( first )
-            first = false;
-        else
-            stream << ".";
-        stream << item;
+    std::string str;
+    const char* delim = "";
+    for ( auto item : SST_ELI_COMPILED_VERSION ) {
+        str += delim;
+        delim = ".";
+        str += std::to_string(item);
     }
-    return stream.str();
+    return str;
 }
 
 const std::vector<int>&

--- a/src/sst/core/eli/elibase.cc
+++ b/src/sst/core/eli/elibase.cc
@@ -22,8 +22,6 @@ namespace ELI {
 
 std::unique_ptr<LoadedLibraries::LibraryMap> LoadedLibraries::loaders_ {};
 
-static const std::vector<int> SST_ELI_COMPILED_VERSION = { 0, 9, 0 };
-
 bool
 LoadedLibraries::addLoader(
     const std::string& lib, const std::string& name, const std::string& alias, LibraryLoader* loader)


### PR DESCRIPTION
- Remove redundant `static` definition of `SST_ELI_COMPILED_VERSION` in `elibase.cc`
- Use:
  -  `std::string`, `std::to_string` and mutable `delim`iter
- instead of
  -  `std::stringstream`, `operator<<` and more complicated `bool` variable
- to create version string
- Change `#include <sstream>` to `#include <ostream>` since `std::ostream` is used but `std::stringstream` is no longer used