### PR TITLE
Change typedef declarations to modern using aliases

### DIFF
--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -102,8 +102,8 @@ public:
     std::string toString() const override;
 
 private:
-    /*     typedef std::list<Clock::HandlerBase*> HandlerMap_t; */
-    typedef std::vector<Clock::HandlerBase*> StaticHandlerMap_t;
+    /* using HandlerMap_t = std::list<Clock::HandlerBase*>; */
+    using StaticHandlerMap_t = std::vector<Clock::HandlerBase*>;
 
     Clock() {}
 

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -46,7 +46,7 @@ class ComponentInfo
 {
 
 public:
-    typedef std::vector<ConfigStatistic> statEnableList_t; /*!< List of Enabled Statistics */
+    using statEnableList_t = std::vector<ConfigStatistic>; /*!< List of Enabled Statistics */
 
     // Share Flags for SubComponent loading
     static const uint64_t SHARE_PORTS  = 0x1;
@@ -290,8 +290,8 @@ private:
     std::unordered_set<ComponentInfo*, ComponentInfo::HashID, ComponentInfo::EqualsID> dataByID;
 
 public:
-    typedef std::unordered_set<ComponentInfo*, ComponentInfo::HashID, ComponentInfo::EqualsID>::const_iterator
-        const_iterator;
+    using const_iterator =
+        std::unordered_set<ComponentInfo*, ComponentInfo::HashID, ComponentInfo::EqualsID>::const_iterator;
 
     const_iterator begin() const { return dataByID.begin(); }
 

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -38,8 +38,8 @@ class Config;
 class TimeLord;
 class ConfigGraph;
 
-typedef SparseVectorMap<ComponentId_t> ComponentIdMap_t;
-typedef std::vector<LinkId_t>          LinkIdMap_t;
+using ComponentIdMap_t = SparseVectorMap<ComponentId_t>;
+using LinkIdMap_t      = std::vector<LinkId_t>;
 
 /** Represents the configuration of a generic Link */
 class ConfigLink : public SST::Core::Serialization::serializable
@@ -211,7 +211,7 @@ public:
     ImplementSerializable(SST::ConfigStatOutput)
 };
 
-typedef SparseVectorMap<LinkId_t, ConfigLink*> ConfigLinkMap_t;
+using ConfigLinkMap_t = SparseVectorMap<LinkId_t, ConfigLink*>;
 
 /**
    Class that represents a PortModule in ConfigGraph
@@ -394,16 +394,16 @@ private:
 };
 
 /** Map names to Links */
-// typedef std::map<std::string,ConfigLink> ConfigLinkMap_t;
-// typedef SparseVectorMap<std::string,ConfigLink> ConfigLinkMap_t;
+// using ConfigLinkMap_t = std::map<std::string,ConfigLink>;
+// using ConfigLinkMap_t = SparseVectorMap<std::string,ConfigLink>;
 /** Map IDs to Components */
-typedef SparseVectorMap<ComponentId_t, ConfigComponent*> ConfigComponentMap_t;
+using ConfigComponentMap_t     = SparseVectorMap<ComponentId_t, ConfigComponent*>;
 /** Map names to Components */
-typedef std::map<std::string, ComponentId_t>             ConfigComponentNameMap_t;
+using ConfigComponentNameMap_t = std::map<std::string, ComponentId_t>;
 /** Map names to Parameter Sets: XML only */
-typedef std::map<std::string, Params*>                   ParamsMap_t;
+using ParamsMap_t              = std::map<std::string, Params*>;
 /** Map names to variable values:  XML only */
-typedef std::map<std::string, std::string>               VariableMap_t;
+using VariableMap_t            = std::map<std::string, std::string>;
 
 class PartitionGraph;
 
@@ -636,8 +636,8 @@ public:
     }
 };
 
