### PR TITLE
Empty (void) parameter lists

### DIFF
--- a/src/sst/core/activity.h
+++ b/src/sst/core/activity.h
@@ -136,7 +136,7 @@ public:
 
 
     /** Function which will be called when the time for this Activity comes to pass. */
-    virtual void execute(void) = 0;
+    virtual void execute() = 0;
 
     /** Set the time for which this Activity should be delivered */
     inline void setDeliveryTime(SimTime_t time) { delivery_time = time; }

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -92,7 +92,7 @@ public:
     /** Called when SIGINT or SIGTERM has been seen.
      * Allows components opportunity to clean up external state.
      */
-    virtual void emergencyShutdown(void) {}
+    virtual void emergencyShutdown() {}
 
     /** Returns Component/SubComponent Name */
     inline const std::string& getName() const { return my_info->getName(); }

--- a/src/sst/core/checkpointAction.cc
+++ b/src/sst/core/checkpointAction.cc
@@ -73,7 +73,7 @@ CheckpointAction::~CheckpointAction() {}
 
 // Generate checkpoint on simulation time period
 void
-CheckpointAction::execute(void)
+CheckpointAction::execute()
 {
     Simulation_impl* sim = Simulation_impl::getSimulation();
     createCheckpoint(sim);

--- a/src/sst/core/checkpointAction.h
+++ b/src/sst/core/checkpointAction.h
@@ -70,7 +70,7 @@ public:
     void setCheckpoint();
 
     /** Called by TimeVortex to trigger checkpoint on simulation clock interval - not used in parallel simulation */
-    void execute(void) override;
+    void execute() override;
 
     /** Called by SyncManager to check whether a checkpoint should be generated */
     SimTime_t check(SimTime_t current_time);

--- a/src/sst/core/clock.cc
+++ b/src/sst/core/clock.cc
@@ -82,7 +82,7 @@ Clock::getNextCycle()
 }
 
 void
-Clock::execute(void)
+Clock::execute()
 {
     Simulation_impl* sim = Simulation_impl::getSimulation();
 

--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -107,7 +107,7 @@ private:
 
     Clock() {}
 
-    void execute(void) override;
+    void execute() override;
 
     Cycle_t            currentCycle;
     TimeConverter*     period;

--- a/src/sst/core/configBase.cc
+++ b/src/sst/core/configBase.cc
@@ -95,7 +95,7 @@ ConfigBase::parseWallTimeToSeconds(const std::string& arg, bool& success, const 
 void
 ConfigBase::addOption(
     struct option opt, const char* argname, const char* desc, std::function<int(const char* arg)> callback,
-    std::vector<bool> annotations, std::function<std::string(void)> ext_help)
+    std::vector<bool> annotations, std::function<std::string()> ext_help)
 {
     // Put this into the options vector
     options.emplace_back(opt, argname, desc, callback, false, annotations, ext_help, false);
@@ -143,7 +143,7 @@ ConfigBase::addHeading(const char* desc)
     struct option     opt = { "", optional_argument, 0, 0 };
     std::vector<bool> vec;
     options.emplace_back(
-        opt, "", desc, std::function<int(const char* arg)>(), true, vec, std::function<std::string(void)>(), false);
+        opt, "", desc, std::function<int(const char* arg)>(), true, vec, std::function<std::string()>(), false);
 }
 
 std::string
@@ -287,8 +287,8 @@ ConfigBase::printExtHelp(const std::string& option)
     else {
         Util::SmartTextFormatter formatter({ 2, 5, 8 }, 1);
 
-        std::function<std::string(void)>& func = extra_help_map[option];
-        std::string                       help = func();
+        std::function<std::string()>& func = extra_help_map[option];
+        std::string                   help = func();
         formatter.append(help);
         fprintf(stderr, "%s\n", formatter.str().c_str());
     }

--- a/src/sst/core/configBase.h
+++ b/src/sst/core/configBase.h
@@ -38,12 +38,12 @@ struct LongOption
     std::function<int(const char* arg)> callback;
     bool                                header; // if true, desc is actually the header
     std::vector<bool>                   annotations;
-    std::function<std::string(void)>    ext_help;
+    std::function<std::string()>        ext_help;
     mutable bool                        set_cmdline;
 
     LongOption(
         struct option opt, const char* argname, const char* desc, const std::function<int(const char* arg)>& callback,
-        bool header, std::vector<bool> annotations, std::function<std::string(void)> ext_help, bool set_cmdline) :
+        bool header, std::vector<bool> annotations, std::function<std::string()> ext_help, bool set_cmdline) :
         opt(opt),
         argname(argname),
         desc(desc),
