### PR TITLE
Add override, [[noreturn]] and format attributes

### DIFF
--- a/external/tinyxml/tinyxml.h
+++ b/external/tinyxml/tinyxml.h
@@ -397,8 +397,8 @@ protected:
     static void ConvertUTF32ToUTF8( unsigned long input, char* output, int* length );
 
 private:
-    TiXmlBase( const TiXmlBase& );                // not implemented.
-    void operator=( const TiXmlBase& base );    // not allowed.
+    TiXmlBase( const TiXmlBase& )                 = delete; // not implemented.
+    TiXmlBase& operator=( const TiXmlBase& base ) = delete; // not allowed.
 
     struct Entity
     {
@@ -1641,10 +1641,10 @@ class TiXmlHandle
 {
 public:
     /// Create a handle from any node (at any depth of the tree.) This can be a null pointer.
-    TiXmlHandle( TiXmlNode* _node )                    { this->node = _node; }
+    explicit TiXmlHandle( TiXmlNode* _node ) { this->node = _node; }
     /// Copy constructor
     TiXmlHandle( const TiXmlHandle& ref )            { this->node = ref.node; }
-    TiXmlHandle operator=( const TiXmlHandle& ref ) { if ( &ref != this ) this->node = ref.node; return *this; }
+    TiXmlHandle& operator=( const TiXmlHandle& ref ) { if ( &ref != this ) this->node = ref.node; return *this; }
 
     /// Return a handle to the first child node.
     TiXmlHandle FirstChild() const;

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -35,8 +35,6 @@
 
 namespace SST {
 
-BaseComponent::BaseComponent() : SST::Core::Serialization::serializable_base() {}
-
 BaseComponent::BaseComponent(ComponentId_t id) :
     SST::Core::Serialization::serializable_base(),
     my_info(Simulation_impl::getSimulation()->getComponentInfo(id)),

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -70,12 +70,14 @@ protected:
         BaseComponent*, Statistics::StatisticProcessingEngine*, const std::string& /*type*/,
         const std::string& /*name*/, const std::string& /*subId*/, Params&)>;
 
-    // For serialization only
-    BaseComponent();
+    BaseComponent() = default; // For serialization only
 
 public:
-    BaseComponent(ComponentId_t id);
+    explicit BaseComponent(ComponentId_t id);
     virtual ~BaseComponent();
+
+    BaseComponent(const BaseComponent&)            = delete;
+    BaseComponent& operator=(const BaseComponent&) = delete;
 
     const std::string& getType() const { return my_info->getType(); }
 
@@ -758,7 +760,8 @@ protected:
         @param format Format string.  All valid formats for printf are available.
         @param ... Arguments for format.
      */
-    void fatal(uint32_t line, const char* file, const char* func, int exit_code, const char* format, ...) const
+    [[noreturn]] void
+    fatal(uint32_t line, const char* file, const char* func, int exit_code, const char* format, ...) const
         __attribute__((format(printf, 6, 7)));
 
     /** Convenience function for testing for and reporting fatal
@@ -858,8 +861,9 @@ private:
     }
 
     // Utility function used by fatal and sst_assert
-    void
-    vfatal(uint32_t line, const char* file, const char* func, int exit_code, const char* format, va_list arg) const;
+    [[noreturn]] void
+    vfatal(uint32_t line, const char* file, const char* func, int exit_code, const char* format, va_list arg) const
+        __attribute__((format(printf, 6, 0)));
 
     // Get the statengine from Simulation_impl
     StatisticProcessingEngine* getStatEngine();

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -76,7 +76,7 @@ public:
     explicit BaseComponent(ComponentId_t id);
     virtual ~BaseComponent();
 
-    BaseComponent(const BaseComponent&)            = delete;
+    BaseComponent(const BaseComponent&) = delete;
     BaseComponent& operator=(const BaseComponent&) = delete;
 
     const std::string& getType() const { return my_info->getType(); }

--- a/src/sst/core/bootsst.cc
+++ b/src/sst/core/bootsst.cc
@@ -15,7 +15,8 @@
 #include "sst/core/configShared.h"
 
 #include <cstdlib>
-#include <string.h>
+#include <cstring>
+#include <memory>
 #include <unistd.h> // for opterr
 
 int
@@ -31,14 +32,14 @@ main(int argc, char* argv[])
     SST::ConfigShared cfg(true, true, true, true);
 
     // Make a copy of the argv array (shallow)
-    char* argv_copy[argc + 1];
+    auto argv_copy = std::make_unique<char*[]>(argc + 1);
     for ( int i = 0; i < argc; ++i ) {
         argv_copy[i] = argv[i];
     }
     argv[argc] = nullptr;
 
     // All ranks parse the command line
-    cfg.parseCmdLine(argc, argv_copy);
+    cfg.parseCmdLine(argc, argv_copy.get());
 
     if ( cfg.no_env_config() ) config_env = 0;
     if ( cfg.verbose() ) verbose = 1;

--- a/src/sst/core/bootsstinfo.cc
+++ b/src/sst/core/bootsstinfo.cc
@@ -14,6 +14,9 @@
 #include "sst/core/bootshared.h"
 #include "sst/core/configShared.h"
 
+#include <cstdio>
+#include <memory>
+
 int
 main(int argc, char* argv[])
 {
@@ -26,13 +29,13 @@ main(int argc, char* argv[])
     SST::ConfigShared cfg(true, true, true, true);
 
     // Make a copy of the argv array (shallow)
-    char* argv_copy[argc + 1];
+    auto argv_copy = std::make_unique<char*[]>(argc + 1);
     for ( int i = 0; i < argc; ++i ) {
         argv_copy[i] = argv[i];
     }
     argv[argc] = nullptr;
 
-    cfg.parseCmdLine(argc, argv_copy, true);
+    cfg.parseCmdLine(argc, argv_copy.get(), true);
 
     if ( cfg.no_env_config() ) config_env = false;
 

--- a/src/sst/core/cfgoutput/dotConfigOutput.h
+++ b/src/sst/core/cfgoutput/dotConfigOutput.h
@@ -21,7 +21,7 @@ namespace SST::Core {
 class DotConfigGraphOutput : public ConfigGraphOutput
 {
 public:
-    DotConfigGraphOutput(const char* path);
+    explicit DotConfigGraphOutput(const char* path);
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 
 protected:

--- a/src/sst/core/cfgoutput/jsonConfigOutput.h
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.h
@@ -22,7 +22,7 @@ class JSONConfigGraphOutput : public ConfigGraphOutput
 {
 
 public:
-    JSONConfigGraphOutput(const char* path);
+    explicit JSONConfigGraphOutput(const char* path);
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 };
 

--- a/src/sst/core/cfgoutput/pythonConfigOutput.h
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.h
@@ -23,7 +23,7 @@ namespace SST::Core {
 class PythonConfigGraphOutput : public ConfigGraphOutput
 {
 public:
-    PythonConfigGraphOutput(const char* path);
+    explicit PythonConfigGraphOutput(const char* path);
 
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 

--- a/src/sst/core/cfgoutput/xmlConfigOutput.h
+++ b/src/sst/core/cfgoutput/xmlConfigOutput.h
@@ -21,7 +21,7 @@ namespace SST::Core {
 class XMLConfigGraphOutput : public ConfigGraphOutput
 {
 public:
-    XMLConfigGraphOutput(const char* path);
+    explicit XMLConfigGraphOutput(const char* path);
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 
 protected:

--- a/src/sst/core/checkpointAction.cc
+++ b/src/sst/core/checkpointAction.cc
@@ -62,8 +62,6 @@ CheckpointAction::CheckpointAction(
     setPriority(SYNCPRIORITY);
 }
 
-CheckpointAction::~CheckpointAction() {}
-
 // Generate checkpoint on simulation time period
 void
 CheckpointAction::execute()

--- a/src/sst/core/checkpointAction.h
+++ b/src/sst/core/checkpointAction.h
@@ -64,7 +64,7 @@ public:
     Create a new checkpoint object for the simulation core to initiate checkpoints
     */
     CheckpointAction(Config* cfg, RankInfo this_rank, Simulation_impl* sim, TimeConverter* period);
-    ~CheckpointAction();
+    ~CheckpointAction() = default;
 
     /** Generate a checkpoint next time check() is called */
     void setCheckpoint();

--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -107,6 +107,9 @@ private:
 
     Clock() {}
 
+    Clock(const Clock&)            = delete;
+    Clock& operator=(const Clock&) = delete;
+
     void execute() override;
 
     Cycle_t            currentCycle;

--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -107,7 +107,7 @@ private:
 
     Clock() {}
 
-    Clock(const Clock&)            = delete;
+    Clock(const Clock&) = delete;
     Clock& operator=(const Clock&) = delete;
 
     void execute() override;

--- a/src/sst/core/component.cc
+++ b/src/sst/core/component.cc
@@ -30,8 +30,6 @@ Component::Component(ComponentId_t id) : BaseComponent(id)
     // currentlyLoadingSubComponent = my_info;
 }
 
-Component::~Component() {}
-
 void
 Component::registerAsPrimaryComponent()
 {
@@ -58,8 +56,5 @@ Component::serialize_order(SST::Core::Serialization::serializer& ser)
 {
     BaseComponent::serialize_order(ser);
 }
-
-// For serialization only
-Component::Component() : BaseComponent() {}
 
 } // namespace SST

--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -47,8 +47,8 @@ public:
     /** Constructor. Generally only called by the factory class.
         @param id Unique component ID
     */
-    Component(ComponentId_t id);
-    virtual ~Component();
+    explicit Component(ComponentId_t id);
+    virtual ~Component() = default;
 
     /** Register as a primary component, which allows the component to
         specify when it is and is not OK to end simulation.  The
@@ -97,9 +97,7 @@ public:
 
 protected:
     friend class SubComponent;
-
-    // For Serialization only
-    Component();
+    Component() = default; // For Serialization only
 };
 
 } // namespace SST

--- a/src/sst/core/componentExtension.cc
+++ b/src/sst/core/componentExtension.cc
@@ -26,7 +26,4 @@ ComponentExtension::serialize_order(SST::Core::Serialization::serializer& ser)
     BaseComponent::serialize_order(ser);
 }
 
-// For serialization only
-ComponentExtension::ComponentExtension() : BaseComponent() {}
-
 } // namespace SST

--- a/src/sst/core/componentExtension.h
+++ b/src/sst/core/componentExtension.h
@@ -29,13 +29,12 @@ class ComponentExtension : public BaseComponent
 {
 
 public:
-    ComponentExtension(ComponentId_t id);
+    explicit ComponentExtension(ComponentId_t id);
 
-    virtual ~ComponentExtension() {};
+    ~ComponentExtension() override = default;
 
 private:
-    // For serialization only
-    ComponentExtension();
+    ComponentExtension() = default; // For serialization only
 
     ImplementSerializable(SST::ComponentExtension)
     void serialize_order(SST::Core::Serialization::serializer& ser) override;

--- a/src/sst/core/configBase.cc
+++ b/src/sst/core/configBase.cc
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <getopt.h>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
@@ -302,13 +303,13 @@ ConfigBase::parseCmdLine(int argc, char* argv[], bool ignore_unknown)
         // Turn off printing of errors in getopt_long
         opterr = 0;
     }
-    struct option sst_long_options[num_options + 2];
+    auto sst_long_options = std::make_unique<option[]>(num_options + 2);
 
     // Because a zero index can mean two different things, we put in a
     // dummy so we don't ever get a zero index
     sst_long_options[0] = { "*DUMMY_ARGUMENT*", no_argument, nullptr, 0 };
-    int option_map[num_options + 1];
-    option_map[0] = 0;
+    auto option_map     = std::make_unique<int[]>(num_options + 1);
+    option_map[0]       = 0;
     {
         int count = 1;
 
@@ -344,7 +345,8 @@ ConfigBase::parseCmdLine(int argc, char* argv[], bool ignore_unknown)
     int status = 0;
     while ( 0 == status ) {
         int       option_index = 0;
-        const int intC = getopt_long(my_argc, argv, short_options_string.c_str(), sst_long_options, &option_index);
+        const int intC =
+            getopt_long(my_argc, argv, short_options_string.c_str(), sst_long_options.get(), &option_index);
 
         if ( intC == -1 ) /* We're done */
             break;

--- a/src/sst/core/configGraphOutput.h
+++ b/src/sst/core/configGraphOutput.h
@@ -54,7 +54,7 @@ protected:
 class ConfigGraphOutput
 {
 public:
-    ConfigGraphOutput(const char* path) { outputFile = fopen(path, "wt"); }
+    explicit ConfigGraphOutput(const char* path) { outputFile = fopen(path, "wt"); }
 
     virtual ~ConfigGraphOutput() { fclose(outputFile); }
 

--- a/src/sst/core/elemLoader.h
+++ b/src/sst/core/elemLoader.h
@@ -24,7 +24,7 @@ class ElemLoader
 {
 public:
     /** Create a new ElementLoader with a given searchpath of directories */
-    ElemLoader(const std::string& searchPaths);
+    explicit ElemLoader(const std::string& searchPaths);
     ~ElemLoader();
 
     /** Attempt to load a library

--- a/src/sst/core/eli/elementbuilder.h
+++ b/src/sst/core/eli/elementbuilder.h
@@ -27,6 +27,8 @@ struct Builder
 
     template <class NewBase>
     using ChangeBase = Builder<NewBase, Args...>;
+
+    virtual ~Builder() = default;
 };
 
 template <class Base, class... CtorArgs>
@@ -104,6 +106,9 @@ struct BuilderLoader : public LibraryLoader
     {
         BuilderLibraryDatabase<Base, CtorArgs...>::getLibrary(elemlib_)->readdBuilder(elem_, alias_, builder_);
     }
+
+  BuilderLoader(const BuilderLoader&)            = delete;
+  BuilderLoader& operator=(const BuilderLoader&) = delete;
 
 private:
     std::string elemlib_;

--- a/src/sst/core/eli/elementbuilder.h
+++ b/src/sst/core/eli/elementbuilder.h
@@ -107,8 +107,8 @@ struct BuilderLoader : public LibraryLoader
         BuilderLibraryDatabase<Base, CtorArgs...>::getLibrary(elemlib_)->readdBuilder(elem_, alias_, builder_);
     }
 
-  BuilderLoader(const BuilderLoader&) = delete;
-  BuilderLoader& operator=(const BuilderLoader&) = delete;
+    BuilderLoader(const BuilderLoader&) = delete;
+    BuilderLoader& operator=(const BuilderLoader&) = delete;
 
 private:
     std::string elemlib_;

--- a/src/sst/core/eli/elementbuilder.h
+++ b/src/sst/core/eli/elementbuilder.h
@@ -107,7 +107,7 @@ struct BuilderLoader : public LibraryLoader
         BuilderLibraryDatabase<Base, CtorArgs...>::getLibrary(elemlib_)->readdBuilder(elem_, alias_, builder_);
     }
 
-  BuilderLoader(const BuilderLoader&)            = delete;
+  BuilderLoader(const BuilderLoader&) = delete;
   BuilderLoader& operator=(const BuilderLoader&) = delete;
 
 private:

--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -104,6 +104,9 @@ public:
         Policy::toString(os);
         Parent::toString(os);
     }
+
+    BuilderInfoImpl(const BuilderInfoImpl&)            = delete;
+    BuilderInfoImpl& operator=(const BuilderInfoImpl&) = delete;
 };
 
 template <>
@@ -119,6 +122,9 @@ protected:
     {}
 
     void toString(std::ostream& UNUSED(os)) const {}
+
+    BuilderInfoImpl(const BuilderInfoImpl&)            = delete;
+    BuilderInfoImpl& operator=(const BuilderInfoImpl&) = delete;
 };
 
 template <class Base, class T>
@@ -135,7 +141,7 @@ class InfoLibrary
 public:
     using BaseInfo = typename Base::BuilderInfo;
 
-    InfoLibrary(const std::string& name) : name_(name) {}
+    explicit InfoLibrary(const std::string& name) : name_(name) {}
 
     BaseInfo* getInfo(const std::string& name)
     {
@@ -243,6 +249,9 @@ private:
     std::string elemlib_;
     std::string elem_;
     Info*       info_;
+
+    InfoLoader(const InfoLoader&)            = delete;
+    InfoLoader& operator=(const InfoLoader&) = delete;
 };
 
 template <class Base>

--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -105,7 +105,7 @@ public:
         Parent::toString(os);
     }
 
-    BuilderInfoImpl(const BuilderInfoImpl&)            = delete;
+    BuilderInfoImpl(const BuilderInfoImpl&) = delete;
     BuilderInfoImpl& operator=(const BuilderInfoImpl&) = delete;
 };
 
@@ -123,7 +123,7 @@ protected:
 
     void toString(std::ostream& UNUSED(os)) const {}
 
-    BuilderInfoImpl(const BuilderInfoImpl&)            = delete;
+    BuilderInfoImpl(const BuilderInfoImpl&) = delete;
     BuilderInfoImpl& operator=(const BuilderInfoImpl&) = delete;
 };
 
@@ -250,7 +250,7 @@ private:
     std::string elem_;
     Info*       info_;
 
-    InfoLoader(const InfoLoader&)            = delete;
+    InfoLoader(const InfoLoader&) = delete;
     InfoLoader& operator=(const InfoLoader&) = delete;
 };
 

--- a/src/sst/core/event.cc
+++ b/src/sst/core/event.cc
@@ -23,8 +23,6 @@ namespace SST {
 std::atomic<uint64_t>     SST::Event::id_counter(0);
 const SST::Event::id_type SST::Event::NO_ID = std::make_pair(0, -1);
 
-Event::~Event() {}
-
 void
 Event::execute()
 {

--- a/src/sst/core/event.h
+++ b/src/sst/core/event.h
@@ -79,7 +79,7 @@ public:
         last_comp  = "";
 #endif
     }
-    virtual ~Event();
+    ~Event() override = default;
 
     /** Clones the event in for the case of a broadcast */
     virtual Event* clone();

--- a/src/sst/core/factory.h
+++ b/src/sst/core/factory.h
@@ -309,9 +309,9 @@ public:
 private:
     friend int ::main(int argc, char** argv);
 
-    void notFound(const std::string& baseName, const std::string& type, const std::string& errorMsg);
+    [[noreturn]] void notFound(const std::string& baseName, const std::string& type, const std::string& errorMsg);
 
-    Factory(const std::string& searchPaths);
+    explicit Factory(const std::string& searchPaths);
     ~Factory();
 
     Factory(const Factory&) = delete;            // Don't Implement

--- a/src/sst/core/heartbeat.cc
+++ b/src/sst/core/heartbeat.cc
@@ -36,8 +36,6 @@ SimulatorHeartbeat::SimulatorHeartbeat(
     if ( (0 == this_rank) ) { lastTime = sst_get_cpu_time(); }
 }
 
-SimulatorHeartbeat::~SimulatorHeartbeat() {}
-
 void
 SimulatorHeartbeat::schedule()
 {

--- a/src/sst/core/heartbeat.h
+++ b/src/sst/core/heartbeat.h
@@ -36,7 +36,7 @@ public:
     Create a new heartbeat object for the simulation core to show progress
     */
     SimulatorHeartbeat(Config* cfg, int this_rank, Simulation_impl* sim, TimeConverter* period);
-    ~SimulatorHeartbeat();
+    ~SimulatorHeartbeat() = default;
 
     // Used to re-schedule the new heartbeat event during restart
     void schedule();

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -33,7 +33,7 @@ public:
     /**
        Creates a new self partition scheme.
     */
-    SimpleDebugger(Params& params);
+    explicit SimpleDebugger(Params& params);
 
     void execute(const std::string& msg) override;
 

--- a/src/sst/core/impl/partitioners/simplepart.cc
+++ b/src/sst/core/impl/partitioners/simplepart.cc
@@ -17,6 +17,7 @@
 #include "sst/core/warnmacros.h"
 
 #include <map>
+#include <memory>
 #include <stdlib.h>
 #include <vector>
 
@@ -192,8 +193,8 @@ SimplePartitioner::performPartition(PartitionGraph* graph)
             graph->getNumComponents() % 2 == 1 ? (graph->getNumComponents() / 2) + 1 : (graph->getNumComponents() / 2);
         const int B_size = graph->getNumComponents() / 2;
 
-        ComponentId_t setA[A_size];
-        ComponentId_t setB[B_size];
+        auto setA = std::make_unique<ComponentId_t[]>(A_size);
+        auto setB = std::make_unique<ComponentId_t[]>(B_size);
 
         int indexA = 0;
         int indexB = 0;
@@ -229,7 +230,7 @@ SimplePartitioner::performPartition(PartitionGraph* graph)
             }
         }
 
-        simple_partition_step(component_map, setA, A_size, 0, setB, B_size, 1, timeTable, 1);
+        simple_partition_step(component_map, setA.get(), A_size, 0, setB.get(), B_size, 1, timeTable, 1);
     }
 }
 

