### PR TITLE
Use _t and _v traits instead of ::type and ::value

### DIFF
--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -1138,7 +1138,7 @@ public:
 
 
 template <class T>
-class serialize_impl<T*, typename std::enable_if<std::is_base_of<SST::BaseComponent, T>::value>::type>
+class serialize_impl<T*, std::enable_if_t<std::is_base_of_v<SST::BaseComponent, T>>>
 {
     template <class A>
     friend class serialize;

--- a/src/sst/core/decimal_fixedpoint.h
+++ b/src/sst/core/decimal_fixedpoint.h
@@ -217,7 +217,7 @@ public:
        @param init Initialization value.
      */
     template <class T>
-    decimal_fixedpoint(T init, typename std::enable_if<std::is_unsigned<T>::value>::type* = nullptr)
+    decimal_fixedpoint(T init, std::enable_if_t<std::is_unsigned_v<T>>* = nullptr)
     {
         from_uint64(init);
     }
@@ -228,8 +228,7 @@ public:
        @param init Initialization value.
      */
     template <class T>
-    decimal_fixedpoint(
-        T init, typename std::enable_if<std::is_signed<T>::value && std::is_integral<T>::value>::type* = nullptr)
+    decimal_fixedpoint(T init, std::enable_if_t<std::is_signed_v<T> && std::is_integral_v<T>>* = nullptr)
     {
         if ( init < 0 ) {
             from_uint64(-init);
@@ -246,7 +245,7 @@ public:
        @param init Initialization value.
      */
     template <class T>
-    decimal_fixedpoint(const T init, typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr)
+    decimal_fixedpoint(const T init, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr)
     {
         from_double(init);
     }
@@ -408,7 +407,7 @@ public:
        Templated conversion function for unsigned types.
      */
     template <typename T>
-    T convert_to(typename std::enable_if<std::is_unsigned<T>::value>::type* = 0) const
+    T convert_to(std::enable_if_t<std::is_unsigned_v<T>>* = nullptr) const
     {
         return static_cast<T>(toUnsignedLong());
     }
@@ -417,7 +416,7 @@ public:
        Templated conversion function for signed integral types.
      */
     template <typename T>
-    T convert_to(typename std::enable_if<std::is_signed<T>::value && std::is_integral<T>::value>::type* = 0) const
+    T convert_to(std::enable_if_t<std::is_signed_v<T> && std::is_integral_v<T>>* = nullptr) const
     {
         return static_cast<T>(toLong());
     }
@@ -426,7 +425,7 @@ public:
        Templated conversion function for floating point types.
      */
     template <typename T>
-    T convert_to(typename std::enable_if<std::is_floating_point<T>::value>::type* = 0) const
+    T convert_to(std::enable_if_t<std::is_floating_point_v<T>>* = nullptr) const
     {
         return static_cast<T>(toDouble());
     }

--- a/src/sst/core/eli/attributeInfo.h
+++ b/src/sst/core/eli/attributeInfo.h
@@ -74,14 +74,14 @@ private:
 } // namespace SST
 
 // clang-format off
-#define SST_ELI_DOCUMENT_ATTRIBUTES(...)                                                                           \
-    static const std::vector<SST::ElementInfoAttribute>& ELI_getAttributes()                                       \
-    {                                                                                                              \
-        static std::vector<SST::ElementInfoAttribute> var  = { __VA_ARGS__ };                                      \
-        auto parent = SST::ELI::GetAttributes<                                                                     \
-            typename std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
-        SST::ELI::combineEliInfo(var, parent);                                                                     \
-        return var;                                                                                                \
+#define SST_ELI_DOCUMENT_ATTRIBUTES(...)                                                                      \
+    static const std::vector<SST::ElementInfoAttribute>& ELI_getAttributes()                                  \
+    {                                                                                                         \
+        static std::vector<SST::ElementInfoAttribute> var  = { __VA_ARGS__ };                                 \
+        auto parent = SST::ELI::GetAttributes<                                                                \
+           std::conditional_t<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>>::get(); \
+        SST::ELI::combineEliInfo(var, parent);                                                                \
+        return var;                                                                                           \
     }
 // clang-format on
 

--- a/src/sst/core/eli/elementbuilder.h
+++ b/src/sst/core/eli/elementbuilder.h
@@ -184,13 +184,11 @@ struct DerivedBuilder : public Builder<Base, Args...>
     Base* create(Args... ctorArgs) override { return Allocator<Base, T>()(std::forward<Args>(ctorArgs)...); }
 };
 
-template <class T, class U>
-struct is_tuple_constructible : public std::false_type
-{};
+template <class, class>
+inline constexpr bool is_tuple_constructible_v = false;
 
 template <class T, class... Args>
-struct is_tuple_constructible<T, std::tuple<Args...>> : public std::is_constructible<T, Args...>
-{};
+inline constexpr bool is_tuple_constructible_v<T, std::tuple<Args...>> = std::is_constructible_v<T, Args...>;
 
 struct BuilderDatabase
 {
@@ -230,7 +228,7 @@ template <class NewCtor, class OldCtor>
 struct ExtendedCtor
 {
     template <class T>
-    using is_constructible = typename NewCtor::template is_constructible<T>;
+    static constexpr bool is_constructible_v = NewCtor::template is_constructible_v<T>;
 
     /**
       The derived Ctor can "block" the more abstract Ctor, meaning an object
@@ -238,14 +236,14 @@ struct ExtendedCtor
       checks if both the derived API and the parent API are still valid
     */
     template <class T>
-    static typename std::enable_if<OldCtor::template is_constructible<T>::value, bool>::type add()
+    static std::enable_if_t<OldCtor::template is_constructible_v<T>, bool> add()
     {
         // if abstract, force an allocation to generate meaningful errors
         return NewCtor::template add<T>() && OldCtor::template add<T>();
     }
 
     template <class T>
-    static typename std::enable_if<!OldCtor::template is_constructible<T>::value, bool>::type add()
+    static std::enable_if_t<!OldCtor::template is_constructible_v<T>, bool> add()
     {
         // if abstract, force an allocation to generate meaningful errors
         return NewCtor::template add<T>();
@@ -262,7 +260,7 @@ template <class Base, class... Args>
 struct SingleCtor
 {
     template <class T>
-    using is_constructible = std::is_constructible<T, Args...>;
+    static constexpr bool is_constructible_v = std::is_constructible_v<T, Args...>;
 
     template <class T>
     static bool add()
@@ -283,15 +281,12 @@ template <class Base, class Ctor, class... Ctors>
 struct CtorList : public CtorList<Base, Ctors...>
 {
     template <class T> // if T is constructible with Ctor arguments
-    using is_constructible = typename std::conditional<
-        is_tuple_constructible<T, Ctor>::value,
-        std::true_type,                                                 // yes, constructible
-        typename CtorList<Base, Ctors...>::template is_constructible<T> // not constructible here but maybe later
-        >::type;
+    static constexpr bool is_constructible_v =
+        is_tuple_constructible_v<T, Ctor>                            // yes, constructible
+        || CtorList<Base, Ctors...>::template is_constructible_v<T>; // not constructible here but maybe later
 
     template <class T, int NumValid = 0, class U = T>
-    static typename std::enable_if<std::is_abstract<U>::value || is_tuple_constructible<U, Ctor>::value, bool>::type
-    add()
+    static std::enable_if_t<std::is_abstract_v<U> || is_tuple_constructible_v<U, Ctor>, bool> add()
     {
         // if abstract, force an allocation to generate meaningful errors
         auto* fact = ElementsBuilder<Base, Ctor>::template makeBuilder<U>();
@@ -300,8 +295,7 @@ struct CtorList : public CtorList<Base, Ctors...>
     }
 
     template <class T, int NumValid = 0, class U = T>
-    static typename std::enable_if<!std::is_abstract<U>::value && !is_tuple_constructible<U, Ctor>::value, bool>::type
-    add()
+    static std::enable_if_t<!std::is_abstract_v<U> && !is_tuple_constructible_v<U, Ctor>, bool> add()
     {
         return CtorList<Base, Ctors...>::template add<T, NumValid>();
     }
@@ -323,8 +317,8 @@ class NoValidConstructorsForDerivedType<0>
 template <class Base>
 struct CtorList<Base, void>
 {
-    template <class T>
-    using is_constructible = std::false_type;
+    template <class>
+    static constexpr bool is_constructible_v = false;
 
     template <class T, int numValidCtors>
     static bool add()

--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -420,15 +420,15 @@ SST_ELI_getTertiaryNumberFromVersion(SST_ELI_element_version_extraction ver)
 // this class.  Sny local information will overwrite any inherited
 // information.  See comment for SST_ELI_DECLARE_BASE in elibase.h for
 // info on how __EliDerivedLevel is used.
-#define SST_ELI_REGISTER_DERIVED(base, cls, lib, name, version, desc)         \
-    [[maybe_unused]] static constexpr int __EliDerivedLevel =                 \
-        std::is_same<base, cls>::value ? __EliBaseLevel : __EliBaseLevel + 1; \
-    static bool ELI_isLoaded()                                                \
-    {                                                                         \
-        return SST::ELI::InstantiateBuilder<base, cls>::isLoaded() &&         \
-               SST::ELI::InstantiateBuilderInfo<base, cls>::isLoaded();       \
-    }                                                                         \
-    SST_ELI_FORCE_INSTANTIATION(base, cls)                                    \
+#define SST_ELI_REGISTER_DERIVED(base, cls, lib, name, version, desc)    \
+    [[maybe_unused]] static constexpr int __EliDerivedLevel =            \
+        std::is_same_v<base, cls> ? __EliBaseLevel : __EliBaseLevel + 1; \
+    static bool ELI_isLoaded()                                           \
+    {                                                                    \
+        return SST::ELI::InstantiateBuilder<base, cls>::isLoaded() &&    \
+               SST::ELI::InstantiateBuilderInfo<base, cls>::isLoaded();  \
+    }                                                                    \
+    SST_ELI_FORCE_INSTANTIATION(base, cls)                               \
     SST_ELI_DEFAULT_INFO(lib, name, ELI_FORWARD_AS_ONE(version), desc)
 
 #define SST_ELI_REGISTER_EXTERN(base, cls)                              \

--- a/src/sst/core/eli/paramsInfo.h
+++ b/src/sst/core/eli/paramsInfo.h
@@ -81,14 +81,14 @@ private:
 } // namespace SST
 
 // clang-format off
-#define SST_ELI_DOCUMENT_PARAMS(...)                                                                               \
-    static const std::vector<SST::ElementInfoParam>& ELI_getParams()                                               \
-    {                                                                                                              \
-        static std::vector<SST::ElementInfoParam> var    = { __VA_ARGS__ };                                        \
-        auto parent = SST::ELI::GetParams<                                                                         \
-            typename std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
-        SST::ELI::combineEliInfo(var, parent);                                                                     \
-        return var;                                                                                                \
+#define SST_ELI_DOCUMENT_PARAMS(...)                                                                           \
+    static const std::vector<SST::ElementInfoParam>& ELI_getParams()                                           \
+    {                                                                                                          \
+        static std::vector<SST::ElementInfoParam> var    = { __VA_ARGS__ };                                    \
+        auto parent = SST::ELI::GetParams<                                                                     \
+            std::conditional_t<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>>::get(); \
+        SST::ELI::combineEliInfo(var, parent);                                                                 \
+        return var;                                                                                            \
     }
 // clang-format on
 

--- a/src/sst/core/eli/portsInfo.h
+++ b/src/sst/core/eli/portsInfo.h
@@ -77,14 +77,14 @@ private:
 } // namespace SST
 
 // clang-format off
-#define SST_ELI_DOCUMENT_PORTS(...)                                                                                \
-    static const std::vector<SST::ElementInfoPort>& ELI_getPorts()                                                 \
-    {                                                                                                              \
-        static std::vector<SST::ElementInfoPort> var    = { __VA_ARGS__ };                                         \
-        auto parent = SST::ELI::InfoPorts<                                                                         \
-            typename std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
-        SST::ELI::combineEliInfo(var, parent);                                                                     \
-        return var;                                                                                                \
+#define SST_ELI_DOCUMENT_PORTS(...)                                                                           \
+    static const std::vector<SST::ElementInfoPort>& ELI_getPorts()                                            \
+    {                                                                                                         \
+        static std::vector<SST::ElementInfoPort> var    = { __VA_ARGS__ };                                    \
+        auto parent = SST::ELI::InfoPorts<                                                                    \
+           std::conditional_t<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>>::get(); \
+        SST::ELI::combineEliInfo(var, parent);                                                                \
+        return var;                                                                                           \
     }
 // clang-format on
 

--- a/src/sst/core/eli/profilePointInfo.h
+++ b/src/sst/core/eli/profilePointInfo.h
@@ -71,14 +71,14 @@ private:
 } // namespace SST
 
 // clang-format off
-#define SST_ELI_DOCUMENT_PROFILE_POINTS(...)                                                                       \
-    static const std::vector<SST::ElementInfoProfilePoint>& ELI_getProfilePoints()                                 \
-    {                                                                                                              \
-        static std::vector<SST::ElementInfoProfilePoint> var = { __VA_ARGS__ };                                    \
-        auto parent = SST::ELI::InfoProfilePoints<                                                                 \
-            typename std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
-        SST::ELI::combineEliInfo(var, parent);                                                                     \
-        return var;                                                                                                \
+#define SST_ELI_DOCUMENT_PROFILE_POINTS(...)                                                                  \
+    static const std::vector<SST::ElementInfoProfilePoint>& ELI_getProfilePoints()                            \
+    {                                                                                                         \
+        static std::vector<SST::ElementInfoProfilePoint> var = { __VA_ARGS__ };                               \
+        auto parent = SST::ELI::InfoProfilePoints<                                                            \
+           std::conditional_t<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>>::get(); \
+        SST::ELI::combineEliInfo(var, parent);                                                                \
+        return var;                                                                                           \
     }
 // clang-format on
 #define SST_ELI_DELETE_PROFILE_POINT(point) \

--- a/src/sst/core/eli/simpleInfo.h
+++ b/src/sst/core/eli/simpleInfo.h
@@ -54,17 +54,21 @@ public:
     static bool const value = (sizeof(HasFunction<T>(0)) == sizeof(Match));
 };
 
+template <class T, int index, class InfoType>
+inline constexpr bool checkForELI_getSimpleInfoFunction_v =
+    checkForELI_getSimpleInfoFunction<T, index, InfoType>::value;
+
 // Actual functions that use checkForELI_getSimpleInfoFunction class
 // to create functions to get the information from the class
 template <class T, int index, class InfoType>
-typename std::enable_if<checkForELI_getSimpleInfoFunction<T, index, InfoType>::value, const InfoType&>::type
+std::enable_if_t<checkForELI_getSimpleInfoFunction_v<T, index, InfoType>, const InfoType&>
 ELI_templatedGetSimpleInfo()
 {
     return T::ELI_getSimpleInfo(SimpleInfoPlaceHolder<index, InfoType>());
 }
 
 template <class T, int index, class InfoType>
-typename std::enable_if<not checkForELI_getSimpleInfoFunction<T, index, InfoType>::value, const InfoType&>::type
+std::enable_if_t<!checkForELI_getSimpleInfoFunction_v<T, index, InfoType>, const InfoType&>
 ELI_templatedGetSimpleInfo()
 {
     static InfoType var;

--- a/src/sst/core/eli/statsInfo.h
+++ b/src/sst/core/eli/statsInfo.h
@@ -85,14 +85,14 @@ public:
 } // namespace SST
 
 // clang-format off
-#define SST_ELI_DOCUMENT_STATISTICS(...)                                                                           \
-    static const std::vector<SST::ElementInfoStatistic>& ELI_getStatistics()                                       \
-    {                                                                                                              \
-        static std::vector<SST::ElementInfoStatistic> var    = { __VA_ARGS__ };                                    \
-        auto parent = SST::ELI::InfoStats<                                                                         \
-            typename std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
-        SST::ELI::combineEliInfo(var, parent);                                                                     \
-        return var;                                                                                                \
+#define SST_ELI_DOCUMENT_STATISTICS(...)                                                                    \
+    static const std::vector<SST::ElementInfoStatistic>& ELI_getStatistics()                                \
+    {                                                                                                       \
+        static std::vector<SST::ElementInfoStatistic> var    = { __VA_ARGS__ };                             \
+        auto parent = SST::ELI::InfoStats<                                                                  \
+         std::conditional_t<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>>::get(); \
+        SST::ELI::combineEliInfo(var, parent);                                                              \
+        return var;                                                                                         \
     }
 // clang-format on
 

--- a/src/sst/core/eli/subcompSlotInfo.h
+++ b/src/sst/core/eli/subcompSlotInfo.h
@@ -71,14 +71,14 @@ private:
 } // namespace SST
 
 // clang-format off
-#define SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(...)                                                                   \
-    static const std::vector<SST::ElementInfoSubComponentSlot>& ELI_getSubComponentSlots()                         \
-    {                                                                                                              \
-        static std::vector<SST::ElementInfoSubComponentSlot> var = { __VA_ARGS__ };                                \
-        auto parent = SST::ELI::InfoSubs<                                                                          \
-            typename std::conditional<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>::type>::get(); \
-        SST::ELI::combineEliInfo(var, parent);                                                                     \
-        return var;                                                                                                \
+#define SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(...)                                                               \
+    static const std::vector<SST::ElementInfoSubComponentSlot>& ELI_getSubComponentSlots()                     \
+    {                                                                                                          \
+        static std::vector<SST::ElementInfoSubComponentSlot> var = { __VA_ARGS__ };                            \
+        auto parent = SST::ELI::InfoSubs<                                                                      \
+            std::conditional_t<(__EliDerivedLevel > __EliBaseLevel), __LocalEliBase, __ParentEliBase>>::get(); \
+        SST::ELI::combineEliInfo(var, parent);                                                                 \
+        return var;                                                                                            \
     }
 // clang-format on
 #define SST_ELI_DELETE_SUBCOMPONENT_SLOT(slot) \

--- a/src/sst/core/from_string.h
+++ b/src/sst/core/from_string.h
@@ -20,15 +20,15 @@ namespace SST {
 namespace Core {
 
 template <class T>
-typename std::enable_if<std::is_integral<T>::value, T>::type
+std::enable_if_t<std::is_integral_v<T>, T>
 from_string(const std::string& input)
 {
-    if ( std::is_signed<T>::value ) {
-        if ( std::is_same<int, T>::value ) { return std::stoi(input, nullptr, 0); }
-        else if ( std::is_same<long, T>::value ) {
+    if constexpr ( std::is_signed_v<T> ) {
+        if constexpr ( std::is_same_v<int, T> ) { return std::stoi(input, nullptr, 0); }
+        else if constexpr ( std::is_same_v<long, T> ) {
             return std::stol(input, nullptr, 0);
         }
-        else if ( std::is_same<long long, T>::value ) {
+        else if constexpr ( std::is_same_v<long long, T> ) {
             return std::stoll(input, nullptr, 0);
         }
         else { // Smaller than 32-bit
@@ -36,7 +36,7 @@ from_string(const std::string& input)
         }
     }
     else {
-        if ( std::is_same<bool, T>::value ) {
+        if constexpr ( std::is_same_v<bool, T> ) {
             // valid pairs: true/false, t/f, yes/no, y/n, on/off, 1/0
             std::string transform(input);
             for ( auto& c : transform )
@@ -54,10 +54,10 @@ from_string(const std::string& input)
                 throw std::invalid_argument("from_string: no valid conversion");
             }
         }
-        else if ( std::is_same<unsigned long, T>::value ) {
+        else if constexpr ( std::is_same_v<unsigned long, T> ) {
             return std::stoul(input, nullptr, 0);
         }
-        else if ( std::is_same<unsigned long long, T>::value ) {
+        else if constexpr ( std::is_same_v<unsigned long long, T> ) {
             return std::stoull(input, nullptr, 0);
         }
         else { // Smaller than 32-bit
@@ -67,14 +67,14 @@ from_string(const std::string& input)
 }
 
 template <class T>
-typename std::enable_if<std::is_floating_point<T>::value, T>::type
+std::enable_if_t<std::is_floating_point_v<T>, T>
 from_string(const std::string& input)
 {
-    if ( std::is_same<float, T>::value ) { return stof(input); }
-    else if ( std::is_same<double, T>::value ) {
+    if constexpr ( std::is_same_v<float, T> ) { return stof(input); }
+    else if constexpr ( std::is_same_v<double, T> ) {
         return stod(input);
     }
-    else if ( std::is_same<long double, T>::value ) {
+    else if constexpr ( std::is_same_v<long double, T> ) {
         return stold(input);
     }
     else { // make compiler happy
@@ -83,11 +83,11 @@ from_string(const std::string& input)
 }
 
 template <class T>
-typename std::enable_if<std::is_class<T>::value, T>::type
+std::enable_if_t<std::is_class_v<T>, T>
 from_string(const std::string& input)
 {
     static_assert(
-        std::is_constructible<T, std::string>::value,
+        std::is_constructible_v<T, std::string>,
         "ERROR: from_string can only be used with integral and floating point types and with classes that have a "
         "constructor that takes a single string as input.\n");
     return T(input);

--- a/src/sst/core/impl/timevortex/timeVortexBinnedMap.h
+++ b/src/sst/core/impl/timevortex/timeVortexBinnedMap.h
@@ -153,10 +153,9 @@ private:
     typedef std::map<SimTime_t, TimeUnit*> mapType_t;
 
     // Accessed by multiple threads, must be locked when accessing
-    mapType_t                                                            map;
-    typename std::conditional<TS, std::atomic<uint64_t>, uint64_t>::type insertOrder;
-
-    typename std::conditional<TS, std::atomic<uint64_t>, uint64_t>::type current_depth;
+    mapType_t                                               map;
+    std::conditional_t<TS, std::atomic<uint64_t>, uint64_t> insertOrder;
+    std::conditional_t<TS, std::atomic<uint64_t>, uint64_t> current_depth;
 
     // Should only ever be accessed by the "active" thread, or in a
     // mutex.  There are no internal mutexes.

--- a/src/sst/core/impl/timevortex/timeVortexPQ.h
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.h
@@ -79,7 +79,7 @@ private:
     uint64_t max_depth;
 
     // Need current depth to be atomic if we are thread safe
-    typename std::conditional<TS, std::atomic<uint64_t>, uint64_t>::type current_depth;
+    std::conditional_t<TS, std::atomic<uint64_t>, uint64_t> current_depth;
 
     CACHE_ALIGNED(SST::Core::ThreadSafe::Spinlock, slock);
 };

--- a/src/sst/core/params.h
+++ b/src/sst/core/params.h
@@ -317,8 +317,7 @@ public:
      * converted to type T, an invalid_argument exception is thrown.
      */
     template <class T>
-    typename std::enable_if<not std::is_same<std::string, T>::value, T>::type
-    find(const std::string& k, T default_value, bool& found) const
+    std::enable_if_t<!std::is_same_v<std::string, T>, T> find(const std::string& k, T default_value, bool& found) const
     {
         return find_impl<T>(k, default_value, found);
     }
@@ -350,7 +349,7 @@ public:
      *   specified as a string literal
      */
     template <class T>
-    typename std::enable_if<std::is_same<bool, T>::value, T>::type
+    std::enable_if_t<std::is_same_v<bool, T>, T>
     find(const std::string& k, const char* default_value, bool& found) const
     {
         if ( nullptr == default_value ) { return find_impl<T>(k, static_cast<T>(0), found); }
@@ -399,8 +398,7 @@ public:
      *   specified as a string literal
      */
     template <class T>
-    typename std::enable_if<std::is_same<bool, T>::value, T>::type
-    find(const std::string& k, const char* default_value) const
+    std::enable_if_t<std::is_same_v<bool, T>, T> find(const std::string& k, const char* default_value) const
     {
         bool tmp;
         if ( nullptr == default_value ) { return find_impl<T>(k, static_cast<T>(0), tmp); }
@@ -433,7 +431,7 @@ public:
      * @param found - set to true if the the parameter was found
      */
     template <class T>
-    typename std::enable_if<not std::is_same<bool, T>::value, T>::type find(const std::string& k, bool& found) const
+    std::enable_if_t<!std::is_same_v<bool, T>, T> find(const std::string& k, bool& found) const
     {
         T default_value = T();
         return find_impl<T>(k, default_value, found);

--- a/src/sst/core/serialization/impl/serialize_array.h
+++ b/src/sst/core/serialization/impl/serialize_array.h
@@ -84,7 +84,7 @@ raw_ptr(TPtr*& ptr)
    fundamental types and enums.
  */
 template <class T, int N>
-class serialize_impl<T[N], typename std::enable_if<std::is_fundamental<T>::value || std::is_enum<T>::value>::type>
+class serialize_impl<T[N], std::enable_if_t<std::is_fundamental_v<T> || std::is_enum_v<T>>>
 {
     template <class A>
     friend class serialize;
@@ -101,7 +101,7 @@ class serialize_impl<T[N], typename std::enable_if<std::is_fundamental<T>::value
    non base types.
  */
 template <class T, int N>
-class serialize_impl<T[N], typename std::enable_if<!std::is_fundamental<T>::value && !std::is_enum<T>::value>::type>
+class serialize_impl<T[N], std::enable_if_t<!std::is_fundamental_v<T> && !std::is_enum_v<T>>>
 {
     template <class A>
     friend class serialize;
@@ -126,8 +126,7 @@ class serialize_impl<T[N], typename std::enable_if<!std::is_fundamental<T>::valu
  */
 template <class T, class IntType>
 class serialize_impl<
-    pvt::ser_array_wrapper<T, IntType>,
-    typename std::enable_if<std::is_fundamental<T>::value || std::is_enum<T>::value>::type>
+    pvt::ser_array_wrapper<T, IntType>, std::enable_if_t<std::is_fundamental_v<T> || std::is_enum_v<T>>>
 {
     template <class A>
     friend class serialize;
@@ -145,8 +144,7 @@ class serialize_impl<
  */
 template <class T, class IntType>
 class serialize_impl<
-    pvt::ser_array_wrapper<T, IntType>,
-    typename std::enable_if<!std::is_fundamental<T>::value && !std::is_enum<T>::value>::type>
+    pvt::ser_array_wrapper<T, IntType>, std::enable_if_t<!std::is_fundamental_v<T> && !std::is_enum_v<T>>>
 {
     template <class A>
     friend class serialize;

--- a/src/sst/core/serialization/serializable.h
+++ b/src/sst/core/serialization/serializable.h
@@ -50,8 +50,7 @@ void map_serializable(serializable_base*& s, serializer& ser, const char* name);
 
 
 template <class T>
-class serialize_impl<
-    T*, typename std::enable_if<std::is_base_of<SST::Core::Serialization::serializable, T>::value>::type>
+class serialize_impl<T*, std::enable_if_t<std::is_base_of_v<SST::Core::Serialization::serializable, T>>>
 {
 
     template <class A>
@@ -120,8 +119,7 @@ serialize_intrusive_ptr(T*& t, serializer& ser)
 }
 
 template <class T>
-class serialize_impl<
-    T, typename std::enable_if<std::is_base_of<SST::Core::Serialization::serializable, T>::value>::type>
+class serialize_impl<T, std::enable_if_t<std::is_base_of_v<SST::Core::Serialization::serializable, T>>>
 {
     template <class A>
     friend class serialize;

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -29,8 +29,8 @@ namespace Serialization {
 // Workaround for use with static_assert(), since static_assert(false)
 // will always assert, even when in an untaken if constexpr path.
 // This can be used in any serialize_impl class, if needed/
-template <class>
-constexpr bool dependent_false = false;
+template <typename...>
+inline constexpr bool dependent_false = false;
 
 /**
    Base serialize class.
@@ -52,10 +52,9 @@ public:
             // If it falls through to the default, let's check to see if it's
             // a non-polymorphic class and try to call serialize_order
             if constexpr (
-                std::is_class_v<typename std::remove_pointer<T>::type> &&
-                !std::is_polymorphic_v<typename std::remove_pointer<T>::type> ) {
+                std::is_class_v<std::remove_pointer_t<T>> && !std::is_polymorphic_v<std::remove_pointer_t<T>> ) {
                 if ( ser.mode() == serializer::UNPACK ) {
-                    t = new typename std::remove_pointer<T>::type();
+                    t = new std::remove_pointer_t<T>();
                     ser.report_new_pointer(reinterpret_cast<uintptr_t>(t));
                 }
                 t->serialize_order(ser);
@@ -81,10 +80,9 @@ public:
             // If it falls through to the default, let's check to see if it's
             // a non-polymorphic class and try to call serialize_order
             if constexpr (
-                std::is_class_v<typename std::remove_pointer<T>::type> &&
-                !std::is_polymorphic_v<typename std::remove_pointer<T>::type> ) {
+                std::is_class_v<std::remove_pointer_t<T>> && !std::is_polymorphic_v<std::remove_pointer_t<T>> ) {
                 if ( ser.mode() == serializer::UNPACK ) {
-                    t = new typename std::remove_pointer<T>::type();
+                    t = new std::remove_pointer_t<T>();
                     ser.report_new_pointer(reinterpret_cast<uintptr_t>(t));
                 }
                 if ( ser.mode() == serializer::MAP ) {
@@ -327,7 +325,7 @@ public:
  */
 
 template <class T>
-class serialize_impl<T, typename std::enable_if<std::is_fundamental<T>::value || std::is_enum<T>::value>::type>
+class serialize_impl<T, std::enable_if_t<std::is_fundamental_v<T> || std::is_enum_v<T>>>
 {
     template <class A>
     friend class serialize;
@@ -371,7 +369,7 @@ class serialize_impl<bool>
    independent copy after deserialization.
  */
 template <class T>
-class serialize_impl<T*, typename std::enable_if<std::is_fundamental<T>::value || std::is_enum<T>::value>::type>
+class serialize_impl<T*, std::enable_if_t<std::is_fundamental_v<T> || std::is_enum_v<T>>>
 {
     template <class A>
     friend class serialize;
@@ -416,7 +414,7 @@ class serialize_impl<std::pair<U, V>>
 //    a serialize_order function
 //  */
 // template <class T>
-// class serialize_impl<T, typename std::enable_if<std::is_class<T>::value && !std::is_polymorphic<T>::value>::type>
+// class serialize_impl<T, std::enable_if_t<std::is_class_v<T> && !std::is_polymorphic_v<T>>>
 // {
 //     template <class A>
 //     friend class serialize;

--- a/src/sst/core/shared/sharedArray.h
+++ b/src/sst/core/shared/sharedArray.h
@@ -28,7 +28,7 @@ namespace Shared {
 template <typename T>
 class SharedArray : public SharedObject
 {
-    static_assert(!std::is_pointer<T>::value, "Cannot use a pointer type with SharedArray");
+    static_assert(!std::is_pointer_v<T>, "Cannot use a pointer type with SharedArray");
 
     // Forward declaration.  Defined below
     class Data;

--- a/src/sst/core/shared/sharedMap.h
+++ b/src/sst/core/shared/sharedMap.h
@@ -27,7 +27,7 @@ namespace Shared {
 template <typename keyT, typename valT>
 class SharedMap : public SharedObject
 {
-    static_assert(!std::is_pointer<valT>::value, "Cannot use a pointer type as value with SharedMap");
+    static_assert(!std::is_pointer_v<valT>, "Cannot use a pointer type as value with SharedMap");
 
     // Forward declaration.  Defined below
     class Data;

--- a/src/sst/core/shared/sharedSet.h
+++ b/src/sst/core/shared/sharedSet.h
@@ -27,7 +27,7 @@ namespace Shared {
 template <typename valT>
 class SharedSet : public SharedObject
 {
-    static_assert(!std::is_pointer<valT>::value, "Cannot use a pointer type as value with SharedSet");
+    static_assert(!std::is_pointer_v<valT>, "Cannot use a pointer type as value with SharedSet");
 
     // Forward declaration.  Defined below
     class Data;

--- a/src/sst/core/ssthandler.h
+++ b/src/sst/core/ssthandler.h
@@ -1161,12 +1161,8 @@ public:
 template <typename returnT, typename argT, typename classT, typename dataT, auto funcT>
 class SSTHandler2 : public SSTHandlerBase<returnT, argT>
 {
-
-    // This has to be dependent on a template, otherwise it always
-    // assers.  Need to make sure it covers both cases to assert
-    // if this template is expanded.
-    static_assert(std::is_fundamental<dataT>::value, "Mismatched handler templates.");
-    static_assert(!std::is_fundamental<dataT>::value, "Mismatched handler templates.");
+    // This has to be dependent on a template parameter, otherwise it always asserts.
+    static_assert((funcT, false), "Mismatched handler templates.");
 };
 
 

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -286,7 +286,7 @@ private:
  * Used for distinguishing fundamental types (collected by value)
  * and composite struct types (collected by reference)
  */
-template <class T, bool F = std::is_fundamental<T>::value>
+template <class T, bool = std::is_fundamental_v<T>>
 struct StatisticCollector
 {};
 

--- a/src/sst/core/statapi/statnull.h
+++ b/src/sst/core/statapi/statnull.h
@@ -35,7 +35,7 @@ namespace Statistics {
 
     @tparam T A template for holding the main data type of this statistic
 */
-template <class T, bool B = std::is_fundamental<T>::value>
+template <class T, bool = std::is_fundamental_v<T>>
 struct NullStatisticBase
 {};
 


### PR DESCRIPTION
This changes the code to use `trait_t<...>` for `typename trait<...>::type` (C++14) and `trait_v<...>` for `trait<...>::value` (C++17), and refactors the ElementBuilder to define `is_tuple_constructible_v<...>` in terms of `is_tuple_constructible<...>::value` and apply it recursively.

For serialization code which depends on Boolean traits tests, `if constexpr( ... )` is used for the `if`-tests, since the controlling expression is constant and can be optimized at compile-time, and because this allows the code in the future to use operations or access fields which are only valid for certain template arguments.

