### PR TITLE
Use modern techniques to delete copy constructors and assignment operators

### DIFF
--- a/src/sst/core/checkpointAction.h
+++ b/src/sst/core/checkpointAction.h
@@ -84,10 +84,9 @@ public:
     NotSerializable(SST::CheckpointAction);
 
 private:
-    CheckpointAction() {}
-    CheckpointAction(const CheckpointAction&);
+    CheckpointAction(const CheckpointAction&) = delete;
+    CheckpointAction& operator=(const CheckpointAction&) = delete;
 
-    void operator=(CheckpointAction const&);
     void createCheckpoint(Simulation_impl* sim); // The actual checkpoint operation
 
     RankInfo       rank_;          // RankInfo for this thread/rank

--- a/src/sst/core/exit.h
+++ b/src/sst/core/exit.h
@@ -98,9 +98,9 @@ public:
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::Exit)
 private:
-    Exit() {}                    // for serialization only
-    Exit(const Exit&);           // Don't implement
-    void operator=(Exit const&); // Don't implement
+    Exit()            = default;           // for serialization only
+    Exit(const Exit&) = delete;            // Don't implement
+    Exit& operator=(const Exit&) = delete; // Don't implement
 
     //     bool handler( Event* );
 

--- a/src/sst/core/factory.h
+++ b/src/sst/core/factory.h
@@ -314,9 +314,8 @@ private:
     Factory(const std::string& searchPaths);
     ~Factory();
 
-    Factory();                      // Don't Implement
-    Factory(Factory const&);        // Don't Implement
-    void operator=(Factory const&); // Don't Implement
+    Factory(const Factory&) = delete;            // Don't Implement
+    Factory& operator=(const Factory&) = delete; // Don't Implement
 
     static Factory* instance;
 

--- a/src/sst/core/heartbeat.h
+++ b/src/sst/core/heartbeat.h
@@ -45,10 +45,10 @@ public:
     ImplementSerializable(SST::SimulatorHeartbeat)
 
 private:
-    SimulatorHeartbeat() {};
-    SimulatorHeartbeat(const SimulatorHeartbeat&);
+    SimulatorHeartbeat()                          = default;
+    SimulatorHeartbeat(const SimulatorHeartbeat&) = delete;
+    SimulatorHeartbeat& operator=(const SimulatorHeartbeat&) = delete;
 
-    void           operator=(SimulatorHeartbeat const&);
     void           execute() override;
     int            rank;
     TimeConverter* m_period;

--- a/src/sst/core/interactiveConsole.h
+++ b/src/sst/core/interactiveConsole.h
@@ -123,9 +123,8 @@ protected:
     SST::Core::Serialization::ObjectMap* getComponentObjectMap();
 
 private:
-    InteractiveConsole(const InteractiveConsole&);
-
-    void operator=(InteractiveConsole const&);
+    InteractiveConsole(const InteractiveConsole&) = delete;
+    InteractiveConsole& operator=(const InteractiveConsole&) = delete;
 };
 
 } // namespace SST

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -332,10 +332,9 @@ public:
     // To enable main to set up globals
     friend int ::main(int argc, char** argv);
 
-    Simulation_impl() {}
     Simulation_impl(Config* config, RankInfo my_rank, RankInfo num_ranks, bool restart);