@@ -148,7 +148,7 @@ protected:
      */
     void addOption(
         struct option opt, const char* argname, const char* desc, std::function<int(const char* arg)> callback,
-        std::vector<bool> annotations, std::function<std::string(void)> ext_help = std::function<std::string(void)>());
+        std::vector<bool> annotations, std::function<std::string()> ext_help = std::function<std::string()>());
 
     /**
        Adds a heading to the usage output
@@ -222,7 +222,7 @@ private:
     std::function<int(int num, const char* arg)> positional_args;
 
     // Map to hold extended help function calls
-    std::map<std::string, std::function<std::string(void)>> extra_help_map;
+    std::map<std::string, std::function<std::string()>> extra_help_map;
 
     // Annotations
     std::vector<AnnotationInfo> annotations_;

--- a/src/sst/core/configShared.cc
+++ b/src/sst/core/configShared.cc
@@ -83,7 +83,7 @@ ConfigShared::addVerboseOptions(bool sdl_avail)
 
  */
 std::string
-ConfigShared::getLibPath(void) const
+ConfigShared::getLibPath() const
 {
     std::string fullLibPath;
 

--- a/src/sst/core/configShared.h
+++ b/src/sst/core/configShared.h
@@ -141,7 +141,7 @@ public:
     std::string libpath() const { return libpath_; }
     std::string addLibPath() const { return addlibpath_; }
 
-    std::string getLibPath(void) const;
+    std::string getLibPath() const;
 };
 
 } // namespace SST

--- a/src/sst/core/event.cc
+++ b/src/sst/core/event.cc
@@ -26,7 +26,7 @@ const SST::Event::id_type SST::Event::NO_ID = std::make_pair(0, -1);
 Event::~Event() {}
 
 void
-Event::execute(void)
+Event::execute()
 {
     (*reinterpret_cast<HandlerBase*>(delivery_info))(this);
 }

--- a/src/sst/core/event.h
+++ b/src/sst/core/event.h
@@ -159,7 +159,7 @@ private:
 
 
     /** Cause this event to fire */
-    void execute(void) override;
+    void execute() override;
 
     /**
        This sets the information needed to get the event properly
@@ -184,7 +184,7 @@ private:
     inline Link* getDeliveryLink() { return reinterpret_cast<Link*>(delivery_info); }
 
     /** Gets the link id associated with this event.  For use by SST Core only */
-    inline LinkId_t getTag(void) const { return getOrderTag(); }
+    inline LinkId_t getTag() const { return getOrderTag(); }
 
 
     /** Holds the delivery information.  This is stored as a

--- a/src/sst/core/exit.h
+++ b/src/sst/core/exit.h
@@ -72,7 +72,7 @@ public:
      * @return End time of the simulation
      */
     SimTime_t computeEndTime();
-    void      execute(void) override;
+    void      execute() override;
     void      check();
 
     /**

--- a/src/sst/core/heartbeat.cc
+++ b/src/sst/core/heartbeat.cc
@@ -56,7 +56,7 @@ SimulatorHeartbeat::schedule()
 }
 
 void
-SimulatorHeartbeat::execute(void)
+SimulatorHeartbeat::execute()
 {
     Simulation_impl* sim = Simulation_impl::getSimulation();
     const double     now = sst_get_cpu_time();

--- a/src/sst/core/heartbeat.h
+++ b/src/sst/core/heartbeat.h
@@ -49,7 +49,7 @@ private:
     SimulatorHeartbeat(const SimulatorHeartbeat&);
 
     void           operator=(SimulatorHeartbeat const&);
-    void           execute(void) override;
+    void           execute() override;
     int            rank;
     TimeConverter* m_period;
     double         lastTime;

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -236,7 +236,7 @@ public:
     // /**
     //  * Returns a handle to the underlying SST::Link
     //  */
-    // virtual Link* getLink(void) const = 0;
+    // virtual Link* getLink() const = 0;
 
     /**
      * Send a Request to the network.

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -1242,7 +1242,7 @@ public:
      * @return Pointer to a Request response
      *          Upon receipt, the receiver takes responsibility for deleting the event
      */
