### PR TITLE
Fix Valgrind memory errors

### DIFF
--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -33,8 +33,8 @@ class Clock : public Action
 {
 public:
     /** Create a new clock with a specified period */
-    Clock(TimeConverter* period, int priority = CLOCKPRIORITY);
-    ~Clock();
+    explicit Clock(TimeConverter* period, int priority = CLOCKPRIORITY);
+    ~Clock() = default;
 
     /**
        Base handler for clock functions.
@@ -102,10 +102,11 @@ public:
     std::string toString() const override;
 
 private:
-    /* using HandlerMap_t = std::list<Clock::HandlerBase*>; */
-    using StaticHandlerMap_t = std::vector<Clock::HandlerBase*>;
+    using StaticHandlerMap_t = std::vector<std::unique_ptr<Clock::HandlerBase>>;
 
-    Clock() {}
+    Clock()                        = default; // For serialization only
+    Clock(const Clock&)            = delete;
+    Clock& operator=(const Clock&) = delete;
 
     void execute() override;
 

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -34,6 +34,7 @@ ComponentInfo::ComponentInfo(ComponentId_t id, const std::string& name) :
     enabled_stat_names_(nullptr),
     enabled_all_stats_(false),
     all_stat_config_(nullptr),
+    statLoadLevel(0),
     coordinates(3, 0.0),
     subIDIndex(1),
     slot_name(""),
@@ -55,6 +56,7 @@ ComponentInfo::ComponentInfo() :
     enabled_stat_names_(nullptr),
     enabled_all_stats_(false),
     all_stat_config_(nullptr),
+    statLoadLevel(0),
     coordinates(3, 0.0),
     subIDIndex(1),
     slot_name(""),
@@ -170,9 +172,9 @@ ComponentInfo::ComponentInfo(ComponentInfo&& o) :
     stat_configs_(o.stat_configs_),
     all_stat_config_(o.all_stat_config_),
     statLoadLevel(o.statLoadLevel),
-    coordinates(o.coordinates),
+    coordinates(std::move(o.coordinates)),
     subIDIndex(o.subIDIndex),
-    slot_name(o.slot_name),
+    slot_name(std::move(o.slot_name)),
     slot_num(o.slot_num),
     share_flags(o.share_flags)
 {

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -369,6 +369,7 @@ private:
         id(id),
         graph(graph),
         name(name),
+        slot_num(0),
         type(type),
         weight(weight),
         rank(rank),

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -1234,6 +1234,11 @@ SSTPythonModelDefinition::SSTPythonModelDefinition(
     // Init the model
     initModel(script_file, verbosity, configObj, argc, argv);
 
+    // Free the arguments
+    for ( int i = 0; i < argc; ++i ) {
+        free(argv[i]);
+    }
+
     // Free the vector
     free(argv);
 }

--- a/src/sst/core/model/python/pymodel_comp.cc
+++ b/src/sst/core/model/python/pymodel_comp.cc
@@ -94,6 +94,7 @@ compInit(ComponentPy_t* self, PyObject* args, PyObject* UNUSED(kwds))
         char*         prefixed_name = gModel->addNamePrefix(name);
         ComponentId_t id            = gModel->addComponent(prefixed_name, type);
         obj                         = new PyComponent(self, id);
+        free(prefixed_name);
         gModel->getOutput()->verbose(
             CALL_INFO, 3, 0, "Creating component [%s] of type [%s]: id [%" PRIu64 "]\n", name, type, id);
     }

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -237,7 +237,7 @@ public:
     }
 
     /** Returns reference to the Component Info Map */
-    const ComponentInfoMap& getComponentInfoMap() { return compInfoMap; }
+    const ComponentInfoMap& getComponentInfoMap() const { return compInfoMap; }
 
     /** returns the component with the given ID */
     BaseComponent* getComponent(const ComponentId_t& id) const

--- a/src/sst/core/testElements/coreTest_Checkpoint.cc
+++ b/src/sst/core/testElements/coreTest_Checkpoint.cc
@@ -97,7 +97,18 @@ coreTestCheckpoint::coreTestCheckpoint(ComponentId_t id, Params& params) : Compo
     stat_null       = registerStatistic<uint32_t>("nullstat");
 }
 