--- a/src/sst/core/impl/portmodules/randomDrop.h
+++ b/src/sst/core/impl/portmodules/randomDrop.h
@@ -39,7 +39,7 @@ public:
         { "verbose", "Debugging output", "false"}
     )
 
-    RandomDrop(Params& params);
+    explicit RandomDrop(Params& params);
 
     // For serialization only
     RandomDrop() = default;

--- a/src/sst/core/impl/timevortex/timeVortexBinnedMap.cc
+++ b/src/sst/core/impl/timevortex/timeVortexBinnedMap.cc
@@ -194,8 +194,9 @@ public:
         "sst",
         "timevortex.map.binned.ts",
         SST_ELI_ELEMENT_VERSION(1,0,0),
-        "[EXPERIMENTAL] Thread safe verion of TimeVortex based on std::map with events binned into time buckets.  Do not reference this element directly, just specify sst.timevortex.map.binned and this version will be selected when it is needed based on other parameters.")
-
+        "[EXPERIMENTAL] Thread-safe verion of TimeVortex based on std::map with events binned into time buckets."
+        "  Do not reference this element directly; just specify sst.timevortex.map.binned and this version will"
+        " be selected when it is needed based on other parameters.")
 
     TimeVortexBinnedMap_ts(Params& params) : TimeVortexBinnedMapBase<true>(params) {}
     SST_ELI_EXPORT(TimeVortexBinnedMap_ts)