-    virtual Request* poll(void) = 0;
+    virtual Request* poll() = 0;
 
     /**
      * Get cache/memory line size (in bytes) from the memory system

--- a/src/sst/core/interfaces/stringEvent.h
+++ b/src/sst/core/interfaces/stringEvent.h
@@ -35,7 +35,7 @@ public:
     virtual Event* clone() override { return new StringEvent(*this); }
 
     /** Returns the contents of this Event */
-    const std::string& getString(void) { return str; }
+    const std::string& getString() { return str; }
 
 private:
     std::string str;

--- a/src/sst/core/interprocess/ipctunnel.h
+++ b/src/sst/core/interprocess/ipctunnel.h
@@ -194,7 +194,7 @@ public:
         }
     }
 
-    const std::string& getRegionName(void) const { return filename; }
+    const std::string& getRegionName() const { return filename; }
 
     /** return a pointer to the ShareDataType region */
     ShareDataType* getSharedData() { return sharedData; }

--- a/src/sst/core/interprocess/mmapchild_pin3.h
+++ b/src/sst/core/interprocess/mmapchild_pin3.h
@@ -94,7 +94,7 @@ public:
     TunnelType* getTunnel() { return tunnel; }
 
     /** Return the name of the mmap'd file */
-    const std::string& getRegionName(void) const { return filename; }
+    const std::string& getRegionName() const { return filename; }
 
 private:
     void*       shmPtr;

--- a/src/sst/core/interprocess/mmapparent.h
+++ b/src/sst/core/interprocess/mmapparent.h
@@ -103,7 +103,7 @@ public:
     }
 
     /** returns name of the mmap'd file */
-    const std::string& getRegionName(void) const { return filename; }
+    const std::string& getRegionName() const { return filename; }
 
     /** return the created tunnel pointer */
     TunnelType* getTunnel() { return tunnel; }

--- a/src/sst/core/interprocess/shmchild.h
+++ b/src/sst/core/interprocess/shmchild.h
@@ -95,7 +95,7 @@ public:
     TunnelType* getTunnel() { return tunnel; }
 
     /** return the name of the shared memory region */
-    const std::string& getRegionName(void) const { return filename; }
+    const std::string& getRegionName() const { return filename; }
 
 private:
     void* shmPtr;

--- a/src/sst/core/interprocess/shmparent.h
+++ b/src/sst/core/interprocess/shmparent.h
@@ -106,7 +106,7 @@ public:
     }
 
     /** returns name of the mmap'd region */
-    const std::string& getRegionName(void) const { return filename; }
+    const std::string& getRegionName() const { return filename; }
 
     /** return the created tunnel pointer */
     TunnelType* getTunnel() { return tunnel; }

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -582,7 +582,7 @@ public:
     NullEvent() : Event() {}
     ~NullEvent() {}
 
-    void execute(void) override
+    void execute() override
     {
         (*reinterpret_cast<HandlerBase*>(delivery_info))(nullptr);
         delete this;

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -1017,7 +1017,7 @@ static struct PyModuleDef sstModuleDef
 #endif
 
 static PyObject*
-PyInit_sst(void)
+PyInit_sst()
 {
     // Initialize our types
     PyModel_ComponentType.tp_new    = PyType_GenericNew;
@@ -1347,7 +1347,7 @@ SSTPythonModelDefinition::pushNamePrefix(const char* name)
 }
 
 void
-SSTPythonModelDefinition::popNamePrefix(void)
+SSTPythonModelDefinition::popNamePrefix()
 {
     if ( nameStack.empty() ) return;
     size_t off = nameStack.back();

--- a/src/sst/core/model/python/pymodel.h
+++ b/src/sst/core/model/python/pymodel.h
@@ -77,14 +77,14 @@ protected:
 #endif
 
 public: /* Public, but private.  Called only from Python functions */
-    Config* getConfig(void) const { return config; }
+    Config* getConfig() const { return config; }
 
     bool setConfigEntryFromModel(const std::string& entryName, const std::string& value)
     {
         return setOptionFromModel(entryName, value);
     }
 
-    ConfigGraph* getGraph(void) const { return graph; }
+    ConfigGraph* getGraph() const { return graph; }
 
     Output* getOutput() const { return output; }
 
@@ -110,7 +110,7 @@ public: /* Public, but private.  Called only from Python functions */
     void setLinkNoCut(const char* link_name) const { graph->setLinkNoCut(link_name); }
 
     void  pushNamePrefix(const char* name);
-    void  popNamePrefix(void);
+    void  popNamePrefix();
     char* addNamePrefix(const char* name) const;
 
     void setStatisticOutput(const char* Name) { graph->setStatisticOutput(Name); }

--- a/src/sst/core/oneshot.cc
+++ b/src/sst/core/oneshot.cc
@@ -99,7 +99,7 @@ OneShot::scheduleOneShot()
 }
 
 void
-OneShot::execute(void)
+OneShot::execute()
 {
     // Execute the OneShot when the TimeVortex tells us to go.
     // This will call all registered callbacks.

--- a/src/sst/core/oneshot.h
+++ b/src/sst/core/oneshot.h
@@ -93,7 +93,7 @@ private:
     OneShot() {}
 
     // Called by the Simulation (Activity Queue) when delay time as elapsed
-    void execute(void) override;
+    void execute() override;
 
     // Activates this OneShot object, by inserting into the simulation's
     // timeVortex for future execution.

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -169,7 +169,7 @@ public:
         }
     }
 
