### PR TITLE
Reformat long TimeVortex string messages to be split across lines.

### DIFF
--- a/src/sst/core/impl/timevortex/timeVortexBinnedMap.cc
+++ b/src/sst/core/impl/timevortex/timeVortexBinnedMap.cc
@@ -194,8 +194,9 @@ public:
         "sst",
         "timevortex.map.binned.ts",
         SST_ELI_ELEMENT_VERSION(1,0,0),
-        "[EXPERIMENTAL] Thread safe verion of TimeVortex based on std::map with events binned into time buckets.  Do not reference this element directly, just specify sst.timevortex.map.binned and this version will be selected when it is needed based on other parameters.")
-
+        "[EXPERIMENTAL] Thread-safe verion of TimeVortex based on std::map with events binned into time buckets."
+        "  Do not reference this element directly; just specify sst.timevortex.map.binned and this version will"
+        " be selected when it is needed based on other parameters.")
 
     TimeVortexBinnedMap_ts(Params& params) : TimeVortexBinnedMapBase<true>(params) {}
     SST_ELI_EXPORT(TimeVortexBinnedMap_ts)

--- a/src/sst/core/impl/timevortex/timeVortexPQ.cc
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.cc
@@ -166,9 +166,10 @@ public:
         TimeVortexPQ_ts,
         "sst",
         "timevortex.priority_queue.ts",
-        SST_ELI_ELEMENT_VERSION(1,0,0),
-        "Thread safe verion of TimeVortex based on std::priority_queue.  Do not reference this element directly, just specify sst.timevortex.priority_queue and this version will be selected when it is needed based on other parameters.")
-
+        SST_ELI_ELEMENT_VERSION(1, 0, 0),
+        "Thread-safe verion of TimeVortex based on std::priority_queue.  Do not reference this element directly; just"
+        " specify sst.timevortex.priority_queue and this version will be selected when it is needed based on other"
+        " parameters.")
 
     TimeVortexPQ_ts(Params& params) : TimeVortexPQBase<true>(params) {}
     TimeVortexPQ_ts() : TimeVortexPQBase<true>() {} // For serialization only


### PR DESCRIPTION
Reformat long TimeVortex string messages to be split across lines.