--- a/src/sst/core/impl/timevortex/timeVortexBinnedMap.h
+++ b/src/sst/core/impl/timevortex/timeVortexBinnedMap.h
@@ -129,7 +129,7 @@ private:
 
 
 public:
-    TimeVortexBinnedMapBase(Params& params);
+    explicit TimeVortexBinnedMapBase(Params& params);
     ~TimeVortexBinnedMapBase();
 
     bool      empty() override;

--- a/src/sst/core/impl/timevortex/timeVortexPQ.cc
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.cc
@@ -153,7 +153,10 @@ public:
     TimeVortexPQ() : TimeVortexPQBase<false>() {} // For serialization only
     ~TimeVortexPQ() {}
 
-    void serialize_order(SST::Core::Serialization::serializer& ser) { TimeVortexPQBase<false>::serialize_order(ser); }
+    void serialize_order(SST::Core::Serialization::serializer& ser) override
+    {
+        TimeVortexPQBase<false>::serialize_order(ser);
+    }
 
     SST_ELI_EXPORT(TimeVortexPQ)
 };
@@ -166,15 +169,19 @@ public:
         TimeVortexPQ_ts,
         "sst",
         "timevortex.priority_queue.ts",
-        SST_ELI_ELEMENT_VERSION(1,0,0),
-        "Thread safe verion of TimeVortex based on std::priority_queue.  Do not reference this element directly, just specify sst.timevortex.priority_queue and this version will be selected when it is needed based on other parameters.")
-
+        SST_ELI_ELEMENT_VERSION(1, 0, 0),
+        "Thread-safe verion of TimeVortex based on std::priority_queue.  Do not reference this element directly; just"
+        " specify sst.timevortex.priority_queue and this version will be selected when it is needed based on other"
+        " parameters.")
 
     TimeVortexPQ_ts(Params& params) : TimeVortexPQBase<true>(params) {}
     TimeVortexPQ_ts() : TimeVortexPQBase<true>() {} // For serialization only
     ~TimeVortexPQ_ts() {}
 
-    void serialize_order(SST::Core::Serialization::serializer& ser) { TimeVortexPQBase<true>::serialize_order(ser); }
+    void serialize_order(SST::Core::Serialization::serializer& ser) override
+    {
+        TimeVortexPQBase<true>::serialize_order(ser);
+    }
 
     SST_ELI_EXPORT(TimeVortexPQ_ts)
 };

--- a/src/sst/core/impl/timevortex/timeVortexPQ.h
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.h
@@ -36,7 +36,7 @@ class TimeVortexPQBase : public TimeVortex
 
 public:
     // TimeVortexPQ();
-    TimeVortexPQBase(Params& params);
+    explicit TimeVortexPQBase(Params& params);
     TimeVortexPQBase(); // For serialization only
     ~TimeVortexPQBase();
 

--- a/src/sst/core/initQueue.cc
+++ b/src/sst/core/initQueue.cc
@@ -15,7 +15,6 @@
 
 namespace SST {
 
-InitQueue::InitQueue() : ActivityQueue() {}
 InitQueue::~InitQueue()
 {
     // Need to delete any events left in the queue

--- a/src/sst/core/initQueue.h
+++ b/src/sst/core/initQueue.h
@@ -24,7 +24,7 @@ namespace SST {
 class InitQueue : public ActivityQueue
 {
 public:
-    InitQueue();
+    InitQueue() = default;
     ~InitQueue();
 
     bool      empty() override;

--- a/src/sst/core/interactiveConsole.cc
+++ b/src/sst/core/interactiveConsole.cc
@@ -25,11 +25,6 @@ namespace SST {
 SST_ELI_DEFINE_INFO_EXTERN(SST::InteractiveConsole)
 SST_ELI_DEFINE_CTOR_EXTERN(SST::InteractiveConsole)
 
-
-InteractiveConsole::InteractiveConsole() {}
-
-InteractiveConsole::~InteractiveConsole() {}
-
 UnitAlgebra
 InteractiveConsole::getCoreTimeBase() const
 {

--- a/src/sst/core/interactiveConsole.h
+++ b/src/sst/core/interactiveConsole.h
@@ -53,8 +53,8 @@ public:
     /**
     Create a new checkpoint object for the simulation core to initiate checkpoints
     */
-    InteractiveConsole();
-    virtual ~InteractiveConsole();
+    InteractiveConsole()          = default;
+    virtual ~InteractiveConsole() = default;
 
     /** Called by TimeVortex to trigger checkpoint on simulation clock interval - not used in parallel simulation */
     virtual void execute(const std::string& msg) = 0;

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -38,7 +38,8 @@ namespace SST::Interfaces {
 class SimpleNetwork : public SubComponent
 {
 public:
-    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork, int)
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork,
+                                      int)
 
     /** All Addresses can be 64-bit */
     using nid_t = int64_t;
@@ -174,7 +175,8 @@ public:
     {
 
     public:
-        SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork::NetworkInspector,std::string)
+        SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork::NetworkInspector,
+                                          std::string)
 
         NetworkInspector(ComponentId_t id) : SubComponent(id) {}
 

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -100,7 +100,9 @@ public:
     class RequestConverter; // Convert request to SST::Event* according to type
     class RequestHandler;   // Handle a request according to type
 
-    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::StandardMem,TimeConverter*,HandlerBase*)
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::StandardMem,
+                                      TimeConverter*,
+                                      HandlerBase*)
 
     /** All Addresses can be 64-bit */
     using Addr = uint64_t;
@@ -1272,7 +1274,10 @@ public:
     /**
      * Serialization function
      */
-    virtual void serialize_order(SST::Core::Serialization::serializer& ser) { SST::SubComponent::serialize_order(ser); }
+    void serialize_order(SST::Core::Serialization::serializer& ser) override
+    {
+        SST::SubComponent::serialize_order(ser);
+    }
 };
 
 } // namespace SST::Interfaces

--- a/src/sst/core/interprocess/tunneldef.h
+++ b/src/sst/core/interprocess/tunneldef.h
@@ -22,8 +22,10 @@
 
 #include "sst/core/interprocess/circularBuffer.h"
 
-#include <inttypes.h>
+#include <atomic>
+#include <cinttypes>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 namespace SST::Core::Interprocess {
@@ -33,10 +35,10 @@ extern uint32_t globalMMAPIPCCount;
 /* Internal bookkeeping */
 struct InternalSharedData
 {
-    volatile uint32_t expectedChildren;
-    size_t            shmSegSize;
-    size_t            numBuffers;
-    size_t            offsets[0]; // offset[0] points to user region, offset[1]... points to circular buffers
+    std::atomic_uint32_t expectedChildren;
+    size_t               shmSegSize;
+    size_t               numBuffers;
+    size_t               offsets[0]; // offset[0] points to user region, offset[1]... points to circular buffers
 };
 
 /**

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -112,6 +112,8 @@ public:
            @param key Key that would be passed into the eventSent() function.
          */
         virtual void serializeEventAttachPointKey(SST::Core::Serialization::serializer& ser, uintptr_t& key);
+
+        virtual ~AttachPoint() = default;
     };
 
     friend class LinkPair;
@@ -322,7 +324,7 @@ private:
         value used for enforce_link_order (if that feature is
         enabled).
      */
-    Link(LinkId_t tag);
+    explicit Link(LinkId_t tag);
 
     Link(const Link& l);
 

--- a/src/sst/core/model/element_python.cc
+++ b/src/sst/core/model/element_python.cc
@@ -36,7 +36,11 @@ SST_ELI_DEFINE_INFO_EXTERN(SSTElementPythonModule)
 
 // Utility function to parse the python exceptions from loading
 // modules and format and print them on abort.
-void
+static void
+abortOnPyErr(uint32_t line, const char* file, const char* func, uint32_t exit_code, const char* format, ...)
+    __attribute__((format(printf, 5, 6)));
+
+static void
 abortOnPyErr(uint32_t line, const char* file, const char* func, uint32_t exit_code, const char* format, ...)
 {
     PyObject *exc, *val, *tb;

--- a/src/sst/core/model/element_python.cc
+++ b/src/sst/core/model/element_python.cc
@@ -36,8 +36,7 @@ SST_ELI_DEFINE_INFO_EXTERN(SSTElementPythonModule)
 
 // Utility function to parse the python exceptions from loading
 // modules and format and print them on abort.
-static void
-abortOnPyErr(uint32_t line, const char* file, const char* func, uint32_t exit_code, const char* format, ...)
+static void abortOnPyErr(uint32_t line, const char* file, const char* func, uint32_t exit_code, const char* format, ...)
     __attribute__((format(printf, 5, 6)));
 
 static void

--- a/src/sst/core/model/element_python.h
+++ b/src/sst/core/model/element_python.h
@@ -117,6 +117,8 @@ public:
      *  \return full name of module as a string
      */
     std::string getFullModuleName();
+
+    virtual ~SSTElementPythonModuleCode() = default;
 };
 
 /**
@@ -154,7 +156,7 @@ public:
      * of.  Primary module name will be sst.library and submodules
      * under this can also be created.
      */
-    SSTElementPythonModule(const std::string& library);
+    explicit SSTElementPythonModule(const std::string& library);
 
     virtual void* load();
 

--- a/src/sst/core/model/python/pymodel_comp.h
+++ b/src/sst/core/model/python/pymodel_comp.h
@@ -44,6 +44,9 @@ struct ComponentHolder
     virtual std::string           getName();
     SST::ComponentId_t            getID();
     SST::ConfigComponent*         getSubComp(const std::string& name, int slot_num);
+
+    ComponentHolder(const ComponentHolder&)            = delete;
+    ComponentHolder& operator=(const ComponentHolder&) = delete;
 };
 
 struct PyComponent : ComponentHolder
@@ -51,13 +54,13 @@ struct PyComponent : ComponentHolder
     uint16_t subCompId;
 
     PyComponent(ComponentPy_t* pobj, SST::ComponentId_t id) : ComponentHolder(pobj, id), subCompId(0) {}
-    ~PyComponent() {}
+    ~PyComponent() override = default;
 };
 
 struct PySubComponent : ComponentHolder
 {
     PySubComponent(ComponentPy_t* pobj, SST::ComponentId_t id) : ComponentHolder(pobj, id) {}
-    ~PySubComponent() {}
+    ~PySubComponent() override = default;
     int getSlot();
 };
 

--- a/src/sst/core/model/python/pymodel_comp.h
+++ b/src/sst/core/model/python/pymodel_comp.h
@@ -45,7 +45,7 @@ struct ComponentHolder
     SST::ComponentId_t            getID();
     SST::ConfigComponent*         getSubComp(const std::string& name, int slot_num);
 