-    // For void*, we get sizeof(void), which errors.
+    // For void*, we get sizeof(), which errors.
     // Create a wrapper that casts to char* and uses above
     template <typename Int>
     void binary(void*& buffer, Int& size)

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -985,7 +985,7 @@ Simulation_impl::signalShutdown(bool abnormal)
 // If this version is called, we need to set the end time in the exit
 // object as well
 void
-Simulation_impl::endSimulation(void)
+Simulation_impl::endSimulation()
 {
     m_exit->setEndTime(currentSimCycle);
     endSimulation(currentSimCycle);
@@ -1232,7 +1232,7 @@ Simulation_impl::getSyncQueueDataSize() const
 }
 
 Statistics::StatisticProcessingEngine*
-Simulation_impl::getStatisticsProcessingEngine(void)
+Simulation_impl::getStatisticsProcessingEngine()
 {
     return &stat_engine;
 }

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -142,7 +142,7 @@ public:
     static Simulation_impl* getSimulation() { return instanceMap.at(std::this_thread::get_id()); }
 
     /** Return the TimeLord associated with this Simulation */
-    static TimeLord* getTimeLord(void) { return &timeLord; }
+    static TimeLord* getTimeLord() { return &timeLord; }
 
     /** Return the base simulation Output class instance */
     static Output& getSimulationOutput() { return sim_output; }
@@ -237,7 +237,7 @@ public:
     }
 
     /** Returns reference to the Component Info Map */
-    const ComponentInfoMap& getComponentInfoMap(void) { return compInfoMap; }
+    const ComponentInfoMap& getComponentInfoMap() { return compInfoMap; }
 
     /** returns the component with the given ID */
     BaseComponent* getComponent(const ComponentId_t& id) const
@@ -323,7 +323,7 @@ public:
     SimTime_t getClockForHandler(Clock::HandlerBase* handler);
 
     /** Return the Statistic Processing Engine associated with this Simulation */
-    Statistics::StatisticProcessingEngine* getStatisticsProcessingEngine(void);
+    Statistics::StatisticProcessingEngine* getStatisticsProcessingEngine();
 
 
     friend class Link;
@@ -400,7 +400,7 @@ public:
 
     /** Normal Shutdown
      */