-coreTestCheckpoint::~coreTestCheckpoint() {}
+coreTestCheckpoint::~coreTestCheckpoint()
+{
+    delete mersenne;
+    delete marsaglia;
+    delete xorshift;
+    delete dist_const;
+    delete dist_discrete;
+    delete dist_expon;
+    delete dist_gauss;
+    delete dist_poisson;
+    delete dist_uniform;
+}
 
 void
 coreTestCheckpoint::init(unsigned UNUSED(phase))

--- a/src/sst/core/testElements/coreTest_Checkpoint.h
+++ b/src/sst/core/testElements/coreTest_Checkpoint.h
@@ -27,22 +27,16 @@ namespace SST::CoreTestCheckpoint {
 class coreTestCheckpointEvent : public SST::Event
 {
 public:
-    coreTestCheckpointEvent() : SST::Event(), counter(1000) {}
+    explicit coreTestCheckpointEvent(uint32_t c) : counter(c) {}
+    coreTestCheckpointEvent()  = default;
+    ~coreTestCheckpointEvent() = default;
 
-    coreTestCheckpointEvent(uint32_t c) : SST::Event(), counter(c) {}
+    bool decCount() { return counter == 0 || --counter == 0; }
 
-    ~coreTestCheckpointEvent() {}
-
-    bool decCount()
-    {
-        if ( counter != 0 ) counter--;
-        return counter == 0;
-    }
-
-    uint32_t getCount() { return counter; }
+    uint32_t getCount() const { return counter; }
 
 private:
-    uint32_t counter;
+    uint32_t counter = 1000;
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {
@@ -102,7 +96,9 @@ public:
     )
 
     coreTestCheckpoint(ComponentId_t id, SST::Params& params);
-    virtual ~coreTestCheckpoint();
+    coreTestCheckpoint(const coreTestCheckpoint&)            = delete;
+    coreTestCheckpoint& operator=(const coreTestCheckpoint&) = delete;
+    ~coreTestCheckpoint() override;
 
     void init(unsigned phase) override;
 
@@ -138,20 +134,19 @@ private:
     Output*             output;
     int                 output_frequency;
 
-    RNG::Random*             mersenne;
-    RNG::Random*             marsaglia;
-    RNG::Random*             xorshift;
-    RNG::RandomDistribution* dist_const;
-    RNG::RandomDistribution* dist_discrete;
-    RNG::RandomDistribution* dist_expon;
-    RNG::RandomDistribution* dist_gauss;
-    RNG::RandomDistribution* dist_poisson;
-    RNG::RandomDistribution* dist_uniform;
-
-    Statistic<uint32_t>* stat_eventcount;
-    Statistic<uint32_t>* stat_rng;
-    Statistic<double>*   stat_dist;
-    Statistic<uint32_t>* stat_null;
+    RNG::Random*             mersenne        = nullptr;
+    RNG::Random*             marsaglia       = nullptr;
+    RNG::Random*             xorshift        = nullptr;
+    RNG::RandomDistribution* dist_const      = nullptr;
+    RNG::RandomDistribution* dist_discrete   = nullptr;
+    RNG::RandomDistribution* dist_expon      = nullptr;
+    RNG::RandomDistribution* dist_gauss      = nullptr;
+    RNG::RandomDistribution* dist_poisson    = nullptr;
+    RNG::RandomDistribution* dist_uniform    = nullptr;
+    Statistic<uint32_t>*     stat_eventcount = nullptr;
+    Statistic<uint32_t>*     stat_rng        = nullptr;
+    Statistic<double>*       stat_dist       = nullptr;
+    Statistic<uint32_t>*     stat_null       = nullptr;
 };
 
 } // namespace SST::CoreTestCheckpoint


### PR DESCRIPTION
This fixes some Valgrind errors, namely uninitialized data and memory leaks, but there are still "definite" leaks, some of which are caused by classes containing pointers being destroyed without deleting the pointers, even if it does not occur until program exit.