-    ComponentHolder(const ComponentHolder&)            = delete;
+    ComponentHolder(const ComponentHolder&) = delete;
     ComponentHolder& operator=(const ComponentHolder&) = delete;
 };
 

--- a/src/sst/core/model/sstmodel.h
+++ b/src/sst/core/model/sstmodel.h
@@ -38,7 +38,7 @@ public:
     static bool                            isElementParallelCapable(const std::string& type);
     static const std::vector<std::string>& getElementSupportedExtensions(const std::string& type);
 
-    SSTModelDescription(Config* cfg);
+    explicit SSTModelDescription(Config* cfg);
     virtual ~SSTModelDescription() {};
 
     /** Create the ConfigGraph

--- a/src/sst/core/output.h
+++ b/src/sst/core/output.h
@@ -122,7 +122,7 @@ public:
 
     ~Output();
 
-    Output(const Output&)            = default;
+    Output(const Output&) = default;
     Output& operator=(const Output&) = default;
 
     /** Initialize the object after construction
@@ -496,14 +496,14 @@ private:
     uint32_t    getThreadRank() const;
     std::string buildPrefixString(uint32_t line, const std::string& file, const std::string& func) const;
 
-    void outputprintf(uint32_t line, const std::string& file, const std::string& func, const char* format, va_list arg) const
+    void
+    outputprintf(uint32_t line, const std::string& file, const std::string& func, const char* format, va_list arg) const
         __attribute__((format(printf, 5, 0)));
 
     void outputprintf(const char* format, va_list arg) const __attribute__((format(printf, 2, 0)));
 
     // Versions of outputprintf that takes variable arguments instead of va_list
-    void
-    outputprintf(uint32_t line, const std::string& file, const std::string& func, const char* format, ...) const
+    void outputprintf(uint32_t line, const std::string& file, const std::string& func, const char* format, ...) const
        __attribute__((format(printf, 5, 6)))
     {
         va_list args;

--- a/src/sst/core/output.h
+++ b/src/sst/core/output.h
@@ -122,6 +122,9 @@ public:
 
     ~Output();
 
+    Output(const Output&)            = default;
+    Output& operator=(const Output&) = default;
+
     /** Initialize the object after construction
         @param prefix Prefix to be prepended to all strings emitted by calls to
                debug(), verbose(), fatal() and possibly output().
@@ -492,13 +495,16 @@ private:
     uint32_t    getNumThreads() const;
     uint32_t    getThreadRank() const;
     std::string buildPrefixString(uint32_t line, const std::string& file, const std::string& func) const;
-    void        outputprintf(
-               uint32_t line, const std::string& file, const std::string& func, const char* format, va_list arg) const;
-    void outputprintf(const char* format, va_list arg) const;
+
+    void outputprintf(uint32_t line, const std::string& file, const std::string& func, const char* format, va_list arg) const
+        __attribute__((format(printf, 5, 0)));
+
+    void outputprintf(const char* format, va_list arg) const __attribute__((format(printf, 2, 0)));
 
     // Versions of outputprintf that takes variable arguments instead of va_list
-    inline void
+    void
     outputprintf(uint32_t line, const std::string& file, const std::string& func, const char* format, ...) const
+       __attribute__((format(printf, 5, 6)))
     {
         va_list args;
         va_start(args, format);
@@ -506,7 +512,7 @@ private:
         va_end(args);
     }
 
-    inline void outputprintf(const char* format, ...) const
+    void outputprintf(const char* format, ...) const __attribute__((format(printf, 2, 3)))
     {
         va_list args;
         va_start(args, format);

--- a/src/sst/core/output.h
+++ b/src/sst/core/output.h
@@ -504,7 +504,7 @@ private:
 
     // Versions of outputprintf that takes variable arguments instead of va_list
     void outputprintf(uint32_t line, const std::string& file, const std::string& func, const char* format, ...) const
-       __attribute__((format(printf, 5, 6)))
+        __attribute__((format(printf, 5, 6)))
     {
         va_list args;
         va_start(args, format);

--- a/src/sst/core/pollingLinkQueue.cc
+++ b/src/sst/core/pollingLinkQueue.cc
@@ -15,7 +15,6 @@
 
 namespace SST {
 
-PollingLinkQueue::PollingLinkQueue() : ActivityQueue() {}
 PollingLinkQueue::~PollingLinkQueue()
 {
     // Need to delete any events left in the queue

--- a/src/sst/core/pollingLinkQueue.h
+++ b/src/sst/core/pollingLinkQueue.h
@@ -24,7 +24,7 @@ namespace SST {
 class PollingLinkQueue : public ActivityQueue
 {
 public:
-    PollingLinkQueue();
+    PollingLinkQueue() = default;
     ~PollingLinkQueue();
 
     bool      empty() override;

--- a/src/sst/core/portModule.cc
+++ b/src/sst/core/portModule.cc
@@ -21,8 +21,6 @@ namespace SST {
 SST_ELI_DEFINE_INFO_EXTERN(PortModule)
 SST_ELI_DEFINE_CTOR_EXTERN(PortModule)
 
-PortModule::PortModule() {}
-
 uintptr_t
 PortModule::registerLinkAttachTool(const AttachPointMetaData& UNUSED(mdata))
 {

--- a/src/sst/core/portModule.h
+++ b/src/sst/core/portModule.h
@@ -56,8 +56,7 @@ public:
         // ELI::ProvidesStats, // Will add stats in the future
         ELI::ProvidesAttributes)
 
-
-    PortModule();
+    PortModule() = default;
     virtual ~PortModule() {};
 
     /******* Functions inherited from Link::AttachPoint *******/

--- a/src/sst/core/profile/profiletool.h
+++ b/src/sst/core/profile/profiletool.h
@@ -37,7 +37,7 @@ public:
         ELI::ProvidesInterface,
         ELI::ProvidesParams)
 
-    ProfileTool(const std::string& name);
+    explicit ProfileTool(const std::string& name);
 
     virtual ~ProfileTool() {}
 

--- a/src/sst/core/realtime.cc
+++ b/src/sst/core/realtime.cc
@@ -82,8 +82,6 @@ SST_ELI_DEFINE_INFO_EXTERN(RealTimeAction)
 SST_ELI_DEFINE_CTOR_EXTERN(RealTimeAction)
 
 
-RealTimeAction::RealTimeAction() {}
-
 UnitAlgebra
 RealTimeAction::getCoreTimeBase() const
 {

--- a/src/sst/core/realtime.h
+++ b/src/sst/core/realtime.h
@@ -156,7 +156,7 @@ private:
 class RealTimeManager : public SST::Core::Serialization::serializable
 {
 public:
-    RealTimeManager(RankInfo num_ranks);
+    explicit RealTimeManager(RankInfo num_ranks);
     RealTimeManager();
 
     /** Register actions */

--- a/src/sst/core/realtimeAction.h
+++ b/src/sst/core/realtimeAction.h
@@ -32,8 +32,8 @@ public:
     SST_ELI_DECLARE_DEFAULT_INFO_EXTERN()
     SST_ELI_DECLARE_DEFAULT_CTOR_EXTERN()
 
-
-    RealTimeAction();
+    RealTimeAction()          = default;
+    virtual ~RealTimeAction() = default;
 
     /* Optional function called just before run loop starts. Passes in
      * the next scheduled time of the event or 0 if the event is not

--- a/src/sst/core/rng/mersenne.h
+++ b/src/sst/core/rng/mersenne.h
@@ -38,7 +38,7 @@ public:
        Create a new Mersenne RNG with a specified seed
        @param[in] seed The seed for this RNG
     */
-    MersenneRNG(unsigned int seed);
+    explicit MersenneRNG(unsigned int seed);
 
     /**
        Creates a new Mersenne using a random seed which is obtained from the system

--- a/src/sst/core/serialization/impl/serialize_string.h
+++ b/src/sst/core/serialization/impl/serialize_string.h
@@ -63,7 +63,7 @@ public:
        Disallow copying and assignment
      */
 
-    ObjectMapString(const ObjectMapString&)            = delete;
+    ObjectMapString(const ObjectMapString&) = delete;
     ObjectMapString& operator=(const ObjectMapString&) = delete;
 };
 

--- a/src/sst/core/serialization/impl/serialize_string.h
+++ b/src/sst/core/serialization/impl/serialize_string.h
@@ -57,7 +57,14 @@ public:
         return "std::string";
     }
 
-    ObjectMapString(std::string* addr) : ObjectMap(), addr_(addr) {}
+    explicit ObjectMapString(std::string* addr) : ObjectMap(), addr_(addr) {}
+
+    /**
+       Disallow copying and assignment
+     */
+
+    ObjectMapString(const ObjectMapString&)            = delete;
+    ObjectMapString& operator=(const ObjectMapString&) = delete;
 };
 
 template <>

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -47,6 +47,9 @@ struct ObjectMapMetaData
        Constructor for intializing data memebers
      */
     ObjectMapMetaData(ObjectMap* parent, const std::string& name) : parent(parent), name(name) {}
+
+    ObjectMapMetaData( const ObjectMapMetaData& ) = delete;
+    ObjectMapMetaData& operator=( const ObjectMapMetaData& ) = delete;
 };
 
 /**
@@ -347,6 +350,13 @@ public:
     virtual ~ObjectMap() {}
 
     /**
+       Disallow copying and assignment
+     */
+
+    ObjectMap(const ObjectMap&)            = delete;
+    ObjectMap& operator=(const ObjectMap&) = delete;
+
+    /**
        Static function to demangle type names returned from typeid(T).name()
 
        @param name typename returned from typeid(T).name()
@@ -476,6 +486,13 @@ public:
     }
 
     /**
+       Disallow copying and assignment
+     */
+
+    ObjectMapWithChildren(const ObjectMapWithChildren&)            = delete;
+    ObjectMapWithChildren& operator=(const ObjectMapWithChildren&) = delete;
+
+    /**
        Adds a variable to this ObjectMap
 
        @param name Name of the object in the context of this ObjectMap
@@ -564,6 +581,13 @@ public:
        Default constructor
      */
     ObjectMapClass() : ObjectMapWithChildren() {}
+
+    /**
+       Disallow copying and assignment
+     */
+
+    ObjectMapClass(const ObjectMapClass&)            = delete;
+    ObjectMapClass& operator=(const ObjectMapClass&) = delete;
 
     /**
        Constructor
@@ -661,7 +685,7 @@ public:
      */
     const std::vector<std::pair<std::string, ObjectMap*>>& getVariables() override { return emptyVars; }
 
-    ObjectMapFundamental(T* addr) : ObjectMap(), addr_(addr) {}
+    explicit ObjectMapFundamental(T* addr) : ObjectMap(), addr_(addr) {}
 
     /**
        Destructor.  Should not be called directly (i.e. do not call
@@ -670,6 +694,13 @@ public:
        children.
      */
     ~ObjectMapFundamental() {}