-    Simulation_impl(Simulation_impl const&); // Don't Implement
-    void operator=(Simulation_impl const&);  // Don't implement
+    Simulation_impl(const Simulation_impl&) = delete;            // Don't Implement
+    Simulation_impl& operator=(const Simulation_impl&) = delete; // Don't implement
 
     /** Get a handle to a TimeConverter
      * @param cycles Frequency which is the base of the TimeConverter

--- a/src/sst/core/testElements/coreTest_ClockerComponent.h
+++ b/src/sst/core/testElements/coreTest_ClockerComponent.h
@@ -51,9 +51,9 @@ public:
     void finish() {}
 
 private:
-    coreTestClockerComponent();                                // for serialization only
-    coreTestClockerComponent(const coreTestClockerComponent&); // do not implement
-    void operator=(const coreTestClockerComponent&);           // do not implement
+    coreTestClockerComponent();                                                    // for serialization only
+    coreTestClockerComponent(const coreTestClockerComponent&) = delete;            // do not implement
+    coreTestClockerComponent& operator=(const coreTestClockerComponent&) = delete; // do not implement
 
     virtual bool tick(SST::Cycle_t);
 

--- a/src/sst/core/testElements/coreTest_Component.h
+++ b/src/sst/core/testElements/coreTest_Component.h
@@ -123,8 +123,8 @@ public:
     coreTestComponent(); // for serialization only
 
 private:
-    coreTestComponent(const coreTestComponent&); // do not implement
-    void operator=(const coreTestComponent&);    // do not implement
+    coreTestComponent(const coreTestComponent&) = delete;            // do not implement
+    coreTestComponent& operator=(const coreTestComponent&) = delete; // do not implement
 
     void         handleEvent(SST::Event* ev);
     virtual bool clockTic(SST::Cycle_t);

--- a/src/sst/core/testElements/coreTest_DistribComponent.h
+++ b/src/sst/core/testElements/coreTest_DistribComponent.h
@@ -61,9 +61,9 @@ public:
     void setup() {}
 
 private:
-    coreTestDistribComponent();                                // for serialization only
-    coreTestDistribComponent(const coreTestDistribComponent&); // do not implement
-    void operator=(const coreTestDistribComponent&);           // do not implement
+    coreTestDistribComponent();                                                    // for serialization only
+    coreTestDistribComponent(const coreTestDistribComponent&) = delete;            // do not implement
+    coreTestDistribComponent& operator=(const coreTestDistribComponent&) = delete; // do not implement
 
     virtual bool tick(SST::Cycle_t);
 

--- a/src/sst/core/testElements/coreTest_MessageGeneratorComponent.h
+++ b/src/sst/core/testElements/coreTest_MessageGeneratorComponent.h
@@ -57,9 +57,9 @@ public:
     }
 
 private:
-    coreTestMessageGeneratorComponent();                                         // for serialization only
-    coreTestMessageGeneratorComponent(const coreTestMessageGeneratorComponent&); // do not implement
-    void operator=(const coreTestMessageGeneratorComponent&);                    // do not implement
+    coreTestMessageGeneratorComponent();                                                  // for serialization only
+    coreTestMessageGeneratorComponent(const coreTestMessageGeneratorComponent&) = delete; // do not implement
+    coreTestMessageGeneratorComponent& operator=(const coreTestMessageGeneratorComponent&) = delete; // do not implement
 
     void         handleEvent(SST::Event* ev);
     virtual bool tick(SST::Cycle_t);

--- a/src/sst/core/testElements/coreTest_ParamComponent.h
+++ b/src/sst/core/testElements/coreTest_ParamComponent.h
@@ -62,9 +62,9 @@ public:
     void finish() {}
 
 private:
-    coreTestParamComponent();                              // for serialization only
-    coreTestParamComponent(const coreTestParamComponent&); // do not implement
-    void operator=(const coreTestParamComponent&);         // do not implement
+    coreTestParamComponent();                                                  // for serialization only
+    coreTestParamComponent(const coreTestParamComponent&) = delete;            // do not implement
+    coreTestParamComponent& operator=(const coreTestParamComponent&) = delete; // do not implement
 };
 
 } // namespace SST::CoreTestParamComponent

--- a/src/sst/core/testElements/coreTest_PerfComponent.h
+++ b/src/sst/core/testElements/coreTest_PerfComponent.h
@@ -103,9 +103,9 @@ public:
     void finish() { printf("Perf Test Component Finished.\n"); }
 
 private:
-    coreTestPerfComponent();                             // for serialization only
-    coreTestPerfComponent(const coreTestPerfComponent&); // do not implement
-    void operator=(const coreTestPerfComponent&);        // do not implement
+    coreTestPerfComponent();                                                 // for serialization only
+    coreTestPerfComponent(const coreTestPerfComponent&) = delete;            // do not implement
+    coreTestPerfComponent& operator=(const coreTestPerfComponent&) = delete; // do not implement
 
     void         handleEvent(SST::Event* ev);
     virtual bool clockTic(SST::Cycle_t);

--- a/src/sst/core/testElements/coreTest_PortModule.h
+++ b/src/sst/core/testElements/coreTest_PortModule.h
@@ -148,9 +148,9 @@ private:
 
     PortSubComponent* sub_ = nullptr;
 
-    coreTestPortModuleComponent() {}                                 // for serialization only
-    coreTestPortModuleComponent(const coreTestPortModuleComponent&); // do not implement
-    void operator=(const coreTestPortModuleComponent&);              // do not implement
+    coreTestPortModuleComponent()                                   = default;           // for serialization only
+    coreTestPortModuleComponent(const coreTestPortModuleComponent&) = delete;            // do not implement
+    coreTestPortModuleComponent& operator=(const coreTestPortModuleComponent&) = delete; // do not implement
 
     bool tick(SST::Cycle_t);
     void handleEvent(SST::Event* ev);

--- a/src/sst/core/testElements/coreTest_RNGComponent.h
+++ b/src/sst/core/testElements/coreTest_RNGComponent.h
@@ -60,9 +60,9 @@ public:
     void finish() {}
 
 private:
-    coreTestRNGComponent();                            // for serialization only
-    coreTestRNGComponent(const coreTestRNGComponent&); // do not implement
-    void operator=(const coreTestRNGComponent&);       // do not implement
+    coreTestRNGComponent();                                                // for serialization only
+    coreTestRNGComponent(const coreTestRNGComponent&) = delete;            // do not implement
+    coreTestRNGComponent& operator=(const coreTestRNGComponent&) = delete; // do not implement
 
     virtual bool tick(SST::Cycle_t);
 

--- a/src/sst/core/testElements/coreTest_StatisticsComponent.h
+++ b/src/sst/core/testElements/coreTest_StatisticsComponent.h
@@ -65,8 +65,8 @@ public:
 
 private:
     StatisticsComponentInt();
-    StatisticsComponentInt(const StatisticsComponentInt&); // do not implement
-    void operator=(const StatisticsComponentInt&);         // do not implement
+    StatisticsComponentInt(const StatisticsComponentInt&) = delete;            // do not implement
+    StatisticsComponentInt& operator=(const StatisticsComponentInt&) = delete; // do not implement
 
     virtual bool Clock1Tick(SST::Cycle_t);
 
@@ -126,8 +126,8 @@ public:
 
 private:
     StatisticsComponentFloat();
-    StatisticsComponentFloat(const StatisticsComponentFloat&); // do not implement
-    void operator=(const StatisticsComponentFloat&);           // do not implement
+    StatisticsComponentFloat(const StatisticsComponentFloat&) = delete; // do not implement
+    void operator=(const StatisticsComponentFloat&) = delete;           // do not implement
 
     virtual bool Clock1Tick(SST::Cycle_t);
 

--- a/src/sst/core/timeLord.h
+++ b/src/sst/core/timeLord.h
@@ -92,8 +92,8 @@ private:
     TimeLord() : initialized(false) {}
     ~TimeLord();
 
-    TimeLord(TimeLord const&);       // Don't Implement
-    void operator=(TimeLord const&); // Don't Implement
+    TimeLord(const TimeLord&) = delete;            // Don't Implement
+    TimeLord& operator=(const TimeLord&) = delete; // Don't Implement
 
     bool                 initialized;
     std::recursive_mutex slock;


### PR DESCRIPTION
This uses modern methods of deleting copy constructors and copy assignment operators, with `= delete`.

Copy assignment operators declared `void operator=()` were changed to `class& operator=()` to become a copy assignment operator as defined by the language, so that the default one can be deleted.

For some classes, a default constructor previously explicitly declared `private` to prevent its use outside of the class was removed, because the declaration of the copy constructor causes the deletion of the default constructor.