-    void endSimulation(void);
+    void endSimulation();
     void endSimulation(SimTime_t end);
 
     typedef enum {

--- a/src/sst/core/statapi/statengine.h
+++ b/src/sst/core/statapi/statengine.h
@@ -26,7 +26,7 @@
 
 /* Forward declare for Friendship */
 extern int  main(int argc, char** argv);
-extern void finalize_statEngineConfig(void);
+extern void finalize_statEngineConfig();
 
 namespace SST {
 class BaseComponent;
@@ -100,7 +100,7 @@ public:
 private:
     friend class SST::Simulation_impl;
     friend int ::main(int argc, char** argv);
-    friend void ::finalize_statEngineConfig(void);
+    friend void ::finalize_statEngineConfig();
 
     StatisticProcessingEngine();
     void setup(Simulation_impl* sim, ConfigGraph* graph);

--- a/src/sst/core/statapi/statoutputcsv.cc
+++ b/src/sst/core/statapi/statoutputcsv.cc
@@ -268,7 +268,7 @@ StatisticOutputCSV::outputField(fieldHandle_t fieldHandle, double data)
 }
 
 bool
-StatisticOutputCSV::openFile(void)
+StatisticOutputCSV::openFile()
 {
     if ( m_useCompression ) {
 #ifdef HAVE_LIBZ
@@ -301,7 +301,7 @@ StatisticOutputCSV::openFile(void)
 }
 
 void
-StatisticOutputCSV::closeFile(void)
+StatisticOutputCSV::closeFile()
 {
     if ( m_useCompression ) {
 #ifdef HAVE_LIBZ

--- a/src/sst/core/statapi/statoutputjson.cc
+++ b/src/sst/core/statapi/statoutputjson.cc
@@ -231,7 +231,7 @@ StatisticOutputJSON::outputField(fieldHandle_t UNUSED(fieldHandle), double data)
 }
 
 bool
-StatisticOutputJSON::openFile(void)
+StatisticOutputJSON::openFile()
 {
     m_hFile = fopen(m_FilePath.c_str(), "w");
 
@@ -248,7 +248,7 @@ StatisticOutputJSON::openFile(void)
 }
 
 void
-StatisticOutputJSON::closeFile(void)
+StatisticOutputJSON::closeFile()
 {
     fclose(m_hFile);
 }

--- a/src/sst/core/statapi/statoutputtxt.cc
+++ b/src/sst/core/statapi/statoutputtxt.cc
@@ -311,7 +311,7 @@ StatisticOutputTextBase::outputField(fieldHandle_t fieldHandle, double data)
 
 
 bool
-StatisticOutputTextBase::openFile(void)
+StatisticOutputTextBase::openFile()
 {
     if ( !outputsToFile() ) {
         m_hFile = stdout;
@@ -349,7 +349,7 @@ StatisticOutputTextBase::openFile(void)
 }
 
 void
-StatisticOutputTextBase::closeFile(void)
+StatisticOutputTextBase::closeFile()
 {
     if ( !outputsToFile() ) return;
     if ( m_useCompression ) {

--- a/src/sst/core/sync/rankSyncSerialSkip.cc
+++ b/src/sst/core/sync/rankSyncSerialSkip.cc
@@ -142,7 +142,7 @@ RankSyncSerialSkip::execute(int thread)
 }
 
 void
-RankSyncSerialSkip::exchange(void)
+RankSyncSerialSkip::exchange()
 {
 #ifdef SST_CONFIG_HAVE_MPI
     // Maximum number of outstanding requests is 3 times the number

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -365,7 +365,7 @@ SyncManager::exchangeLinkInfo()
 }
 
 void
-SyncManager::execute(void)
+SyncManager::execute()
 {
     SST_SYNC_PROFILE_START
 

--- a/src/sst/core/sync/syncManager.h
+++ b/src/sst/core/sync/syncManager.h
@@ -140,7 +140,7 @@ public:
     ActivityQueue*
          registerLink(const RankInfo& to_rank, const RankInfo& from_rank, const std::string& name, Link* link);
     void exchangeLinkInfo();
-    void execute(void) override;
+    void execute() override;
 
     /** Cause an exchange of Initialization Data to occur */
     void exchangeLinkUntimedData(std::atomic<int>& msg_count);

--- a/src/sst/core/sync/threadSyncDirectSkip.h
+++ b/src/sst/core/sync/threadSyncDirectSkip.h
@@ -41,7 +41,7 @@ public:
 
     void before() override {}
     void after() override;
-    void execute(void) override;
+    void execute() override;
 
     /** Cause an exchange of Untimed Data to occur */
     void processLinkUntimedData() override {}

--- a/src/sst/core/sync/threadSyncSimpleSkip.h
+++ b/src/sst/core/sync/threadSyncSimpleSkip.h
@@ -42,7 +42,7 @@ public:
 
     void before() override;
     void after() override;
-    void execute(void) override;
+    void execute() override;
 
     /** Set signals to exchange during sync */
     void setSignals(int end, int usr, int alrm) override;

--- a/src/sst/core/testElements/coreTest_MemPoolTest.h
+++ b/src/sst/core/testElements/coreTest_MemPoolTest.h
@@ -162,8 +162,8 @@ public:
     ~MemPoolTestComponent() {}
 
     void eventHandler(Event* ev, int port);
-    void setup(void) override;
-    void finish(void) override;
+    void setup() override;
+    void finish() override;
     void complete(unsigned int phase) override;
 
 private:


### PR DESCRIPTION
In C++ ([and C23](https://en.cppreference.com/w/c/language/function_declaration)), an empty function parameter list of `()` is equivalent to `(void)`.