+
+    /**
+       Disallow copying and assignment
+     */
+
+    ObjectMapFundamental(const ObjectMapFundamental&)            = delete;
+    ObjectMapFundamental& operator=(const ObjectMapFundamental&) = delete;
 
     /**
        Return the type represented by this ObjectMap as given by the

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -48,8 +48,8 @@ struct ObjectMapMetaData
      */
     ObjectMapMetaData(ObjectMap* parent, const std::string& name) : parent(parent), name(name) {}
 
-    ObjectMapMetaData( const ObjectMapMetaData& ) = delete;
-    ObjectMapMetaData& operator=( const ObjectMapMetaData& ) = delete;
+    ObjectMapMetaData(const ObjectMapMetaData&) = delete;
+    ObjectMapMetaData& operator=(const ObjectMapMetaData&) = delete;
 };
 
 /**
@@ -353,7 +353,7 @@ public:
        Disallow copying and assignment
      */
 
-    ObjectMap(const ObjectMap&)            = delete;
+    ObjectMap(const ObjectMap&) = delete;
     ObjectMap& operator=(const ObjectMap&) = delete;
 
     /**
@@ -489,7 +489,7 @@ public:
        Disallow copying and assignment
      */
 
-    ObjectMapWithChildren(const ObjectMapWithChildren&)            = delete;
+    ObjectMapWithChildren(const ObjectMapWithChildren&) = delete;
     ObjectMapWithChildren& operator=(const ObjectMapWithChildren&) = delete;
 
     /**
@@ -586,7 +586,7 @@ public:
        Disallow copying and assignment
      */
 
-    ObjectMapClass(const ObjectMapClass&)            = delete;
+    ObjectMapClass(const ObjectMapClass&) = delete;
     ObjectMapClass& operator=(const ObjectMapClass&) = delete;
 
     /**
@@ -699,7 +699,7 @@ public:
        Disallow copying and assignment
      */
 
-    ObjectMapFundamental(const ObjectMapFundamental&)            = delete;
+    ObjectMapFundamental(const ObjectMapFundamental&) = delete;
     ObjectMapFundamental& operator=(const ObjectMapFundamental&) = delete;
 
     /**

--- a/src/sst/core/serialization/serializable_base.h
+++ b/src/sst/core/serialization/serializable_base.h
@@ -129,7 +129,7 @@ public:
 
 protected:
     enum cxn_flag_t { ConstructorFlag };
-    static void serializable_abort(uint32_t line, const char* file, const char* func, const char* obj);
+    [[noreturn]] static void serializable_abort(uint32_t line, const char* file, const char* func, const char* obj);
 };
 
 

--- a/src/sst/core/sstconfigtool.cc
+++ b/src/sst/core/sstconfigtool.cc
@@ -21,36 +21,38 @@
 #include <map>
 #include <string>
 
-void
+[[noreturn]] void
 print_usage(FILE* output)
 {
-    fprintf(output, "sst-config\n");
-    fprintf(output, "sst-config --<KEY>\n");
-    fprintf(output, "sst-config <GROUP> <KEY>\n");
-    fprintf(output, "\n");
-    fprintf(output, "<GROUP>    Name of group to which the key belongs\n");
-    fprintf(output, "           (e.g. DRAMSim group contains all DRAMSim\n");
-    fprintf(output, "           KEY=VALUE settings).\n");
-    fprintf(output, "<KEY>      Name of the setting key to find.\n");
-    fprintf(output, "           If <GROUP> not specified this is found in\n");
-    fprintf(output, "           the \'SSTCore\' default group.\n");
-    fprintf(output, "\n");
-    fprintf(output, "Example 1:\n");
-    fprintf(output, "  sst-config --CXX\n");
-    fprintf(output, "           Finds the CXX compiler specified by the core\n");
-    fprintf(output, "Example 2:\n");
-    fprintf(output, "  sst-config DRAMSim CPPFLAGS\n");
-    fprintf(output, "           Finds CPPFLAGS associated with DRAMSim\n");
-    fprintf(output, "Example 3:\n");
-    fprintf(output, "  sst-config\n");
-    fprintf(output, "           Dumps entire configuration found.\n");
-    fprintf(output, "\n");
-    fprintf(output, "The use of -- for the single <KEY> (Example 1) is\n");
-    fprintf(output, "intentional to closely replicate behaviour of the\n");
-    fprintf(output, "pkg-config tool used in Linux environments. This\n");
-    fprintf(output, "should not be specified when using <GROUP> as well.\n");
-    fprintf(output, "\n");
-    fprintf(output, "Return: 0 is key found, 1 key/group not found\n");
+    fputs(
+        "sst-config\n"
+        "sst-config --<KEY>\n"
+        "sst-config <GROUP> <KEY>\n"
+        "\n"
+        "<GROUP>    Name of group to which the key belongs\n"
+        "           (e.g. DRAMSim group contains all DRAMSim\n"
+        "           KEY=VALUE settings).\n"
+        "<KEY>      Name of the setting key to find.\n"
+        "           If <GROUP> not specified this is found in\n"
+        "           the \'SSTCore\' default group.\n"
+        "\n"
+        "Example 1:\n"
+        "  sst-config --CXX\n"
+        "           Finds the CXX compiler specified by the core\n"
+        "Example 2:\n"
+        "  sst-config DRAMSim CPPFLAGS\n"
+        "           Finds CPPFLAGS associated with DRAMSim\n"
+        "Example 3:\n"
+        "  sst-config\n"
+        "           Dumps entire configuration found.\n"
+        "\n"
+        "The use of -- for the single <KEY> (Example 1) is\n"
+        "intentional to closely replicate behaviour of the\n"
+        "pkg-config tool used in Linux environments. This\n"
+        "should not be specified when using <GROUP> as well.\n"
+        "\n"
+        "Return: 0 is key found, 1 key/group not found\n",
+        output);
     exit(1);
 }
 

--- a/src/sst/core/ssthandler.h
+++ b/src/sst/core/ssthandler.h
@@ -452,6 +452,8 @@ public:
         virtual void
         serializeHandlerInterceptPointKey(SST::Core::Serialization::serializer& UNUSED(ser), uintptr_t& UNUSED(key))
         {}
+
+        virtual ~InterceptPoint() = default;
     };
 
 private:
@@ -1058,6 +1060,9 @@ public:
         data(data)
     {}
 
+    SSTHandler(const SSTHandler&)            = delete;
+    SSTHandler& operator=(const SSTHandler&) = delete;
+
     returnT operator_impl(argT arg) override { return (object->*member)(arg, data); }
 
     NotSerializable(SSTHandler)
@@ -1082,6 +1087,9 @@ public:
      */
     SSTHandler(classT* const object, PtrMember member) : SSTHandlerBase<returnT, argT>(), member(member), object(object)
     {}
+
+    SSTHandler(const SSTHandler&)            = delete;
+    SSTHandler& operator=(const SSTHandler&) = delete;
 
     returnT operator_impl(argT arg) override { return (object->*member)(arg); }
 
@@ -1114,6 +1122,9 @@ public:
         data(data)
     {}
 
+    SSTHandlerNoArgs(const SSTHandlerNoArgs&)            = delete;
+    SSTHandlerNoArgs& operator=(const SSTHandlerNoArgs&) = delete;
+
     void operator_impl() override { return (object->*member)(data); }
 
     NotSerializable(SSTHandlerNoArgs)
@@ -1141,6 +1152,9 @@ public:
         member(member),
         object(object)
     {}
+
+    SSTHandlerNoArgs(const SSTHandlerNoArgs&)            = delete;
+    SSTHandlerNoArgs& operator=(const SSTHandlerNoArgs&) = delete;
 
     void operator_impl() override { return (object->*member)(); }
 
@@ -1185,6 +1199,9 @@ public:
 
     SSTHandler2() {}
 
+    SSTHandler2(const SSTHandler2&)            = delete;
+    SSTHandler2& operator=(const SSTHandler2&) = delete;
+
     returnT operator_impl(argT arg) override { return (object->*funcT)(arg, data); }
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override
@@ -1212,8 +1229,11 @@ public:
      * @param object - Pointer to Object upon which to call the handler
      * @param member - Member function to call as the handler
      */
-    SSTHandler2(classT* const object) : SSTHandlerBase<returnT, argT>(), object(object) {}
+    explicit SSTHandler2(classT* const object) : SSTHandlerBase<returnT, argT>(), object(object) {}
     SSTHandler2() {}
+
+    SSTHandler2(const SSTHandler2&)            = delete;
+    SSTHandler2& operator=(const SSTHandler2&) = delete;
 
     returnT operator_impl(argT arg) override { return (object->*funcT)(arg); }
 
@@ -1245,6 +1265,9 @@ public:
     SSTHandler2(classT* const object, dataT data) : SSTHandlerBase<returnT, void>(), object(object), data(data) {}
     SSTHandler2() {}
 
+    SSTHandler2(const SSTHandler2&)            = delete;
+    SSTHandler2& operator=(const SSTHandler2&) = delete;
+
     returnT operator_impl() override { return (object->*funcT)(data); }
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override
@@ -1272,8 +1295,11 @@ public:
      * @param object - Pointer to Object upon which to call the handler
      * @param data - Additional argument to pass to handler
      */
-    SSTHandler2(classT* const object) : SSTHandlerBase<returnT, void>(), object(object) {}
+    explicit SSTHandler2(classT* const object) : SSTHandlerBase<returnT, void>(), object(object) {}
     SSTHandler2() {}
+
+    SSTHandler2(const SSTHandler2&)            = delete;
+    SSTHandler2& operator=(const SSTHandler2&) = delete;
 
     returnT operator_impl() override { return (object->*funcT)(); }
 

--- a/src/sst/core/ssthandler.h
+++ b/src/sst/core/ssthandler.h
@@ -1060,7 +1060,7 @@ public:
         data(data)
     {}
 
-    SSTHandler(const SSTHandler&)            = delete;
+    SSTHandler(const SSTHandler&) = delete;
     SSTHandler& operator=(const SSTHandler&) = delete;
 
     returnT operator_impl(argT arg) override { return (object->*member)(arg, data); }
@@ -1088,7 +1088,7 @@ public:
     SSTHandler(classT* const object, PtrMember member) : SSTHandlerBase<returnT, argT>(), member(member), object(object)
     {}
 
-    SSTHandler(const SSTHandler&)            = delete;
+    SSTHandler(const SSTHandler&) = delete;
     SSTHandler& operator=(const SSTHandler&) = delete;
 
     returnT operator_impl(argT arg) override { return (object->*member)(arg); }
@@ -1122,7 +1122,7 @@ public:
         data(data)
     {}
 
-    SSTHandlerNoArgs(const SSTHandlerNoArgs&)            = delete;
+    SSTHandlerNoArgs(const SSTHandlerNoArgs&) = delete;
     SSTHandlerNoArgs& operator=(const SSTHandlerNoArgs&) = delete;
 
     void operator_impl() override { return (object->*member)(data); }
@@ -1153,7 +1153,7 @@ public:
         object(object)
     {}
 
-    SSTHandlerNoArgs(const SSTHandlerNoArgs&)            = delete;
+    SSTHandlerNoArgs(const SSTHandlerNoArgs&) = delete;
     SSTHandlerNoArgs& operator=(const SSTHandlerNoArgs&) = delete;
 
     void operator_impl() override { return (object->*member)(); }