-typedef SparseVectorMap<ComponentId_t, PartitionComponent*> PartitionComponentMap_t;
-typedef SparseVectorMap<LinkId_t, PartitionLink>            PartitionLinkMap_t;
+using PartitionComponentMap_t = SparseVectorMap<ComponentId_t, PartitionComponent*>;
+using PartitionLinkMap_t      = SparseVectorMap<LinkId_t, PartitionLink>;
 
 class PartitionGraph
 {

--- a/src/sst/core/eli/elementbuilder.h
+++ b/src/sst/core/eli/elementbuilder.h
@@ -22,7 +22,7 @@ namespace ELI {
 template <class Base, class... Args>
 struct Builder
 {
-    typedef Base* (*createFxn)(Args...);
+    using createFxn = Base* (*)(Args...);
 
     virtual Base* create(Args... ctorArgs) = 0;
 

--- a/src/sst/core/eli/simpleInfo.h
+++ b/src/sst/core/eli/simpleInfo.h
@@ -39,10 +39,10 @@ class checkForELI_getSimpleInfoFunction
     template <typename F, F>
     struct check;
 
-    typedef char Match;
-    typedef long NotMatch;
+    using Match    = char;
+    using NotMatch = long;
 
-    typedef const InfoType& (*functionsig)(SimpleInfoPlaceHolder<index, InfoType>);
+    using functionsig = const InfoType& (*)(SimpleInfoPlaceHolder<index, InfoType>);
 
     template <typename F>
     static Match HasFunction(check<functionsig, &F::ELI_getSimpleInfo>*);

--- a/src/sst/core/event.h
+++ b/src/sst/core/event.h
@@ -67,9 +67,9 @@ public:
     using Handler2 = SSTHandler2<void, Event*, classT, dataT, funcT>;
 
     /** Type definition of unique identifiers */
-    typedef std::pair<uint64_t, int> id_type;
+    using id_type = std::pair<uint64_t, int>;
     /** Constant, default value for id_types */
-    static const id_type             NO_ID;
+    static const id_type NO_ID;
 
     Event() : Activity(), delivery_info(0)
     {

--- a/src/sst/core/impl/timevortex/timeVortexBinnedMap.h
+++ b/src/sst/core/impl/timevortex/timeVortexBinnedMap.h
@@ -150,7 +150,7 @@ private:
     // for concurrent access.
     TimeUnit* current_time_unit;
 
-    typedef std::map<SimTime_t, TimeUnit*> mapType_t;
+    using mapType_t = std::map<SimTime_t, TimeUnit*>;
 
     // Accessed by multiple threads, must be locked when accessing
     mapType_t                                                            map;

--- a/src/sst/core/impl/timevortex/timeVortexPQ.h
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.h
@@ -59,7 +59,7 @@ public:
     virtual void fixup_handlers() override;
 
 private:
-    typedef std::priority_queue<Activity*, std::vector<Activity*>, Activity::greater<true, true, true>> dataType_t;
+    using dataType_t = std::priority_queue<Activity*, std::vector<Activity*>, Activity::greater<true, true, true>>;
 
     template <class T, class S, class C>
     S& getContainer(std::priority_queue<T, S, C>& q)

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -38,10 +38,10 @@ namespace Interfaces {
 class SimpleNetwork : public SubComponent
 {
 public:
-    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork,int)
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork, int)
 
     /** All Addresses can be 64-bit */
-    typedef int64_t nid_t;
+    using nid_t = int64_t;
 #define PRI_NID PRIi64
 
     static const nid_t INIT_BROADCAST_ADDR;
@@ -96,11 +96,11 @@ public:
         /**
          * Trace types
          */
-        typedef enum {
+        enum TraceType {
             NONE,  /*!< No tracing enabled */
             ROUTE, /*!< Trace route information only */
             FULL   /*!< Trace all movements of packets through network */
-        } TraceType;
+        };
 
         /** Constructor */
         Request() :

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -103,7 +103,7 @@ public:
     SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::StandardMem,TimeConverter*,HandlerBase*)
 
     /** All Addresses can be 64-bit */
-    typedef uint64_t Addr;
+    using Addr = uint64_t;
 #define PRI_ADDR PRIx64
 
     /**
@@ -112,8 +112,8 @@ public:
     class Request
     {
     public:
-        typedef uint64_t id_t;
-        typedef uint32_t flags_t;
+        using id_t    = uint64_t;
+        using flags_t = uint32_t;
 
         /** Flags that modify requests.
          * Each bit in a 32-bit field (flags_t) defines a seperate flag.

--- a/src/sst/core/interprocess/ipctunnel.h
+++ b/src/sst/core/interprocess/ipctunnel.h
@@ -41,7 +41,7 @@ template <typename ShareDataType, typename MsgType>
 class IPCTunnel
 {
 
-    typedef SST::Core::Interprocess::CircularBuffer<MsgType> CircBuff_t;
+    using CircBuff_t = SST::Core::Interprocess::CircularBuffer<MsgType>;
 
     struct InternalSharedData
     {

--- a/src/sst/core/interprocess/mmapparent.cc
+++ b/src/sst/core/interprocess/mmapparent.cc
@@ -17,5 +17,5 @@
 
 #include "sst/core/interprocess/tunneldef.h"
 
-typedef SST::Core::Interprocess::TunnelDef<int, int> testtunnel;
+using testtunnel = SST::Core::Interprocess::TunnelDef<int, int>;
 template class SST::Core::Interprocess::MMAPParent<testtunnel>;

--- a/src/sst/core/interprocess/shmparent.cc
+++ b/src/sst/core/interprocess/shmparent.cc
@@ -18,7 +18,7 @@
 #include "sst/core/interprocess/shmchild.h"
 #include "sst/core/interprocess/tunneldef.h"
 
-typedef SST::Core::Interprocess::TunnelDef<int, int> testtunnel;
+using testtunnel = SST::Core::Interprocess::TunnelDef<int, int>;
 
 template class SST::Core::Interprocess::SHMParent<testtunnel>;
 template class SST::Core::Interprocess::SHMChild<testtunnel>;

--- a/src/sst/core/interprocess/tunneldef.h
+++ b/src/sst/core/interprocess/tunneldef.h
@@ -56,7 +56,7 @@ template <typename ShareDataType, typename MsgType>
 class TunnelDef
 {
 
-    typedef SST::Core::Interprocess::CircularBuffer<MsgType> CircBuff_t;
+    using CircBuff_t = SST::Core::Interprocess::CircularBuffer<MsgType>;
 
 public:
     /** Create a new tunnel

--- a/src/sst/core/model/element_python.h
+++ b/src/sst/core/model/element_python.h
@@ -19,7 +19,7 @@
 
 namespace SST {
 
-typedef void* (*genPythonModuleFunction)(void);
+using genPythonModuleFunction = void* (*)(void);
 
 /** Class to represent the code that needs to be added to create the
  * python module struture for the library.

--- a/src/sst/core/oneshot.h
+++ b/src/sst/core/oneshot.h
@@ -81,13 +81,13 @@ public:
     NotSerializable(SST::OneShot)
 
 private:
-    typedef std::vector<OneShot::HandlerBase*> HandlerList_t;
+    using HandlerList_t = std::vector<OneShot::HandlerBase*>;
 
     // Since this only gets fixed latency events, the times will fire
     // in order of arrival.  No need to use a full map, a double ended
     // queue will work just as well
-    // typedef std::map<SimTime_t, HandlerList_t*> HandlerVectorMap_t;
-    typedef std::deque<std::pair<SimTime_t, HandlerList_t*>> HandlerVectorMap_t;
+    // using HandlerVectorMap_t = std::map<SimTime_t, HandlerList_t*>;
+    using HandlerVectorMap_t = std::deque<std::pair<SimTime_t, HandlerList_t*>>;
 
     // Generic constructor for serialization
     OneShot() {}

--- a/src/sst/core/params.h
+++ b/src/sst/core/params.h
@@ -193,7 +193,7 @@ NO_VARIABLE:
         }
     }
 
-    typedef std::map<uint32_t, std::string>::const_iterator const_iterator; /*!< Const Iterator type */
+    using const_iterator = std::map<uint32_t, std::string>::const_iterator; /*!< Const Iterator type */
 
     const std::string& getString(const std::string& name, bool& found) const;
 
@@ -229,8 +229,8 @@ NO_VARIABLE:
     void getDelimitedTokens(const std::string& value, char delim, std::vector<std::string>& tokens) const;
 
 public:
-    typedef std::string                    key_type; /*!< Type of key (string) */
-    typedef std::set<key_type, KeyCompare> KeySet_t; /*!< Type of a set of keys */
+    using key_type = std::string;                    /*!< Type of key (string) */
+    using KeySet_t = std::set<key_type, KeyCompare>; /*!< Type of a set of keys */
 
     /**
      * Enable or disable parameter verification on an instance

--- a/src/sst/core/profile.h
+++ b/src/sst/core/profile.h
@@ -28,7 +28,7 @@ namespace Profile {
 #define CLOCK std::chrono::steady_clock
 #endif
 
-typedef CLOCK::time_point ProfData_t;
+using ProfData_t = CLOCK::time_point;
 
 inline ProfData_t
 now()
@@ -50,7 +50,7 @@ getElapsed(const ProfData_t& since)
 }
 
 #else
-typedef double ProfData_t;
+using ProfData_t = double;
 
 inline ProfData_t
 now()

--- a/src/sst/core/serialization/impl/serialize_atomic.h
+++ b/src/sst/core/serialization/impl/serialize_atomic.h
@@ -28,7 +28,7 @@ namespace Serialization {
 template <class T>
 class serialize_impl<std::atomic<T>>
 {
-    typedef std::atomic<T> Value;
+    using Value = std::atomic<T>;
 
 public:
     void operator()(Value& v, serializer& ser)

--- a/src/sst/core/serialization/impl/serialize_deque.h
+++ b/src/sst/core/serialization/impl/serialize_deque.h
@@ -28,7 +28,7 @@ namespace Serialization {
 template <class T>
 class serialize_impl<std::deque<T>>
 {
-    typedef std::deque<T> Deque;
+    using Deque = std::deque<T>;
 
 public:
     void operator()(Deque& v, serializer& ser)

--- a/src/sst/core/serialization/impl/serialize_list.h
+++ b/src/sst/core/serialization/impl/serialize_list.h
@@ -28,12 +28,12 @@ namespace Serialization {
 template <class T>
 class serialize_impl<std::list<T>>
 {
-    typedef std::list<T> List;
+    using List = std::list<T>;
 
 public:
     void operator()(List& v, serializer& ser)
     {
-        typedef typename List::iterator iterator;
+        using iterator = typename List::iterator;
         switch ( ser.mode() ) {
         case serializer::SIZER:
         {

--- a/src/sst/core/serialization/impl/serialize_map.h
+++ b/src/sst/core/serialization/impl/serialize_map.h
@@ -34,12 +34,12 @@ namespace Serialization {
 template <class Key, class Value>
 class serialize_impl<std::map<Key, Value>>
 {
-    typedef std::map<Key, Value> Map;
+    using Map = std::map<Key, Value>;
 
 public:
     void operator()(Map& m, serializer& ser)
     {
-        typedef typename std::map<Key, Value>::iterator iterator;
+        using iterator = typename std::map<Key, Value>::iterator;
         switch ( ser.mode() ) {
 
         case serializer::SIZER:
@@ -93,12 +93,12 @@ public:
 template <class Key, class Value>
 class serialize<std::unordered_map<Key, Value>>
 {
-    typedef std::unordered_map<Key, Value> Map;
+    using Map = std::unordered_map<Key, Value>;
 
 public:
     void operator()(Map& m, serializer& ser)
     {
-        typedef typename std::unordered_map<Key, Value>::iterator iterator;
+        using iterator = typename std::unordered_map<Key, Value>::iterator;
         switch ( ser.mode() ) {
 
         case serializer::SIZER:

--- a/src/sst/core/serialization/impl/serialize_multiset.h
+++ b/src/sst/core/serialization/impl/serialize_multiset.h
@@ -29,12 +29,12 @@ namespace Serialization {
 template <class T, class C>
 class serialize<std::multiset<T, C>>
 {
-    typedef std::multiset<T, C> MultiSet;
+    using MultiSet = std::multiset<T, C>;
 
 public:
     void operator()(MultiSet& v, serializer& ser)
     {
-        typedef typename std::multiset<T>::iterator iterator;
+        using iterator = typename std::multiset<T>::iterator;
         switch ( ser.mode() ) {
         case serializer::SIZER:
         {
@@ -84,12 +84,12 @@ public:
 template <class T>
 class serialize<std::unordered_multiset<T>>
 {
-    typedef std::unordered_multiset<T> MultiSet;
+    using MultiSet = std::unordered_multiset<T>;
 
 public:
     void operator()(MultiSet& v, serializer& ser)
     {
-        typedef typename std::unordered_multiset<T>::iterator iterator;
+        using iterator = typename std::unordered_multiset<T>::iterator;
         switch ( ser.mode() ) {
         case serializer::SIZER:
         {

--- a/src/sst/core/serialization/impl/serialize_priority_queue.h
+++ b/src/sst/core/serialization/impl/serialize_priority_queue.h
@@ -29,7 +29,7 @@ namespace Serialization {
 template <class T, class S, class C>
 class serialize<std::priority_queue<T, S, C>>
 {
-    typedef std::priority_queue<T, S, C> Pqueue;
+    using Pqueue = std::priority_queue<T, S, C>;
 
 public:
     S& getContainer(std::priority_queue<T, S, C>& q)

--- a/src/sst/core/serialization/impl/serialize_set.h
+++ b/src/sst/core/serialization/impl/serialize_set.h
@@ -29,12 +29,12 @@ namespace Serialization {
 template <class T>
 class serialize<std::set<T>>
 {
-    typedef std::set<T> Set;
+    using Set = std::set<T>;
 
 public:
     void operator()(Set& v, serializer& ser)
     {
-        typedef typename std::set<T>::iterator iterator;
+        using iterator = typename Set::iterator;
         switch ( ser.mode() ) {
         case serializer::SIZER:
         {
@@ -84,12 +84,12 @@ public:
 template <class T>
 class serialize<std::unordered_set<T>>
 {
-    typedef std::unordered_set<T> Set;
+    using Set = std::unordered_set<T>;
 
 public:
     void operator()(Set& v, serializer& ser)
     {
-        typedef typename std::unordered_set<T>::iterator iterator;
+        using iterator = typename Set::iterator;
         switch ( ser.mode() ) {
         case serializer::SIZER:
         {

--- a/src/sst/core/serialization/impl/serialize_vector.h
+++ b/src/sst/core/serialization/impl/serialize_vector.h
@@ -55,7 +55,7 @@ class serialize_impl<std::vector<T>>
     template <class A>
     friend class serialize;
 
-    typedef std::vector<T> Vector;
+    using Vector = std::vector<T>;
 
     void operator()(Vector& v, serializer& ser)
     {
@@ -110,7 +110,7 @@ class serialize_impl<std::vector<bool>>
     template <class A>
     friend class serialize;
 
-    typedef std::vector<bool> Vector;
+    using Vector = std::vector<bool>;
 
     void operator()(Vector& v, serializer& ser)
     {

--- a/src/sst/core/serialization/serializable_base.h
+++ b/src/sst/core/serialization/serializable_base.h
@@ -130,7 +130,7 @@ public:
     virtual ~serializable_base() {}
 
 protected:
-    typedef enum { ConstructorFlag } cxn_flag_t;
+    enum cxn_flag_t { ConstructorFlag };
     static void serializable_abort(uint32_t line, const char* file, const char* func, const char* obj);
 };
 
@@ -243,8 +243,8 @@ public:
 class serializable_factory
 {
 protected:
-    typedef std::unordered_map<long, serializable_builder*> builder_map;
-    static builder_map*                                     builders_;
+    using builder_map = std::unordered_map<long, serializable_builder*>;
+    static builder_map* builders_;
 
 public:
     static serializable_base* get_serializable(uint32_t cls_id);

--- a/src/sst/core/serialization/statics.h
+++ b/src/sst/core/serialization/statics.h
@@ -21,7 +21,7 @@ namespace Serialization {
 class statics
 {
 public:
-    typedef void (*clear_fxn)(void);
+    using clear_fxn = void (*)(void);
 
     static void register_finish(clear_fxn fxn);
 

--- a/src/sst/core/shared/sharedArray.h
+++ b/src/sst/core/shared/sharedArray.h
@@ -103,8 +103,8 @@ public:
 
     /*** Typedefs and functions to mimic parts of the vector API ***/
 
-    typedef typename std::vector<T>::const_iterator         const_iterator;
-    typedef typename std::vector<T>::const_reverse_iterator const_reverse_iterator;
+    using const_iterator         = typename std::vector<T>::const_iterator;
+    using const_reverse_iterator = typename std::vector<T>::const_reverse_iterator;
 
     /**
        Get the length of the array.
@@ -496,8 +496,8 @@ public:
 
     /*** Typedefs and functions to mimic parts of the vector API ***/
 
-    typedef typename std::vector<bool>::const_iterator         const_iterator;
-    typedef typename std::vector<bool>::const_reverse_iterator const_reverse_iterator;
+    using const_iterator         = typename std::vector<bool>::const_iterator;
+    using const_reverse_iterator = typename std::vector<bool>::const_reverse_iterator;
 
     /**
        Get the length of the array.

--- a/src/sst/core/shared/sharedMap.h
+++ b/src/sst/core/shared/sharedMap.h
@@ -76,8 +76,8 @@ public:
     }
 
     /*** Typedefs and functions to mimic parts of the vector API ***/
-    typedef typename std::map<keyT, valT>::const_iterator         const_iterator;
-    typedef typename std::map<keyT, valT>::const_reverse_iterator const_reverse_iterator;
+    using const_iterator         = typename std::map<keyT, valT>::const_iterator;
+    using const_reverse_iterator = typename std::map<keyT, valT>::const_reverse_iterator;
 
     /**
        Get the size of the map.

--- a/src/sst/core/shared/sharedSet.h
+++ b/src/sst/core/shared/sharedSet.h
@@ -76,8 +76,8 @@ public:
     }
 
     /*** Typedefs and functions to mimic parts of the vector API ***/
-    typedef typename std::set<valT>::const_iterator         const_iterator;
-    typedef typename std::set<valT>::const_reverse_iterator const_reverse_iterator;
+    using const_iterator         = typename std::set<valT>::const_iterator;
+    using const_reverse_iterator = typename std::set<valT>::const_reverse_iterator;
 
     /**
        Get the size of the set.

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -131,8 +131,8 @@ public:
 
     /******** End Public API from Simulation ********/
 
-    typedef std::map<std::pair<SimTime_t, int>, Clock*>   clockMap_t;   /*!< Map of times to clocks */
-    typedef std::map<std::pair<SimTime_t, int>, OneShot*> oneShotMap_t; /*!< Map of times to OneShots */
+    using clockMap_t   = std::map<std::pair<SimTime_t, int>, Clock*>;   /*!< Map of times to clocks */
+    using oneShotMap_t = std::map<std::pair<SimTime_t, int>, OneShot*>; /*!< Map of times to OneShots */
 
     ~Simulation_impl();
 
@@ -403,11 +403,11 @@ public:
     void endSimulation(void);
     void endSimulation(SimTime_t end);
 
-    typedef enum {
+    enum ShutdownMode_t {
         SHUTDOWN_CLEAN,     /* Normal shutdown */
         SHUTDOWN_SIGNAL,    /* SIGINT or SIGTERM received */
         SHUTDOWN_EMERGENCY, /* emergencyShutdown() called */
-    } ShutdownMode_t;
+    };
 
     friend class SyncManager;
 

--- a/src/sst/core/sparseVectorMap.h
+++ b/src/sst/core/sparseVectorMap.h
@@ -150,8 +150,8 @@ public:
         }
     }
 
-    typedef typename std::vector<classT>::iterator       iterator;
-    typedef typename std::vector<classT>::const_iterator const_iterator;
+    using iterator       = typename std::vector<classT>::iterator;
+    using const_iterator = typename std::vector<classT>::const_iterator;
 
     /**
        Insert new value into SparseVectorMap.  The inserted class must
@@ -407,8 +407,8 @@ public:
         }
     }
 
-    typedef typename std::vector<classT*>::iterator       iterator;
-    typedef typename std::vector<classT*>::const_iterator const_iterator;
+    using iterator       = typename std::vector<classT*>::iterator;
+    using const_iterator = typename std::vector<classT*>::const_iterator;
 
     /**
        Insert new value into SparseVectorMap.  The inserted class must
@@ -682,8 +682,8 @@ public:
         }
     }
 
-    typedef typename std::vector<keyT>::iterator       iterator;
-    typedef typename std::vector<keyT>::const_iterator const_iterator;
+    using iterator       = typename std::vector<keyT>::iterator;
+    using const_iterator = typename std::vector<keyT>::const_iterator;
 
     /**
        Insert new value into SparseVectorMap.  The inserted class must

--- a/src/sst/core/sst_types.h
+++ b/src/sst/core/sst_types.h
@@ -17,13 +17,13 @@
 
 namespace SST {
 
-typedef uint64_t ComponentId_t;
-typedef uint64_t StatisticId_t;
-typedef uint32_t LinkId_t;
-typedef uint64_t HandlerId_t;
-typedef uint64_t Cycle_t;
-typedef uint64_t SimTime_t;
-typedef double   Time_t;
+using ComponentId_t = uint64_t;
+using StatisticId_t = uint64_t;
+using LinkId_t      = uint32_t;
+using HandlerId_t   = uint64_t;
+using Cycle_t       = uint64_t;
+using SimTime_t     = uint64_t;
+using Time_t        = double;
 
 #define PRI_SIMTIME PRIu64
 
@@ -46,10 +46,10 @@ static constexpr StatisticId_t STATALL_ID = std::numeric_limits<StatisticId_t>::
 #define COMPDEFINED_SUBCOMPONENT_ID_CREATE(compId, sCompId) \
     ((((uint64_t)sCompId) << COMPONENT_ID_BITS) | compId | 0x8000000000000000ULL)
 
-typedef double watts;
-typedef double joules;
-typedef double farads;
-typedef double volts;
+using watts  = double;
+using joules = double;
+using farads = double;
+using volts  = double;
 
 #ifndef LIKELY
 #define LIKELY(x)   __builtin_expect((int)(x), 1)

--- a/src/sst/core/ssthandler.h
+++ b/src/sst/core/ssthandler.h
@@ -1040,7 +1040,7 @@ template <typename returnT, typename argT, typename classT, typename dataT = voi
 class SSTHandler : public SSTHandlerBase<returnT, argT>
 {
 private:
-    typedef returnT (classT::*PtrMember)(argT, dataT);
+    using PtrMember = returnT (classT::*)(argT, dataT);
     classT*         object;
     const PtrMember member;
     dataT           data;
@@ -1071,7 +1071,7 @@ template <typename returnT, typename argT, typename classT>
 class SSTHandler<returnT, argT, classT, void> : public SSTHandlerBase<returnT, argT>
 {
 private:
-    typedef returnT (classT::*PtrMember)(argT);
+    using PtrMember = returnT (classT::*)(argT);
     const PtrMember member;
     classT*         object;
 
@@ -1096,7 +1096,7 @@ template <typename returnT, typename classT, typename dataT = void>
 class SSTHandlerNoArgs : public SSTHandlerBaseNoArgs<returnT>
 {
 private:
-    typedef returnT (classT::*PtrMember)(dataT);
+    using PtrMember = returnT (classT::*)(dataT);
     classT*         object;
     const PtrMember member;
     dataT           data;
@@ -1127,7 +1127,7 @@ template <typename returnT, typename classT>
 class SSTHandlerNoArgs<returnT, classT, void> : public SSTHandlerBaseNoArgs<returnT>
 {
 private:
-    typedef returnT (classT::*PtrMember)();
+    using PtrMember = returnT (classT::*)();
     const PtrMember member;
     classT*         object;
 

--- a/src/sst/core/sstinfo.h
+++ b/src/sst/core/sstinfo.h
@@ -39,7 +39,7 @@ namespace SST {
 class SSTInfoConfig : public ConfigShared
 {
 public:
-    typedef std::multimap<std::string, std::string> FilterMap_t;
+    using FilterMap_t = std::multimap<std::string, std::string>;
     /** Create a new SSTInfo configuration and parse the Command Line. */
     SSTInfoConfig(bool suppress_print);
     ~SSTInfoConfig();

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -46,7 +46,7 @@ class StatisticBase
 {
 public:
     /** Statistic collection mode */
-    typedef enum { STAT_MODE_UNDEFINED, STAT_MODE_COUNT, STAT_MODE_PERIODIC, STAT_MODE_DUMP_AT_END } StatMode_t;
+    enum StatMode_t { STAT_MODE_UNDEFINED, STAT_MODE_COUNT, STAT_MODE_PERIODIC, STAT_MODE_DUMP_AT_END };
 
     // Enable/Disable of Statistic
     /** Enable Statistic for collections */

--- a/src/sst/core/statapi/statengine.h
+++ b/src/sst/core/statapi/statengine.h
@@ -138,9 +138,9 @@ private:
     void castError(const std::string& type, const std::string& statName, const std::string& fieldName);
 
 private:
-    typedef std::vector<StatisticBase*>           StatArray_t;   /*!< Array of Statistics */
-    typedef std::map<SimTime_t, StatArray_t*>     StatMap_t;     /*!< Map of simtimes to Statistic Arrays */
-    typedef std::map<ComponentId_t, StatArray_t*> CompStatMap_t; /*!< Map of ComponentId's to StatInfo Arrays */
+    using StatArray_t   = std::vector<StatisticBase*>;           /*!< Array of Statistics */
+    using StatMap_t     = std::map<SimTime_t, StatArray_t*>;     /*!< Map of simtimes to Statistic Arrays */
+    using CompStatMap_t = std::map<ComponentId_t, StatArray_t*>; /*!< Map of ComponentId's to StatInfo Arrays */
 
     StatArray_t   m_EventStatisticArray;  /*!< Array of Event Based Statistics */
     StatMap_t     m_PeriodicStatisticMap; /*!< Map of Array's of Periodic Based Statistics */

--- a/src/sst/core/statapi/stathistogram.h
+++ b/src/sst/core/statapi/stathistogram.h
@@ -321,10 +321,10 @@ private:
 
 private:
     // Bin Map Definition
-    typedef std::map<BinDataType, CountType> HistoMap_t;
+    using HistoMap_t = std::map<BinDataType, CountType>;
 
     // Iterator over the histogram bins
-    typedef typename HistoMap_t::iterator HistoMapItr_t;
+    using HistoMapItr_t = typename HistoMap_t::iterator;
 
     // The minimum value in the Histogram
     BinDataType m_minValue;

--- a/src/sst/core/statapi/statoutputhdf5.h
+++ b/src/sst/core/statapi/statoutputhdf5.h
@@ -114,14 +114,14 @@ protected:
     StatisticOutputHDF5(); // For serialization
 
 private:
-    typedef union {
+    union StatData_u {
         int32_t  i32;
         uint32_t u32;
         int64_t  i64;
         uint64_t u64;
         float    f;
         double   d;
-    } StatData_u;
+    };
 
     class DataSet
     {

--- a/src/sst/core/stringize.h
+++ b/src/sst/core/stringize.h
@@ -67,8 +67,8 @@ tokenize(std::vector<std::string>& output, const std::string& input, const std::
 
 struct char_delimiter
 {
-    typedef std::string::const_iterator iter;
-    const std::string                   delim;
+    using iter = std::string::const_iterator;
+    const std::string delim;
     char_delimiter(const std::string& delim = " \t\v\f\n\r") : delim(delim) {}
 
     /**
@@ -89,10 +89,8 @@ struct char_delimiter
 
 struct escaped_list_separator
 {
-    typedef std::string::const_iterator iter;
-    std::string                         e;
-    std::string                         q;
-    std::string                         s;
+    using iter = std::string::const_iterator;
+    std::string e, q, s;
 
     escaped_list_separator(
         const std::string& esc = "\\", const std::string& sep = ",", const std::string& quote = "\"") :
@@ -180,12 +178,12 @@ class Tokenizer
         using iterator_category = std::input_iterator_tag;
     };
 
-    typedef token_iter<TokenizerFunc> iter;
+    using iter = token_iter<TokenizerFunc>;
 
 public:
-    typedef iter        iterator;
-    typedef iter        const_iterator;
-    typedef std::string value_type;
+    using iterator       = iter;
+    using const_iterator = iter;
+    using value_type     = std::string;
 
     iter begin() { return iter(f, first, last); }
     iter end() { return iter(f, last, last); }

--- a/src/sst/core/sync/rankSyncParallelSkip.h
+++ b/src/sst/core/sync/rankSyncParallelSkip.h
@@ -108,10 +108,10 @@ private:
         ImplementSerializable(comm_recv_pair)
     };
 
-    typedef std::map<RankInfo, comm_send_pair> comm_send_map_t;
-    typedef std::map<RankInfo, comm_recv_pair> comm_recv_map_t;
-    // typedef std::map<LinkId_t, Link*>          link_map_t;
-    typedef std::map<std::string, uintptr_t>   link_map_t;
+    using comm_send_map_t = std::map<RankInfo, comm_send_pair>;
+    using comm_recv_map_t = std::map<RankInfo, comm_recv_pair>;
+    // using link_map_t = std::map<LinkId_t, Link*>;
+    using link_map_t      = std::map<std::string, uintptr_t>;
 
     // TimeConverter* period;
     comm_send_map_t comm_send_map;

--- a/src/sst/core/sync/rankSyncSerialSkip.h
+++ b/src/sst/core/sync/rankSyncSerialSkip.h
@@ -71,8 +71,8 @@ private:
         ImplementSerializable(comm_pair)
     };
 
-    typedef std::map<int, comm_pair>         comm_map_t;
-    typedef std::map<std::string, uintptr_t> link_map_t;
+    using comm_map_t = std::map<int, comm_pair>;
+    using link_map_t = std::map<std::string, uintptr_t>;
 
     // TimeConverter* period;
     comm_map_t comm_map;

--- a/src/sst/core/testElements/coreTest_ComponentEvent.h
+++ b/src/sst/core/testElements/coreTest_ComponentEvent.h
@@ -18,11 +18,10 @@ namespace CoreTestComponent {
 class coreTestComponentEvent : public SST::Event
 {
 public:
-    typedef std::vector<char> dataVec;
+    using dataVec = std::vector<char>;
     coreTestComponentEvent() : SST::Event() {}
     dataVec payload;
 
-public:
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {
         Event::serialize_order(ser);

--- a/src/sst/core/threadsafe.h
+++ b/src/sst/core/threadsafe.h
@@ -116,7 +116,7 @@ public:
 };
 
 #if 0
-typedef std::mutex Spinlock;
+using Spinlock = std::mutex;
 #else
 class Spinlock
 {

--- a/src/sst/core/timeLord.h
+++ b/src/sst/core/timeLord.h
@@ -36,8 +36,8 @@ class UnitAlgebra;
  */
 class TimeLord
 {
-    typedef std::map<SimTime_t, TimeConverter*>   TimeConverterMap_t;
-    typedef std::map<std::string, TimeConverter*> StringToTCMap_t;
+    using TimeConverterMap_t = std::map<SimTime_t, TimeConverter*>;
+    using StringToTCMap_t    = std::map<std::string, TimeConverter*>;
 
 public:
     /**

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -28,7 +28,7 @@
 
 namespace SST {
 
-typedef decimal_fixedpoint<3, 3> sst_big_num;
+using sst_big_num = decimal_fixedpoint<3, 3>;
 
 /**
  * Helper class internal to UnitAlgebra.
@@ -38,7 +38,7 @@ typedef decimal_fixedpoint<3, 3> sst_big_num;
 class Units
 {
 
-    typedef uint8_t unit_id_t;
+    using unit_id_t = uint8_t;
 
 private:
     friend class UnitAlgebra;


### PR DESCRIPTION
This uses the more modern `using name = type;` syntax which is easier to read than `typedef type name;` and can be expanded to template aliases.