Some of the fixed errors are listed below.
```
==388622== Syscall param writev(vector[1]) points to uninitialised byte(s)
==388622==    at 0x576C06D: __writev (writev.c:26)
==388622==    by 0x576C06D: writev (writev.c:24)
==388622==    by 0x54A2C71: std::__basic_file<char>::xsputn_2(char const*, long, char const*, long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.32)
==388622==    by 0x54E732B: std::basic_filebuf<char, std::char_traits<char> >::xsputn(char const*, long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.32)
==388622==    by 0x55109A5: std::ostream::write(char const*, long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.32)
==388622==    by 0x45C466: SST::Simulation_impl::checkpoint(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (simulation.cc:1723)
==388622==    by 0x334B90: SST::CheckpointAction::createCheckpoint(SST::Simulation_impl*) (checkpointAction.cc:123)
==388622==    by 0x33530C: SST::CheckpointAction::execute() (checkpointAction.cc:72)
==388622==    by 0x457E57: SST::Simulation_impl::run() (simulation.cc:871)
==388622==    by 0x2D3D7D: start_simulation(unsigned int, SimThreadInfo_t&, SST::Core::ThreadSafe::Barrier&) (main.cc:596)
==388622==    by 0x2B1377: main (main.cc:1104)
==388622==  Address 0x97b17b2 is 98 bytes inside a block of size 16,912 alloc'd
==388622==    at 0x4859047: operator new(unsigned long) (vg_replace_malloc.c:472)
==388622==    by 0x2EC15C: allocate (new_allocator.h:137)
==388622==    by 0x2EC15C: allocate (alloc_traits.h:464)
==388622==    by 0x2EC15C: _M_allocate (stl_vector.h:378)
==388622==    by 0x2EC15C: std::__cxx1998::vector<char, std::allocator<char> >::_M_default_append(unsigned long) (vector.tcc:657)
==388622==    by 0x45C612: resize (stl_vector.h:1011)
==388622==    by 0x45C612: resize (vector:370)
==388622==    by 0x45C612: SST::Simulation_impl::checkpoint(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (simulation.cc:1716)
==388622==    by 0x334B90: SST::CheckpointAction::createCheckpoint(SST::Simulation_impl*) (checkpointAction.cc:123)
==388622==    by 0x33530C: SST::CheckpointAction::execute() (checkpointAction.cc:72)
==388622==    by 0x457E57: SST::Simulation_impl::run() (simulation.cc:871)
==388622==    by 0x2D3D7D: start_simulation(unsigned int, SimThreadInfo_t&, SST::Core::ThreadSafe::Barrier&) (main.cc:596)
==388622==    by 0x2B1377: main (main.cc:1104)
==388622==  Uninitialised value was created by a heap allocation
==388622==    at 0x4859047: operator new(unsigned long) (vg_replace_malloc.c:472)
==388622==    by 0x373873: SST::ConfigGraph::addComponent(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (configGraph.cc:784)
==388622==    by 0x59600E: addComponent (pymodel.h:94)
==388622==    by 0x59600E: compInit(ComponentPy_t*, _object*, _object*) (pymodel_comp.cc:95)
==388622==    by 0x4A7E431: ??? (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4A186C0: _PyObject_MakeTpCall (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x49ABBB6: _PyEval_EvalFrameDefault (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4C6E13B: ??? (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4B069F4: PyEval_EvalCode (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4B55E28: ??? (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4B567E5: _PyRun_SimpleFileObject (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4B56DBF: _PyRun_AnyFileObject (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4B56E7C: PyRun_AnyFileExFlags (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==

==388622== 12 bytes in 4 blocks are definitely lost in loss record 391 of 2,169
==388622==    at 0x48588A1: malloc (vg_replace_malloc.c:431)
==388622==    by 0x570078D: strdup (strdup.c:42)
==388622==    by 0x595FDA: compInit(ComponentPy_t*, _object*, _object*) (pymodel_comp.cc:94)
==388622==    by 0x4A7E431: ??? (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4A186C0: _PyObject_MakeTpCall (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x49ABBB6: _PyEval_EvalFrameDefault (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4C6E13B: ??? (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4B069F4: PyEval_EvalCode (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4B55E28: ??? (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4B567E5: _PyRun_SimpleFileObject (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4B56DBF: _PyRun_AnyFileObject (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==    by 0x4B56E7C: PyRun_AnyFileExFlags (in /usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0)
==388622==
```