@@ -1199,7 +1199,7 @@ public:
 
     SSTHandler2() {}
 
-    SSTHandler2(const SSTHandler2&)            = delete;
+    SSTHandler2(const SSTHandler2&) = delete;
     SSTHandler2& operator=(const SSTHandler2&) = delete;
 
     returnT operator_impl(argT arg) override { return (object->*funcT)(arg, data); }
@@ -1232,7 +1232,7 @@ public:
     explicit SSTHandler2(classT* const object) : SSTHandlerBase<returnT, argT>(), object(object) {}
     SSTHandler2() {}
 
-    SSTHandler2(const SSTHandler2&)            = delete;
+    SSTHandler2(const SSTHandler2&) = delete;
     SSTHandler2& operator=(const SSTHandler2&) = delete;
 
     returnT operator_impl(argT arg) override { return (object->*funcT)(arg); }
@@ -1265,7 +1265,7 @@ public:
     SSTHandler2(classT* const object, dataT data) : SSTHandlerBase<returnT, void>(), object(object), data(data) {}
     SSTHandler2() {}
 
-    SSTHandler2(const SSTHandler2&)            = delete;
+    SSTHandler2(const SSTHandler2&) = delete;
     SSTHandler2& operator=(const SSTHandler2&) = delete;
 
     returnT operator_impl() override { return (object->*funcT)(data); }
@@ -1298,7 +1298,7 @@ public:
     explicit SSTHandler2(classT* const object) : SSTHandlerBase<returnT, void>(), object(object) {}
     SSTHandler2() {}
 
-    SSTHandler2(const SSTHandler2&)            = delete;
+    SSTHandler2(const SSTHandler2&) = delete;
     SSTHandler2& operator=(const SSTHandler2&) = delete;
 
     returnT operator_impl() override { return (object->*funcT)(); }

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -58,8 +58,9 @@ static unsigned int             g_textPos;
 #endif
 
 
+void sst_dprintf(FILE* fp, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 void
-dprintf(FILE* fp, const char* fmt, ...)
+sst_dprintf(FILE* fp, const char* fmt, ...)
 {
     if ( g_configuration.doVerbose() ) {
         va_list args;
@@ -69,6 +70,7 @@ dprintf(FILE* fp, const char* fmt, ...)
     }
 }
 
+static void xmlComment(TiXmlNode* owner, const char* fmt...) __attribute__((format(printf, 2, 3)));
 static void
 xmlComment(TiXmlNode* owner, const char* fmt...)
 {
@@ -664,12 +666,12 @@ OverallOutputter::outputXML()
     // Create a Timestamp Format: 2015.02.15_20:20:00
     std::strftime(TimeStamp, 32, "%Y.%m.%d_%H:%M:%S", ptm);
 
-    dprintf(stdout, "\n");
-    dprintf(stdout, "================================================================================\n");
-    dprintf(stdout, "GENERATING XML FILE SSTInfo.xml as %s\n", g_configuration.getXMLFilePath().c_str());
-    dprintf(stdout, "================================================================================\n");
-    dprintf(stdout, "\n");
-    dprintf(stdout, "\n");
+    sst_dprintf(stdout, "\n");
+    sst_dprintf(stdout, "================================================================================\n");
+    sst_dprintf(stdout, "GENERATING XML FILE SSTInfo.xml as %s\n", g_configuration.getXMLFilePath().c_str());
+    sst_dprintf(stdout, "================================================================================\n");
+    sst_dprintf(stdout, "\n");
+    sst_dprintf(stdout, "\n");
 
     // Create the XML Document
     TiXmlDocument XMLDocument;
@@ -750,8 +752,6 @@ SSTInfoConfig::SSTInfoConfig(bool suppress_print) : ConfigShared(suppress_print,
 
     addPositionalCallback(std::bind(&SSTInfoConfig::setPositionalArg, this, _1, _2));
 }
-
-SSTInfoConfig::~SSTInfoConfig() {}
 
 std::string
 SSTInfoConfig::getUsagePrelude()

--- a/src/sst/core/sstinfo.h
+++ b/src/sst/core/sstinfo.h
@@ -41,8 +41,8 @@ class SSTInfoConfig : public ConfigShared
 public:
     using FilterMap_t = std::multimap<std::string, std::string>;
     /** Create a new SSTInfo configuration and parse the Command Line. */
-    SSTInfoConfig(bool suppress_print);
-    ~SSTInfoConfig();
+    explicit SSTInfoConfig(bool suppress_print);
+    ~SSTInfoConfig() = default;
 
     /** Return the list of elements to be processed. */
     std::set<std::string> getElementsToProcessArray()
@@ -165,7 +165,7 @@ public:
     /** Create a new SSTInfoElement_LibraryInfo object.
      * @param eli Pointer to an ElementLibraryInfo object.
      */
-    SSTLibraryInfo(const std::string& name) : m_name(name) {}
+    explicit SSTLibraryInfo(const std::string& name) : m_name(name) {}
 
     /** Return the Name of the Library. */
     // std::string getLibraryName() {if (m_eli && m_eli->name) return m_eli->name; else return ""; }

--- a/src/sst/core/statapi/stataccumulator.h
+++ b/src/sst/core/statapi/stataccumulator.h
@@ -67,8 +67,7 @@ public:
 
     AccumulatorStatistic() : Statistic<NumberBase>() {} // For serialization only
 
-    virtual const std::string& getStatTypeName() const { return stat_type_; }
-
+    virtual const std::string& getStatTypeName() const override { return stat_type_; }
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -342,6 +342,8 @@ struct StatisticCollector<T, true>
             addData_impl(data);
         }
     }
+
+    virtual ~StatisticCollector() = default;
 };
 
 template <class... Args>
@@ -367,6 +369,8 @@ struct StatisticCollector<std::tuple<Args...>, false>
     {
         addData_impl(std::make_tuple(std::forward<InArgs>(args)...));
     }
+
+    virtual ~StatisticCollector() = default;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/sst/core/statapi/statengine.h
+++ b/src/sst/core/statapi/statengine.h
@@ -132,6 +132,7 @@ private:
     void handleStatisticEngineStopTimeEvent(SimTime_t timeFactor);
 
     void addStatisticToCompStatMap(StatisticBase* Stat, StatisticFieldInfo::fieldType_t fieldType);
+
     [[noreturn]] void castError(const std::string& type, const std::string& statName, const std::string& fieldName);
 
 private:

--- a/src/sst/core/statapi/statengine.h
+++ b/src/sst/core/statapi/statengine.h
@@ -132,7 +132,7 @@ private:
     void handleStatisticEngineStopTimeEvent(SimTime_t timeFactor);
 
     void addStatisticToCompStatMap(StatisticBase* Stat, StatisticFieldInfo::fieldType_t fieldType);
-    void castError(const std::string& type, const std::string& statName, const std::string& fieldName);
+    [[noreturn]] void castError(const std::string& type, const std::string& statName, const std::string& fieldName);
 
 private:
     using StatArray_t   = std::vector<StatisticBase*>;           /*!< Array of Statistics */

--- a/src/sst/core/statapi/stathistogram.h
+++ b/src/sst/core/statapi/stathistogram.h
@@ -91,7 +91,7 @@ public:
 
     HistogramStatistic() : Statistic<BinDataType>() {} // For serialization ONLY
 
-    virtual const std::string& getStatTypeName() const { return stat_type_; }
+    virtual const std::string& getStatTypeName() const override { return stat_type_; }
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {

--- a/src/sst/core/statapi/statoutput.cc
+++ b/src/sst/core/statapi/statoutput.cc
@@ -31,8 +31,6 @@ StatisticOutput::StatisticOutput(Params& outputParameters)
 SST_ELI_DEFINE_CTOR_EXTERN(StatisticOutput)
 SST_ELI_DEFINE_INFO_EXTERN(StatisticOutput)
 
-StatisticOutput::~StatisticOutput() {}
-
 void
 StatisticOutput::serialize_order(SST::Core::Serialization::serializer& ser)
 {

--- a/src/sst/core/statapi/statoutput.h
+++ b/src/sst/core/statapi/statoutput.h
@@ -60,7 +60,7 @@ public:
     using FieldNameMap_t   = std::unordered_map<std::string, fieldHandle_t>;
 
 public:
-    ~StatisticOutput();
+    ~StatisticOutput() = default;
 
     /** Return the Statistic Output name */
     std::string& getStatisticOutputName() { return m_statOutputName; }
@@ -146,7 +146,7 @@ protected:
     /** Construct a base StatisticOutput
      * @param outputParameters - The parameters for the statistic Output.
      */
-    StatisticOutput(Params& outputParameters);
+    explicit StatisticOutput(Params& outputParameters);
     StatisticOutput() { ; } // For serialization only
     void setStatisticOutputName(const std::string& name) { m_statOutputName = name; }
 
@@ -279,7 +279,7 @@ public:
         /** Construct a base StatisticOutput
          * @param outputParameters - The parameters for the statistic Output.
          */
-        StatisticFieldsOutput(Params& outputParameters);
+        explicit StatisticFieldsOutput(Params& outputParameters);
 
     // For Serialization
     StatisticFieldsOutput() : m_highestFieldHandle(0), m_currentFieldStatName("") {}

--- a/src/sst/core/statapi/statoutputcsv.h
+++ b/src/sst/core/statapi/statoutputcsv.h
@@ -41,7 +41,7 @@ public:
     /** Construct a StatOutputCSV
      * @param outputParameters - Parameters used for this Statistic Output
      */
-    StatisticOutputCSV(Params& outputParameters);
+    explicit StatisticOutputCSV(Params& outputParameters);
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::Statistics::StatisticOutputCSV)
@@ -101,7 +101,7 @@ protected:
 private:
     bool openFile();
     void closeFile();
-    int  print(const char* fmt, ...);
+    int  print(const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 
 private:
 #ifdef HAVE_LIBZ

--- a/src/sst/core/statapi/statoutputhdf5.h
+++ b/src/sst/core/statapi/statoutputhdf5.h
@@ -44,7 +44,7 @@ public:
     /** Construct a StatOutputHDF5
      * @param outputParameters - Parameters used for this Statistic Output
      */
-    StatisticOutputHDF5(Params& outputParameters);
+    explicit StatisticOutputHDF5(Params& outputParameters);
 
     bool acceptsGroups() const override { return true; }
 

--- a/src/sst/core/statapi/statoutputjson.h
+++ b/src/sst/core/statapi/statoutputjson.h
@@ -36,7 +36,7 @@ public:
     /** Construct a StatOutputJSON
      * @param outputParameters - Parameters used for this Statistic Output
      */
-    StatisticOutputJSON(Params& outputParameters);
+    explicit StatisticOutputJSON(Params& outputParameters);
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::Statistics::StatisticOutputJSON)

--- a/src/sst/core/statapi/statoutputtxt.h
+++ b/src/sst/core/statapi/statoutputtxt.h
@@ -27,7 +27,7 @@ public:
     /** Construct a StatOutputTxt
      * @param outputParameters - Parameters used for this Statistic Output
      */
-    StatisticOutputTextBase(Params& outputParameters);
+    explicit StatisticOutputTextBase(Params& outputParameters);
 
     /** This output supports adding statistics during runtime if the header is embedded in the output */
     virtual bool supportsDynamicRegistration() const override { return m_outputInlineHeader; }
@@ -93,7 +93,7 @@ protected:
 private:
     bool openFile();
     void closeFile();
-    int  print(const char* fmt, ...);
+    int  print(const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 
 private:
 #ifdef HAVE_LIBZ
@@ -161,7 +161,7 @@ public:
     /** Construct a StatOutputTxt
      * @param outputParameters - Parameters used for this Statistic Output
      */
-    StatisticOutputTxt(Params& outputParameters);
+    explicit StatisticOutputTxt(Params& outputParameters);
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::Statistics::StatisticOutputTxt)
@@ -232,7 +232,7 @@ public:
     /** Construct a StatOutputTxt
      * @param outputParameters - Parameters used for this Statistic Output
      */
-    StatisticOutputConsole(Params& outputParameters);
+    explicit StatisticOutputConsole(Params& outputParameters);
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::Statistics::StatisticOutputConsole)

