### PR TITLE
Use Meyers singletons

### DIFF
--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -230,7 +230,7 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
                 // loop all the elements in the element lib
                 for ( auto& elempair : libpair.second ) {
                     // loop all the loaders in the element
-                    for ( auto* loader : elempair.second ) {
+                    for ( auto& loader : elempair.second ) {
                         loader->load();
                     }
                 }

--- a/src/sst/core/eli/elementbuilder.h
+++ b/src/sst/core/eli/elementbuilder.h
@@ -145,8 +145,8 @@ struct CachedAllocator
     template <class... Args>
     Base* operator()(Args&&... ctorArgs)
     {
-        static T cached(std::forward<Args>(ctorArgs)...);
-        return &cached;
+        static T* cached = new T(std::forward<Args>(ctorArgs)...);
+        return cached;
     }
 };
 

--- a/src/sst/core/eli/elementbuilder.h
+++ b/src/sst/core/eli/elementbuilder.h
@@ -38,14 +38,7 @@ public:
 
     BuilderLibrary(const std::string& name) : name_(name) {}
 
-    BaseBuilder* getBuilder(const std::string& name)
-    {
-        auto iter = factories_.find(name);
-        if ( iter == factories_.end() ) { return nullptr; }
-        else {
-            return iter->second;
-        }
-    }
+    BaseBuilder* getBuilder(const std::string& name) { return factories_[name]; }
 
     const std::map<std::string, BaseBuilder*>& getMap() const { return factories_; }
 
@@ -88,28 +81,15 @@ public:
 
     static Library* getLibrary(const std::string& name)
     {
-        if ( !libraries ) { libraries = new std::map<std::string, Library*>; }
-        auto iter = libraries->find(name);
-        if ( iter == libraries->end() ) {
-            auto* info         = new Library(name);
-            (*libraries)[name] = info;
-            return info;
-        }
-        else {
-            return iter->second;
-        }
+        static Map libraries; // Database
+        auto&      lib = libraries[name];
+        if ( !lib ) lib = new Library(name);
+        return lib;
     }
 
     template <class NewBase>
     using ChangeBase = BuilderLibraryDatabase<NewBase, CtorArgs...>;
-
-private:
-    // Database - needs to be a pointer for static init order
-    static Map* libraries;
 };
-
-template <class Base, class... CtorArgs>
-typename BuilderLibraryDatabase<Base, CtorArgs...>::Map* BuilderLibraryDatabase<Base, CtorArgs...>::libraries = nullptr;
 
 template <class Base, class Builder, class... CtorArgs>
 struct BuilderLoader : public LibraryLoader
@@ -147,11 +127,8 @@ struct InstantiateBuilder
 {
     static bool isLoaded() { return loaded; }
 
-    static const bool loaded;
+    static inline const bool loaded = Base::Ctor::template add<T>();
 };
-
-template <class Base, class T>
-const bool InstantiateBuilder<Base, T>::loaded = Base::Ctor::template add<T>();
 
 template <class Base, class T, class Enable = void>
 struct Allocator
@@ -169,14 +146,10 @@ struct CachedAllocator
     template <class... Args>
     Base* operator()(Args&&... ctorArgs)
     {
-        if ( !cached_ ) { cached_ = new T(std::forward<Args>(ctorArgs)...); }
-        return cached_;
+        static T cached(std::forward<Args>(ctorArgs)...);
+        return &cached;
     }
-
-    static Base* cached_;
 };
-template <class Base, class T>
-Base* CachedAllocator<Base, T>::cached_ = nullptr;
 
 template <class T, class Base, class... Args>
 struct DerivedBuilder : public Builder<Base, Args...>

--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -59,10 +59,8 @@ class DataBase
 public:
     static T* get(const std::string& elemlib, const std::string& elem)
     {
-        if ( !infos_ ) return nullptr;
-
-        auto libiter = infos_->find(elemlib);
-        if ( libiter != infos_->end() ) {
+        auto libiter = infos().find(elemlib);
+        if ( libiter != infos().end() ) {
             auto& submap   = libiter->second;
             auto  elemiter = submap.find(elem);
             if ( elemiter != submap.end() ) { return elemiter->second; }
@@ -70,21 +68,15 @@ public:
         return nullptr;
     }
 
-    static void add(const std::string& elemlib, const std::string& elem, T* info)
-    {
-        if ( !infos_ ) {
-            infos_ = std::unique_ptr<std::map<std::string, std::map<std::string, T*>>>(
-                new std::map<std::string, std::map<std::string, T*>>);
-        }
-
-        (*infos_)[elemlib][elem] = info;
-    }
+    static void add(const std::string& elemlib, const std::string& elem, T* info) { infos()[elemlib][elem] = info; }
 
 private:
-    static std::unique_ptr<std::map<std::string, std::map<std::string, T*>>> infos_;
+    static auto& infos()
+    {
+        static std::map<std::string, std::map<std::string, T*>> infos_;
+        return infos_;
+    }
 };
-template <class T>
-std::unique_ptr<std::map<std::string, std::map<std::string, T*>>> DataBase<T>::infos_;
 
 template <class Policy, class... Policies>
 class BuilderInfoImpl : public Policy, public BuilderInfoImpl<Policies...>
@@ -166,7 +158,7 @@ public:
         return count;
     }
 
