### PR TITLE
Use C++17 nested namespaces; remove using namespace std

### DIFF
--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -919,9 +919,7 @@ BaseComponent::serialize_order(SST::Core::Serialization::serializer& ser)
     }
 }
 
-namespace Core {
-namespace Serialization {
-namespace pvt {
+namespace Core::Serialization::pvt {
 
 static const long null_ptr_id = -1;
 
@@ -997,9 +995,6 @@ SerializeBaseComponentHelper::map_basecomponent(serializable_base*& s, serialize
     ser.mapper().map_hierarchy_end(); // obj_map
 }
 
-} // namespace pvt
-} // namespace Serialization
-} // namespace Core
-
+} // namespace Core::Serialization::pvt
 
 } // namespace SST

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -49,13 +49,9 @@ class TimeConverter;
 class UnitAlgebra;
 
 
-namespace Core {
-namespace Serialization {
-namespace pvt {
+namespace Core::Serialization::pvt {
 class SerializeBaseComponentHelper;
-} // namespace pvt
-} // namespace Serialization
-} // namespace Core
+}
 
 /**
  * Main component object for the simulation.
@@ -1117,11 +1113,9 @@ public:
     }
 };
 
-namespace Core {
-namespace Serialization {
+namespace Core::Serialization {
 
 namespace pvt {
-
 class SerializeBaseComponentHelper
 {
 public:
@@ -1169,8 +1163,7 @@ class serialize_impl<T*, typename std::enable_if<std::is_base_of<SST::BaseCompon
     }
 };
 
-} // namespace Serialization
-} // namespace Core
+} // namespace Core::Serialization
 
 } // namespace SST
 

--- a/src/sst/core/cfgoutput/dotConfigOutput.h
+++ b/src/sst/core/cfgoutput/dotConfigOutput.h
@@ -16,8 +16,7 @@
 #include "sst/core/configGraph.h"
 #include "sst/core/configGraphOutput.h"
 
-namespace SST {
-namespace Core {
+namespace SST::Core {
 
 class DotConfigGraphOutput : public ConfigGraphOutput
 {
@@ -33,7 +32,6 @@ protected:
     void generateDot(const ConfigLink* link, const uint32_t dot_verbosity) const;
 };
 
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core
 
 #endif // SST_CORE_DOT_CONFIG_OUTPUT_H

--- a/src/sst/core/cfgoutput/jsonConfigOutput.h
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.h
@@ -16,8 +16,7 @@
 #include "sst/core/configGraph.h"
 #include "sst/core/configGraphOutput.h"
 
-namespace SST {
-namespace Core {
+namespace SST::Core {
 
 class JSONConfigGraphOutput : public ConfigGraphOutput
 {
@@ -27,7 +26,6 @@ public:
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 };
 
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core
 
 #endif // SST_CORE_JSON_CONFIG_OUTPUT_H

--- a/src/sst/core/cfgoutput/pythonConfigOutput.h
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.h
@@ -18,8 +18,7 @@
 
 #include <map>
 
-namespace SST {
-namespace Core {
+namespace SST::Core {
 
 class PythonConfigGraphOutput : public ConfigGraphOutput
 {
@@ -51,7 +50,6 @@ private:
     std::map<LinkId_t, std::string> linkMap;
 };
 
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core
 
 #endif // SST_CORE_PYTHON_CONFIG_OUTPUT_H

--- a/src/sst/core/cfgoutput/xmlConfigOutput.h
+++ b/src/sst/core/cfgoutput/xmlConfigOutput.h
@@ -16,8 +16,7 @@
 #include "sst/core/configGraph.h"
 #include "sst/core/configGraphOutput.h"
 
-namespace SST {
-namespace Core {
+namespace SST::Core {
 
 class XMLConfigGraphOutput : public ConfigGraphOutput
 {
@@ -30,7 +29,6 @@ protected:
     void generateXML(const std::string& indent, const ConfigLink* link, const ConfigComponentMap_t& compMap) const;
 };
 
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core
 
 #endif // SST_CORE_XML_CONFIG_OUTPUT_H

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -34,13 +34,9 @@ class ConfigStatistic;
 class Simulation_impl;
 class TimeConverter;
 
-namespace Core {
-namespace Serialization {
-namespace pvt {
+namespace Core::Serialization::pvt {
 class SerializeBaseComponentHelper;
-} // namespace pvt
-} // namespace Serialization
-} // namespace Core
+} // namespace Core::Serialization::pvt
 
 class ComponentInfo
 {
@@ -52,8 +48,7 @@ public:
     static const uint64_t SHARE_PORTS  = 0x1;
     static const uint64_t SHARE_STATS  = 0x2;
     static const uint64_t INSERT_STATS = 0x4;
-
-    static const uint64_t SHARE_NONE = 0x0;
+    static const uint64_t SHARE_NONE   = 0x0;
 
 private:
     // Mask to make sure users are only setting the flags that are

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -25,8 +25,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-using namespace std;
-
 namespace SST {
 
 //// Helper class for setting options
@@ -1197,7 +1195,7 @@ Config::checkArgsAfterParsing()
 
 
 bool
-Config::setOptionFromModel(const string& entryName, const string& value)
+Config::setOptionFromModel(const std::string& entryName, const std::string& value)
 {
     // Check to make sure option is settable in the SDL file
     if ( getAnnotation(entryName, 'S') ) { return setOptionExternal(entryName, value); }

--- a/src/sst/core/configBase.cc
+++ b/src/sst/core/configBase.cc
@@ -29,8 +29,6 @@
 #define E_OK 0
 #endif
 
-using namespace std;
-
 namespace SST {
 
 bool
@@ -431,7 +429,7 @@ ConfigBase::parseCmdLine(int argc, char* argv[], bool ignore_unknown)
 
 
 bool
-ConfigBase::setOptionExternal(const string& entryName, const string& value)
+ConfigBase::setOptionExternal(const std::string& entryName, const std::string& value)
 {
     // NOTE: print outs in this function will not be suppressed
     for ( auto& option : options ) {

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -26,8 +26,6 @@
 #include <fstream>
 #include <string.h>
 
-using namespace std;
-
 namespace {
 // bool zero_latency_warning = false;
 
@@ -931,7 +929,7 @@ ConfigGraph::findStatistic(StatisticId_t id) const
 ConfigGraph*
 ConfigGraph::getSubGraph(uint32_t start_rank, uint32_t end_rank)
 {
-    set<uint32_t> rank_set;
+    std::set<uint32_t> rank_set;
     for ( uint32_t i = start_rank; i <= end_rank; i++ ) {
         rank_set.insert(i);
     }
@@ -1392,7 +1390,7 @@ PartitionComponent::print(std::ostream& os, const PartitionGraph* graph) const
     for ( ComponentIdMap_t::const_iterator git = group.begin(); git != group.end(); ++git ) {
         os << *git << " ";
     }
-    os << ")" << endl;
+    os << ")" << std::endl;
     os << "  weight = " << weight << std::endl;
     os << "  rank = " << rank.rank << std::endl;
     os << "  thread = " << rank.thread << std::endl;

--- a/src/sst/core/configShared.cc
+++ b/src/sst/core/configShared.cc
@@ -17,8 +17,6 @@
 
 #include <functional>
 
-using namespace std;
-
 namespace SST {
 
 ConfigShared::ConfigShared(bool suppress_print, bool include_libpath, bool include_env, bool include_verbose) :

--- a/src/sst/core/eli/attributeInfo.h
+++ b/src/sst/core/eli/attributeInfo.h
@@ -18,8 +18,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace ELI {
+namespace SST::ELI {
 
 template <typename, typename = void>
 struct GetAttributes
@@ -70,8 +69,7 @@ private:
     std::vector<ElementInfoAttribute> attributes_;
 };
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI
 
 // clang-format off
 #define SST_ELI_DOCUMENT_ATTRIBUTES(...)                                                                           \

--- a/src/sst/core/eli/categoryInfo.h
+++ b/src/sst/core/eli/categoryInfo.h
@@ -19,8 +19,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace ELI {
+namespace SST::ELI {
 
 class ProvidesCategory
 {
@@ -61,7 +60,6 @@ private:
 #define SST_ELI_CATEGORY_INFO(cat) \
     static uint32_t ELI_getCategory() { return cat; }
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI
 
 #endif

--- a/src/sst/core/eli/defaultInfo.h
+++ b/src/sst/core/eli/defaultInfo.h
@@ -17,8 +17,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace ELI {
+namespace SST::ELI {
 
 class ProvidesDefaultInfo
 {
@@ -73,8 +72,7 @@ private:
     std::string      alias_;
 };
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI
 
 #define SST_ELI_INSERT_COMPILE_INFO()                     \
     static const std::string& ELI_getCompileDate()        \

--- a/src/sst/core/eli/elementbuilder.h
+++ b/src/sst/core/eli/elementbuilder.h
@@ -16,8 +16,7 @@
 
 #include <type_traits>
 
-namespace SST {
-namespace ELI {
+namespace SST::ELI {
 
 template <class Base, class... Args>
 struct Builder
@@ -333,8 +332,7 @@ struct CtorList<Base, void>
     }
 };
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI
 
 #define ELI_CTOR(...)      std::tuple<__VA_ARGS__>
 #define ELI_DEFAULT_CTOR() std::tuple<>

--- a/src/sst/core/eli/elementinfo.cc
+++ b/src/sst/core/eli/elementinfo.cc
@@ -19,12 +19,11 @@
 #include <string>
 #include <vector>
 
-namespace SST {
+namespace SST::ELI {
 
 /**************************************************************************
   BaseElementInfo class functions
 **************************************************************************/
-namespace ELI {
 
 void
 force_instantiate_bool(bool UNUSED(b), const char* UNUSED(name))
@@ -135,5 +134,4 @@ ProvidesParams::init()
     }
 }
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI

--- a/src/sst/core/eli/elibase.cc
+++ b/src/sst/core/eli/elibase.cc
@@ -13,12 +13,11 @@
 
 #include "sst/core/eli/elibase.h"
 