--- a/src/sst/core/statapi/statuniquecount.h
+++ b/src/sst/core/statapi/statuniquecount.h
@@ -49,7 +49,7 @@ public:
 
     UniqueCountStatistic() : Statistic<T>() {}
 
-    virtual const std::string& getStatTypeName() const { return stat_type_; }
+    virtual const std::string& getStatTypeName() const override { return stat_type_; }
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {

--- a/src/sst/core/stringize.h
+++ b/src/sst/core/stringize.h
@@ -211,7 +211,7 @@ private:
 
    @return formatted string, potentially truncated at length max_length - 1
  */
-std::string vformat_string(size_t max_length, const char* format, va_list args);
+std::string vformat_string(size_t max_length, const char* format, va_list args) __attribute__((format(printf, 2, 0)));
 
 /**
    Creates a string using a printf like function call.  This function
@@ -227,7 +227,7 @@ std::string vformat_string(size_t max_length, const char* format, va_list args);
 
    @return formatted string
  */
-std::string vformat_string(const char* format, va_list args);
+std::string vformat_string(const char* format, va_list args) __attribute__((format(printf, 1, 0)));
 
 /**
    Creates a string using a printf like function call.  This function

--- a/src/sst/core/subcomponent.cc
+++ b/src/sst/core/subcomponent.cc
@@ -28,7 +28,4 @@ SubComponent::serialize_order(SST::Core::Serialization::serializer& ser)
     BaseComponent::serialize_order(ser);
 }
 
-// For serialization only
-SubComponent::SubComponent() : BaseComponent() {}
-
 } // namespace SST

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -43,7 +43,7 @@ public:
         ELI::ProvidesProfilePoints,
         ELI::ProvidesAttributes)
 
-    SubComponent(ComponentId_t id);
+    explicit SubComponent(ComponentId_t id);
 
     virtual ~SubComponent() {};
 
@@ -58,8 +58,7 @@ public:
     virtual void finish() override {}
 
 protected:
-    // For serialization only
-    SubComponent();
+    SubComponent() = default; // For serialization only
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
 
     friend class Component;

--- a/src/sst/core/sync/rankSyncParallelSkip.h
+++ b/src/sst/core/sync/rankSyncParallelSkip.h
@@ -28,7 +28,7 @@ class RankSyncParallelSkip : public RankSync
 {
 public:
     /** Create a new Sync object which fires with a specified period */
-    RankSyncParallelSkip(RankInfo num_ranks);
+    explicit RankSyncParallelSkip(RankInfo num_ranks);
     RankSyncParallelSkip() {} // For serialization
     virtual ~RankSyncParallelSkip();
 

--- a/src/sst/core/sync/rankSyncSerialSkip.h
+++ b/src/sst/core/sync/rankSyncSerialSkip.h
@@ -27,7 +27,7 @@ class RankSyncSerialSkip : public RankSync
 {
 public:
     /** Create a new Sync object which fires with a specified period */
-    RankSyncSerialSkip(RankInfo num_ranks);
+    explicit RankSyncSerialSkip(RankInfo num_ranks);
     RankSyncSerialSkip() {} // For serialization
     virtual ~RankSyncSerialSkip();
 

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -321,8 +321,6 @@ SyncManager::SyncManager()
     sim_ = Simulation_impl::getSimulation();
 }
 
-SyncManager::~SyncManager() {}
-
 /** Register a Link which this Sync Object is responsible for */
 ActivityQueue*
 SyncManager::registerLink(const RankInfo& to_rank, const RankInfo& from_rank, const std::string& name, Link* link)

--- a/src/sst/core/sync/syncManager.h
+++ b/src/sst/core/sync/syncManager.h
@@ -134,7 +134,7 @@ public:
         const RankInfo& rank, const RankInfo& num_ranks, SimTime_t min_part,
         const std::vector<SimTime_t>& interThreadLatencies, RealTimeManager* real_time);
     SyncManager(); // For serialization only
-    virtual ~SyncManager();
+    virtual ~SyncManager() = default;
 
     /** Register a Link which this Sync Object is responsible for */
     ActivityQueue*

--- a/src/sst/core/sync/syncQueue.cc
+++ b/src/sst/core/sync/syncQueue.cc
@@ -34,8 +34,6 @@ using namespace Core::Serialization;
 
 RankSyncQueue::RankSyncQueue(RankInfo to_rank) : SyncQueue(to_rank), buffer(nullptr), buf_size(0) {}
 
-RankSyncQueue::~RankSyncQueue() {}
-
 bool
 RankSyncQueue::empty()
 {

--- a/src/sst/core/sync/syncQueue.h
+++ b/src/sst/core/sync/syncQueue.h
@@ -57,8 +57,8 @@ public:
         uint32_t buffer_size;
     };
 
-    RankSyncQueue(RankInfo to_rank);
-    ~RankSyncQueue();
+    explicit RankSyncQueue(RankInfo to_rank);
+    ~RankSyncQueue() = default;
 
     bool      empty() override;
     int       size() override;

--- a/src/sst/core/testElements/coreTest_Checkpoint.cc
+++ b/src/sst/core/testElements/coreTest_Checkpoint.cc
@@ -97,8 +97,6 @@ coreTestCheckpoint::coreTestCheckpoint(ComponentId_t id, Params& params) : Compo
     stat_null       = registerStatistic<uint32_t>("nullstat");
 }
 
-coreTestCheckpoint::~coreTestCheckpoint() {}
-
 void
 coreTestCheckpoint::init(unsigned UNUSED(phase))
 {

--- a/src/sst/core/testElements/coreTest_Checkpoint.h
+++ b/src/sst/core/testElements/coreTest_Checkpoint.h
@@ -102,7 +102,7 @@ public:
     )
 
     coreTestCheckpoint(ComponentId_t id, SST::Params& params);
-    virtual ~coreTestCheckpoint();
+    virtual ~coreTestCheckpoint() = default;
 
     void init(unsigned phase) override;
 

--- a/src/sst/core/testElements/coreTest_ClockerComponent.h
+++ b/src/sst/core/testElements/coreTest_ClockerComponent.h
@@ -47,8 +47,8 @@ public:
     )
 
     coreTestClockerComponent(SST::ComponentId_t id, SST::Params& params);
-    void setup() {}
-    void finish() {}
+    void setup() override {}
+    void finish() override {}
 
 private:
     coreTestClockerComponent();                                                    // for serialization only

--- a/src/sst/core/testElements/coreTest_Component.cc
+++ b/src/sst/core/testElements/coreTest_Component.cc
@@ -73,11 +73,6 @@ coreTestComponent::~coreTestComponent()
     delete rng;
 }
 
-coreTestComponent::coreTestComponent() : coreTestComponentBase2()
-{
-    // for serialization only
-}
-
 // incoming events are scanned and deleted
 void
 coreTestComponent::handleEvent(Event* ev)

--- a/src/sst/core/testElements/coreTest_Component.h
+++ b/src/sst/core/testElements/coreTest_Component.h
@@ -69,7 +69,7 @@ public:
         {"Slink", "Link to the coreTestComponent to the South", { "coreTestComponent.coreTestComponentEvent", "" } }
     )
 
-    coreTestComponentBase2(ComponentId_t id) : coreTestComponentBase(id) {}
+    explicit coreTestComponentBase2(ComponentId_t id) : coreTestComponentBase(id) {}
     ~coreTestComponentBase2() {}
 
     coreTestComponentBase2() : coreTestComponentBase() {}
@@ -120,7 +120,7 @@ public:
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::CoreTestComponent::coreTestComponent)
-    coreTestComponent(); // for serialization only
+    coreTestComponent() = default; // for serialization only
 
 private:
     coreTestComponent(const coreTestComponent&) = delete;            // do not implement

--- a/src/sst/core/testElements/coreTest_DistribComponent.h
+++ b/src/sst/core/testElements/coreTest_DistribComponent.h
@@ -57,8 +57,8 @@ public:
     )
 
     coreTestDistribComponent(SST::ComponentId_t id, SST::Params& params);
-    void finish();
-    void setup() {}
+    void finish() override;
+    void setup() override {}
 
 private:
     coreTestDistribComponent();                                                    // for serialization only

--- a/src/sst/core/testElements/coreTest_Links.cc
+++ b/src/sst/core/testElements/coreTest_Links.cc
@@ -55,8 +55,6 @@ coreTestLinks::coreTestLinks(ComponentId_t id, Params& params) : Component(id), 
     registerClock("100 MHz", new Clock::Handler<coreTestLinks>(this, &coreTestLinks::clockTic));
 }
 
-coreTestLinks::~coreTestLinks() {}
-
 // incoming events are scanned and deleted
 void
 coreTestLinks::handleEvent(Event* ev, std::string from)

--- a/src/sst/core/testElements/coreTest_Links.h
+++ b/src/sst/core/testElements/coreTest_Links.h
@@ -51,10 +51,10 @@ public:
     )
 
     coreTestLinks(SST::ComponentId_t id, SST::Params& params);
-    ~coreTestLinks();
+    ~coreTestLinks() = default;
 
-    void setup() {}
-    void finish() {}
+    void setup() override {}
+    void finish() override {}
 
 private:
     int my_id;

--- a/src/sst/core/testElements/coreTest_MessageGeneratorComponent.h
+++ b/src/sst/core/testElements/coreTest_MessageGeneratorComponent.h
@@ -50,8 +50,8 @@ public:
     )
 
     coreTestMessageGeneratorComponent(SST::ComponentId_t id, SST::Params& params);
-    void setup() {}
-    void finish()
+    void setup() override {}
+    void finish() override
     {
         fprintf(stdout, "Component completed at: %" PRIu64 " milliseconds\n", (uint64_t)getCurrentSimTimeMilli());
     }

