### PR TITLE
Allow user to specify seconds-only wall time in either S or Ss format

### DIFF
--- a/src/sst/core/configBase.cc
+++ b/src/sst/core/configBase.cc
@@ -60,8 +60,8 @@ uint32_t
 ConfigBase::parseWallTimeToSeconds(const std::string& arg, bool& success, const std::string& option)
 {
     // first attempt to parse seconds only. Assume \d+[s] until it's not
-    char* pos;
-    unsigned long  seconds = strtoul(arg.c_str(), &pos, 10);
+    char*         pos;
+    unsigned long seconds = strtoul(arg.c_str(), &pos, 10);
     while ( isspace(*pos) )
         ++pos;
     if ( *pos == 's' || *pos == 'S' ) {

--- a/src/sst/core/configBase.cc
+++ b/src/sst/core/configBase.cc
@@ -59,14 +59,29 @@ ConfigBase::parseBoolean(const std::string& arg, bool& success, const std::strin
 uint32_t
 ConfigBase::parseWallTimeToSeconds(const std::string& arg, bool& success, const std::string& option)
 {
+    // first attempt to parse seconds only. Assume \d+[s] until it's not
+    char* pos;
+    unsigned long  seconds = strtoul(arg.c_str(), &pos, 10);
+    while ( isspace(*pos) )
+        ++pos;
+    if ( *pos == 's' || *pos == 'S' ) {
+        while ( isspace(*++pos) )
+            ;
+        if ( !*pos ) {
+            if ( seconds <= UINT32_MAX ) {
+                success = true;
+                return seconds;
+            }
+        }
+    }
+
     static const char* templates[] = { "%H:%M:%S", "%M:%S", "%S", "%Hh", "%Mm", "%Ss" };
     const size_t       n_templ     = sizeof(templates) / sizeof(templates[0]);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
     struct tm res = {}; /* This warns on GCC 4.8 due to a bug in GCC */
 #pragma GCC diagnostic pop
-    char*    p;
-    uint32_t seconds;
+    char* p;
 
     for ( size_t i = 0; i < n_templ; i++ ) {
         memset(&res, '\0', sizeof(res));


### PR DESCRIPTION
This PR allows the user to specify seconds-only wall time in either S or Ss format ( e.g. >60s ). Fixes issue #1165.
ConfigBase::parseWallTimeToSeconds(...) is modified to first check if the argument is of the form S or Ss and parses the value directly. If that fails the normal path is followed.