-namespace SST {
+namespace SST::ELI {
 
 /**************************************************************************
   BaseElementInfo class functions
 **************************************************************************/
-namespace ELI {
 
 std::unique_ptr<LoadedLibraries::LibraryMap> LoadedLibraries::loaders_ {};
 
@@ -48,5 +47,4 @@ LoadedLibraries::isLoaded(const std::string& name)
     }
 }
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI

--- a/src/sst/core/eli/interfaceInfo.h
+++ b/src/sst/core/eli/interfaceInfo.h
@@ -15,8 +15,7 @@
 #include <iostream>
 #include <string>
 
-namespace SST {
-namespace ELI {
+namespace SST::ELI {
 
 class ProvidesInterface
 {
@@ -40,8 +39,7 @@ private:
     std::string iface_;
 };
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI
 
 #define SST_ELI_INTERFACE_INFO(interface) \
     static const std::string ELI_getInterface() { return interface; }

--- a/src/sst/core/eli/paramsInfo.h
+++ b/src/sst/core/eli/paramsInfo.h
@@ -17,8 +17,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace ELI {
+namespace SST::ELI {
 
 template <typename, typename = void>
 struct GetParams
@@ -77,8 +76,7 @@ private:
     std::vector<ElementInfoParam> params_;
 };
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI
 
 // clang-format off
 #define SST_ELI_DOCUMENT_PARAMS(...)                                                                               \

--- a/src/sst/core/eli/portsInfo.h
+++ b/src/sst/core/eli/portsInfo.h
@@ -17,8 +17,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace ELI {
+namespace SST::ELI {
 
 template <typename, typename = void>
 struct InfoPorts
@@ -73,8 +72,7 @@ private:
     std::vector<ElementInfoPort> ports_;
 };
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI
 
 // clang-format off
 #define SST_ELI_DOCUMENT_PORTS(...)                                                                                \

--- a/src/sst/core/eli/profilePointInfo.h
+++ b/src/sst/core/eli/profilePointInfo.h
@@ -17,8 +17,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace ELI {
+namespace SST::ELI {
 
 template <typename, typename = void>
 struct InfoProfilePoints
@@ -67,8 +66,7 @@ private:
     std::vector<ElementInfoProfilePoint> points_;
 };
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI
 
 // clang-format off
 #define SST_ELI_DOCUMENT_PROFILE_POINTS(...)                                                                       \

--- a/src/sst/core/eli/simpleInfo.h
+++ b/src/sst/core/eli/simpleInfo.h
@@ -14,8 +14,7 @@
 
 #include "sst/core/eli/elibase.h"
 
-namespace SST {
-namespace ELI {
+namespace SST::ELI {
 
 // ProvidesSimpleInfo is a class to quickly add ELI info to an ELI
 // Base API.  This class should only be used for APIs that aren't
@@ -93,8 +92,7 @@ private:
     InfoType info_;
 };
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI
 
 // Macro used by the API to create macros to populate the added ELI
 // info

--- a/src/sst/core/eli/statsInfo.h
+++ b/src/sst/core/eli/statsInfo.h
@@ -17,8 +17,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace ELI {
+namespace SST::ELI {
 
 template <typename, typename = void>
 struct InfoStats
@@ -81,8 +80,7 @@ public:
     }
 };
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI
 
 // clang-format off
 #define SST_ELI_DOCUMENT_STATISTICS(...)                                                                           \

--- a/src/sst/core/eli/subcompSlotInfo.h
+++ b/src/sst/core/eli/subcompSlotInfo.h
@@ -17,8 +17,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace ELI {
+namespace SST::ELI {
 
 template <typename, typename = void>
 struct InfoSubs
@@ -67,8 +66,7 @@ private:
     std::vector<ElementInfoSubComponentSlot> slots_;
 };
 
-} // namespace ELI
-} // namespace SST
+} // namespace SST::ELI
 
 // clang-format off
 #define SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(...)                                                                   \

--- a/src/sst/core/env/envconfig.h
+++ b/src/sst/core/env/envconfig.h
@@ -21,9 +21,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace Core {
-namespace Environment {
+namespace SST::Core::Environment {
 
 /***
 \class EnvironmentConfigGroup envconfig.h "sst/core/env/envconfig.h"
@@ -122,8 +120,6 @@ private:
     std::map<std::string, EnvironmentConfigGroup*> groups;
 };
 
-} // namespace Environment
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Environment
 
 #endif // SST_CORE_ENV_ENVCONFIG_H

--- a/src/sst/core/env/envquery.h
+++ b/src/sst/core/env/envquery.h
@@ -23,9 +23,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace Core {
-namespace Environment {
+namespace SST::Core::Environment {
 
 /**
 Reads the next new-line delimited entry in a file and put
@@ -53,8 +51,6 @@ take precedence over the default configuration locations.
 */
 EnvironmentConfiguration* getSSTEnvironmentConfiguration(const std::vector<std::string>& overridePaths);
 
-} // namespace Environment
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Environment
 
 #endif // SST_CORE_ENV_ENVQUERY_H

--- a/src/sst/core/from_string.h
+++ b/src/sst/core/from_string.h
@@ -16,8 +16,7 @@
 #include <string>
 #include <type_traits>
 
-namespace SST {
-namespace Core {
+namespace SST::Core {
 
 template <class T>
 typename std::enable_if<std::is_integral<T>::value, T>::type
@@ -93,7 +92,6 @@ from_string(const std::string& input)
     return T(input);
 }
 
-} // end namespace Core
-} // end namespace SST
+} // end namespace SST::Core
 
 #endif // SST_CORE_FROM_STRING_H

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -16,9 +16,7 @@
 #include "sst/core/stringize.h"
 #include "sst/core/timeConverter.h"
 
-namespace SST {
-namespace IMPL {
-namespace Interactive {
+namespace SST::IMPL::Interactive {
 
 SimpleDebugger::SimpleDebugger(Params& UNUSED(params)) : InteractiveConsole() {}
 
@@ -289,7 +287,4 @@ SimpleDebugger::dispatch_cmd(std::string cmd)
     }
 }
 
-
-} // namespace Interactive
-} // namespace IMPL
-} // namespace SST
+} // namespace SST::IMPL::Interactive

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -15,9 +15,7 @@
 #include "sst/core/eli/elementinfo.h"
 #include "sst/core/interactiveConsole.h"
 
-namespace SST {
-namespace IMPL {
-namespace Interactive {
+namespace SST::IMPL::Interactive {
 
 /**
    Self partitioner actually does nothing.  It is simply a pass
@@ -63,8 +61,6 @@ private:
     void dispatch_cmd(std::string cmd);
 };
 
-} // namespace Interactive
-} // namespace IMPL
-} // namespace SST
+} // namespace SST::IMPL::Interactive
 
 #endif

--- a/src/sst/core/impl/partitioners/linpart.cc
+++ b/src/sst/core/impl/partitioners/linpart.cc
@@ -17,7 +17,6 @@
 #include "sst/core/output.h"
 #include "sst/core/warnmacros.h"
 
-using namespace std;
 using namespace SST::IMPL::Partition;
 
 SSTLinearPartition::SSTLinearPartition(RankInfo mpiranks, RankInfo UNUSED(my_rank), int verbosity)

--- a/src/sst/core/impl/partitioners/linpart.h
+++ b/src/sst/core/impl/partitioners/linpart.h
@@ -16,11 +16,10 @@
 #include "sst/core/sstpart.h"
 
 namespace SST {
-
 class Output;
+}
 
-namespace IMPL {
-namespace Partition {
+namespace SST::IMPL::Partition {
 
 /**
 Performs a linear partition scheme of an SST simulation configuration. In this
@@ -68,8 +67,6 @@ public:
     bool spawnOnAllRanks() override { return false; }
 };
 
-} // namespace Partition
-} // namespace IMPL
-} // namespace SST
+} // namespace SST::IMPL::Partition
 
 #endif

--- a/src/sst/core/impl/partitioners/rrobin.cc
+++ b/src/sst/core/impl/partitioners/rrobin.cc
@@ -16,11 +16,7 @@
 #include "sst/core/configGraph.h"
 #include "sst/core/warnmacros.h"
 
-using namespace std;
-
-namespace SST {
-namespace IMPL {
-namespace Partition {
+namespace SST::IMPL::Partition {
 
 SSTRoundRobinPartition::SSTRoundRobinPartition(RankInfo world_size, RankInfo UNUSED(my_rank), int UNUSED(verbosity)) :
     SSTPartitioner(),
@@ -45,6 +41,4 @@ SSTRoundRobinPartition::performPartition(PartitionGraph* graph)
     }
 }
 
-} // namespace Partition
-} // namespace IMPL
-} // namespace SST
+} // namespace SST::IMPL::Partition

--- a/src/sst/core/impl/partitioners/rrobin.h
+++ b/src/sst/core/impl/partitioners/rrobin.h
@@ -14,9 +14,7 @@
 #include "sst/core/eli/elementinfo.h"
 #include "sst/core/sstpart.h"
 
-namespace SST {
-namespace IMPL {
-namespace Partition {
+namespace SST::IMPL::Partition {
 
 class SSTRoundRobinPartition : public SST::Partition::SSTPartitioner
 {
@@ -46,7 +44,6 @@ public:
     bool spawnOnAllRanks() override { return false; }
 };
 
-} // namespace Partition
-} // namespace IMPL
-} // namespace SST
+} // namespace SST::IMPL::Partition
+
 #endif // SST_CORE_IMPL_PARTITONERS_RROBIN_H

--- a/src/sst/core/impl/partitioners/selfpart.h
+++ b/src/sst/core/impl/partitioners/selfpart.h
@@ -15,9 +15,7 @@
 #include "sst/core/eli/elementinfo.h"
 #include "sst/core/sstpart.h"
 
-namespace SST {
-namespace IMPL {
-namespace Partition {
+namespace SST::IMPL::Partition {
 
 /**
    Self partitioner actually does nothing.  It is simply a pass
@@ -50,8 +48,6 @@ public:
     bool spawnOnAllRanks() override { return false; }
 };
 
-} // namespace Partition
-} // namespace IMPL
-} // namespace SST
+} // namespace SST::IMPL::Partition
 
 #endif

--- a/src/sst/core/impl/partitioners/simplepart.cc
+++ b/src/sst/core/impl/partitioners/simplepart.cc
@@ -224,7 +224,8 @@ SimplePartitioner::performPartition(PartitionGraph* graph)
 
                 // ConfigLink* theLink = (*linkItr);
                 PartitionLink& theLink = linkMap[*linkItr];
-                compConnectMap->insert(std::pair<ComponentId_t, SimTime_t>(theLink.component[1], theLink.getMinLatency()));
+                compConnectMap->insert(
+                    std::pair<ComponentId_t, SimTime_t>(theLink.component[1], theLink.getMinLatency()));
             }
         }
 

--- a/src/sst/core/impl/partitioners/simplepart.cc
+++ b/src/sst/core/impl/partitioners/simplepart.cc
@@ -20,11 +20,7 @@
 #include <stdlib.h>
 #include <vector>
 
-using namespace std;
-
-namespace SST {
-namespace IMPL {
-namespace Partition {
+namespace SST::IMPL::Partition {
 
 SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo UNUSED(my_rank), int UNUSED(verbosity)) :
     SSTPartitioner(),
@@ -71,17 +67,14 @@ findIndex(ComponentId_t* theArray, const int length, ComponentId_t findThis)
 static SimTime_t
 cost_external_links(
     ComponentId_t* setA, const int lengthA, ComponentId_t* setB, const int lengthB,
-    map<ComponentId_t, map<ComponentId_t, SimTime_t>*>& timeTable)
+    std::map<ComponentId_t, std::map<ComponentId_t, SimTime_t>*>& timeTable)
 {
 
     SimTime_t cost = 0;
 
     for ( int i = 0; i < lengthA; i++ ) {
-        map<ComponentId_t, SimTime_t>* compMap = timeTable[setA[i]];
-
-        for ( map<ComponentId_t, SimTime_t>::const_iterator compMapItr = compMap->begin(); compMapItr != compMap->end();
-              compMapItr++ ) {
-
+        auto* compMap = timeTable[setA[i]];
+        for ( auto compMapItr = compMap->cbegin(); compMapItr != compMap->cend(); compMapItr++ ) {
             if ( findIndex(setB, lengthB, compMapItr->first) > -1 ) { cost += compMapItr->second; }
         }
     }
@@ -93,7 +86,7 @@ cost_external_links(
 void
 SimplePartitioner::simple_partition_step(
     PartitionComponentMap_t& component_map, ComponentId_t* setA, const int lengthA, int rankA, ComponentId_t* setB,
-    const int lengthB, int rankB, map<ComponentId_t, map<ComponentId_t, SimTime_t>*> timeTable, int step)
+    const int lengthB, int rankB, std::map<ComponentId_t, std::map<ComponentId_t, SimTime_t>*> timeTable, int step)
 {
 
     SimTime_t costExt = cost_external_links(setA, lengthA, setB, lengthB, timeTable);
@@ -206,7 +199,7 @@ SimplePartitioner::performPartition(PartitionGraph* graph)
         int indexB = 0;
         int count  = 0;
 
-        map<ComponentId_t, map<ComponentId_t, SimTime_t>*> timeTable;
+        std::map<ComponentId_t, std::map<ComponentId_t, SimTime_t>*> timeTable;
 
         // size_t nComp = component_map.size();
         // for(size_t theComponent = 0 ; theComponent < nComp ; theComponent++ ) {
@@ -215,8 +208,7 @@ SimplePartitioner::performPartition(PartitionGraph* graph)
 
             ComponentId_t theComponent = (*compItr)->id;
 
-            map<ComponentId_t, SimTime_t>* compConnectMap = new map<ComponentId_t, SimTime_t>();
-            timeTable[theComponent]                       = compConnectMap;
+            auto compConnectMap = timeTable[theComponent] = new std::map<ComponentId_t, SimTime_t>();
 
             if ( count++ % 2 == 0 ) { setA[indexA++] = theComponent; }
             else {
@@ -232,13 +224,12 @@ SimplePartitioner::performPartition(PartitionGraph* graph)
 
                 // ConfigLink* theLink = (*linkItr);
                 PartitionLink& theLink = linkMap[*linkItr];
-                compConnectMap->insert(pair<ComponentId_t, SimTime_t>(theLink.component[1], theLink.getMinLatency()));
+                compConnectMap->insert(std::pair<ComponentId_t, SimTime_t>(theLink.component[1], theLink.getMinLatency()));
             }
         }
 
         simple_partition_step(component_map, setA, A_size, 0, setB, B_size, 1, timeTable, 1);
     }
 }
-} // namespace Partition
-} // namespace IMPL
-} // namespace SST
+
+} // namespace SST::IMPL::Partition

--- a/src/sst/core/impl/partitioners/simplepart.h
+++ b/src/sst/core/impl/partitioners/simplepart.h
@@ -19,9 +19,7 @@
 
 #include <map>
 
-namespace SST {
-namespace IMPL {
-namespace Partition {
+namespace SST::IMPL::Partition {
 
 class SimplePartitioner : public SST::Partition::SSTPartitioner
 {
@@ -59,7 +57,6 @@ public:
     bool spawnOnAllRanks() override { return false; }
 };
 
-} // namespace Partition
-} // namespace IMPL
-} // namespace SST
+} // namespace SST::IMPL::Partition
+
 #endif // SST_CORE_IMPL_PARTITONERS_SIMPLERPART_H

--- a/src/sst/core/impl/partitioners/singlepart.cc
+++ b/src/sst/core/impl/partitioners/singlepart.cc
@@ -16,8 +16,6 @@
 #include "sst/core/configGraph.h"
 #include "sst/core/warnmacros.h"
 
-using namespace std;
-
 using namespace SST::IMPL::Partition;
 
 SSTSinglePartition::SSTSinglePartition(RankInfo UNUSED(total_ranks), RankInfo UNUSED(my_rank), int UNUSED(verbosity)) {}

--- a/src/sst/core/impl/partitioners/singlepart.h
+++ b/src/sst/core/impl/partitioners/singlepart.h
@@ -15,9 +15,7 @@
 #include "sst/core/eli/elementinfo.h"
 #include "sst/core/sstpart.h"
 
-namespace SST {
-namespace IMPL {
-namespace Partition {
+namespace SST::IMPL::Partition {
 
 /**
    Single partitioner is a virtual partitioner used for serial jobs.
@@ -49,8 +47,6 @@ public:
     bool spawnOnAllRanks() override { return false; }
 };
 
-} // namespace Partition
-} // namespace IMPL
-} // namespace SST
+} // namespace SST::IMPL::Partition
 
 #endif

--- a/src/sst/core/impl/portmodules/randomDrop.cc
+++ b/src/sst/core/impl/portmodules/randomDrop.cc
@@ -16,9 +16,7 @@
 #include "sst/core/event.h"
 #include "sst/core/params.h"
 
-namespace SST {
-namespace IMPL {
-namespace PortModule {
+namespace SST::IMPL::PortModule {
 
 RandomDrop::RandomDrop(Params& params) : rng_(7, 13)
 {
@@ -104,7 +102,4 @@ RandomDrop::serialize_order(SST::Core::Serialization::serializer& ser)
     ser& print_info_;
 }
 
-
-} // namespace PortModule
-} // namespace IMPL
-} // namespace SST
+} // namespace SST::IMPL::PortModule

--- a/src/sst/core/impl/portmodules/randomDrop.h
+++ b/src/sst/core/impl/portmodules/randomDrop.h
@@ -19,10 +19,7 @@
 
 #include <sst/core/rng/marsaglia.h>
 
-
-namespace SST {
-namespace IMPL {
-namespace PortModule {
+namespace SST::IMPL::PortModule {
 
 class RandomDrop : public SST::PortModule
 {
@@ -88,8 +85,6 @@ private:
     std::string* print_info_ = nullptr;
 };
 
-} // namespace PortModule
-} // namespace IMPL
-} // namespace SST
+} // namespace SST::IMPL::PortModule
 
 #endif // SST_CORE_IMPL_PORTMODULE_RANDOMDROP_H

--- a/src/sst/core/impl/timevortex/timeVortexBinnedMap.cc
+++ b/src/sst/core/impl/timevortex/timeVortexBinnedMap.cc
@@ -18,8 +18,7 @@
 
 #include <algorithm>
 
-namespace SST {
-namespace IMPL {
+namespace SST::IMPL {
 
 // We sort backwards so we can work from the bottom of the vector
 // (faster delete)
@@ -202,6 +201,4 @@ public:
     SST_ELI_EXPORT(TimeVortexBinnedMap_ts)
 };
 
-
-} // namespace IMPL
-} // namespace SST
+} // namespace SST::IMPL

--- a/src/sst/core/impl/timevortex/timeVortexPQ.cc
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.cc
@@ -16,8 +16,7 @@
 #include "sst/core/clock.h"
 #include "sst/core/output.h"
 
-namespace SST {
-namespace IMPL {
+namespace SST::IMPL {
 
 template <bool TS>
 TimeVortexPQBase<TS>::TimeVortexPQBase(Params& UNUSED(params)) :
@@ -180,5 +179,4 @@ public:
     SST_ELI_EXPORT(TimeVortexPQ_ts)
 };
 
-} // namespace IMPL
-} // namespace SST
+} // namespace SST::IMPL

--- a/src/sst/core/interactiveConsole.cc
+++ b/src/sst/core/interactiveConsole.cc
@@ -18,9 +18,7 @@
 #include "sst/core/simulation_impl.h"
 #include "sst/core/timeLord.h"
 
-
 namespace SST {
-
 
 /************ InteractiveConsole ***********/
 
@@ -118,5 +116,4 @@ InteractiveConsole::getComponentObjectMap()
     return Simulation_impl::getSimulation()->getComponentObjectMap();
 }
 
-
-} /* End namespace SST */
+} // namespace SST

--- a/src/sst/core/interfaces/TestEvent.h
+++ b/src/sst/core/interfaces/TestEvent.h
@@ -14,8 +14,7 @@
 
 #include "sst/core/event.h"
 
-namespace SST {
-namespace Interfaces {
+namespace SST::Interfaces {
 
 /**  Test Event
  *   Useful for early-testing of components.
@@ -40,7 +39,6 @@ public:
     ImplementSerializable(SST::Interfaces::TestEvent);
 };
 
-} // namespace Interfaces
-} // namespace SST
+} // namespace SST::Interfaces
 
 #endif // SST_CORE_INTERFACES_TEST_EVENT_H

--- a/src/sst/core/interfaces/simpleNetwork.cc
+++ b/src/sst/core/interfaces/simpleNetwork.cc
@@ -15,12 +15,8 @@
 
 #include "sst/core/objectComms.h"
 
-using namespace std;
-
-namespace SST {
-namespace Interfaces {
+namespace SST::Interfaces {
 
 const SimpleNetwork::nid_t SimpleNetwork::INIT_BROADCAST_ADDR = 0xffffffffffffffffl;
 
-} // namespace Interfaces
-} // namespace SST
+} // namespace SST::Interfaces

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -25,12 +25,12 @@
 #include <unordered_map>
 
 namespace SST {
-
 class Component;
 class Event;
 class Link;
+} // namespace SST
 
-namespace Interfaces {
+namespace SST::Interfaces {
 
 /**
  * Generic network interface
@@ -320,7 +320,6 @@ public:
     virtual const UnitAlgebra& getLinkBW() const = 0;
 };
 
-} // namespace Interfaces
-} // namespace SST
+} // namespace SST::Interfaces
 
 #endif // SST_CORE_INTERFACES_SIMPLENETWORK_H

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -28,11 +28,11 @@
 #include <utility>
 
 namespace SST {
-
 class Component;
 class Event;
+} // namespace SST
 
-namespace Interfaces {
+namespace SST::Interfaces {
 /**
  * Generic interface to Memory models
  *
@@ -1275,7 +1275,6 @@ public:
     virtual void serialize_order(SST::Core::Serialization::serializer& ser) { SST::SubComponent::serialize_order(ser); }
 };
 
-} // namespace Interfaces
-} // namespace SST
+} // namespace SST::Interfaces
 
 #endif // SST_CORE_INTERFACES_STANDARDMEM_H

--- a/src/sst/core/interfaces/stringEvent.h
+++ b/src/sst/core/interfaces/stringEvent.h
@@ -15,8 +15,7 @@
 #include "sst/core/event.h"
 #include "sst/core/sst_types.h"
 
-namespace SST {
-namespace Interfaces {
+namespace SST::Interfaces {
 
 /**
  * Simple event to pass strings between components
@@ -50,7 +49,6 @@ public:
     ImplementSerializable(SST::Interfaces::StringEvent);
 };
 
-} // namespace Interfaces
-} // namespace SST
+} // namespace SST::Interfaces
 
 #endif // SST_CORE_INTERFACES_STRINGEVENT_H

--- a/src/sst/core/interprocess/circularBuffer.h
+++ b/src/sst/core/interprocess/circularBuffer.h
@@ -14,9 +14,7 @@
 
 #include "sstmutex.h"
 
-namespace SST {
-namespace Core {
-namespace Interprocess {
+namespace SST::Core::Interprocess {
 
 template <typename T>
 class CircularBuffer
@@ -118,8 +116,6 @@ private:
     T        buffer[0];
 };
 
-} // namespace Interprocess
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Interprocess
 
 #endif // SST_CORE_INTERPROCESS_CIRCULARBUFFER_H

--- a/src/sst/core/interprocess/ipctunnel.cc
+++ b/src/sst/core/interprocess/ipctunnel.cc
@@ -13,10 +13,8 @@
 
 #include <inttypes.h>
 
-namespace SST {
-namespace Core {
-namespace Interprocess {
+namespace SST::Core::Interprocess {
+
 uint32_t globalIPCTunnelCount = 0;
-}
-} // namespace Core
-} // namespace SST
+
+} // namespace SST::Core::Interprocess

--- a/src/sst/core/interprocess/ipctunnel.h
+++ b/src/sst/core/interprocess/ipctunnel.h
@@ -24,9 +24,7 @@
 #include <unistd.h>
 #include <vector>
 
-namespace SST {
-namespace Core {
-namespace Interprocess {
+namespace SST::Core::Interprocess {
 
 extern uint32_t globalIPCTunnelCount;
 /**
@@ -252,8 +250,6 @@ private:
     std::vector<CircBuff_t*> circBuffs;
 };
 
-} // namespace Interprocess
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Interprocess
 
 #endif // SST_CORE_INTERPROCESS_IPCTUNNEL_H

--- a/src/sst/core/interprocess/mmapchild_pin3.h
+++ b/src/sst/core/interprocess/mmapchild_pin3.h
@@ -16,9 +16,7 @@
 
 #include "pin.H"
 
-namespace SST {
-namespace Core {
-namespace Interprocess {
+namespace SST::Core::Interprocess {
 
 /** Class supports an IPC tunnel between two or more processes, via an mmap'd file
  * This class attaches to an existing tunnel for a child process using PinCRT
@@ -104,8 +102,6 @@ private:
     TunnelType* tunnel;
 };
 
-} // namespace Interprocess
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Interprocess
 
 #endif // SST_CORE_INTERPROCESS_TUNNEL_MMAP_CHILD_PIN3_H

--- a/src/sst/core/interprocess/mmapparent.h
+++ b/src/sst/core/interprocess/mmapparent.h
@@ -23,9 +23,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-namespace SST {
-namespace Core {
-namespace Interprocess {
+namespace SST::Core::Interprocess {
 
 /** Class supports an IPC tunnel between two or more processes, via an mmap'd file.
  * This class creates the tunnel for the parent/master process
@@ -118,8 +116,6 @@ private:
     TunnelType* tunnel;
 };
 
-} // namespace Interprocess
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Interprocess
 
 #endif // SST_CORE_INTERPROCESS_TUNNEL_MMAP_PARENT_H

--- a/src/sst/core/interprocess/shmchild.h
+++ b/src/sst/core/interprocess/shmchild.h
@@ -24,9 +24,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-namespace SST {
-namespace Core {
-namespace Interprocess {
+namespace SST::Core::Interprocess {
 
 /** Class supports an IPC tunnel between two or more processes, via posix shared memory
  * This class attaches to an existing tunnel for a child process
@@ -107,8 +105,6 @@ private:
     TunnelType* tunnel;
 };
 
-} // namespace Interprocess
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Interprocess
 
 #endif // SST_CORE_INTERPROCESS_TUNNEL_SHM_CHILD_H

--- a/src/sst/core/interprocess/shmparent.h
+++ b/src/sst/core/interprocess/shmparent.h
@@ -23,9 +23,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-namespace SST {
-namespace Core {
-namespace Interprocess {
+namespace SST::Core::Interprocess {
 
 /** Class supports an IPC tunnel between two or more processes via posix shared memory
  * This class creates the tunnel for the parent/master process
@@ -121,8 +119,6 @@ private:
     TunnelType* tunnel;
 };
 
-} // namespace Interprocess
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Interprocess
 
 #endif // SST_CORE_INTERPROCESS_TUNNEL_SHM_PARENT_H

--- a/src/sst/core/interprocess/sstmutex.h
+++ b/src/sst/core/interprocess/sstmutex.h
@@ -15,9 +15,7 @@
 #include <sched.h>
 #include <time.h>
 
-namespace SST {
-namespace Core {
-namespace Interprocess {
+namespace SST::Core::Interprocess {
 
 #define SST_CORE_INTERPROCESS_LOCKED   1
 #define SST_CORE_INTERPROCESS_UNLOCKED 0
@@ -78,8 +76,6 @@ private:
     volatile int lockVal;
 };
 
-} // namespace Interprocess
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Interprocess
 
 #endif // SST_CORE_INTERPROCESS_MUTEX_H

--- a/src/sst/core/interprocess/tunneldef.h
+++ b/src/sst/core/interprocess/tunneldef.h
@@ -26,9 +26,7 @@
 #include <unistd.h>
 #include <vector>
 
-namespace SST {
-namespace Core {
-namespace Interprocess {
+namespace SST::Core::Interprocess {
 
 extern uint32_t globalMMAPIPCCount;
 
@@ -245,8 +243,6 @@ private:
     std::vector<CircBuff_t*> circBuffs;
 };
 
-} // namespace Interprocess
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Interprocess
 
 #endif // SST_CORE_INTERPROCESS_TUNNEL_DEF_H

--- a/src/sst/core/iouse.h
+++ b/src/sst/core/iouse.h
@@ -14,13 +14,11 @@
 
 #include <inttypes.h>
 
-namespace SST {
-namespace Core {
+namespace SST::Core {
 
 uint64_t maxInputOperations();
 uint64_t maxOutputOperations();
 
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core
 
 #endif // SST_CORE_IOUSE_H

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -546,8 +546,8 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
                 // If we are a MPI_parallel job, need to makes sure that all used
                 // libraries are loaded on all ranks.
 #ifdef SST_CONFIG_HAVE_MPI
-                set<string> lib_names;
-                set<string> other_lib_names;
+                std::set<std::string> lib_names;
+                std::set<std::string> other_lib_names;
                 Factory::getFactory()->getLoadedLibraryNames(lib_names);
 
                 // Send my lib_names to the next lowest rank

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -135,7 +135,7 @@ dump_partition(Config& cfg, ConfigGraph* graph, const RankInfo& size)
                 cfg.component_partition_file().c_str());
         }
 
-        std::ofstream            graph_file(cfg.component_partition_file().c_str());
+        std::ofstream         graph_file(cfg.component_partition_file().c_str());
         ConfigComponentMap_t& component_map = graph->getComponentMap();
 
         for ( uint32_t i = 0; i < size.rank; i++ ) {

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -69,7 +69,6 @@ REENABLE_WARNING
 
 using namespace SST::Core;
 using namespace SST::Partition;
-using namespace std;
 using namespace SST;
 
 
@@ -136,7 +135,7 @@ dump_partition(Config& cfg, ConfigGraph* graph, const RankInfo& size)
                 cfg.component_partition_file().c_str());
         }
 
-        ofstream              graph_file(cfg.component_partition_file().c_str());
+        std::ofstream            graph_file(cfg.component_partition_file().c_str());
         ConfigComponentMap_t& component_map = graph->getComponentMap();
 
         for ( uint32_t i = 0; i < size.rank; i++ ) {
@@ -308,7 +307,7 @@ start_graph_creation(
         try {
             model_name = extension_map.at(extension);
         }
-        catch ( exception& e ) {
+        catch ( std::exception& e ) {
             std::cerr << "Unsupported SDL file type: \"" << extension << "\"" << std::endl;
             return -1;
         }

--- a/src/sst/core/math/sqrt.h
+++ b/src/sst/core/math/sqrt.h
@@ -12,8 +12,7 @@
 #ifndef SST_CORE_MATH_SQRT_H
 #define SST_CORE_MATH_SQRT_H
 
-namespace SST {
-namespace Math {
+namespace SST::Math {
 
 // Implements uint32_t square root based on algorithm from:
 // Reference: http://en.wikipedia.org/wiki/Methods_of_computing_square_roots
@@ -42,7 +41,6 @@ square_root(const uint32_t input)
     return res;
 };
 
-} // namespace Math
-} // namespace SST
+} // namespace SST::Math
 
 #endif // SST_CORE_MATH_SQRT_H

--- a/src/sst/core/mempool.cc
+++ b/src/sst/core/mempool.cc
@@ -23,8 +23,7 @@
 #include <sys/time.h>
 #include <vector>
 
-namespace SST {
-namespace Core {
+namespace SST::Core {
 
 #ifdef USE_MEMPOOL
 
@@ -506,6 +505,4 @@ MemPoolItem::print(const std::string& header, Output& out) const
     out.output("%s%s\n", header.c_str(), toString().c_str());
 }
 
-
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core

--- a/src/sst/core/mempoolAccessor.h
+++ b/src/sst/core/mempoolAccessor.h
@@ -12,10 +12,7 @@
 #ifndef SST_CORE_MEMPOOL_ACCESSOR_H
 #define SST_CORE_MEMPOOL_ACCESSOR_H
 
-
-namespace SST {
-
-namespace Core {
+namespace SST::Core {
 
 // Class to access stats/data about the mempools.  This is here to
 // limit exposure to the USE_MEMPOOL #define, which will only be in
@@ -51,7 +48,6 @@ public:
     static void printUndeletedMemPoolItems(const std::string& header, Output& out);
 };
 
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core
 
 #endif // SST_CORE_MEMPOOL_ACCESSOR_H

--- a/src/sst/core/memuse.h
+++ b/src/sst/core/memuse.h
@@ -14,8 +14,7 @@
 
 #include <inttypes.h>
 
-namespace SST {
-namespace Core {
+namespace SST::Core {
 
 uint64_t localMemSize();
 uint64_t maxLocalMemSize();
@@ -23,7 +22,6 @@ uint64_t maxGlobalMemSize();
 uint64_t maxLocalPageFaults();
 uint64_t globalPageFaults();
 
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core
 
 #endif // SST_CORE_MEMUSE_H

--- a/src/sst/core/model/json/jsonmodel.h
+++ b/src/sst/core/model/json/jsonmodel.h
@@ -36,8 +36,7 @@
 using namespace SST;
 using json = nlohmann::json;
 
-namespace SST {
-namespace Core {
+namespace SST::Core {
 
 class SSTJSONModelDefinition : public SSTModelDescription
 {
@@ -74,7 +73,6 @@ private:
     ComponentId_t findComponentIdByName(const std::string& Name);
 };
 
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core
 
 #endif // SST_CORE_MODEL_JSON_JSONMODEL_H

--- a/src/sst/core/model/python/pymodel.h
+++ b/src/sst/core/model/python/pymodel.h
@@ -35,8 +35,7 @@ REENABLE_WARNING
 
 using namespace SST;
 
-namespace SST {
-namespace Core {
+namespace SST::Core {
 
 class SSTPythonModelDefinition : public SSTModelDescription
 {
@@ -175,7 +174,6 @@ PyObject*
 buildEnabledStatistic(ConfigComponent* cc, const char* statName, PyObject* statParamDict, bool apply_to_children);
 PyObject* buildEnabledStatistics(ConfigComponent* cc, PyObject* statList, PyObject* paramDict, bool apply_to_children);
 
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core
 
 #endif // SST_CORE_MODEL_PYTHON_PYMODEL_H

--- a/src/sst/core/model/python/pymodel_comp.h
+++ b/src/sst/core/model/python/pymodel_comp.h
@@ -25,7 +25,7 @@ REENABLE_WARNING
 
 namespace SST {
 class ConfigComponent;
-} // namespace SST
+}
 
 extern "C" {
 

--- a/src/sst/core/objectComms.h
+++ b/src/sst/core/objectComms.h
@@ -24,9 +24,7 @@ REENABLE_WARNING
 #include <memory>
 #include <typeinfo>
 
-namespace SST {
-
-namespace Comms {
+namespace SST::Comms {
 
 #ifdef SST_CONFIG_HAVE_MPI
 template <typename dataType>
@@ -148,8 +146,6 @@ all_gather(dataType& data, std::vector<dataType>& out_data)
 
 #endif
 
-} // namespace Comms
-
-} // namespace SST
+} // namespace SST::Comms
 
 #endif // SST_CORE_OBJECTCOMMS_H

--- a/src/sst/core/objectSerialization.h
+++ b/src/sst/core/objectSerialization.h
@@ -16,9 +16,7 @@
 
 #include <vector>
 
-namespace SST {
-
-namespace Comms {
+namespace SST::Comms {
 
 template <typename dataType>
 std::vector<char>
@@ -75,8 +73,6 @@ deserialize(char* buffer, int blen, dataType& tgt)
     ser& tgt;
 }
 
-} // namespace Comms
-
-} // namespace SST
+} // namespace SST::Comms
 
 #endif // SST_CORE_OBJECTSERIALIZATION_H

--- a/src/sst/core/profile.h
+++ b/src/sst/core/profile.h
@@ -16,9 +16,7 @@
 
 #include <chrono>
 
-namespace SST {
-namespace Core {
-namespace Profile {
+namespace SST::Core::Profile {
 
 #ifdef __SST_ENABLE_PROFILE__
 
@@ -72,8 +70,6 @@ getElapsed(const ProfData_t& UNUSED(since))
 
 #endif
 
-} // namespace Profile
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Profile
 
 #endif // SST_CORE_CORE_PROFILE_H

--- a/src/sst/core/profile/clockHandlerProfileTool.cc
+++ b/src/sst/core/profile/clockHandlerProfileTool.cc
@@ -19,9 +19,7 @@
 
 #include <chrono>
 
-namespace SST {
-namespace Profile {
-
+namespace SST::Profile {
 
 ClockHandlerProfileTool::ClockHandlerProfileTool(const std::string& name, Params& params) : ProfileTool(name)
 {
@@ -162,6 +160,4 @@ public:
     SST_ELI_EXPORT(ClockHandlerProfileToolTimeSteady)
 };
 
-
-} // namespace Profile
-} // namespace SST
+} // namespace SST::Profile

--- a/src/sst/core/profile/clockHandlerProfileTool.h
+++ b/src/sst/core/profile/clockHandlerProfileTool.h
@@ -22,10 +22,7 @@
 #include <chrono>
 #include <map>
 
-namespace SST {
-
-namespace Profile {
-
+namespace SST::Profile {
 
 class ClockHandlerProfileTool : public ProfileTool, public Clock::HandlerBase::AttachPoint
 {
@@ -121,7 +118,6 @@ private:
     std::map<std::string, clock_data_t> times_;
 };
 
-} // namespace Profile
-} // namespace SST
+} // namespace SST::Profile
 
 #endif // SST_CORE_PROFILE_CLOCKHANDLERPROFILETOOL_H

--- a/src/sst/core/profile/componentProfileTool.cc
+++ b/src/sst/core/profile/componentProfileTool.cc
@@ -19,9 +19,7 @@
 
 #include <chrono>
 
-namespace SST {
-namespace Profile {
-
+namespace SST::Profile {
 
 ComponentProfileTool::ComponentProfileTool(const std::string& name, Params& params) : ProfileTool(name)
 {
@@ -174,6 +172,4 @@ public:
     SST_ELI_EXPORT(ComponentCodeSegmentProfileToolTimeSteady)
 };
 
-
-} // namespace Profile
-} // namespace SST
+} // namespace SST::Profile

--- a/src/sst/core/profile/componentProfileTool.h
+++ b/src/sst/core/profile/componentProfileTool.h
@@ -21,10 +21,10 @@
 #include <map>
 
 namespace SST {
-
 class BaseComponent;
+}
 
-namespace Profile {
+namespace SST::Profile {
 
 // Base class for profiling tools designed to profile in Components
 // and SubComponents. For these types of profiling tools, you can
@@ -188,7 +188,6 @@ private:
     std::map<std::string, segment_data_t> times_;
 };
 
-} // namespace Profile
-} // namespace SST
+} // namespace SST::Profile
 
 #endif // SST_CORE_PROFILE_COMPONENTPROFILETOOL_H

--- a/src/sst/core/profile/eventHandlerProfileTool.cc
+++ b/src/sst/core/profile/eventHandlerProfileTool.cc
@@ -19,9 +19,7 @@
 
 #include <chrono>
 
-namespace SST {
-namespace Profile {
-
+namespace SST::Profile {
 
 EventHandlerProfileTool::EventHandlerProfileTool(const std::string& name, Params& params) : ProfileTool(name)
 {
@@ -201,6 +199,4 @@ public:
     SST_ELI_EXPORT(EventHandlerProfileToolTimeSteady)
 };
 
-
-} // namespace Profile
-} // namespace SST
+} // namespace SST::Profile

--- a/src/sst/core/profile/eventHandlerProfileTool.h
+++ b/src/sst/core/profile/eventHandlerProfileTool.h
@@ -23,10 +23,7 @@
 #include <chrono>
 #include <map>
 
-namespace SST {
-
-namespace Profile {
-
+namespace SST::Profile {
 
 class EventHandlerProfileTool : public ProfileTool, public Event::HandlerBase::AttachPoint, public Link::AttachPoint
 {
@@ -149,7 +146,6 @@ private:
     std::map<std::string, event_data_t> times_;
 };
 
-} // namespace Profile
-} // namespace SST
+} // namespace SST::Profile
 
 #endif // SST_CORE_PROFILE_EVENTHANDLERPROFILETOOL_H

--- a/src/sst/core/profile/profiletool.cc
+++ b/src/sst/core/profile/profiletool.cc
@@ -17,14 +17,11 @@
 
 #include <atomic>
 
-namespace SST {
-namespace Profile {
+namespace SST::Profile {
 
 SST_ELI_DEFINE_INFO_EXTERN(ProfileTool)
 SST_ELI_DEFINE_CTOR_EXTERN(ProfileTool)
 
-
 ProfileTool::ProfileTool(const std::string& name) : name(name) {}
 
-} // namespace Profile
-} // namespace SST
+} // namespace SST::Profile

--- a/src/sst/core/profile/profiletool.h
+++ b/src/sst/core/profile/profiletool.h
@@ -17,10 +17,10 @@
 #include "sst/core/warnmacros.h"
 
 namespace SST {
-
 class Params;
+}
 
-namespace Profile {
+namespace SST::Profile {
 
 /**
    ProfileTool is a class loadable through the factory which allows
@@ -49,8 +49,7 @@ protected:
     const std::string name;
 };
 
-} // namespace Profile
-} // namespace SST
+} // namespace SST::Profile
 
 // Register profile tools.  Must register an interface
 // (API) first, then you can register a subcomponent that implements

--- a/src/sst/core/profile/syncProfileTool.cc
+++ b/src/sst/core/profile/syncProfileTool.cc
@@ -18,9 +18,7 @@
 
 #include <chrono>
 
-namespace SST {
-namespace Profile {
-
+namespace SST::Profile {
 
 SyncProfileTool::SyncProfileTool(const std::string& name, Params& UNUSED(params)) : ProfileTool(name) {}
 
@@ -101,6 +99,4 @@ public:
     SST_ELI_EXPORT(SyncProfileToolTimeSteady)
 };
 
-
-} // namespace Profile
-} // namespace SST
+} // namespace SST::Profile

--- a/src/sst/core/profile/syncProfileTool.h
+++ b/src/sst/core/profile/syncProfileTool.h
@@ -21,9 +21,7 @@
 #include <chrono>
 #include <map>
 
-namespace SST {
-
-namespace Profile {
+namespace SST::Profile {
 
 // Initial version of sync profiling tool.  The API is not yet complete.
 class SyncProfileTool : public ProfileTool
@@ -103,7 +101,6 @@ private:
     typename T::time_point start_time_;
 };
 
-} // namespace Profile
-} // namespace SST
+} // namespace SST::Profile
 
 #endif // SST_CORE_PROFILE_SYNCPROFILETOOL_H

--- a/src/sst/core/rng/constant.h
+++ b/src/sst/core/rng/constant.h
@@ -15,10 +15,7 @@
 #include "distrib.h"
 #include "math.h"
 
-using namespace SST::RNG;
-
-namespace SST {
-namespace RNG {
+namespace SST::RNG {
 
 /**
     \class ConstantDistribution constant.h "sst/core/rng/constant.h"
@@ -76,9 +73,8 @@ protected:
     double mean;
 };
 
-using SSTConstantDistribution = SST::RNG::ConstantDistribution;
+using SSTConstantDistribution = ConstantDistribution;
 
-} // namespace RNG
-} // namespace SST
+} // namespace SST::RNG
 
 #endif // SST_CORE_RNG_CONSTANT_H

--- a/src/sst/core/rng/constant.h
+++ b/src/sst/core/rng/constant.h
@@ -73,8 +73,8 @@ protected:
     double mean;
 };
 
-using SSTConstantDistribution = ConstantDistribution;
-
 } // namespace SST::RNG
+
+using SSTConstantDistribution = SST::RNG::ConstantDistribution;
 
 #endif // SST_CORE_RNG_CONSTANT_H

--- a/src/sst/core/rng/discrete.h
+++ b/src/sst/core/rng/discrete.h
@@ -151,8 +151,8 @@ protected:
     uint32_t probCount;
 };
 
-using SSTDiscreteDistribution = DiscreteDistribution;
-
 } // namespace SST::RNG
+
+using SSTDiscreteDistribution = SST::RNG::DiscreteDistribution;
 
 #endif // SST_CORE_RNG_DISCRETE_H

--- a/src/sst/core/rng/discrete.h
+++ b/src/sst/core/rng/discrete.h
@@ -19,10 +19,7 @@
 
 #include <cstdlib> // for malloc/free
 
-using namespace SST::RNG;
-
-namespace SST {
-namespace RNG {
+namespace SST::RNG {
 
 /**
     \class DiscreteDistribution discrete.h "sst/core/rng/discrete.h"
@@ -30,7 +27,7 @@ namespace RNG {
     Creates a discrete distribution for use within SST. This distribution is the same across
     platforms and compilers.
 */
-class DiscreteDistribution : public SST::RNG::RandomDistribution
+class DiscreteDistribution : public RandomDistribution
 {
 
 public:
@@ -40,7 +37,7 @@ public:
         \param probsCount The number of discrete outcomes
     */
     DiscreteDistribution(const double* probs, const uint32_t probsCount) :
-        SST::RNG::RandomDistribution(),
+        RandomDistribution(),
         probCount(probsCount)
     {
 
@@ -61,7 +58,7 @@ public:
         \param lambda The lambda of the exponential distribution
         \param baseDist The base random number generator to take the distribution from.
     */
-    DiscreteDistribution(const double* probs, const uint32_t probsCount, SST::RNG::Random* baseDist) :
+    DiscreteDistribution(const double* probs, const uint32_t probsCount, Random* baseDist) :
         RandomDistribution(),
         probCount(probsCount)
     {
@@ -132,13 +129,13 @@ public:
     /**
         Serialization macro
     */
-    ImplementSerializable(SST::RNG::DiscreteDistribution)
+    ImplementSerializable(DiscreteDistribution)
 
 protected:
     /**
         Sets the base random number generator for the distribution.
     */
-    SST::RNG::Random* baseDistrib;
+    Random* baseDistrib;
 
     /**
         Controls whether the base distribution should be deleted when this class is destructed.
@@ -156,9 +153,8 @@ protected:
     uint32_t probCount;
 };
 
-using SSTDiscreteDistribution = SST::RNG::DiscreteDistribution;
+using SSTDiscreteDistribution = DiscreteDistribution;
 
-} // namespace RNG
-} // namespace SST
+} // namespace SST::RNG
 
 #endif // SST_CORE_RNG_DISCRETE_H

--- a/src/sst/core/rng/discrete.h
+++ b/src/sst/core/rng/discrete.h
@@ -36,9 +36,7 @@ public:
         \param probs An array of probabilities for each outcome
         \param probsCount The number of discrete outcomes
     */
-    DiscreteDistribution(const double* probs, const uint32_t probsCount) :
-        RandomDistribution(),
-        probCount(probsCount)
+    DiscreteDistribution(const double* probs, const uint32_t probsCount) : RandomDistribution(), probCount(probsCount)
     {
 
         probabilities   = (double*)malloc(sizeof(double) * probsCount);

--- a/src/sst/core/rng/distrib.h
+++ b/src/sst/core/rng/distrib.h
@@ -14,8 +14,7 @@
 
 #include "sst/core/serialization/serializable.h"
 
-namespace SST {
-namespace RNG {
+namespace SST::RNG {
 
 /**
  * \class RandomDistribution
@@ -46,9 +45,8 @@ public:
     ImplementVirtualSerializable(SST::RNG::RandomDistribution)
 };
 
-using SSTRandomDistribution = SST::RNG::RandomDistribution;
+using SSTRandomDistribution = RandomDistribution;
 
-} // namespace RNG
-} // namespace SST
+} // namespace SST::RNG
 
 #endif // SST_CORE_RNG_DISTRIB_H

--- a/src/sst/core/rng/distrib.h
+++ b/src/sst/core/rng/distrib.h
@@ -45,8 +45,8 @@ public:
     ImplementVirtualSerializable(SST::RNG::RandomDistribution)
 };
 
-using SSTRandomDistribution = RandomDistribution;
-
 } // namespace SST::RNG
+
+using SSTRandomDistribution = SST::RNG::RandomDistribution;
 
 #endif // SST_CORE_RNG_DISTRIB_H

--- a/src/sst/core/rng/expon.h
+++ b/src/sst/core/rng/expon.h
@@ -114,8 +114,8 @@ protected:
     bool deleteDistrib;
 };
 
-using SSTExponentialDistribution = ExponentialDistribution;
-
 } // namespace SST::RNG
+
+using SSTExponentialDistribution = SST::RNG::ExponentialDistribution;
 
 #endif // SST_CORE_RNG_EXPON_H

--- a/src/sst/core/rng/expon.h
+++ b/src/sst/core/rng/expon.h
@@ -102,7 +102,7 @@ protected:
     /**
         Sets the lambda of the exponential distribution.
     */
-    double            lambda;
+    double  lambda;
     /**
         Sets the base random number generator for the distribution.
     */

--- a/src/sst/core/rng/expon.h
+++ b/src/sst/core/rng/expon.h
@@ -17,10 +17,7 @@
 #include "mersenne.h"
 #include "rng.h"
 
-using namespace SST::RNG;
-
-namespace SST {
-namespace RNG {
+namespace SST::RNG {
 
 /**
     \class ExponentialDistribution expon.h "sst/core/rng/expon.h"
@@ -49,7 +46,7 @@ public:
         \param mn The lambda of the exponential distribution
         \param baseDist The base random number generator to take the distribution from.
     */
-    ExponentialDistribution(const double mn, SST::RNG::Random* baseDist) : RandomDistribution()
+    ExponentialDistribution(const double mn, Random* baseDist) : RandomDistribution()
     {
 
         lambda        = mn;
@@ -109,7 +106,7 @@ protected:
     /**
         Sets the base random number generator for the distribution.
     */
-    SST::RNG::Random* baseDistrib;
+    Random* baseDistrib;
 
     /**
         Controls whether the base distribution should be deleted when this class is destructed.
@@ -117,9 +114,8 @@ protected:
     bool deleteDistrib;
 };
 
-using SSTExponentialDistribution = SST::RNG::ExponentialDistribution;
+using SSTExponentialDistribution = ExponentialDistribution;
 
-} // namespace RNG
-} // namespace SST
+} // namespace SST::RNG
 
 #endif // SST_CORE_RNG_EXPON_H

--- a/src/sst/core/rng/gaussian.h
+++ b/src/sst/core/rng/gaussian.h
@@ -17,10 +17,7 @@
 #include "mersenne.h"
 #include "rng.h"
 
-using namespace SST::RNG;
-
-namespace SST {
-namespace RNG {
+namespace SST::RNG {
 
 /**
     \class GaussianDistribution gaussian.h "sst/core/rng/gaussian.h"
@@ -53,7 +50,7 @@ public:
        deviation. \param mn The mean of the Gaussian distribution \param sd The standard deviation of the Gaussian
        distribution \param baseRNG The random number generator as the base of the distribution
     */
-    GaussianDistribution(double mn, double sd, SST::RNG::Random* baseRNG) : RandomDistribution()
+    GaussianDistribution(double mn, double sd, Random* baseRNG) : RandomDistribution()
     {
 
         mean   = mn;
@@ -151,7 +148,7 @@ protected:
     /**
         The base random number generator for the distribution
     */
-    SST::RNG::Random* baseDistrib;
+    Random* baseDistrib;
     /**
         Random numbers for the distribution are read in pairs, this stores the second of the pair
     */
@@ -168,9 +165,8 @@ protected:
     bool deleteDistrib;
 };
 
-using SSTGaussianDistribution = SST::RNG::GaussianDistribution;
+using SSTGaussianDistribution = GaussianDistribution;
 
-} // namespace RNG
-} // namespace SST
+} // namespace SST::RNG
 
 #endif // SST_CORE_RNG_GAUSSIAN_H

--- a/src/sst/core/rng/gaussian.h
+++ b/src/sst/core/rng/gaussian.h
@@ -165,8 +165,8 @@ protected:
     bool deleteDistrib;
 };
 
-using SSTGaussianDistribution = GaussianDistribution;
-
 } // namespace SST::RNG
+
+using SSTGaussianDistribution = SST::RNG::GaussianDistribution;
 
 #endif // SST_CORE_RNG_GAUSSIAN_H

--- a/src/sst/core/rng/gaussian.h
+++ b/src/sst/core/rng/gaussian.h
@@ -140,11 +140,11 @@ protected:
     /**
         The mean of the Gaussian distribution
     */
-    double            mean;
+    double  mean;
     /**
         The standard deviation of the Gaussian distribution
     */
-    double            stddev;
+    double  stddev;
     /**
         The base random number generator for the distribution
     */
@@ -152,11 +152,11 @@ protected:
     /**
         Random numbers for the distribution are read in pairs, this stores the second of the pair
     */
-    double            unusedPair;
+    double  unusedPair;
     /**
         Random numbers for the distribution are read in pairs, this tells the code to use the second of the pair
     */
-    bool              usePair;
+    bool    usePair;
 
     /**
         Controls whether the destructor deletes the distribution (we need to ensure we do this IF we created the

--- a/src/sst/core/rng/marsaglia.h
+++ b/src/sst/core/rng/marsaglia.h
@@ -24,8 +24,7 @@
 #define MARSAGLIA_INT32_MAX  2147483647L
 #define MARSAGLIA_INT64_MAX  9223372036854775807LL
 
-namespace SST {
-namespace RNG {
+namespace SST::RNG {
 /**
     \class MarsagliaRNG marsaglia.h "sst/core/rng/marsaglia.h"
 
@@ -37,7 +36,7 @@ namespace RNG {
         For more information see the Multiply-with-carry Random Number Generator article
     at Wikipedia (http://en.wikipedia.org/wiki/Multiply-with-carry).
 */
-class MarsagliaRNG : public SST::RNG::Random
+class MarsagliaRNG : public Random
 {
 
 public:
@@ -119,7 +118,6 @@ private:
     unsigned int m_w;
 };
 
-} // namespace RNG
-} // namespace SST
+} // namespace SST::RNG
 
 #endif // SST_CORE_RNG_MARSAGLIA_H

--- a/src/sst/core/rng/mersenne.cc
+++ b/src/sst/core/rng/mersenne.cc
@@ -26,7 +26,7 @@ using namespace SST::RNG;
     Generate a new random number generator with a random selection for the
     seed.
 */
-MersenneRNG::MersenneRNG() : SST::RNG::Random()
+MersenneRNG::MersenneRNG() : Random()
 {
     numbers = (uint32_t*)malloc(sizeof(uint32_t) * 624);
 
@@ -45,7 +45,7 @@ MersenneRNG::MersenneRNG() : SST::RNG::Random()
 /*
     Seed the Mersenne and then make a group of numbers
 */
-MersenneRNG::MersenneRNG(unsigned int startSeed) : SST::RNG::Random()
+MersenneRNG::MersenneRNG(unsigned int startSeed) : Random()
 {
     seed(startSeed);
 }

--- a/src/sst/core/rng/mersenne.h
+++ b/src/sst/core/rng/mersenne.h
@@ -22,8 +22,7 @@
 #define MERSENNE_INT32_MAX  2147483647L
 #define MERSENNE_INT64_MAX  9223372036854775807LL
 
-namespace SST {
-namespace RNG {
+namespace SST::RNG {
 /**
     \class MersenneRNG mersenne.h "sst/core/rng/mersenne.h"
 
@@ -31,7 +30,7 @@ namespace RNG {
     RNG provides a better "randomness" to the distribution of outputs but is computationally
     more expensive than the Marsaglia RNG.
 */
-class MersenneRNG : public SST::RNG::Random
+class MersenneRNG : public Random
 {
 
 public:
@@ -110,7 +109,6 @@ private:
     int index;
 };
 
-} // namespace RNG
-} // namespace SST
+} // namespace SST::RNG
 
 #endif // SST_CORE_RNG_MERSENNE_H

--- a/src/sst/core/rng/poisson.h
+++ b/src/sst/core/rng/poisson.h
@@ -120,8 +120,8 @@ protected:
     bool deleteDistrib;
 };
 
-using SSTPoissonDistribution = PoissonDistribution;
-
 } // namespace SST::RNG
+
+using SSTPoissonDistribution = SST::RNG::PoissonDistribution;
 
 #endif // SST_CORE_RNG_POISSON_H

--- a/src/sst/core/rng/poisson.h
+++ b/src/sst/core/rng/poisson.h
@@ -17,10 +17,7 @@
 #include "mersenne.h"
 #include "rng.h"
 
-using namespace SST::RNG;
-
-namespace SST {
-namespace RNG {
+namespace SST::RNG {
 
 /**
     \class PoissonDistribution poisson.h "sst/core/rng/poisson.h"
@@ -48,7 +45,7 @@ public:
         \param lambda The lambda of the Poisson distribution
         \param baseDist The base random number generator to take the distribution from.
     */
-    PoissonDistribution(const double mn, SST::RNG::Random* baseDist) : RandomDistribution(), lambda(mn)
+    PoissonDistribution(const double mn, Random* baseDist) : RandomDistribution(), lambda(mn)
     {
 
         baseDistrib   = baseDist;
@@ -115,7 +112,7 @@ protected:
     /**
         Sets the base random number generator for the distribution.
     */
-    SST::RNG::Random* baseDistrib;
+    Random* baseDistrib;
 
     /**
         Controls whether the base distribution should be deleted when this class is destructed.
@@ -123,9 +120,8 @@ protected:
     bool deleteDistrib;
 };
 
-using SSTPoissonDistribution = SST::RNG::PoissonDistribution;
+using SSTPoissonDistribution = PoissonDistribution;
 
-} // namespace RNG
-} // namespace SST
+} // namespace SST::RNG
 
 #endif // SST_CORE_RNG_POISSON_H

--- a/src/sst/core/rng/poisson.h
+++ b/src/sst/core/rng/poisson.h
@@ -108,11 +108,11 @@ protected:
     /**
         Sets the lambda of the Poisson distribution.
     */
-    const double      lambda;
+    const double lambda;
     /**
         Sets the base random number generator for the distribution.
     */
-    Random* baseDistrib;
+    Random*      baseDistrib;
 
     /**
         Controls whether the base distribution should be deleted when this class is destructed.

--- a/src/sst/core/rng/rng.h
+++ b/src/sst/core/rng/rng.h
@@ -16,8 +16,7 @@
 
 #include <stdint.h>
 
-namespace SST {
-namespace RNG {
+namespace SST::RNG {
 
 /**
     \class Random rng.h "sst/core/rng/rng.h"
@@ -64,7 +63,6 @@ public:
     ImplementVirtualSerializable(SST::RNG::Random)
 };
 
-} // namespace RNG
-} // namespace SST
+} // namespace SST::RNG
 
 #endif // SST_CORE_RNG_RNG_H

--- a/src/sst/core/rng/uniform.h
+++ b/src/sst/core/rng/uniform.h
@@ -131,8 +131,8 @@ protected:
     double probPerBin;
 };
 
-using SSTUniformDistribution = UniformDistribution;
-
 } // namespace SST::RNG
+
+using SSTUniformDistribution = SST::RNG::UniformDistribution;
 
 #endif // SST_CORE_RNG_UNIFORM_H

--- a/src/sst/core/rng/uniform.h
+++ b/src/sst/core/rng/uniform.h
@@ -17,10 +17,7 @@
 #include "mersenne.h"
 #include "rng.h"
 
-using namespace SST::RNG;
-
-namespace SST {
-namespace RNG {
+namespace SST::RNG {
 
 /**
     \class UniformDistribution uniform.h "sst/core/rng/uniform.h"
@@ -54,7 +51,7 @@ public:
             \param probsCount Number of probability bins in the distribution
             \param baseDist The base random number generator to take the distribution from.
     */
-    UniformDistribution(const uint32_t probsCount, SST::RNG::Random* baseDist) :
+    UniformDistribution(const uint32_t probsCount, Random* baseDist) :
         RandomDistribution(),
         deleteDistrib(false),
         probCount(probsCount),
@@ -116,7 +113,7 @@ protected:
     /**
         Sets the base random number generator for the distribution.
     */
-    SST::RNG::Random* baseDistrib;
+    Random* baseDistrib;
 
     /**
         Controls whether the base distribution should be deleted when this class is destructed.
@@ -134,9 +131,8 @@ protected:
     double probPerBin;
 };
 
-using SSTUniformDistribution = SST::RNG::UniformDistribution;
+using SSTUniformDistribution = UniformDistribution;
 
-} // namespace RNG
-} // namespace SST
+} // namespace SST::RNG
 
 #endif // SST_CORE_RNG_UNIFORM_H

--- a/src/sst/core/rng/xorshift.cc
+++ b/src/sst/core/rng/xorshift.cc
@@ -26,7 +26,7 @@ using namespace SST::RNG;
     Generate a new random number generator with a random selection for the
     seed.
 */
-XORShiftRNG::XORShiftRNG() : SST::RNG::Random()
+XORShiftRNG::XORShiftRNG() : Random()
 {
     struct timeval now;
     gettimeofday(&now, nullptr);
@@ -40,7 +40,7 @@ XORShiftRNG::XORShiftRNG() : SST::RNG::Random()
 /*
     Seed the Mersenne and then make a group of numbers
 */
-XORShiftRNG::XORShiftRNG(unsigned int startSeed) : SST::RNG::Random()
+XORShiftRNG::XORShiftRNG(unsigned int startSeed) : Random()
 {
 
     assert(startSeed != 0);

--- a/src/sst/core/rng/xorshift.h
+++ b/src/sst/core/rng/xorshift.h
@@ -22,8 +22,7 @@
 #define XORSHIFT_INT32_MAX  2147483647L
 #define XORSHIFT_INT64_MAX  9223372036854775807LL
 
-namespace SST {
-namespace RNG {
+namespace SST::RNG {
 /**
     \class XORShiftRNG xorshift.h "sst/core/rng/xorshift.h"
 
@@ -101,7 +100,6 @@ protected:
     uint32_t w;
 };
 
-} // namespace RNG
-} // namespace SST
+} // namespace SST::RNG
 
 #endif // SST_CORE_RNG_XORSHIFT_H

--- a/src/sst/core/serialization/impl/mapper.h
+++ b/src/sst/core/serialization/impl/mapper.h
@@ -23,10 +23,7 @@
 #include <typeinfo>
 #include <vector>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
-namespace pvt {
+namespace SST::Core::Serialization::pvt {
 
 class ser_mapper
 {
@@ -88,9 +85,6 @@ private:
     int indent = 0;
 };
 
-} // namespace pvt
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization::pvt
 
 #endif // SST_CORE_SERIALIZATION_IMPL_MAPPER_H

--- a/src/sst/core/serialization/impl/packer.h
+++ b/src/sst/core/serialization/impl/packer.h
@@ -21,10 +21,7 @@
 
 #include <string>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
-namespace pvt {
+namespace SST::Core::Serialization::pvt {
 
 class ser_packer : public ser_buffer_accessor
 {
@@ -48,9 +45,6 @@ public:
     void pack_string(std::string& str);
 };
 
-} // namespace pvt
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization::pvt
 
 #endif // SST_CORE_SERIALIZATION_IMPL_PACKER_H

--- a/src/sst/core/serialization/impl/ser_buffer_accessor.h
+++ b/src/sst/core/serialization/impl/ser_buffer_accessor.h
@@ -22,10 +22,7 @@
 #include <cstring>
 #include <exception>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
-namespace pvt {
+namespace SST::Core::Serialization::pvt {
 
 // class ser_buffer_overrun : public spkt_error {
 class ser_buffer_overrun : public std::exception
@@ -92,9 +89,6 @@ protected:
     size_t max_size_;
 };
 
-} // namespace pvt
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization::pvt
 
 #endif // SST_CORE_SERIALIZATION_IMPL_SER_BUFFER_ACCESSOR_H

--- a/src/sst/core/serialization/impl/serialize_array.h
+++ b/src/sst/core/serialization/impl/serialize_array.h
@@ -19,9 +19,7 @@
 
 #include "sst/core/serialization/serializer.h"
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 namespace pvt {
 
 template <class TPtr, class IntType>
@@ -225,8 +223,6 @@ operator&(serializer& ser, pvt::raw_ptr_wrapper<TPtr> ptr)
     // serialize<pvt::raw_ptr_wrapper<TPtr>>()(ptr, ser);
 }
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_IMPL_SERIALIZE_ARRAY_H

--- a/src/sst/core/serialization/impl/serialize_atomic.h
+++ b/src/sst/core/serialization/impl/serialize_atomic.h
@@ -21,9 +21,7 @@
 
 #include <atomic>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 template <class T>
 class serialize_impl<std::atomic<T>>
@@ -66,8 +64,6 @@ public:
     }
 };
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_IMPL_SERIALIZE_VECTOR_H

--- a/src/sst/core/serialization/impl/serialize_deque.h
+++ b/src/sst/core/serialization/impl/serialize_deque.h
@@ -21,9 +21,7 @@
 
 #include <deque>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 template <class T>
 class serialize_impl<std::deque<T>>
@@ -77,8 +75,6 @@ public:
     }
 };
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_IMPL_SERIALIZE_DEQUE_H

--- a/src/sst/core/serialization/impl/serialize_list.h
+++ b/src/sst/core/serialization/impl/serialize_list.h
@@ -21,9 +21,7 @@
 
 #include <list>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 template <class T>
 class serialize_impl<std::list<T>>
@@ -80,8 +78,6 @@ public:
     }
 };
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_IMPL_SERIALIZE_LIST_H

--- a/src/sst/core/serialization/impl/serialize_map.h
+++ b/src/sst/core/serialization/impl/serialize_map.h
@@ -23,9 +23,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 /**
    Class used to map std::map
@@ -149,8 +147,6 @@ public:
     }
 };
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_IMPL_SERIALIZE_MAP_H

--- a/src/sst/core/serialization/impl/serialize_multiset.h
+++ b/src/sst/core/serialization/impl/serialize_multiset.h
@@ -22,9 +22,7 @@
 #include <set>
 #include <unordered_set>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 template <class T, class C>
 class serialize<std::multiset<T, C>>
@@ -136,8 +134,6 @@ public:
     }
 };
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_IMPL_SERIALIZE_MULTISET_H

--- a/src/sst/core/serialization/impl/serialize_priority_queue.h
+++ b/src/sst/core/serialization/impl/serialize_priority_queue.h
@@ -21,10 +21,7 @@
 
 #include <queue>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
-
+namespace SST::Core::Serialization {
 
 template <class T, class S, class C>
 class serialize<std::priority_queue<T, S, C>>
@@ -91,8 +88,6 @@ public:
     }
 };
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_IMPL_SERIALIZE_PRIORITY_QUEUE_H

--- a/src/sst/core/serialization/impl/serialize_set.h
+++ b/src/sst/core/serialization/impl/serialize_set.h
@@ -22,9 +22,7 @@
 #include <set>
 #include <unordered_set>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 template <class T>
 class serialize<std::set<T>>
@@ -136,8 +134,6 @@ public:
     }
 };
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_IMPL_SERIALIZE_SET_H

--- a/src/sst/core/serialization/impl/serialize_string.h
+++ b/src/sst/core/serialization/impl/serialize_string.h
@@ -19,9 +19,7 @@
 
 #include "sst/core/serialization/serializer.h"
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 class ObjectMapString : public ObjectMap
 {
@@ -92,8 +90,6 @@ public:
     }
 };
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_IMPL_SERIALIZE_STRING_H

--- a/src/sst/core/serialization/impl/serialize_vector.h
+++ b/src/sst/core/serialization/impl/serialize_vector.h
@@ -22,10 +22,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
-
+namespace SST::Core::Serialization {
 
 /**
    Class used to map std::vectors.
@@ -161,9 +158,6 @@ class serialize_impl<std::vector<bool>>
     // ObjectMapVector<bool> that knows how to handle the packing.
 };
 
-
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_IMPL_SERIALIZE_VECTOR_H

--- a/src/sst/core/serialization/impl/sizer.h
+++ b/src/sst/core/serialization/impl/sizer.h
@@ -19,10 +19,7 @@
 
 #include "sst/core/warnmacros.h"
 
-namespace SST {
-namespace Core {
-namespace Serialization {
-namespace pvt {
+namespace SST::Core::Serialization::pvt {
 
 class ser_sizer
 {
@@ -47,9 +44,6 @@ protected:
     size_t size_;
 };
 
-} // namespace pvt
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization::pvt
 
 #endif // SST_CORE_SERIALIZATION_IMPL_SIZER_H

--- a/src/sst/core/serialization/impl/unpacker.h
+++ b/src/sst/core/serialization/impl/unpacker.h
@@ -19,10 +19,7 @@
 
 #include "sst/core/serialization/impl/ser_buffer_accessor.h"
 
-namespace SST {
-namespace Core {
-namespace Serialization {
-namespace pvt {
+namespace SST::Core::Serialization::pvt {
 
 class ser_unpacker : public ser_buffer_accessor
 {
@@ -44,9 +41,6 @@ public:
     void unpack_string(std::string& str);
 };
 
-} // namespace pvt
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization::pvt
 
 #endif // SST_CORE_SERIALIZATION_IMPL_UNPACKER_H

--- a/src/sst/core/serialization/objectMap.cc
+++ b/src/sst/core/serialization/objectMap.cc
@@ -17,9 +17,7 @@
 
 #include <cxxabi.h>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 // Static variable instantiation
 std::vector<std::pair<std::string, ObjectMap*>> ObjectMap::emptyVars;
@@ -211,6 +209,4 @@ ObjectMap::listRecursive(const std::string& name, int level, int recurse)
     return ret;
 }
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -18,9 +18,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 class ObjectMap;
 
@@ -683,8 +681,6 @@ public:
 };
 
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_OBJECTMAP_H

--- a/src/sst/core/serialization/objectMapDeferred.h
+++ b/src/sst/core/serialization/objectMapDeferred.h
@@ -14,11 +14,7 @@
 
 #include "sst/core/serialization/serializer.h"
 
-
-namespace SST {
-namespace Core {
-namespace Serialization {
-
+namespace SST::Core::Serialization {
 
 /**
    ObjectMap version that will delay building the internal data
@@ -120,9 +116,6 @@ private:
     std::string type_ = "";
 };
 
-
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_OBJECTMAPDEFERRED_H

--- a/src/sst/core/serialization/serializable.cc
+++ b/src/sst/core/serialization/serializable.cc
@@ -15,10 +15,7 @@
 
 #include <iostream>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
-namespace pvt {
+namespace SST::Core::Serialization::pvt {
 
 static const long null_ptr_id = -1;
 
@@ -69,7 +66,4 @@ map_serializable(serializable_base*& s, serializer& ser, const char* name)
     }
 }
 
-} // namespace pvt
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization::pvt

--- a/src/sst/core/serialization/serializable.h
+++ b/src/sst/core/serialization/serializable.h
@@ -15,11 +15,7 @@
 #include "sst/core/serialization/serializable_base.h"
 #include "sst/core/serialization/serialize.h"
 
-
-namespace SST {
-namespace Core {
-namespace Serialization {
-
+namespace SST::Core::Serialization {
 
 class serializable : public serializable_base
 {
@@ -143,10 +139,7 @@ class serialize_impl<
     }
 };
 
-
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 //#include "sst/core/serialization/serialize_serializable.h"
 

--- a/src/sst/core/serialization/serializable_base.cc
+++ b/src/sst/core/serialization/serializable_base.cc
@@ -20,9 +20,7 @@
 #include <cstring>
 #include <iostream>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 static need_delete_statics<serializable_factory> del_statics;
 serializable_factory::builder_map*               serializable_factory::builders_ = nullptr;
@@ -87,6 +85,4 @@ serializable_factory::get_serializable(uint32_t cls_id)
     return builder->build();
 }
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/serializable_base.h
+++ b/src/sst/core/serialization/serializable_base.h
@@ -20,9 +20,7 @@
 #include <typeinfo>
 #include <unordered_map>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 namespace pvt {
 
@@ -273,9 +271,7 @@ const uint32_t serializable_builder_impl<T>::cls_id_ =
 // class trivially_serializable {
 // };
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #define SerializableName(obj) #obj
 

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -22,9 +22,7 @@
 #include <type_traits>
 #include <typeinfo>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 // Workaround for use with static_assert(), since static_assert(false)
 // will always assert, even when in an untaken if constexpr path.
@@ -461,9 +459,7 @@ sst_map_object(serializer& ser, T& t, const char* name)
 #define SST_SER(obj)        sst_map_object(ser, obj, #obj);
 #define SST_SER_AS_PTR(obj) ser | obj;
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 // These includes have guards to print warnings if they are included
 // independent of this file.  Set the #define that will disable the

--- a/src/sst/core/serialization/serialize_impl_fwd.h
+++ b/src/sst/core/serialization/serialize_impl_fwd.h
@@ -19,16 +19,11 @@
 // serialize_impl
 #include "sst/core/serialization/serializer_fwd.h"
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 template <class T, class Enable>
 class serialize_impl;
 
-
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_SERIALIZE_IMPL_FWD_H

--- a/src/sst/core/serialization/serializer.cc
+++ b/src/sst/core/serialization/serializer.cc
@@ -16,9 +16,7 @@
 #include "sst/core/output.h"
 #include "sst/core/serialization/serializable.h"
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 namespace pvt {
 
 void
@@ -99,6 +97,4 @@ serializer::string(std::string& str)
     }
 }
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -32,9 +32,7 @@
 #include <typeinfo>
 #include <vector>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 /**
  * This class is basically a wrapper for objects to declare the order in
@@ -280,8 +278,6 @@ protected:
     uintptr_t                      split_key;
 };
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_SERIALIZER_H

--- a/src/sst/core/serialization/serializer_fwd.h
+++ b/src/sst/core/serialization/serializer_fwd.h
@@ -12,14 +12,8 @@
 #ifndef SST_CORE_SERIALIZATION_SERIALIZER_FWD_H
 #define SST_CORE_SERIALIZATION_SERIALIZER_FWD_H
 
-namespace SST {
-namespace Core {
-namespace Serialization {
-
+namespace SST::Core::Serialization {
 class serializer;
-
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_SERIALIZER_FWD_H

--- a/src/sst/core/serialization/statics.cc
+++ b/src/sst/core/serialization/statics.cc
@@ -12,9 +12,7 @@
 
 #include "sst/core/serialization/statics.h"
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 std::list<statics::clear_fxn>* statics::fxns_ = nullptr;
 
@@ -40,6 +38,4 @@ statics::finish()
     fxns_ = nullptr;
 }
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/statics.h
+++ b/src/sst/core/serialization/statics.h
@@ -14,9 +14,7 @@
 
 #include <list>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 class statics
 {
@@ -42,8 +40,6 @@ public:
     if ( x ) delete x;     \
     x = 0
 
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SERIALIZATION_STATICS_H

--- a/src/sst/core/shared/sharedArray.h
+++ b/src/sst/core/shared/sharedArray.h
@@ -18,8 +18,7 @@
 
 #include <vector>
 
-namespace SST {
-namespace Shared {
+namespace SST::Shared {
 
 /**
    SharedArray class.  The class is templated to allow for an array
@@ -808,7 +807,7 @@ private:
         };
     };
 };
-} // namespace Shared
-} // namespace SST
+
+} // namespace SST::Shared
 
 #endif // SST_CORE_SHARED_SHAREDARRAY_H

--- a/src/sst/core/shared/sharedMap.h
+++ b/src/sst/core/shared/sharedMap.h
@@ -17,8 +17,7 @@
 
 #include <map>
 
-namespace SST {
-namespace Shared {
+namespace SST::Shared {
 
 /**
    SharedMap class.  The class is templated to allow for Map of any
@@ -372,7 +371,6 @@ private:
     };
 };
 
-} // namespace Shared
-} // namespace SST
+} // namespace SST::Shared
 
 #endif // SST_CORE_SHARED_SHAREDMAP_H

--- a/src/sst/core/shared/sharedObject.cc
+++ b/src/sst/core/shared/sharedObject.cc
@@ -22,8 +22,7 @@
 #include "sst/core/simulation_impl.h"
 #include "sst/core/warnmacros.h"
 
-namespace SST {
-namespace Shared {
+namespace SST::Shared {
 
 namespace Private {
 Output&
@@ -123,5 +122,4 @@ SharedObjectDataManager::updateState(bool finalize)
     }
 }
 
-} // namespace Shared
-} // namespace SST
+} // namespace SST::Shared

--- a/src/sst/core/shared/sharedSet.h
+++ b/src/sst/core/shared/sharedSet.h
@@ -17,8 +17,7 @@
 
 #include <set>
 
-namespace SST {
-namespace Shared {
+namespace SST::Shared {
 
 /**
    SharedSet class.  The class is templated to allow for an array
@@ -348,7 +347,6 @@ private:
     };
 };
 
-} // namespace Shared
-} // namespace SST
+} // namespace SST::Shared
 
 #endif // SST_CORE_SHARED_SHAREDSET_H

--- a/src/sst/core/sparseVectorMap.h
+++ b/src/sst/core/sparseVectorMap.h
@@ -800,9 +800,7 @@ public:
 
 } // namespace SST
 
-namespace SST {
-namespace Core {
-namespace Serialization {
+namespace SST::Core::Serialization {
 
 template <typename keyT, typename classT>
 class serialize<SST::SparseVectorMap<keyT, classT>>
@@ -810,8 +808,6 @@ class serialize<SST::SparseVectorMap<keyT, classT>>
 public:
     void operator()(SST::SparseVectorMap<keyT, classT>& v, SST::Core::Serialization::serializer& ser) { ser& v.data; }
 };
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization
 
 #endif // SST_CORE_SPARSEVECTORMAP_H

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -35,7 +35,6 @@
 #include <string>
 #include <sys/stat.h>
 
-using namespace std;
 using namespace SST;
 using namespace SST::Core;
 
@@ -154,7 +153,7 @@ main(int argc, char* argv[])
 
     // Run interactive mode
     if ( g_configuration.interactiveEnabled() ) {
-        std::cout << "Curses library not found. Run SST-Info without the -i flag." << endl;
+        std::cout << "Curses library not found. Run SST-Info without the -i flag." << std::endl;
     }
 
     return 0;
@@ -764,6 +763,8 @@ SSTInfoConfig::getUsagePrelude()
 void
 SSTInfoConfig::outputUsage()
 {
+    using std::cout;
+    using std::endl;
     cout << "Usage: " << m_AppName << " [<element[.component|subcomponent]>] "
          << " [options]" << endl;
     cout << "  -h, --help               Print Help Message\n";
@@ -851,6 +852,7 @@ SSTLibraryInfo::setLibraryInfo(std::string baseName, std::string componentName, 
 void
 SSTLibraryInfo::outputText(std::stringstream& outputStream)
 {
+    using std::endl;
     if ( this->m_libraryFilter ) {
         outputStream << "\n================================================================================\n";
         outputStream << "ELEMENT LIBRARY: " << this->m_name << endl;

--- a/src/sst/core/sstpart.cc
+++ b/src/sst/core/sstpart.cc
@@ -15,8 +15,7 @@
 
 #include "sst/core/output.h"
 
-namespace SST {
-namespace Partition {
+namespace SST::Partition {
 
 SST_ELI_DEFINE_INFO_EXTERN(SSTPartitioner)
 SST_ELI_DEFINE_CTOR_EXTERN(SSTPartitioner)
@@ -35,5 +34,4 @@ SSTPartitioner::performPartition(ConfigGraph* UNUSED(graph))
     output.fatal(CALL_INFO, 1, "ERROR: chosen partitioner does not support ConfigGraph");
 }
 
-} // namespace Partition
-} // namespace SST
+} // namespace SST::Partition

--- a/src/sst/core/statapi/statbase.cc
+++ b/src/sst/core/statapi/statbase.cc
@@ -23,10 +23,7 @@
 #include "sst/core/statapi/statoutputtxt.h"
 #include "sst/core/statapi/statuniquecount.h"
 
-namespace SST {
-
-namespace Stat {
-namespace pvt {
+namespace SST::Stat::pvt {
 
 void
 registerStatWithEngineOnRestart(SST::Statistics::StatisticBase* s)
@@ -34,11 +31,9 @@ registerStatWithEngineOnRestart(SST::Statistics::StatisticBase* s)
     Simulation_impl::getSimulation()->getStatisticsProcessingEngine()->registerStatisticWithEngine(s);
 }
 
-} // namespace pvt
-} // namespace Stat
+} // namespace SST::Stat::pvt
 
-namespace Statistics {
-
+namespace SST::Statistics {
 
 StatisticBase::StatisticBase(
     BaseComponent* comp, const std::string& statName, const std::string& statSubId, Params& statParams)
@@ -274,5 +269,4 @@ SST_ELI_INSTANTIATE_STATISTIC(UniqueCountStatistic, uint64_t);
 SST_ELI_INSTANTIATE_STATISTIC(UniqueCountStatistic, float);
 SST_ELI_INSTANTIATE_STATISTIC(UniqueCountStatistic, double);
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -590,17 +590,14 @@ private:
 
 } // namespace Statistics
 
-namespace Stat {
-namespace pvt {
+namespace Stat::pvt {
 
 /** Helper function for re-registering statistics during simulation restart */
 void registerStatWithEngineOnRestart(SST::Statistics::StatisticBase* s);
 
-} // namespace pvt
-} // namespace Stat
+} // namespace Stat::pvt
 
-namespace Core {
-namespace Serialization {
+namespace Core::Serialization {
 
 template <class T>
 class serialize_impl<Statistics::Statistic<T>*>
@@ -654,9 +651,7 @@ class serialize_impl<Statistics::Statistic<T>*>
     // }
 };
 
-} // namespace Serialization
-} // namespace Core
-
+} // namespace Core::Serialization
 
 } // namespace SST
 

--- a/src/sst/core/statapi/statengine.cc
+++ b/src/sst/core/statapi/statengine.cc
@@ -28,8 +28,7 @@
 #include <algorithm>
 #include <string>
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 std::vector<StatisticOutput*> StatisticProcessingEngine::m_statOutputs;
 
@@ -644,5 +643,4 @@ StatisticProcessingEngine::serialize_order(SST::Core::Serialization::serializer&
                        // they global already?
 }
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics

--- a/src/sst/core/statapi/statfieldinfo.cc
+++ b/src/sst/core/statapi/statfieldinfo.cc
@@ -17,8 +17,7 @@
 #include "sst/core/simulation_impl.h"
 #include "sst/core/stringize.h"
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 std::map<fieldType_t, StatisticFieldTypeBase*>* StatisticFieldTypeBase::fields_      = nullptr;
 fieldType_t                                     StatisticFieldTypeBase::enumCounter_ = 0;
@@ -98,5 +97,4 @@ static StatisticFieldType<uint64_t> uint64_register("uint64_t", "u64");
 static StatisticFieldType<float>    float_register("float", "f32");
 static StatisticFieldType<double>   double_register("double", "f64");
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics

--- a/src/sst/core/statapi/statfieldinfo.h
+++ b/src/sst/core/statapi/statfieldinfo.h
@@ -17,8 +17,7 @@
 #include <map>
 #include <string>
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 using fieldType_t = uint32_t;
 
@@ -159,7 +158,6 @@ private:
     fieldHandle_t m_fieldHandle;
 };
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics
 
 #endif // SST_CORE_STATAPI_STATFIELDINFO_H

--- a/src/sst/core/statapi/statgroup.cc
+++ b/src/sst/core/statapi/statgroup.cc
@@ -23,8 +23,7 @@
 
 #include <algorithm>
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 StatisticGroup::StatisticGroup(const ConfigStatGroup& csg, StatisticProcessingEngine* engine) :
     isDefault(false),
@@ -96,5 +95,4 @@ StatisticGroup::serialize_order(SST::Core::Serialization::serializer& ser)
     ser& statNames;
 }
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics

--- a/src/sst/core/statapi/stathistogram.h
+++ b/src/sst/core/statapi/stathistogram.h
@@ -17,8 +17,7 @@
 #include "sst/core/statapi/statoutput.h"
 #include "sst/core/warnmacros.h"
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 // NOTE: When calling base class members in classes derived from
 //       a templated base class.  The user must use "this->" in
@@ -360,7 +359,6 @@ private:
     bool                                        m_includeOutOfBounds;
 };
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics
 
 #endif // SST_CORE_STATAPI_STATHISTOGRAM_H

--- a/src/sst/core/statapi/statnull.h
+++ b/src/sst/core/statapi/statnull.h
@@ -16,8 +16,7 @@
 #include "sst/core/statapi/statbase.h"
 #include "sst/core/warnmacros.h"
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 // NOTE: When calling base class members of classes derived from
 //       a templated base class.  The user must use "this->" in
@@ -160,7 +159,6 @@ struct NullStatistic<void> : public Statistic<void>
     }
 };
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics
 
 #endif // SST_CORE_STATAPI_STATNULL_H

--- a/src/sst/core/statapi/statoutput.cc
+++ b/src/sst/core/statapi/statoutput.cc
@@ -18,8 +18,7 @@
 #include "sst/core/statapi/statgroup.h"
 #include "sst/core/stringize.h"
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -265,5 +264,4 @@ StatisticFieldsOutput::serialize_order(SST::Core::Serialization::serializer& ser
     StatisticOutput::serialize_order(ser);
 }
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics

--- a/src/sst/core/statapi/statoutputcsv.cc
+++ b/src/sst/core/statapi/statoutputcsv.cc
@@ -15,8 +15,7 @@
 
 #include "sst/core/stringize.h"
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 StatisticOutputCSV::StatisticOutputCSV(Params& outputParameters) : StatisticFieldsOutput(outputParameters)
 {
@@ -370,5 +369,4 @@ StatisticOutputCSV::serialize_order(SST::Core::Serialization::serializer& ser)
     ser& m_useCompression;
 }
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics

--- a/src/sst/core/statapi/statoutputcsv.h
+++ b/src/sst/core/statapi/statoutputcsv.h
@@ -19,8 +19,7 @@
 #include <zlib.h>
 #endif
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 /**
     \class StatisticOutputCSV
@@ -122,7 +121,6 @@ private:
     bool                     m_useCompression;
 };
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics
 
 #endif // SST_CORE_STATAPI_STATOUTPUTCSV_H

--- a/src/sst/core/statapi/statoutputhdf5.cc
+++ b/src/sst/core/statapi/statoutputhdf5.cc
@@ -20,8 +20,7 @@
 
 #include <algorithm>
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 StatisticOutputHDF5::StatisticOutputHDF5(Params& outputParameters) :
     StatisticFieldsOutput(outputParameters),
@@ -638,6 +637,4 @@ StatisticOutputHDF5::serialize_order(SST::Core::Serialization::serializer& ser)
     }
 }
 
-
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics

--- a/src/sst/core/statapi/statoutputhdf5.h
+++ b/src/sst/core/statapi/statoutputhdf5.h
@@ -23,8 +23,7 @@ REENABLE_WARNING
 #include <map>
 #include <string>
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 /**
     \class StatisticOutputHDF5
@@ -251,7 +250,6 @@ private:
     StatisticInfo* getStatisticInfo(StatisticBase* statistic);
 };
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics
 
 #endif // SST_CORE_STATAPI_STATOUTPUTHDF5_H

--- a/src/sst/core/statapi/statoutputjson.cc
+++ b/src/sst/core/statapi/statoutputjson.cc
@@ -16,8 +16,7 @@
 #include "sst/core/statapi/statoutputcsv.h"
 #include "sst/core/stringize.h"
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 StatisticOutputJSON::StatisticOutputJSON(Params& outputParameters) : StatisticFieldsOutput(outputParameters)
 {
@@ -273,5 +272,4 @@ StatisticOutputJSON::serialize_order(SST::Core::Serialization::serializer& ser)
     ser& m_processedAnyStats;
 }
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics

--- a/src/sst/core/statapi/statoutputjson.h
+++ b/src/sst/core/statapi/statoutputjson.h
@@ -15,8 +15,7 @@
 #include "sst/core/sst_types.h"
 #include "sst/core/statapi/statoutput.h"
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 /**
     \class StatisticOutputJSON
@@ -120,7 +119,6 @@ private:
     int         m_curIndentLevel;
 };
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics
 
 #endif // SST_CORE_STATAPI_STATOUTPUTJSON_H

--- a/src/sst/core/statapi/statoutputtxt.cc
+++ b/src/sst/core/statapi/statoutputtxt.cc
@@ -15,8 +15,7 @@
 
 #include "sst/core/stringize.h"
 
-namespace SST {
-namespace Statistics {
+namespace SST::Statistics {
 
 StatisticOutputTextBase::StatisticOutputTextBase(Params& outputParameters) : StatisticFieldsOutput(outputParameters) {}
 
@@ -448,5 +447,4 @@ StatisticOutputConsole::serialize_order(SST::Core::Serialization::serializer& se
     StatisticOutputTextBase::serialize_order(ser);
 }
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics

--- a/src/sst/core/statapi/statoutputtxt.h
+++ b/src/sst/core/statapi/statoutputtxt.h
@@ -19,9 +19,7 @@
 #include <zlib.h>
 #endif
 
-namespace SST {
-namespace Statistics {
-
+namespace SST::Statistics {
 
 class StatisticOutputTextBase : public StatisticFieldsOutput
 {
@@ -272,7 +270,6 @@ private:
     bool getOutputRankDefault() override { return false; }
 };
 
-} // namespace Statistics
-} // namespace SST
+} // namespace SST::Statistics
 
 #endif // SST_CORE_STATAPI_STATOUTPUTTXT_H

--- a/src/sst/core/testElements/coreTest_Checkpoint.h
+++ b/src/sst/core/testElements/coreTest_Checkpoint.h
@@ -18,8 +18,7 @@
 #include "sst/core/rng/distrib.h"
 #include "sst/core/rng/rng.h"
 
-namespace SST {
-namespace CoreTestCheckpoint {
+namespace SST::CoreTestCheckpoint {
 
 // Very simple starting case
 // Expected to have two components in simulation.
@@ -153,7 +152,6 @@ private:
     Statistic<double>*   stat_dist;
 };
 
-} // namespace CoreTestCheckpoint
-} // namespace SST
+} // namespace SST::CoreTestCheckpoint
 
 #endif // SST_CORE_CORETEST_CHECKPOINT_H

--- a/src/sst/core/testElements/coreTest_ClockerComponent.cc
+++ b/src/sst/core/testElements/coreTest_ClockerComponent.cc
@@ -15,8 +15,7 @@
 
 #include "sst/core/testElements/coreTest_ClockerComponent.h"
 
-namespace SST {
-namespace CoreTestClockerComponent {
+namespace SST::CoreTestClockerComponent {
 
 coreTestClockerComponent::coreTestClockerComponent(ComponentId_t id, Params& params) : Component(id)
 {
@@ -58,7 +57,8 @@ coreTestClockerComponent::coreTestClockerComponent() : Component(-1)
     // for serialization only
 }
 
-bool coreTestClockerComponent::tick(Cycle_t)
+bool
+coreTestClockerComponent::tick(Cycle_t)
 {
     clock_count--;
 
@@ -117,5 +117,4 @@ coreTestClockerComponent::Oneshot2Callback()
 }
 
 // Serialization
-} // namespace CoreTestClockerComponent
-} // namespace SST
+} // namespace SST::CoreTestClockerComponent

--- a/src/sst/core/testElements/coreTest_ClockerComponent.cc
+++ b/src/sst/core/testElements/coreTest_ClockerComponent.cc
@@ -57,8 +57,7 @@ coreTestClockerComponent::coreTestClockerComponent() : Component(-1)
     // for serialization only
 }
 
-bool
-coreTestClockerComponent::tick(Cycle_t)
+bool coreTestClockerComponent::tick(Cycle_t)
 {
     clock_count--;
 

--- a/src/sst/core/testElements/coreTest_ClockerComponent.h
+++ b/src/sst/core/testElements/coreTest_ClockerComponent.h
@@ -14,8 +14,7 @@
 
 #include "sst/core/component.h"
 
-namespace SST {
-namespace CoreTestClockerComponent {
+namespace SST::CoreTestClockerComponent {
 
 class coreTestClockerComponent : public SST::Component
 {
@@ -75,7 +74,6 @@ private:
     int         clock_count;
 };
 
-} // namespace CoreTestClockerComponent
-} // namespace SST
+} // namespace SST::CoreTestClockerComponent
 
 #endif // SST_CORE_CORETEST_CLOCKERCOMPONENT_H

--- a/src/sst/core/testElements/coreTest_Component.h
+++ b/src/sst/core/testElements/coreTest_Component.h
@@ -16,8 +16,7 @@
 #include "sst/core/link.h"
 #include "sst/core/rng/marsaglia.h"
 
-namespace SST {
-namespace CoreTestComponent {
+namespace SST::CoreTestComponent {
 
 // These first two classes are just base classes to test ELI
 // inheritance.  The definition of the ELI items are spread through 2
@@ -146,7 +145,6 @@ private:
     SST::Statistics::Statistic<int>* countW;
 };
 
-} // namespace CoreTestComponent
-} // namespace SST
+} // namespace SST::CoreTestComponent
 
 #endif // SST_CORE_CORETEST_COMPONENT_H

--- a/src/sst/core/testElements/coreTest_ComponentEvent.h
+++ b/src/sst/core/testElements/coreTest_ComponentEvent.h
@@ -12,8 +12,7 @@
 #ifndef SST_CORE_CORETEST_COMPONENTEVENT_H
 #define SST_CORE_CORETEST_COMPONENTEVENT_H
 
-namespace SST {
-namespace CoreTestComponent {
+namespace SST::CoreTestComponent {
 
 class coreTestComponentEvent : public SST::Event
 {
@@ -32,7 +31,6 @@ public:
     ImplementSerializable(SST::CoreTestComponent::coreTestComponentEvent);
 };
 
-} // namespace CoreTestComponent
-} // namespace SST
+} // namespace SST::CoreTestComponent
 
 #endif // SST_CORE_CORETEST_COMPONENTEVENT_H

--- a/src/sst/core/testElements/coreTest_DistribComponent.h
+++ b/src/sst/core/testElements/coreTest_DistribComponent.h
@@ -18,8 +18,7 @@
 using namespace SST;
 using namespace SST::RNG;
 
-namespace SST {
-namespace CoreTestDistribComponent {
+namespace SST::CoreTestDistribComponent {
 
 class coreTestDistribComponent : public SST::Component
 {
@@ -78,7 +77,6 @@ private:
     std::map<int64_t, uint64_t>* bins;
 };
 
-} // namespace CoreTestDistribComponent
-} // namespace SST
+} // namespace SST::CoreTestDistribComponent
 
 #endif // SST_CORE_CORETEST_DISTRIBCOMPONENT_H

--- a/src/sst/core/testElements/coreTest_Links.h
+++ b/src/sst/core/testElements/coreTest_Links.h
@@ -16,8 +16,7 @@
 #include "sst/core/link.h"
 #include "sst/core/rng/marsaglia.h"
 
-namespace SST {
-namespace CoreTestComponent {
+namespace SST::CoreTestComponent {
 
 class coreTestLinks : public SST::Component
 {
@@ -68,7 +67,6 @@ private:
     SST::Link* W;
 };
 
-} // namespace CoreTestComponent
-} // namespace SST
+} // namespace SST::CoreTestComponent
 
 #endif // SST_CORE_CORETEST_LINKS_H

--- a/src/sst/core/testElements/coreTest_LookupTableComponent.cc
+++ b/src/sst/core/testElements/coreTest_LookupTableComponent.cc
@@ -80,8 +80,7 @@ void
 coreTestLookupTableComponent::finish()
 {}
 
-bool
-coreTestLookupTableComponent::tick(SST::Cycle_t)
+bool coreTestLookupTableComponent::tick(SST::Cycle_t)
 {
     bool                done    = false;
     static const size_t nPerRow = 8;

--- a/src/sst/core/testElements/coreTest_LookupTableComponent.cc
+++ b/src/sst/core/testElements/coreTest_LookupTableComponent.cc
@@ -22,8 +22,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-namespace SST {
-namespace CoreTestLookupTableComponent {
+namespace SST::CoreTestLookupTableComponent {
 
 coreTestLookupTableComponent::coreTestLookupTableComponent(SST::ComponentId_t id, SST::Params& params) : Component(id)
 {
@@ -81,7 +80,8 @@ void
 coreTestLookupTableComponent::finish()
 {}
 
-bool coreTestLookupTableComponent::tick(SST::Cycle_t)
+bool
+coreTestLookupTableComponent::tick(SST::Cycle_t)
 {
     bool                done    = false;
     static const size_t nPerRow = 8;
@@ -107,5 +107,4 @@ bool coreTestLookupTableComponent::tick(SST::Cycle_t)
     return false;
 }
 
-} // namespace CoreTestLookupTableComponent
-} // namespace SST
+} // namespace SST::CoreTestLookupTableComponent

--- a/src/sst/core/testElements/coreTest_LookupTableComponent.cc
+++ b/src/sst/core/testElements/coreTest_LookupTableComponent.cc
@@ -80,7 +80,8 @@ void
 coreTestLookupTableComponent::finish()
 {}
 
-bool coreTestLookupTableComponent::tick(SST::Cycle_t)
+bool
+coreTestLookupTableComponent::tick(SST::Cycle_t)
 {
     bool                done    = false;
     static const size_t nPerRow = 8;

--- a/src/sst/core/testElements/coreTest_LookupTableComponent.h
+++ b/src/sst/core/testElements/coreTest_LookupTableComponent.h
@@ -16,8 +16,7 @@
 #include "sst/core/output.h"
 #include "sst/core/sharedRegion.h"
 
-namespace SST {
-namespace CoreTestLookupTableComponent {
+namespace SST::CoreTestLookupTableComponent {
 
 class coreTestLookupTableComponent : public SST::Component
 {
@@ -66,7 +65,6 @@ private:
     SharedRegion*  sregion;
 };
 
-} // namespace CoreTestLookupTableComponent
-} // namespace SST
+} // namespace SST::CoreTestLookupTableComponent
 
 #endif // SST_CORE_CORETEST_LOOKUPTABLECOMPONENT_H

--- a/src/sst/core/testElements/coreTest_MemPoolTest.h
+++ b/src/sst/core/testElements/coreTest_MemPoolTest.h
@@ -17,9 +17,7 @@
 
 #include <vector>
 
-namespace SST {
-namespace CoreTestMemPoolTest {
-
+namespace SST::CoreTestMemPoolTest {
 
 // We'll have 4 different sized events
 
@@ -179,7 +177,6 @@ private:
     Event* createEvent();
 };
 
-} // namespace CoreTestMemPoolTest
-} // namespace SST
+} // namespace SST::CoreTestMemPoolTest
 
 #endif // SST_CORE_CORETEST_COMPONENT_H

--- a/src/sst/core/testElements/coreTest_Message.h
+++ b/src/sst/core/testElements/coreTest_Message.h
@@ -12,8 +12,7 @@
 #ifndef SST_CORE_CORETEST_MESSAGE_H
 #define SST_CORE_CORETEST_MESSAGE_H
 
-namespace SST {
-namespace CoreTestMessageGeneratorComponent {
+namespace SST::CoreTestMessageGeneratorComponent {
 
 class coreTestMessage : public SST::Event
 {
@@ -26,7 +25,6 @@ public:
     ImplementSerializable(SST::CoreTestMessageGeneratorComponent::coreTestMessage);
 };
 
-} // namespace CoreTestMessageGeneratorComponent
-} // namespace SST
+} // namespace SST::CoreTestMessageGeneratorComponent
 
 #endif // SST_CORE_CORETEST_MESSAGE_H

--- a/src/sst/core/testElements/coreTest_MessageGeneratorComponent.h
+++ b/src/sst/core/testElements/coreTest_MessageGeneratorComponent.h
@@ -15,8 +15,7 @@
 #include "sst/core/component.h"
 #include "sst/core/link.h"
 
-namespace SST {
-namespace CoreTestMessageGeneratorComponent {
+namespace SST::CoreTestMessageGeneratorComponent {
 
 class coreTestMessageGeneratorComponent : public SST::Component
 {
@@ -74,7 +73,6 @@ private:
     SST::Link* remote_component;
 };
 
-} // namespace CoreTestMessageGeneratorComponent
-} // namespace SST
+} // namespace SST::CoreTestMessageGeneratorComponent
 
 #endif // SST_CORE_CORETEST_MESSAGEGENERATORCOMPONENT_H

--- a/src/sst/core/testElements/coreTest_Module.h
+++ b/src/sst/core/testElements/coreTest_Module.h
@@ -22,8 +22,7 @@
 using namespace SST;
 using namespace SST::RNG;
 
-namespace SST {
-namespace CoreTestModule {
+namespace SST::CoreTestModule {
 
 class CoreTestModuleExample : public SST::Module
 {
@@ -109,7 +108,6 @@ private:
     CoreTestModuleExample* rng_module;
 };
 
-} // namespace CoreTestModule
-} // namespace SST
+} // namespace SST::CoreTestModule
 
 #endif // SST_CORE_CORETEST_MODULE_H

--- a/src/sst/core/testElements/coreTest_Output.cc
+++ b/src/sst/core/testElements/coreTest_Output.cc
@@ -15,9 +15,7 @@
 
 #include "sst/core/testElements/coreTest_Output.h"
 
-namespace SST {
-namespace CoreTestSerialization {
-
+namespace SST::CoreTestSerialization {
 
 void
 testTraceFunction(int level = 0)
@@ -57,6 +55,4 @@ coreTestOutput::coreTestOutput(ComponentId_t id, Params& params) : Component(id)
     if ( test == "TraceFunction" ) { testTraceFunction(); }
 }
 
-
-} // namespace CoreTestSerialization
-} // namespace SST
+} // namespace SST::CoreTestSerialization

--- a/src/sst/core/testElements/coreTest_Output.h
+++ b/src/sst/core/testElements/coreTest_Output.h
@@ -14,8 +14,7 @@
 
 #include "sst/core/component.h"
 
-namespace SST {
-namespace CoreTestSerialization {
+namespace SST::CoreTestSerialization {
 
 class coreTestOutput : public SST::Component
 {
@@ -52,7 +51,6 @@ public:
 private:
 };
 
-} // namespace CoreTestSerialization
-} // namespace SST
+} // namespace SST::CoreTestSerialization
 
 #endif // SST_CORE_CORETEST_OUTPUT_H

--- a/src/sst/core/testElements/coreTest_ParamComponent.cc
+++ b/src/sst/core/testElements/coreTest_ParamComponent.cc
@@ -17,8 +17,7 @@
 
 #include <cinttypes>
 
-namespace SST {
-namespace CoreTestParamComponent {
+namespace SST::CoreTestParamComponent {
 
 coreTestParamComponent::coreTestParamComponent(ComponentId_t id, Params& params) : Component(id)
 {
@@ -122,5 +121,4 @@ coreTestParamComponent::coreTestParamComponent(ComponentId_t id, Params& params)
 
 coreTestParamComponent::coreTestParamComponent() : Component(-1) {}
 
-} // namespace CoreTestParamComponent
-} // namespace SST
+} // namespace SST::CoreTestParamComponent

--- a/src/sst/core/testElements/coreTest_ParamComponent.h
+++ b/src/sst/core/testElements/coreTest_ParamComponent.h
@@ -14,8 +14,7 @@
 
 #include "sst/core/component.h"
 
-namespace SST {
-namespace CoreTestParamComponent {
+namespace SST::CoreTestParamComponent {
 
 class coreTestParamComponent : public SST::Component
 {
@@ -68,7 +67,6 @@ private:
     void operator=(const coreTestParamComponent&);         // do not implement
 };
 
-} // namespace CoreTestParamComponent
-} // namespace SST
+} // namespace SST::CoreTestParamComponent
 
 #endif // SST_CORE_CORETEST_PARAMCOMPONENT_H

--- a/src/sst/core/testElements/coreTest_PerfComponent.h
+++ b/src/sst/core/testElements/coreTest_PerfComponent.h
@@ -16,8 +16,7 @@
 #include <sst/core/link.h>
 #include <sst/core/rng/marsaglia.h>
 
-namespace SST {
-namespace CoreTestPerfComponent {
+namespace SST::CoreTestPerfComponent {
 
 // These first two classes are just base classes to test ELI
 // inheritance.  The definition of the ELI items are spread through 2
@@ -127,7 +126,6 @@ private:
     SST::Statistics::Statistic<int>* countW;
 };
 
-} // namespace CoreTestPerfComponent
-} // namespace SST
+} // namespace SST::CoreTestPerfComponent
 
 #endif // SST_CORE_CORETEST_PERF_COMPONENT_H

--- a/src/sst/core/testElements/coreTest_PortModule.h
+++ b/src/sst/core/testElements/coreTest_PortModule.h
@@ -16,8 +16,7 @@
 #include "sst/core/event.h"
 #include "sst/core/subcomponent.h"
 
-namespace SST {
-namespace CoreTestPortModule {
+namespace SST::CoreTestPortModule {
 
 class PortSubComponent;
 
@@ -113,7 +112,7 @@ public:
 
     SST_ELI_DOCUMENT_PORTS(
         {"left", "Link to the left. Will only receive on left port.  If nothing is attached to the left port, the component will send sendcount events.", { "" } },
-        {"right", "Link to the right. Will only send on right port.  If nothing is connect to the right port, the component will check the types of the events recieved.", { "" } }  
+        {"right", "Link to the right. Will only send on right port.  If nothing is connect to the right port, the component will check the types of the events recieved.", { "" } }
     )
 
     SST_ELI_DOCUMENT_PARAMS(
@@ -194,7 +193,6 @@ private:
     ImplementSerializable(SST::CoreTestPortModule::PortSubComponent)
 };
 
-} // namespace CoreTestPortModule
-} // namespace SST
+} // namespace SST::CoreTestPortModule
 
 #endif // SST_CORE_CORETEST_PORTMODULE_H

--- a/src/sst/core/testElements/coreTest_RNGComponent.h
+++ b/src/sst/core/testElements/coreTest_RNGComponent.h
@@ -18,8 +18,7 @@
 using namespace SST;
 using namespace SST::RNG;
 
-namespace SST {
-namespace CoreTestRNGComponent {
+namespace SST::CoreTestRNGComponent {
 
 class coreTestRNGComponent : public SST::Component
 {
@@ -74,7 +73,6 @@ private:
     int         rng_count;
 };
 
-} // namespace CoreTestRNGComponent
-} // namespace SST
+} // namespace SST::CoreTestRNGComponent
 
 #endif // SST_CORE_CORETEST_RNGCOMPONENT_H

--- a/src/sst/core/testElements/coreTest_Serialization.cc
+++ b/src/sst/core/testElements/coreTest_Serialization.cc
@@ -30,9 +30,7 @@
 #include <utility>
 #include <vector>
 
-namespace SST {
-namespace CoreTestSerialization {
-
+namespace SST::CoreTestSerialization {
 
 template <typename T>
 struct checkSimpleSerializeDeserialize
@@ -781,6 +779,4 @@ coreTestSerialization::coreTestSerialization(ComponentId_t id, Params& params) :
     }
 }
 
-
-} // namespace CoreTestSerialization
-} // namespace SST
+} // namespace SST::CoreTestSerialization

--- a/src/sst/core/testElements/coreTest_Serialization.h
+++ b/src/sst/core/testElements/coreTest_Serialization.h
@@ -15,8 +15,7 @@
 #include "sst/core/component.h"
 #include "sst/core/rng/rng.h"
 
-namespace SST {
-namespace CoreTestSerialization {
+namespace SST::CoreTestSerialization {
 
 class coreTestSerialization : public SST::Component
 {
@@ -54,7 +53,6 @@ private:
     SST::RNG::Random* rng;
 };
 
-} // namespace CoreTestSerialization
-} // namespace SST
+} // namespace SST::CoreTestSerialization
 
 #endif // SST_CORE_CORETEST_SERIALIZATION_H

--- a/src/sst/core/testElements/coreTest_SharedObjectComponent.cc
+++ b/src/sst/core/testElements/coreTest_SharedObjectComponent.cc
@@ -21,8 +21,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-namespace SST {
-namespace CoreTestSharedObjectsComponent {
+namespace SST::CoreTestSharedObjectsComponent {
 
 using namespace Shared;
 
@@ -384,5 +383,4 @@ coreTestSharedObjectsComponent::serialize_order(SST::Core::Serialization::serial
     if ( test_set ) SST_SER(set)
 }
 
-} // namespace CoreTestSharedObjectsComponent
-} // namespace SST
+} // namespace SST::CoreTestSharedObjectsComponent

--- a/src/sst/core/testElements/coreTest_SharedObjectComponent.h
+++ b/src/sst/core/testElements/coreTest_SharedObjectComponent.h
@@ -18,8 +18,7 @@
 #include "sst/core/shared/sharedMap.h"
 #include "sst/core/shared/sharedSet.h"
 
-namespace SST {
-namespace CoreTestSharedObjectsComponent {
+namespace SST::CoreTestSharedObjectsComponent {
 
 // Class so that we can check to see if the equivalence check works
 // for sets
@@ -131,7 +130,6 @@ private:
     Shared::SharedSet<setItem>  set;
 };
 
-} // namespace CoreTestSharedObjectsComponent
-} // namespace SST
+} // namespace SST::CoreTestSharedObjectsComponent
 
 #endif // SST_CORE_CORETEST_SHAREDOBJECT_H

--- a/src/sst/core/testElements/coreTest_StatisticsComponent.h
+++ b/src/sst/core/testElements/coreTest_StatisticsComponent.h
@@ -19,8 +19,7 @@ using namespace SST;
 using namespace SST::RNG;
 using namespace SST::Statistics;
 
-namespace SST {
-namespace CoreTestStatisticsComponent {
+namespace SST::CoreTestStatisticsComponent {
 
 class StatisticsComponentInt : public SST::Component
 {
@@ -142,7 +141,6 @@ private:
     Statistic<double>* stat3_F64; // For testing stat sharing
 };
 
-} // namespace CoreTestStatisticsComponent
-} // namespace SST
+} // namespace SST::CoreTestStatisticsComponent
 
 #endif // SST_CORE_CORETEST_STATISTICSCOMPONENT_H

--- a/src/sst/core/testElements/coreTest_SubComponent.h
+++ b/src/sst/core/testElements/coreTest_SubComponent.h
@@ -18,8 +18,7 @@
 
 #include <vector>
 
-namespace SST {
-namespace CoreTestSubComponent {
+namespace SST::CoreTestSubComponent {
 
 /*
 
@@ -337,7 +336,6 @@ public:
     void clock(Cycle_t) override;
 };
 
-} // namespace CoreTestSubComponent
-} // namespace SST
+} // namespace SST::CoreTestSubComponent
 
 #endif // SST_CORE_CORETEST_SUBCOMPONENT_H

--- a/src/sst/core/testElements/message_mesh/enclosingComponent.h
+++ b/src/sst/core/testElements/message_mesh/enclosingComponent.h
@@ -21,9 +21,7 @@
 #include "sst/core/ssthandler.h"
 #include "sst/core/subcomponent.h"
 
-namespace SST {
-namespace CoreTest {
-namespace MessageMesh {
+namespace SST::CoreTest::MessageMesh {
 
 class PortInterface : public SST::SubComponent
 {
@@ -233,8 +231,6 @@ private:
     SST::RNG::Random*                 rng;
 };
 
-} // namespace MessageMesh
-} // namespace CoreTest
-} // namespace SST
+} // namespace SST::CoreTest::MessageMesh
 
 #endif // SST_CORE_CORETEST_MESSAGEMESH_ENCLOSINGCOMPONENT_H

--- a/src/sst/core/testElements/message_mesh/messageEvent.h
+++ b/src/sst/core/testElements/message_mesh/messageEvent.h
@@ -14,9 +14,7 @@
 
 #include "sst/core/event.h"
 
-namespace SST {
-namespace CoreTest {
-namespace MessageMesh {
+namespace SST::CoreTest::MessageMesh {
 
 class MessageEvent : public SST::Event
 {
@@ -26,8 +24,6 @@ public:
     ImplementSerializable(SST::CoreTest::MessageMesh::MessageEvent);
 };
 
-} // namespace MessageMesh
-} // namespace CoreTest
-} // namespace SST
+} // namespace SST::CoreTest::MessageMesh
 
 #endif // SST_CORE_CORETEST_MESSAGEMESH_MESSAGEEVENT_H

--- a/src/sst/core/threadsafe.h
+++ b/src/sst/core/threadsafe.h
@@ -32,9 +32,7 @@
 
 #include <time.h>
 
-namespace SST {
-namespace Core {
-namespace ThreadSafe {
+namespace SST::Core::ThreadSafe {
 
 #if defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ < 8))
 #define CACHE_ALIGNED(type, name) type name __attribute__((aligned(64)))
@@ -332,8 +330,6 @@ atomic_fetch_min(std::atomic<T>& min_value, T const& new_value) noexcept
     while ( old_value > new_value && !min_value.compare_exchange_weak(old_value, new_value) ) {}
 }
 
-} // namespace ThreadSafe
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::ThreadSafe
 
 #endif // SST_CORE_THREADSAFE_H

--- a/src/sst/core/timeLord.cc
+++ b/src/sst/core/timeLord.cc
@@ -182,8 +182,7 @@ TimeConverter::getPeriod() const
     return Simulation_impl::getTimeLord()->getTimeBase() * factor;
 }
 
-namespace Core {
-namespace Serialization {
+namespace Core::Serialization {
 
 template <>
 class ObjectMapFundamental<TimeConverter*> : public ObjectMap
@@ -272,7 +271,6 @@ serialize_impl<TimeConverter*>::operator()(
     }
 }
 
-} // namespace Serialization
-} // namespace Core
+} // namespace Core::Serialization
 
 } // namespace SST

--- a/src/sst/core/timeVortex.cc
+++ b/src/sst/core/timeVortex.cc
@@ -17,9 +17,7 @@
 #include "sst/core/simulation_impl.h"
 
 namespace SST {
-
-namespace TV {
-namespace pvt {
+namespace TV::pvt {
 
 void
 pack_timevortex(TimeVortex*& s, SST::Core::Serialization::serializer& ser)
@@ -40,8 +38,7 @@ unpack_timevortex(TimeVortex*& s, SST::Core::Serialization::serializer& ser)
     s->serialize_order(ser);
 }
 
-} // namespace pvt
-} // namespace TV
+} // namespace TV::pvt
 
 TimeVortex::TimeVortex()
 {

--- a/src/sst/core/timeVortex.h
+++ b/src/sst/core/timeVortex.h
@@ -60,14 +60,12 @@ private:
     Simulation_impl* sim_ = nullptr;
 };
 
-namespace TV {
-namespace pvt {
+namespace TV::pvt {
 
 void pack_timevortex(TimeVortex*& s, SST::Core::Serialization::serializer& ser);
 void unpack_timevortex(TimeVortex*& s, SST::Core::Serialization::serializer& ser);
 
-} // namespace pvt
-} // namespace TV
+} // namespace TV::pvt
 
 template <>
 class SST::Core::Serialization::serialize_impl<TimeVortex*>

--- a/src/sst/core/util/smartTextFormatter.cc
+++ b/src/sst/core/util/smartTextFormatter.cc
@@ -18,11 +18,7 @@
 #include <unistd.h>
 #include <vector>
 
-
-using namespace std;
-
-namespace SST {
-namespace Util {
+namespace SST::Util {
 
 void
 SmartTextFormatter::clear()
@@ -241,5 +237,4 @@ SmartTextFormatter::getTerminalWidth()
     return w.ws_col > 0 ? w.ws_col : 80;
 }
 
-} // namespace Util
-} // namespace SST
+} // namespace SST::Util

--- a/src/sst/core/util/smartTextFormatter.h
+++ b/src/sst/core/util/smartTextFormatter.h
@@ -15,8 +15,7 @@
 #include <string>
 #include <vector>
 
-namespace SST {
-namespace Util {
+namespace SST::Util {
 
 /**
    Class to format text for console output.  It will wrap lines at
@@ -156,7 +155,6 @@ private:
 };
 
 
-} // namespace Util
-} // namespace SST
+} // namespace SST::Util
 
 #endif // SST_CORE_UTIL_SMARTTEXTFORMATTER_H


### PR DESCRIPTION
This changes the code to use C++17 [`Nested::Namespace::Syntax`](https://en.cppreference.com/w/cpp/language/namespace).

It also removes `using namespace std` from a few files, since that's generally bad practice.

In the random number generator, it removes redundant namespace prefixes since it is already in the `SST::RNG` namespace.