--- a/src/sst/core/testElements/coreTest_Module.cc
+++ b/src/sst/core/testElements/coreTest_Module.cc
@@ -126,10 +126,6 @@ void
 coreTestModuleLoader::finish()
 {}
 
-coreTestModuleLoader::coreTestModuleLoader() : Component()
-{ /* For serialization ONLY*/
-}
-
 bool coreTestModuleLoader::tick(SST::Cycle_t)
 {
     uint32_t next = rng_module->getNext();

--- a/src/sst/core/testElements/coreTest_Module.h
+++ b/src/sst/core/testElements/coreTest_Module.h
@@ -41,7 +41,7 @@ public:
         { "seed",    "The seed to use for the random number generator.", "11" },
     )
 
-    CoreTestModuleExample(SST::Params& params);
+    explicit CoreTestModuleExample(SST::Params& params);
     ~CoreTestModuleExample();
     std::string getRNGType() const;
     uint32_t    getNext();
@@ -98,7 +98,7 @@ public:
     ImplementSerializable(SST::CoreTestModule::coreTestModuleLoader)
 
 private:
-    coreTestModuleLoader(); // for serialization only
+    coreTestModuleLoader() = default; // for serialization only
 
     virtual bool tick(SST::Cycle_t);
 

--- a/src/sst/core/testElements/coreTest_ParamComponent.h
+++ b/src/sst/core/testElements/coreTest_ParamComponent.h
@@ -58,8 +58,8 @@ public:
 
     coreTestParamComponent(SST::ComponentId_t id, SST::Params& params);
     ~coreTestParamComponent() {}
-    void setup() {}
-    void finish() {}
+    void setup() override {}
+    void finish() override {}
 
 private:
     coreTestParamComponent();                                                  // for serialization only

--- a/src/sst/core/testElements/coreTest_PerfComponent.h
+++ b/src/sst/core/testElements/coreTest_PerfComponent.h
@@ -39,7 +39,7 @@ public:
         {"Nlink", "Link to the coreTestComponent to the North", { "coreTestComponent.coreTestComponentEvent", "" } }
     )
 
-    coreTestPerfComponentBase(ComponentId_t id) : SST::Component(id) {}
+    explicit coreTestPerfComponentBase(ComponentId_t id) : SST::Component(id) {}
     ~coreTestPerfComponentBase() {}
 };
 
@@ -61,7 +61,7 @@ public:
         {"Slink", "Link to the coreTestComponent to the South", { "coreTestComponent.coreTestComponentEvent", "" } }
     )
 
-    coreTestPerfComponentBase2(ComponentId_t id) : coreTestPerfComponentBase(id) {}
+    explicit coreTestPerfComponentBase2(ComponentId_t id) : coreTestPerfComponentBase(id) {}
     ~coreTestPerfComponentBase2() {}
 };
 
@@ -99,8 +99,8 @@ public:
     coreTestPerfComponent(SST::ComponentId_t id, SST::Params& params);
     ~coreTestPerfComponent();
 
-    void setup() {}
-    void finish() { printf("Perf Test Component Finished.\n"); }
+    void setup() override {}
+    void finish() override { printf("Perf Test Component Finished.\n"); }
 
 private:
     coreTestPerfComponent();                                                 // for serialization only

--- a/src/sst/core/testElements/coreTest_PortModule.h
+++ b/src/sst/core/testElements/coreTest_PortModule.h
@@ -68,7 +68,7 @@ public:
         { "install_on_send",  "Controls whether the PortModule is installed on the send or receive side.  Set to true to register on send and false to register on recieve.", "false" },
     )
 
-    TestPortModule(Params& params);
+    explicit TestPortModule(Params& params);
 
     // For serialization only
     TestPortModule() = default;

--- a/src/sst/core/testElements/coreTest_RNGComponent.h
+++ b/src/sst/core/testElements/coreTest_RNGComponent.h
@@ -56,8 +56,8 @@ public:
 
     coreTestRNGComponent(SST::ComponentId_t id, SST::Params& params);
     ~coreTestRNGComponent();
-    void setup() {}
-    void finish() {}
+    void setup() override {}
+    void finish() override {}
 
 private:
     coreTestRNGComponent();                                                // for serialization only

--- a/src/sst/core/testElements/coreTest_StatisticsComponent.h
+++ b/src/sst/core/testElements/coreTest_StatisticsComponent.h
@@ -60,8 +60,8 @@ public:
     )
 
     StatisticsComponentInt(ComponentId_t id, Params& params);
-    void setup() {}
-    void finish() {}
+    void setup() override {}
+    void finish() override {}
 
 private:
     StatisticsComponentInt();
@@ -121,8 +121,8 @@ public:
     )
 
     StatisticsComponentFloat(ComponentId_t id, Params& params);
-    void setup() {}
-    void finish() {}
+    void setup() override {}
+    void finish() override {}
 
 private:
     StatisticsComponentFloat();

--- a/src/sst/core/testElements/message_mesh/enclosingComponent.h
+++ b/src/sst/core/testElements/message_mesh/enclosingComponent.h
@@ -69,7 +69,9 @@ protected:
 class RouteInterface : public SST::SubComponent
 {
 public:
-    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::CoreTest::MessageMesh::RouteInterface, const std::vector<PortInterface*>&, int)
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::CoreTest::MessageMesh::RouteInterface,
+                                      const std::vector<PortInterface*>&,
+                                      int)
 
     RouteInterface(ComponentId_t id) : SubComponent(id) {}
     virtual ~RouteInterface() {}
@@ -107,8 +109,8 @@ public:
 
     EnclosingComponent(ComponentId_t id, Params& params);
 
-    void setup();
-    void finish();
+    void setup() override;
+    void finish() override;
 
 private:
     void handleEvent(SST::Event* ev, int port);
@@ -188,7 +190,7 @@ public:
     MessagePort(ComponentId_t id, Params& params);
     ~MessagePort() {}
 
-    void send(MessageEvent* ev);
+    void send(MessageEvent* ev) override;
     void handleEvent(Event* ev);
 
 private:

--- a/src/sst/core/timeConverter.h
+++ b/src/sst/core/timeConverter.h
@@ -59,7 +59,7 @@ private:
     */
     SimTime_t factor;
 
-    TimeConverter(SimTime_t fact) { factor = fact; }
+    explicit TimeConverter(SimTime_t fact) { factor = fact; }
 
     ~TimeConverter() {}
 

--- a/src/sst/core/uninitializedQueue.cc
+++ b/src/sst/core/uninitializedQueue.cc
@@ -21,10 +21,6 @@ namespace SST {
 
 UninitializedQueue::UninitializedQueue(const std::string& message) : ActivityQueue(), message(message) {}
 
-UninitializedQueue::UninitializedQueue() : ActivityQueue() {}
-
-UninitializedQueue::~UninitializedQueue() {}
-
 bool
 UninitializedQueue::empty()
 {

--- a/src/sst/core/uninitializedQueue.h
+++ b/src/sst/core/uninitializedQueue.h
@@ -26,9 +26,9 @@ public:
     /** Create a new Queue
      * @param message - Message to print when something attempts to use this Queue
      */
-    UninitializedQueue(const std::string& message);
-    UninitializedQueue(); // Only used for serialization
-    ~UninitializedQueue();
+    explicit UninitializedQueue(const std::string& message);
+    UninitializedQueue()  = default; // Only used for serialization
+    ~UninitializedQueue() = default;
 
     bool      empty() override;
     int       size() override;

--- a/src/sst/core/unitAlgebra.cc
+++ b/src/sst/core/unitAlgebra.cc
@@ -515,8 +515,6 @@ UnitAlgebra::hasUnits(const std::string& u) const
     return unit == check_units;
 }
 
-UnitAlgebra::~UnitAlgebra() {}
-
 int64_t
 UnitAlgebra::getRoundedValue() const
 {

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -131,7 +131,7 @@ public:
      @endcode
      */
     UnitAlgebra(const std::string& val);
-    virtual ~UnitAlgebra();
+    virtual ~UnitAlgebra() = default;
 
     /** Copy constructor */
     UnitAlgebra(const UnitAlgebra&) = default;


### PR DESCRIPTION
Add `override` for virtual functions which are overriden (as warned by `-Wsuggest-override`).

For default constructors with all base classes and class members default-initialized `()` and an empty constructor body, and for destructors with an empty body, move the definition from the `.cc` file to the `.h` file with a `= default` definition, except for one case in which a comment specifically wants it to not be inlined for some reason..

Add `explicit` to constructors with a single parameter which should not perform implicit conversions. I built sst-core and sst-elements and got no errors, but if some of the constructors need to perform implicit conversions, then `explicit` can be removed.

Add `= delete` declarations for copy constructors and copy assignment operators for classes which do not need them (or which had marked them as `private`). Not all classes which can have deleted copy constructors and assignment operators were modified by this PR, but many were.

Add virtual destructors `virtual ~func() = default;` or `~func() override = default;` to classes with virtual functions and no declared destructor.

Add `__attribute__((format(...)))` to `printf`-style functions which take format strings. For non-static member functions, the `this` pointer is implicitly the first parameter, so the 2nd and 3rd arguments of the `format()` attribute are increased by one.

Add `[[noreturn]]` to non-virtual functions which do not return, such as calling `Output::fatal()`. (If the function is virtual, then `[[noreturn]]` has little benefit unless the function is marked as `final`, which is dangerous to do because SST Elements and other client code might override SST Core classes, and without a careful analysis of which functions and classes are really `final` in SST Core, it is too risky to add `final` to functions or classes, so `[[noreturn]]` is left off of virtual functions.)

Use `std::make_unique()` for variable-length arrays instead of `array[N]` when `N` is not constant. VLAs are non-standard, and allocate on the stack instead of the heap, which increases the chance of stack overflows.

Replace `volatile` counters with `std::atomic` types, except in one case where the assembly code is listed and analyzed and `volatile` is used for a timing delay. `volatile` is [deprecated in C++20](https://www.youtube.com/watch?v=KJW_DLaVXIY), and most uses of it are replaceable with atomic variables. 

Reformat `SST_ELI_REGISTER_SUBCOMPONENT_API()` macro calls to have one argument per line.

Reformat long `TimeVortex` string messages to be split across lines.

Reformat `sst-config` `print_usage()` to use one call to `fputs()` instead of dozens of consecutive calls to `fprintf()`.

Rename `sst-info`'s `dprintf()` to `sst_dprintf()` since `dprintf()` is a POSIX C function which prints to an integer file descriptor.

Could have been done, but wasn't:

Default constructors and destructors defined with empty bodies in the header could be replaced with `= default` which is more specific than `{}` and could conceivably be more optimized. To minimize diffs, these `{}` default constructors and destructors in headers were left alone. Only if they were newly added, had `override` added, or moved from `.cc` to `.h` files, was `= default` used instead of `{}`.

`virtual` could be removed wherever `override` was used. `override` implies `virtual`, but it was felt that leaving `virtual`, which is at the beginning, would make it more readable. If `virtual` existed before, it was not removed simply because `override` was added, but if neither `virtual` nor `override` existed and `override` applied because the function was `virtual` in a base class, then only `override` was added.