-    const std::map<std::string, BaseInfo*>& getMap() const { return infos_; }
+    const auto& getMap() const { return infos_; }
 
     void readdInfo(const std::string& name, BaseInfo* info)
     {
@@ -208,9 +200,9 @@ public:
 
         std::vector<std::string> ret;
         // First iterate over libraries
-        for ( auto x : (*libraries) ) {
-            for ( auto& y : x.second->getMap() ) {
-                ret.push_back(x.first + "." + y.first);
+        for ( auto& [name, lib] : libraries() ) {
+            for ( auto& [elemlib, info] : lib->getMap() ) {
+                ret.push_back(name + "." + elemlib);
             }
         }
         return ret;
@@ -218,25 +210,19 @@ public:
 
     static Library* getLibrary(const std::string& name)
     {
-        if ( !libraries ) { libraries = new Map; }
-        auto iter = libraries->find(name);
-        if ( iter == libraries->end() ) {
-            auto* info         = new Library(name);
-            (*libraries)[name] = info;
-            return info;
-        }
-        else {
-            return iter->second;
-        }
+        auto& lib = libraries()[name];
+        if ( !lib ) lib = new Library(name);
+        return lib;
     }
 
 private:
-    // Database - needs to be a pointer for static init order
-    static Map* libraries;
+    // Database
+    static Map& libraries()
+    {
+        static Map libs;
+        return libs;
+    }
 };
-
-template <class Base>
-typename InfoLibraryDatabase<Base>::Map* InfoLibraryDatabase<Base>::libraries = nullptr;
 
 template <class Base, class Info>
 struct InfoLoader : public LibraryLoader

--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -71,7 +71,7 @@ public:
     static void add(const std::string& elemlib, const std::string& elem, T* info) { infos()[elemlib][elem] = info; }
 
 private:
-    static auto& infos()
+    static std::map<std::string, std::map<std::string, T*>>& infos()
     {
         static std::map<std::string, std::map<std::string, T*>> infos_;
         return infos_;
@@ -158,7 +158,7 @@ public:
         return count;
     }
 
-    const auto& getMap() const { return infos_; }
+    const std::map<std::string, BaseInfo*>& getMap() const { return infos_; }
 
     void readdInfo(const std::string& name, BaseInfo* info)
     {

--- a/src/sst/core/eli/elibase.cc
+++ b/src/sst/core/eli/elibase.cc
@@ -30,3 +30,5 @@ LoadedLibraries::addLoader(
     library[name].push_back(std::move(shared_loader));
     return true;
 }
+
+} // namespace SST::ELI

--- a/src/sst/core/eli/elibase.cc
+++ b/src/sst/core/eli/elibase.cc
@@ -20,32 +20,16 @@ namespace SST {
 **************************************************************************/
 namespace ELI {
 
-std::unique_ptr<LoadedLibraries::LibraryMap> LoadedLibraries::loaders_ {};
-
 bool
 LoadedLibraries::addLoader(
     const std::string& lib, const std::string& name, const std::string& alias, LibraryLoader* loader)
 {
-    if ( !loaders_ ) { loaders_ = std::unique_ptr<LibraryMap>(new LibraryMap); }
-    (*loaders_)[lib][name].push_back(loader);
-    if ( !alias.empty() ) (*loaders_)[lib][alias].push_back(loader);
+    std::shared_ptr<LibraryLoader> shared_loader(loader);
+
+    auto& library = getLoaders()[lib];
+    if ( !alias.empty() && alias != name ) library[alias].push_back(shared_loader);
+    library[name].push_back(std::move(shared_loader));
     return true;
-}
-
-const LoadedLibraries::LibraryMap&
-LoadedLibraries::getLoaders()
-{
-    if ( !loaders_ ) { loaders_ = std::unique_ptr<LibraryMap>(new LibraryMap); }
-    return *loaders_;
-}
-
-bool
-LoadedLibraries::isLoaded(const std::string& name)
-{
-    if ( loaders_ ) { return loaders_->find(name) != loaders_->end(); }
-    else {
-        return false; // nothing loaded yet
-    }
 }
 
 } // namespace ELI

--- a/src/sst/core/eli/elibase.h
+++ b/src/sst/core/eli/elibase.h
@@ -16,11 +16,9 @@
 
 #include <algorithm>
 #include <cstring>
-#include <functional>
-#include <list>
+#include <deque>
 #include <map>
 #include <memory>
-#include <set>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -124,28 +122,27 @@ combineEliInfo(std::vector<T>& base, const std::vector<T>& add)
 
 struct LibraryLoader
 {
-    virtual void load() = 0;
-    virtual ~LibraryLoader() {}
+    virtual void load()      = 0;
+    virtual ~LibraryLoader() = default;
 };
 
 class LoadedLibraries
 {
 public:
-    using InfoMap    = std::map<std::string, std::list<LibraryLoader*>>;
+    using InfoMap    = std::map<std::string, std::deque<std::shared_ptr<LibraryLoader>>>;
     using LibraryMap = std::map<std::string, InfoMap>;
 
-    static bool isLoaded(const std::string& name);
+    static bool isLoaded(const std::string& name) { return getLoaders().count(name) != 0; }
 
-    /**
-       @return A boolean indicated successfully added
-    */
+    // @return A boolean indicated successfully added
     static bool
     addLoader(const std::string& lib, const std::string& name, const std::string& alias, LibraryLoader* loader);
 
-    static const LibraryMap& getLoaders();
-
-private:
-    static std::unique_ptr<LibraryMap> loaders_;
+    static LibraryMap& getLoaders()
+    {
+        static LibraryMap loaders;
+        return loaders;
+    }
 };
 
 // Template used to get aliases.  Needed because the ELI_getAlias()


### PR DESCRIPTION
1. Use Meyers Singletons (`static` variables local to functions which are initialized on their first call and return a reference to it; avoids `static` initialization order fiasco) instead of pointers allocated on demand.

2. Use `std::shared_ptr` for `LoadedLibraries` loaded libraries so that libraries and aliases can share the same loader pointers without memory leaks. I was prompted to do this by `valgrind`:
```
==3714114== 80 bytes in 1 blocks are definitely lost in loss record 1,155 of 1,554
==3714114==    at 0x4859047: operator new(unsigned long) (vg_replace_malloc.c:472)
==3714114==    by 0x249295: addLoader (elementinfo.h:266)
==3714114==    by 0x249295: addInfo (elementinfo.h:184)
==3714114==    by 0x249295: addInfo (statbase.h:426)
==3714114==    by 0x249295: bool SST::Statistics::Statistic<void>::addDerivedInfo<SST::Statistics::NullStatistic<void> >(std::__cxx\
11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<cha\
r>, std::allocator<char> > const&) (statbase.h:426)
==3714114==    by 0x211E3F: add<SST::Statistics::NullStatistic<void> > (elementinfo.h:281)
==3714114==    by 0x211E3F: __static_initialization_and_destruction_0 (elementinfo.h:286)
==3714114==    by 0x211E3F: _GLOBAL__sub_I_main (main.cc:1281)
==3714114==    by 0x5319BBD: call_init (libc-start.c:145)
==3714114==    by 0x5319BBD: __libc_start_main@@GLIBC_2.34 (libc-start.c:347)
==3714114==    by 0x22E0A4: (below main) (in /home/lkillough/sstcore-14.1.0/libexec/sstsim.x)

==3714114== 80 bytes in 1 blocks are definitely lost in loss record 1,156 of 1,554
==3714114==    at 0x4859047: operator new(unsigned long) (vg_replace_malloc.c:472)
==3714114==    by 0x335C47: addLoader (elementinfo.h:266)
==3714114==    by 0x335C47: addInfo (elementinfo.h:184)
==3714114==    by 0x335C47: SST::RealTimeAction::addInfo(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<ch\
ar> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, SST::ELI::BuilderInfoImpl<SST\
::ELI::ProvidesDefaultInfo, void>*) (realtime.cc:90)
==3714114==    by 0x247986: addDerivedInfo<SST::ExitCleanRealTimeAction> (realtimeAction.h:32)
==3714114==    by 0x247986: bool SST::ELI::ElementsInfo<SST::RealTimeAction>::add<SST::ExitCleanRealTimeAction>() (elementinfo.h:281)
==3714114==    by 0x212037: __static_initialization_and_destruction_0 (elementinfo.h:286)
==3714114==    by 0x212037: _GLOBAL__sub_I_main (main.cc:1281)
==3714114==    by 0x5319BBD: call_init (libc-start.c:145)
==3714114==    by 0x5319BBD: __libc_start_main@@GLIBC_2.34 (libc-start.c:347)
==3714114==    by 0x22E0A4: (below main) (in /home/lkillough/sstcore-14.1.0/libexec/sstsim.x)
==3714114==
```
I can see other places where `std::shared_ptr` and `std::unique_ptr` should be used, but since the memory system is being overhauled, I won't touch the other places.

3. Use C++17 `inline` with `static const` class members so that they can be defined in-class and won't have multiple definition errors if defined in a header.