### PR TITLE
Add more patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ libtool
 *.lo
 *.la
 sst_test_outputs/
+build/
+*.so
+.\#*
+\#*\#
+.gdb_history
+.vscode


### PR DESCRIPTION
- `build/` directory was not included
- `*.so` files were not included
- Files beginning with `.#` or beginning and ending with `#` like `.#file` or `#file#` are Emacs temporary files
- `.gdb_history` is created in a working directory after a GDB session
- `.vscode` is created by VS Code

