### PR TITLE
Reformat SST_ELI_REGISTER_SUBCOMPONENT_API() macro calls

### DIFF
--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -38,7 +38,8 @@ namespace SST::Interfaces {
 class SimpleNetwork : public SubComponent
 {
 public:
-    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork, int)
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork,
+                                      int)
 
     /** All Addresses can be 64-bit */
     using nid_t = int64_t;
@@ -174,7 +175,8 @@ public:
     {
 
     public:
-        SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork::NetworkInspector,std::string)
+        SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork::NetworkInspector,
+                                          std::string)
 
         NetworkInspector(ComponentId_t id) : SubComponent(id) {}
 

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -107,7 +107,9 @@ public:
     class RequestConverter; // Convert request to SST::Event* according to type
     class RequestHandler;   // Handle a request according to type
 
-    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::StandardMem,TimeConverter*,HandlerBase*)
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::StandardMem,
+                                      TimeConverter*,
+                                      HandlerBase*)
 
     /** All Addresses can be 64-bit */
     using Addr = uint64_t;

--- a/src/sst/core/testElements/message_mesh/enclosingComponent.h
+++ b/src/sst/core/testElements/message_mesh/enclosingComponent.h
@@ -69,7 +69,9 @@ protected:
 class RouteInterface : public SST::SubComponent
 {
 public:
-    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::CoreTest::MessageMesh::RouteInterface, const std::vector<PortInterface*>&, int)
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::CoreTest::MessageMesh::RouteInterface,
+                                      const std::vector<PortInterface*>&,
+                                      int)
 
     RouteInterface(ComponentId_t id) : SubComponent(id) {}
     virtual ~RouteInterface() {}


### PR DESCRIPTION
Reformat `SST_ELI_REGISTER_SUBCOMPONENT_API()` macro calls to have one argument per line.