### PR TITLE
Add "explicit" to constructors with a single parameter which should not perform implicit conversions

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@ f150d6f7db2d71f4a77720ee7e7a7385a57bf540
 
 # Initial cmake-format fixes
 1c149870b806f5412c34c918cea96caa14720f3c
+
+# Add explicit to single-parameter constructors which should not perform implicit conversion
+1336f63961e14a8bb50b203f9c35a2472f2db7a8

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,5 +4,5 @@ f150d6f7db2d71f4a77720ee7e7a7385a57bf540
 # Initial cmake-format fixes
 1c149870b806f5412c34c918cea96caa14720f3c
 
-# Add explicit to single-parameter constructors which should not perform implicit conversion
-1336f63961e14a8bb50b203f9c35a2472f2db7a8
+# Add explicit to single-parameter constructors which should not perform implicit conversions
+03ebe85afb00f521ca6f8822e48a4a17711f96dd

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -73,7 +73,7 @@ protected:
     BaseComponent() = default; // For serialization only
 
 public:
-    BaseComponent(ComponentId_t id);
+    explicit BaseComponent(ComponentId_t id);
     virtual ~BaseComponent();
 
     BaseComponent(const BaseComponent&) = delete;

--- a/src/sst/core/cfgoutput/dotConfigOutput.h
+++ b/src/sst/core/cfgoutput/dotConfigOutput.h
@@ -21,7 +21,7 @@ namespace SST::Core {
 class DotConfigGraphOutput : public ConfigGraphOutput
 {
 public:
-    DotConfigGraphOutput(const char* path);
+    explicit DotConfigGraphOutput(const char* path);
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 
 protected:

--- a/src/sst/core/cfgoutput/jsonConfigOutput.h
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.h
@@ -22,7 +22,7 @@ class JSONConfigGraphOutput : public ConfigGraphOutput
 {
 
 public:
-    JSONConfigGraphOutput(const char* path);
+    explicit JSONConfigGraphOutput(const char* path);
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 
 private:

--- a/src/sst/core/cfgoutput/pythonConfigOutput.h
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.h
@@ -23,7 +23,7 @@ namespace SST::Core {
 class PythonConfigGraphOutput : public ConfigGraphOutput
 {
 public:
-    PythonConfigGraphOutput(const char* path);
+    explicit PythonConfigGraphOutput(const char* path);
 
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 

--- a/src/sst/core/cfgoutput/xmlConfigOutput.h
+++ b/src/sst/core/cfgoutput/xmlConfigOutput.h
@@ -21,7 +21,7 @@ namespace SST::Core {
 class XMLConfigGraphOutput : public ConfigGraphOutput
 {
 public:
-    XMLConfigGraphOutput(const char* path);
+    explicit XMLConfigGraphOutput(const char* path);
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 
 protected:

--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -47,7 +47,7 @@ public:
     /** Constructor. Generally only called by the factory class.
         @param id Unique component ID
     */
-    Component(ComponentId_t id);
+    explicit Component(ComponentId_t id);
     virtual ~Component() override = default;
 
     /** Register as a primary component, which allows the component to

--- a/src/sst/core/componentExtension.h
+++ b/src/sst/core/componentExtension.h
@@ -29,7 +29,7 @@ class ComponentExtension : public BaseComponent
 {
 
 public:
-    ComponentExtension(ComponentId_t id);
+    explicit ComponentExtension(ComponentId_t id);
 
     virtual ~ComponentExtension() override = default;
 

--- a/src/sst/core/configBase.h
+++ b/src/sst/core/configBase.h
@@ -112,7 +112,7 @@ protected:
        ConfigBase constructor.  Meant to only be created by main
        function
      */
-    ConfigBase(bool suppress_print) : suppress_print_(suppress_print) {}
+    explicit ConfigBase(bool suppress_print) : suppress_print_(suppress_print) {}
 
     /**
        Default constructor used for serialization.  After

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -100,7 +100,7 @@ public:
 
 private:
     friend class ConfigGraph;
-    ConfigLink(LinkId_t id) : id(id), no_cut(false)
+    explicit ConfigLink(LinkId_t id) : id(id), no_cut(false)
     {
         order = 0;
 
@@ -170,7 +170,7 @@ public:
     size_t                        outputID;
     UnitAlgebra                   outputFrequency;
 
-    ConfigStatGroup(const std::string& name) : name(name), outputID(0) {}
+    explicit ConfigStatGroup(const std::string& name) : name(name), outputID(0) {}
     ConfigStatGroup() {} /* Do not use */
 
     bool addComponent(ComponentId_t id);
@@ -203,7 +203,7 @@ public:
     std::string type;
     Params      params;
 
-    ConfigStatOutput(const std::string& type) : type(type) {}
+    explicit ConfigStatOutput(const std::string& type) : type(type) {}
     ConfigStatOutput() {}
 
     void addParameter(const std::string& key, const std::string& val) { params.insert(key, val); }
@@ -597,14 +597,14 @@ public:
 
     ComponentIdMap_t group;
 
-    PartitionComponent(const ConfigComponent* cc)
+    explicit PartitionComponent(const ConfigComponent* cc)
     {
         id     = cc->id;
         weight = cc->weight;
         rank   = cc->rank;
     }
 
-    PartitionComponent(LinkId_t id) : id(id), weight(0), rank(RankInfo(RankInfo::UNASSIGNED, 0)) {}
+    explicit PartitionComponent(LinkId_t id) : id(id), weight(0), rank(RankInfo(RankInfo::UNASSIGNED, 0)) {}
 
     // PartitionComponent(ComponentId_t id, ConfigGraph* graph, const ComponentIdMap_t& group);
     void print(std::ostream& os, const PartitionGraph* graph) const;

--- a/src/sst/core/configGraphOutput.h
+++ b/src/sst/core/configGraphOutput.h
@@ -31,7 +31,7 @@ namespace Core {
 class ConfigGraphOutputException : public std::exception
 {
 public:
-    ConfigGraphOutputException(const char* msg)
+    explicit ConfigGraphOutputException(const char* msg)
     {
         exMsg = (char*)malloc(sizeof(char) * (strlen(msg) + 1));
         std::strcpy(exMsg, msg);
@@ -55,7 +55,7 @@ protected:
 class ConfigGraphOutput
 {
 public:
-    ConfigGraphOutput(const char* path);
+    explicit ConfigGraphOutput(const char* path);
 
     virtual ~ConfigGraphOutput() { fclose(outputFile); }
 

--- a/src/sst/core/decimal_fixedpoint.h
+++ b/src/sst/core/decimal_fixedpoint.h
@@ -209,7 +209,7 @@ public:
        the c++ double precision strings.  For example 1.234, -1.234,
        0.234, 1.234e14, 1.234e14, etc.
      */
-    decimal_fixedpoint(const std::string& init) { from_string(init); }
+    explicit decimal_fixedpoint(const std::string& init) { from_string(init); }
 
     /**
        Build a decimal_fixedpoint using a 64-bit unsigned number.

--- a/src/sst/core/elemLoader.h
+++ b/src/sst/core/elemLoader.h
@@ -24,7 +24,7 @@ class ElemLoader
 {
 public:
     /** Create a new ElementLoader with a given searchpath of directories */
-    ElemLoader(const std::string& searchPaths);
+    explicit ElemLoader(const std::string& searchPaths);
     ~ElemLoader();
 
     /** Attempt to load a library

--- a/src/sst/core/eli/attributeInfo.h
+++ b/src/sst/core/eli/attributeInfo.h
@@ -62,7 +62,7 @@ public:
 
 protected:
     template <class T>
-    ProvidesAttributes(T* UNUSED(t)) : attributes_(GetAttributes<T>::get())
+    explicit ProvidesAttributes(T* UNUSED(t)) : attributes_(GetAttributes<T>::get())
     {}
 
 private:

--- a/src/sst/core/eli/categoryInfo.h
+++ b/src/sst/core/eli/categoryInfo.h
@@ -50,7 +50,7 @@ public:
 
 protected:
     template <class T>
-    ProvidesCategory(T* UNUSED(t)) : cat_(T::ELI_getCategory())
+    explicit ProvidesCategory(T* UNUSED(t)) : cat_(T::ELI_getCategory())
     {}
 
 private:

--- a/src/sst/core/eli/defaultInfo.h
+++ b/src/sst/core/eli/defaultInfo.h
@@ -58,7 +58,7 @@ public:
 
 protected:
     template <class T>
-    ProvidesDefaultInfo(T* t) : ProvidesDefaultInfo(T::ELI_getLibrary(), T::ELI_getName(), t)
+    explicit ProvidesDefaultInfo(T* t) : ProvidesDefaultInfo(T::ELI_getLibrary(), T::ELI_getName(), t)
     {}
 
 private:

--- a/src/sst/core/eli/elementbuilder.h
+++ b/src/sst/core/eli/elementbuilder.h
@@ -37,7 +37,7 @@ class BuilderLibrary
 public:
     using BaseBuilder = Builder<Base, CtorArgs...>;
 
-    BuilderLibrary(const std::string& name) : name_(name) {}
+    explicit BuilderLibrary(const std::string& name) : name_(name) {}
 
     BaseBuilder* getBuilder(const std::string& name) { return factories_[name]; }
 

--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -114,7 +114,7 @@ class BuilderInfoImpl<void>
 {
 protected:
     template <class... Args>
-    BuilderInfoImpl(Args&&... UNUSED(args))
+    explicit BuilderInfoImpl(Args&&... UNUSED(args))
     {}
 
     template <class XMLNode>
@@ -141,7 +141,7 @@ class InfoLibrary
 public:
     using BaseInfo = typename Base::BuilderInfo;
 
-    InfoLibrary(const std::string& name) : name_(name) {}
+    explicit InfoLibrary(const std::string& name) : name_(name) {}
 
     BaseInfo* getInfo(const std::string& name)
     {

--- a/src/sst/core/eli/interfaceInfo.h
+++ b/src/sst/core/eli/interfaceInfo.h
@@ -32,7 +32,7 @@ public:
 
 protected:
     template <class T>
-    ProvidesInterface(T* UNUSED(t)) : iface_(T::ELI_getInterface())
+    explicit ProvidesInterface(T* UNUSED(t)) : iface_(T::ELI_getInterface())
     {}
 
 private:

--- a/src/sst/core/eli/paramsInfo.h
+++ b/src/sst/core/eli/paramsInfo.h
@@ -64,7 +64,7 @@ public:
 
 protected:
     template <class T>
-    ProvidesParams(T* UNUSED(t)) : params_(GetParams<T>::get())
+    explicit ProvidesParams(T* UNUSED(t)) : params_(GetParams<T>::get())
     {
         init();
     }

--- a/src/sst/core/eli/portsInfo.h
+++ b/src/sst/core/eli/portsInfo.h
@@ -60,7 +60,7 @@ public:
 
 protected:
     template <class T>
-    ProvidesPorts(T* UNUSED(t)) : ports_(InfoPorts<T>::get())
+    explicit ProvidesPorts(T* UNUSED(t)) : ports_(InfoPorts<T>::get())
     {
         init();
     }

--- a/src/sst/core/eli/profilePointInfo.h
+++ b/src/sst/core/eli/profilePointInfo.h
@@ -59,7 +59,7 @@ public:
 
 protected:
     template <class T>
-    ProvidesProfilePoints(T* UNUSED(t)) : points_(InfoProfilePoints<T>::get())
+    explicit ProvidesProfilePoints(T* UNUSED(t)) : points_(InfoProfilePoints<T>::get())
     {}
 
 private:

--- a/src/sst/core/eli/simpleInfo.h
+++ b/src/sst/core/eli/simpleInfo.h
@@ -89,7 +89,7 @@ public:
 
 protected:
     template <class T>
-    ProvidesSimpleInfo(T* UNUSED(t)) : info_(ELI_templatedGetSimpleInfo<T, num, InfoType>())
+    explicit ProvidesSimpleInfo(T* UNUSED(t)) : info_(ELI_templatedGetSimpleInfo<T, num, InfoType>())
     {}
 
 private:

--- a/src/sst/core/eli/statsInfo.h
+++ b/src/sst/core/eli/statsInfo.h
@@ -50,7 +50,7 @@ private:
 
 protected:
     template <class T>
-    ProvidesStats(T* UNUSED(t)) : stats_(InfoStats<T>::get())
+    explicit ProvidesStats(T* UNUSED(t)) : stats_(InfoStats<T>::get())
     {
         init();
     }

--- a/src/sst/core/eli/subcompSlotInfo.h
+++ b/src/sst/core/eli/subcompSlotInfo.h
@@ -59,7 +59,7 @@ public:
 
 protected:
     template <class T>
-    ProvidesSubComponentSlots(T* UNUSED(t)) : slots_(InfoSubs<T>::get())
+    explicit ProvidesSubComponentSlots(T* UNUSED(t)) : slots_(InfoSubs<T>::get())
     {}
 
 private:

--- a/src/sst/core/env/envconfig.h
+++ b/src/sst/core/env/envconfig.h
@@ -60,7 +60,7 @@ class EnvironmentConfigGroup
 {
 
 public:
-    EnvironmentConfigGroup(const std::string& name) : groupName(name) {}
+    explicit EnvironmentConfigGroup(const std::string& name) : groupName(name) {}
     std::string           getName() const;
     std::set<std::string> getKeys() const;
     std::string           getValue(const std::string& key);

--- a/src/sst/core/factory.h
+++ b/src/sst/core/factory.h
@@ -311,7 +311,7 @@ private:
 
     [[noreturn]] void notFound(const std::string& baseName, const std::string& type, const std::string& errorMsg);
 
-    Factory(const std::string& searchPaths);
+    explicit Factory(const std::string& searchPaths);
     ~Factory();
 
     Factory(const Factory&) = delete;            // Don't Implement

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -40,7 +40,7 @@ public:
     /**
        Creates a new self partition scheme.
     */
-    SimpleDebugger(Params& params);
+    explicit SimpleDebugger(Params& params);
 
     void execute(const std::string& msg) override;
 

--- a/src/sst/core/impl/partitioners/selfpart.h
+++ b/src/sst/core/impl/partitioners/selfpart.h
@@ -36,7 +36,7 @@ public:
     /**
        Creates a new self partition scheme.
     */
-    SSTSelfPartition(RankInfo UNUSED(total_ranks), RankInfo UNUSED(my_rank), int UNUSED(verbosity)) {}
+    explicit SSTSelfPartition(RankInfo UNUSED(total_ranks), RankInfo UNUSED(my_rank), int UNUSED(verbosity)) {}
 
     /**
        Performs a partition of an SST simulation configuration

--- a/src/sst/core/impl/portmodules/randomDrop.h
+++ b/src/sst/core/impl/portmodules/randomDrop.h
@@ -39,7 +39,7 @@ public:
         { "verbose", "Debugging output", "false"}
     )
 
-    RandomDrop(Params& params);
+    explicit RandomDrop(Params& params);
 
     // For serialization only
     RandomDrop() = default;

--- a/src/sst/core/impl/timevortex/timeVortexBinnedMap.cc
+++ b/src/sst/core/impl/timevortex/timeVortexBinnedMap.cc
@@ -181,7 +181,7 @@ public:
         "[EXPERIMENTAL] TimeVortex based on std::map with events binned in time buckets.")
 
 
-    TimeVortexBinnedMap(Params& params) : TimeVortexBinnedMapBase<false>(params) {}
+    explicit TimeVortexBinnedMap(Params& params) : TimeVortexBinnedMapBase<false>(params) {}
     SST_ELI_EXPORT(TimeVortexBinnedMap)
 };
 
@@ -198,7 +198,7 @@ public:
         "  Do not reference this element directly; just specify sst.timevortex.map.binned and this version will"
         " be selected when it is needed based on other parameters.")
 
-    TimeVortexBinnedMap_ts(Params& params) : TimeVortexBinnedMapBase<true>(params) {}
+    explicit TimeVortexBinnedMap_ts(Params& params) : TimeVortexBinnedMapBase<true>(params) {}
     SST_ELI_EXPORT(TimeVortexBinnedMap_ts)
 };
 

--- a/src/sst/core/impl/timevortex/timeVortexBinnedMap.h
+++ b/src/sst/core/impl/timevortex/timeVortexBinnedMap.h
@@ -129,7 +129,7 @@ private:
 
 
 public:
-    TimeVortexBinnedMapBase(Params& params);
+    explicit TimeVortexBinnedMapBase(Params& params);
     ~TimeVortexBinnedMapBase();
 
     bool      empty() override;

--- a/src/sst/core/impl/timevortex/timeVortexPQ.cc
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.cc
@@ -149,7 +149,7 @@ public:
         "TimeVortex based on std::priority_queue.")
 
 
-    TimeVortexPQ(Params& params) : TimeVortexPQBase<false>(params) {}
+    explicit TimeVortexPQ(Params& params) : TimeVortexPQBase<false>(params) {}
     TimeVortexPQ() : TimeVortexPQBase<false>() {} // For serialization only
     ~TimeVortexPQ() {}
 
@@ -174,7 +174,7 @@ public:
         " specify sst.timevortex.priority_queue and this version will be selected when it is needed based on other"
         " parameters.")
 
-    TimeVortexPQ_ts(Params& params) : TimeVortexPQBase<true>(params) {}
+    explicit TimeVortexPQ_ts(Params& params) : TimeVortexPQBase<true>(params) {}
     TimeVortexPQ_ts() : TimeVortexPQBase<true>() {} // For serialization only
     ~TimeVortexPQ_ts() {}
 

--- a/src/sst/core/impl/timevortex/timeVortexPQ.h
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.h
@@ -36,7 +36,7 @@ class TimeVortexPQBase : public TimeVortex
 
 public:
     // TimeVortexPQ();
-    TimeVortexPQBase(Params& params);
+    explicit TimeVortexPQBase(Params& params);
     TimeVortexPQBase(); // For serialization only
     ~TimeVortexPQBase();
 

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -176,7 +176,7 @@ public:
     public:
         SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Interfaces::SimpleNetwork::NetworkInspector,std::string)
 
-        NetworkInspector(ComponentId_t id) : SubComponent(id) {}
+        explicit NetworkInspector(ComponentId_t id) : SubComponent(id) {}
 
         virtual ~NetworkInspector() {}
 
@@ -245,7 +245,7 @@ public:
 
 public:
     /** Constructor, designed to be used via 'loadUserSubComponent or loadAnonymousSubComponent'. */
-    SimpleNetwork(SST::ComponentId_t id) : SubComponent(id) {}
+    explicit SimpleNetwork(SST::ComponentId_t id) : SubComponent(id) {}
 
     SimpleNetwork() : SubComponent() {} // For serialization
 

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -149,7 +149,7 @@ public:
             F_RESERVED = 1 << 16, /* Flags <= F_RESERVED are reserved for future expansion */
         };
 
-        Request(flags_t fl = 0)
+        explicit Request(flags_t fl = 0)
         {
             id    = main_id++;
             flags = fl;
@@ -500,7 +500,7 @@ public:
             tid(tid)
         {}
         /** Automatically construct a write response from a Write */
-        WriteResp(Write* wr) :
+        explicit WriteResp(Write* wr) :
             Request(wr->getID(), wr->getAllFlags()),
             pAddr(wr->pAddr),
             vAddr(wr->vAddr),
@@ -626,7 +626,7 @@ public:
     class FlushCache : public Request
     {
     public:
-        FlushCache(
+        explicit FlushCache(
             uint32_t depth = std::numeric_limits<uint32_t>::max(), flags_t flags = 0, Addr instPtr = 0,
             uint32_t tid = 0) :
             Request(flags),
@@ -686,7 +686,7 @@ public:
             iPtr(instPtr),
             tid(tid)
         {}
-        FlushResp(FlushAddr* fl, flags_t newFlags = 0) :
+        explicit FlushResp(FlushAddr* fl, flags_t newFlags = 0) :
             Request(fl->getID(), fl->getAllFlags() | newFlags),
             pAddr(fl->pAddr),
             vAddr(fl->vAddr),
@@ -694,7 +694,7 @@ public:
             iPtr(fl->iPtr),
             tid(fl->tid)
         {}
-        FlushResp(FlushCache* fc, flags_t newFlags = 0) :
+        explicit FlushResp(FlushCache* fc, flags_t newFlags = 0) :
             Request(fc->getID(), fc->getAllFlags() | newFlags),
             pAddr(0),
             vAddr(0),
@@ -1170,7 +1170,7 @@ public:
     class CustomReq : public Request
     {
     public:
-        CustomReq(CustomData* data, flags_t flags = 0, Addr iPtr = 0, uint32_t tid = 0) :
+        explicit CustomReq(CustomData* data, flags_t flags = 0, Addr iPtr = 0, uint32_t tid = 0) :
             Request(flags),
             data(data),
             iPtr(iPtr),
@@ -1263,7 +1263,7 @@ public:
             iPtr(iPtr),
             tid(tid)
         {}
-        CustomResp(CustomReq* req) :
+        explicit CustomResp(CustomReq* req) :
             Request(req->getID(), req->getAllFlags()),
             data(req->getData().makeResponse()),
             iPtr(req->iPtr),
@@ -1387,9 +1387,9 @@ public:
     class RequestHandler : public SST::Core::Serialization::serializable
     {
     public:
-        RequestHandler(SST::Output* o) : out(o) {}
-        RequestHandler() {}
-        virtual ~RequestHandler() {}
+        RequestHandler() = default;
+        explicit RequestHandler(SST::Output* o) : out(o) {}
+        virtual ~RequestHandler() = default;
 
         /* Built in command handlers */
         virtual void handle(Read* UNUSED(request))

--- a/src/sst/core/interfaces/stringEvent.h
+++ b/src/sst/core/interfaces/stringEvent.h
@@ -28,7 +28,7 @@ public:
     /** Create a new StringEvent
      * @param str - The String contents of this event
      */
-    StringEvent(const std::string& str) : SST::Event(), str(str) {}
+    explicit StringEvent(const std::string& str) : SST::Event(), str(str) {}
 
     /** Clone a StringEvent */
     virtual Event* clone() override { return new StringEvent(*this); }

--- a/src/sst/core/interprocess/circularBuffer.h
+++ b/src/sst/core/interprocess/circularBuffer.h
@@ -21,7 +21,7 @@ class CircularBuffer
 {
 
 public:
-    CircularBuffer(size_t mSize = 0)
+    explicit CircularBuffer(size_t mSize = 0)
     {
         buffSize   = mSize;
         readIndex  = 0;

--- a/src/sst/core/interprocess/ipctunnel.h
+++ b/src/sst/core/interprocess/ipctunnel.h
@@ -127,7 +127,7 @@ public:
      * Access an existing Tunnel
      * @param region_name Name of the shared-memory region to access
      */
-    IPCTunnel(const std::string& region_name) : master(false), shmPtr(nullptr), fd(-1)
+    explicit IPCTunnel(const std::string& region_name) : master(false), shmPtr(nullptr), fd(-1)
     {
         fd       = shm_open(region_name.c_str(), O_RDWR, S_IRUSR | S_IWUSR);
         filename = region_name;

--- a/src/sst/core/interprocess/mmapchild_pin3.h
+++ b/src/sst/core/interprocess/mmapchild_pin3.h
@@ -33,7 +33,7 @@ public:
      *
      * @param file_name Name of the shared file to mmap
      */
-    MMAPChild_Pin3(const std::string& file_name)
+    explicit MMAPChild_Pin3(const std::string& file_name)
     {
         filename = file_name;
         NATIVE_FD      fd;

--- a/src/sst/core/interprocess/shmchild.h
+++ b/src/sst/core/interprocess/shmchild.h
@@ -41,7 +41,7 @@ public:
      *
      * @param region_name Name of the shared-memory region to access
      */
-    SHMChild(const std::string& region_name) : shmPtr(nullptr), fd(-1)
+    explicit SHMChild(const std::string& region_name) : shmPtr(nullptr), fd(-1)
     {
         fd       = shm_open(region_name.c_str(), O_RDWR, S_IRUSR | S_IWUSR);
         filename = region_name;

--- a/src/sst/core/interprocess/tunneldef.h
+++ b/src/sst/core/interprocess/tunneldef.h
@@ -76,7 +76,7 @@ public:
      * Child creates the TunnelDef, reads the shmSize, and then resizes its map accordingly
      * @param sPtr Location of shared memory region
      */
-    TunnelDef(void* sPtr) : master(false), shmPtr(sPtr)
+    explicit TunnelDef(void* sPtr) : master(false), shmPtr(sPtr)
     {
         isd     = (InternalSharedData*)shmPtr;
         shmSize = isd->shmSegSize;

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -353,7 +353,7 @@ private:
         value used for enforce_link_order (if that feature is
         enabled).
      */
-    Link(LinkId_t tag);
+    explicit Link(LinkId_t tag);
 
     Link(const Link& l);
 

--- a/src/sst/core/linkPair.h
+++ b/src/sst/core/linkPair.h
@@ -26,7 +26,7 @@ public:
     /** Create a new LinkPair.  This is used when the endpoints are in the same partition.
      * @param order Value used to enforce the link order.
      */
-    LinkPair(LinkId_t order) : left(new Link(order)), right(new Link(order))
+    explicit LinkPair(LinkId_t order) : left(new Link(order)), right(new Link(order))
     {
         my_id = order;
 

--- a/src/sst/core/model/element_python.h
+++ b/src/sst/core/model/element_python.h
@@ -156,7 +156,7 @@ public:
      * of.  Primary module name will be sst.library and submodules
      * under this can also be created.
      */
-    SSTElementPythonModule(const std::string& library);
+    explicit SSTElementPythonModule(const std::string& library);
 
     virtual void* load();
 

--- a/src/sst/core/model/python/pymodel_stat.h
+++ b/src/sst/core/model/python/pymodel_stat.h
@@ -33,7 +33,7 @@ struct PyStatistic
 {
     StatisticId_t id;
 
-    PyStatistic(StatisticId_t id) : id(id) {}
+    explicit PyStatistic(StatisticId_t id) : id(id) {}
     virtual ~PyStatistic() {}
     ConfigStatistic* getStat();
     int              compare(PyStatistic* other);

--- a/src/sst/core/model/sstmodel.h
+++ b/src/sst/core/model/sstmodel.h
@@ -38,7 +38,7 @@ public:
     static bool                            isElementParallelCapable(const std::string& type);
     static const std::vector<std::string>& getElementSupportedExtensions(const std::string& type);
 
-    SSTModelDescription(Config* cfg);
+    explicit SSTModelDescription(Config* cfg);
     virtual ~SSTModelDescription() {};
 
     /** Create the ConfigGraph

--- a/src/sst/core/profile/profiletool.h
+++ b/src/sst/core/profile/profiletool.h
@@ -37,7 +37,7 @@ public:
         ELI::ProvidesInterface,
         ELI::ProvidesParams)
 
-    ProfileTool(const std::string& name);
+    explicit ProfileTool(const std::string& name);
 
     virtual ~ProfileTool() {}
 

--- a/src/sst/core/realtime.h
+++ b/src/sst/core/realtime.h
@@ -170,7 +170,7 @@ private:
 class RealTimeManager : public SST::Core::Serialization::serializable
 {
 public:
-    RealTimeManager(RankInfo num_ranks);
+    explicit RealTimeManager(RankInfo num_ranks);
     RealTimeManager();
 
     /** Register actions */

--- a/src/sst/core/rng/constant.h
+++ b/src/sst/core/rng/constant.h
@@ -31,7 +31,7 @@ public:
         Creates a constant distribution which returns a constant value.
         \param v Is the constant value the user wants returned by the distribution
     */
-    ConstantDistribution(double v) : RandomDistribution() { mean = v; }
+    explicit ConstantDistribution(double v) : RandomDistribution() { mean = v; }
 
     /**
         Destroys the constant distribution

--- a/src/sst/core/rng/expon.h
+++ b/src/sst/core/rng/expon.h
@@ -33,7 +33,7 @@ public:
         Creates an exponential distribution with a specific lambda
         \param mn The lambda of the exponential distribution
     */
-    ExponentialDistribution(const double mn) : RandomDistribution()
+    explicit ExponentialDistribution(const double mn) : RandomDistribution()
     {
 
         lambda        = mn;

--- a/src/sst/core/rng/mersenne.h
+++ b/src/sst/core/rng/mersenne.h
@@ -38,7 +38,7 @@ public:
        Create a new Mersenne RNG with a specified seed
        @param[in] seed The seed for this RNG
     */
-    MersenneRNG(unsigned int seed);
+    explicit MersenneRNG(unsigned int seed);
 
     /**
        Creates a new Mersenne using a random seed which is obtained from the system

--- a/src/sst/core/rng/poisson.h
+++ b/src/sst/core/rng/poisson.h
@@ -33,7 +33,7 @@ public:
         Creates an Poisson distribution with a specific lambda
         \param mn The lambda of the Poisson distribution
     */
-    PoissonDistribution(const double mn) : RandomDistribution(), lambda(mn)
+    explicit PoissonDistribution(const double mn) : RandomDistribution(), lambda(mn)
     {
 
         baseDistrib   = new MersenneRNG();

--- a/src/sst/core/rng/uniform.h
+++ b/src/sst/core/rng/uniform.h
@@ -33,7 +33,7 @@ public:
         Creates an uniform distribution with a specific number of bins
         \param probsCount Number of probability bins in this distribution
     */
-    UniformDistribution(const uint32_t probsCount) :
+    explicit UniformDistribution(const uint32_t probsCount) :
         RandomDistribution(),
         deleteDistrib(true),
         probCount(probsCount),

--- a/src/sst/core/rng/xorshift.h
+++ b/src/sst/core/rng/xorshift.h
@@ -39,7 +39,7 @@ public:
         Create a new Xorshift RNG with a specified seed
         @param[in] seed The seed for this RNG
     */
-    XORShiftRNG(unsigned int seed);
+    explicit XORShiftRNG(unsigned int seed);
 
     /**
         Creates a new Xorshift using a random seed which is obtained from the system

--- a/src/sst/core/serialization/impl/ser_buffer_accessor.h
+++ b/src/sst/core/serialization/impl/ser_buffer_accessor.h
@@ -28,7 +28,7 @@ namespace SST::Core::Serialization::pvt {
 class ser_buffer_overrun : public std::exception
 {
 public:
-    ser_buffer_overrun(int UNUSED(maxsize))
+    explicit ser_buffer_overrun(int UNUSED(maxsize))
     // ser_buffer_overrun(int maxsize) :
     // spkt_error(sprockit::printf("serialization overrun buffer of size %d", maxsize))
     {}

--- a/src/sst/core/shared/sharedArray.h
+++ b/src/sst/core/shared/sharedArray.h
@@ -251,7 +251,10 @@ private:
         verify_type       verify;
 
         Data() : SharedObjectData(), change_set(nullptr), verify(VERIFY_UNINITIALIZED) {}
-        Data(const std::string& name) : SharedObjectData(name), change_set(nullptr), verify(VERIFY_UNINITIALIZED)
+        explicit Data(const std::string& name) :
+            SharedObjectData(name),
+            change_set(nullptr),
+            verify(VERIFY_UNINITIALIZED)
         {
             if ( Private::getNumRanks().rank > 1 ) { change_set = new ChangeSet(name); }
         }
@@ -388,7 +391,11 @@ private:
         public:
             // For serialization
             ChangeSet() : SharedObjectChangeSet() {}
-            ChangeSet(const std::string& name) : SharedObjectChangeSet(name), size(0), verify(VERIFY_UNINITIALIZED) {}
+            explicit ChangeSet(const std::string& name) :
+                SharedObjectChangeSet(name),
+                size(0),
+                verify(VERIFY_UNINITIALIZED)
+            {}
 
             void addChange(int index, const T& value) { changes.emplace_back(index, value); }
 
@@ -644,7 +651,10 @@ private:
         verify_type       verify;
 
         Data() : SharedObjectData(), change_set(nullptr), verify(VERIFY_UNINITIALIZED) {} // For serialization ONLY
-        Data(const std::string& name) : SharedObjectData(name), change_set(nullptr), verify(VERIFY_UNINITIALIZED)
+        explicit Data(const std::string& name) :
+            SharedObjectData(name),
+            change_set(nullptr),
+            verify(VERIFY_UNINITIALIZED)
         {
             if ( Private::getNumRanks().rank > 1 ) { change_set = new ChangeSet(name); }
         }
@@ -782,7 +792,11 @@ private:
         public:
             // For serialization
             ChangeSet() : SharedObjectChangeSet() {}
-            ChangeSet(const std::string& name) : SharedObjectChangeSet(name), size(0), verify(VERIFY_UNINITIALIZED) {}
+            explicit ChangeSet(const std::string& name) :
+                SharedObjectChangeSet(name),
+                size(0),
+                verify(VERIFY_UNINITIALIZED)
+            {}
 
             void addChange(int index, bool value) { changes.emplace_back(index, value); }
 

--- a/src/sst/core/shared/sharedMap.h
+++ b/src/sst/core/shared/sharedMap.h
@@ -260,7 +260,10 @@ private:
         verify_type          verify;
 
         Data() : SharedObjectData(), change_set(nullptr), verify(VERIFY_UNINITIALIZED) {}
-        Data(const std::string& name) : SharedObjectData(name), change_set(nullptr), verify(VERIFY_UNINITIALIZED)
+        explicit Data(const std::string& name) :
+            SharedObjectData(name),
+            change_set(nullptr),
+            verify(VERIFY_UNINITIALIZED)
         {
             if ( Private::getNumRanks().rank > 1 ) { change_set = new ChangeSet(name); }
         }
@@ -351,7 +354,7 @@ private:
         public:
             // For serialization
             ChangeSet() : SharedObjectChangeSet(), verify(VERIFY_UNINITIALIZED) {}
-            ChangeSet(const std::string& name) : SharedObjectChangeSet(name), verify(VERIFY_UNINITIALIZED) {}
+            explicit ChangeSet(const std::string& name) : SharedObjectChangeSet(name), verify(VERIFY_UNINITIALIZED) {}
 
             void addChange(const keyT& key, const valT& value) { changes[key] = value; }
 

--- a/src/sst/core/shared/sharedObject.h
+++ b/src/sst/core/shared/sharedObject.h
@@ -46,7 +46,7 @@ class SharedObjectChangeSet : public SST::Core::Serialization::serializable
 
 public:
     SharedObjectChangeSet() {}
-    SharedObjectChangeSet(const std::string& name) : name(name) {}
+    explicit SharedObjectChangeSet(const std::string& name) : name(name) {}
 
     /**
        Apply the changes to the name shared data.
@@ -190,7 +190,7 @@ protected:
 
        @param name name of the SharedObject
      */
-    SharedObjectData(const std::string& name) :
+    explicit SharedObjectData(const std::string& name) :
         name(name),
         share_count(0),
         publish_count(0),

--- a/src/sst/core/shared/sharedSet.h
+++ b/src/sst/core/shared/sharedSet.h
@@ -230,7 +230,10 @@ private:
         verify_type verify;
 
         Data() : SharedObjectData(), change_set(nullptr), verify(VERIFY_UNINITIALIZED) {}
-        Data(const std::string& name) : SharedObjectData(name), change_set(nullptr), verify(VERIFY_UNINITIALIZED)
+        explicit Data(const std::string& name) :
+            SharedObjectData(name),
+            change_set(nullptr),
+            verify(VERIFY_UNINITIALIZED)
         {
             if ( Private::getNumRanks().rank > 1 ) { change_set = new ChangeSet(name); }
         }
@@ -327,7 +330,7 @@ private:
         public:
             // For serialization
             ChangeSet() : SharedObjectChangeSet(), verify(VERIFY_UNINITIALIZED) {}
-            ChangeSet(const std::string& name) : SharedObjectChangeSet(name), verify(VERIFY_UNINITIALIZED) {}
+            explicit ChangeSet(const std::string& name) : SharedObjectChangeSet(name), verify(VERIFY_UNINITIALIZED) {}
 
             void addChange(const valT& value) { changes.insert(value); }
 

--- a/src/sst/core/sparseVectorMap.h
+++ b/src/sst/core/sparseVectorMap.h
@@ -275,7 +275,7 @@ public:
 class bad_filtered_key_error : public std::runtime_error
 {
 public:
-    bad_filtered_key_error(const std::string& what_arg) : runtime_error(what_arg) {}
+    explicit bad_filtered_key_error(const std::string& what_arg) : runtime_error(what_arg) {}
 };
 
 

--- a/src/sst/core/ssthandler.h
+++ b/src/sst/core/ssthandler.h
@@ -1325,7 +1325,7 @@ public:
      * @param object - Pointer to Object upon which to call the handler
      * @param member - Member function to call as the handler
      */
-    SSTHandler2(classT* const object) : SSTHandlerBase<returnT, argT>(), object(object) {}
+    explicit SSTHandler2(classT* const object) : SSTHandlerBase<returnT, argT>(), object(object) {}
     SSTHandler2() {}
 
     SSTHandler2(const SSTHandler2&) = delete;
@@ -1391,7 +1391,7 @@ public:
      * @param object - Pointer to Object upon which to call the handler
      * @param data - Additional argument to pass to handler
      */
-    SSTHandler2(classT* const object) : SSTHandlerBase<returnT, void>(), object(object) {}
+    explicit SSTHandler2(classT* const object) : SSTHandlerBase<returnT, void>(), object(object) {}
     SSTHandler2() {}
 
     SSTHandler2(const SSTHandler2&) = delete;

--- a/src/sst/core/sstinfo.h
+++ b/src/sst/core/sstinfo.h
@@ -41,7 +41,7 @@ class SSTInfoConfig : public ConfigShared
 public:
     using FilterMap_t = std::multimap<std::string, std::string>;
     /** Create a new SSTInfo configuration and parse the Command Line. */
-    SSTInfoConfig(bool suppress_print);
+    explicit SSTInfoConfig(bool suppress_print);
     ~SSTInfoConfig() override = default;
 
     /** Return the list of elements to be processed. */
@@ -165,7 +165,7 @@ public:
     /** Create a new SSTInfoElement_LibraryInfo object.
      * @param eli Pointer to an ElementLibraryInfo object.
      */
-    SSTLibraryInfo(const std::string& name) : m_name(name) {}
+    explicit SSTLibraryInfo(const std::string& name) : m_name(name) {}
 
     /** Return the Name of the Library. */
     // std::string getLibraryName() {if (m_eli && m_eli->name) return m_eli->name; else return ""; }

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -507,7 +507,7 @@ public:
 
 protected:
     template <class T>
-    ImplementsStatFields(T* UNUSED(t)) :
+    explicit ImplementsStatFields(T* UNUSED(t)) :
         field_name_(T::ELI_fieldName()),
         short_name_(T::ELI_fieldShortName()),
         field_(T::ELI_registerField(T::ELI_fieldName(), T::ELI_fieldShortName()))

--- a/src/sst/core/statapi/statoutput.h
+++ b/src/sst/core/statapi/statoutput.h
@@ -152,7 +152,7 @@ protected:
     /** Construct a base StatisticOutput
      * @param outputParameters - The parameters for the statistic Output.
      */
-    StatisticOutput(Params& outputParameters);
+    explicit StatisticOutput(Params& outputParameters);
     StatisticOutput() { ; } // For serialization only
     void setStatisticOutputName(const std::string& name) { m_statOutputName = name; }
 
@@ -285,7 +285,7 @@ public:
         /** Construct a base StatisticOutput
          * @param outputParameters - The parameters for the statistic Output.
          */
-        StatisticFieldsOutput(Params& outputParameters);
+        explicit StatisticFieldsOutput(Params& outputParameters);
 
     // For Serialization
     StatisticFieldsOutput() : m_highestFieldHandle(0), m_currentFieldStatName("") {}

--- a/src/sst/core/statapi/statoutputcsv.h
+++ b/src/sst/core/statapi/statoutputcsv.h
@@ -41,7 +41,7 @@ public:
     /** Construct a StatOutputCSV
      * @param outputParameters - Parameters used for this Statistic Output
      */
-    StatisticOutputCSV(Params& outputParameters);
+    explicit StatisticOutputCSV(Params& outputParameters);
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::Statistics::StatisticOutputCSV)

--- a/src/sst/core/statapi/statoutputhdf5.h
+++ b/src/sst/core/statapi/statoutputhdf5.h
@@ -44,7 +44,7 @@ public:
     /** Construct a StatOutputHDF5
      * @param outputParameters - Parameters used for this Statistic Output
      */
-    StatisticOutputHDF5(Params& outputParameters);
+    explicit StatisticOutputHDF5(Params& outputParameters);
 
     bool acceptsGroups() const override { return true; }
 
@@ -125,7 +125,7 @@ private:
     class DataSet
     {
     public:
-        DataSet(H5::H5File* file) : file(file) {}
+        explicit DataSet(H5::H5File* file) : file(file) {}
         virtual ~DataSet() {}
         H5::H5File*  getFile() { return file; }
         virtual bool isGroup() const = 0;

--- a/src/sst/core/statapi/statoutputjson.h
+++ b/src/sst/core/statapi/statoutputjson.h
@@ -36,7 +36,7 @@ public:
     /** Construct a StatOutputJSON
      * @param outputParameters - Parameters used for this Statistic Output
      */
-    StatisticOutputJSON(Params& outputParameters);
+    explicit StatisticOutputJSON(Params& outputParameters);
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::Statistics::StatisticOutputJSON)

--- a/src/sst/core/statapi/statoutputtxt.h
+++ b/src/sst/core/statapi/statoutputtxt.h
@@ -27,7 +27,7 @@ public:
     /** Construct a StatOutputTxt
      * @param outputParameters - Parameters used for this Statistic Output
      */
-    StatisticOutputTextBase(Params& outputParameters);
+    explicit StatisticOutputTextBase(Params& outputParameters);
 
     /** This output supports adding statistics during runtime if the header is embedded in the output */
     virtual bool supportsDynamicRegistration() const override { return m_outputInlineHeader; }
@@ -161,7 +161,7 @@ public:
     /** Construct a StatOutputTxt
      * @param outputParameters - Parameters used for this Statistic Output
      */
-    StatisticOutputTxt(Params& outputParameters);
+    explicit StatisticOutputTxt(Params& outputParameters);
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::Statistics::StatisticOutputTxt)
@@ -232,7 +232,7 @@ public:
     /** Construct a StatOutputTxt
      * @param outputParameters - Parameters used for this Statistic Output
      */
-    StatisticOutputConsole(Params& outputParameters);
+    explicit StatisticOutputConsole(Params& outputParameters);
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::Statistics::StatisticOutputConsole)

--- a/src/sst/core/stopAction.h
+++ b/src/sst/core/stopAction.h
@@ -38,7 +38,7 @@ public:
 
     /** Create a new StopAction which includes a message to be printed when it fires
      */
-    StopAction(const std::string& msg)
+    explicit StopAction(const std::string& msg)
     {
         setPriority(STOPACTIONPRIORITY);
         print_message = true;

--- a/src/sst/core/stringize.h
+++ b/src/sst/core/stringize.h
@@ -69,7 +69,7 @@ struct char_delimiter
 {
     using iter = std::string::const_iterator;
     const std::string delim;
-    char_delimiter(const std::string& delim = " \t\v\f\n\r") : delim(delim) {}
+    explicit char_delimiter(const std::string& delim = " \t\v\f\n\r") : delim(delim) {}
 
     /**
      * @return pair<iter, iter> = <tok_end, next_tok>

--- a/src/sst/core/subcomponent.h
+++ b/src/sst/core/subcomponent.h
@@ -43,7 +43,7 @@ public:
         ELI::ProvidesProfilePoints,
         ELI::ProvidesAttributes)
 
-    SubComponent(ComponentId_t id);
+    explicit SubComponent(ComponentId_t id);
 
     virtual ~SubComponent() {};
 

--- a/src/sst/core/sync/rankSyncParallelSkip.h
+++ b/src/sst/core/sync/rankSyncParallelSkip.h
@@ -28,7 +28,7 @@ class RankSyncParallelSkip : public RankSync
 {
 public:
     /** Create a new Sync object which fires with a specified period */
-    RankSyncParallelSkip(RankInfo num_ranks);
+    explicit RankSyncParallelSkip(RankInfo num_ranks);
     RankSyncParallelSkip() {} // For serialization
     virtual ~RankSyncParallelSkip();
 

--- a/src/sst/core/sync/rankSyncSerialSkip.h
+++ b/src/sst/core/sync/rankSyncSerialSkip.h
@@ -27,7 +27,7 @@ class RankSyncSerialSkip : public RankSync
 {
 public:
     /** Create a new Sync object which fires with a specified period */
-    RankSyncSerialSkip(RankInfo num_ranks);
+    explicit RankSyncSerialSkip(RankInfo num_ranks);
     RankSyncSerialSkip() {} // For serialization
     virtual ~RankSyncSerialSkip();
 

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -74,7 +74,7 @@ SimTime_t                 SyncManager::next_rankSync_ = MAX_SIMTIME_T;
 class EmptyRankSync : public RankSync
 {
 public:
-    EmptyRankSync(const RankInfo& num_ranks) : RankSync(num_ranks) { nextSyncTime = MAX_SIMTIME_T; }
+    explicit EmptyRankSync(const RankInfo& num_ranks) : RankSync(num_ranks) { nextSyncTime = MAX_SIMTIME_T; }
     EmptyRankSync() {} // For serialization
     ~EmptyRankSync() {}
 
@@ -134,7 +134,7 @@ public:
     Simulation_impl* sim;
 
 public:
-    EmptyThreadSync(Simulation_impl* sim) : sim(sim) { nextSyncTime = MAX_SIMTIME_T; }
+    explicit EmptyThreadSync(Simulation_impl* sim) : sim(sim) { nextSyncTime = MAX_SIMTIME_T; }
     EmptyThreadSync() {} // For serialization
     ~EmptyThreadSync() {}
 

--- a/src/sst/core/sync/syncManager.h
+++ b/src/sst/core/sync/syncManager.h
@@ -39,7 +39,7 @@ class SyncProfileTool;
 class RankSync
 {
 public:
-    RankSync(RankInfo num_ranks) : num_ranks_(num_ranks) { link_maps.resize(num_ranks_.rank); }
+    explicit RankSync(RankInfo num_ranks) : num_ranks_(num_ranks) { link_maps.resize(num_ranks_.rank); }
     RankSync() : max_period(nullptr) {}
     virtual ~RankSync() {}
 

--- a/src/sst/core/sync/syncQueue.h
+++ b/src/sst/core/sync/syncQueue.h
@@ -30,7 +30,7 @@ namespace SST {
 class SyncQueue : public ActivityQueue
 {
 public:
-    SyncQueue(RankInfo to_rank) : ActivityQueue(), to_rank(to_rank) {}
+    explicit SyncQueue(RankInfo to_rank) : ActivityQueue(), to_rank(to_rank) {}
     ~SyncQueue() {}
 
     /** Accessor method to get to_rank */
@@ -57,7 +57,7 @@ public:
         uint32_t buffer_size;
     };
 
-    RankSyncQueue(RankInfo to_rank);
+    explicit RankSyncQueue(RankInfo to_rank);
     ~RankSyncQueue() = default;
 
     bool      empty() override;
@@ -85,7 +85,7 @@ private:
 class ThreadSyncQueue : public SyncQueue
 {
 public:
-    ThreadSyncQueue(RankInfo to_rank) : SyncQueue(to_rank) {}
+    explicit ThreadSyncQueue(RankInfo to_rank) : SyncQueue(to_rank) {}
     ~ThreadSyncQueue() {}
 
     /** Returns true if the queue is empty */

--- a/src/sst/core/testElements/coreTest_Checkpoint.h
+++ b/src/sst/core/testElements/coreTest_Checkpoint.h
@@ -29,7 +29,7 @@ class coreTestCheckpointEvent : public SST::Event
 public:
     coreTestCheckpointEvent() : SST::Event(), counter(1000) {}
 
-    coreTestCheckpointEvent(uint32_t c) : SST::Event(), counter(c) {}
+    explicit coreTestCheckpointEvent(uint32_t c) : SST::Event(), counter(c) {}
 
     ~coreTestCheckpointEvent() {}
 

--- a/src/sst/core/testElements/coreTest_Component.h
+++ b/src/sst/core/testElements/coreTest_Component.h
@@ -44,7 +44,7 @@ public:
         { "test_element", "true" }
     )
 
-    coreTestComponentBase(ComponentId_t id) : SST::Component(id) {}
+    explicit coreTestComponentBase(ComponentId_t id) : SST::Component(id) {}
     ~coreTestComponentBase() {}
     coreTestComponentBase() : SST::Component() {}
     void serialize_order(SST::Core::Serialization::serializer& ser) override { SST::Component::serialize_order(ser); }
@@ -69,7 +69,7 @@ public:
         {"Slink", "Link to the coreTestComponent to the South", { "coreTestComponent.coreTestComponentEvent", "" } }
     )
 
-    coreTestComponentBase2(ComponentId_t id) : coreTestComponentBase(id) {}
+    explicit coreTestComponentBase2(ComponentId_t id) : coreTestComponentBase(id) {}
     ~coreTestComponentBase2() {}
 
     coreTestComponentBase2() : coreTestComponentBase() {}

--- a/src/sst/core/testElements/coreTest_Module.h
+++ b/src/sst/core/testElements/coreTest_Module.h
@@ -41,7 +41,7 @@ public:
         { "seed",    "The seed to use for the random number generator.", "11" },
     )
 
-    CoreTestModuleExample(SST::Params& params);
+    explicit CoreTestModuleExample(SST::Params& params);
     ~CoreTestModuleExample();
     std::string getRNGType() const;
     uint32_t    getNext();

--- a/src/sst/core/testElements/coreTest_PerfComponent.h
+++ b/src/sst/core/testElements/coreTest_PerfComponent.h
@@ -39,7 +39,7 @@ public:
         {"Nlink", "Link to the coreTestComponent to the North", { "coreTestComponent.coreTestComponentEvent", "" } }
     )
 
-    coreTestPerfComponentBase(ComponentId_t id) : SST::Component(id) {}
+    explicit coreTestPerfComponentBase(ComponentId_t id) : SST::Component(id) {}
     ~coreTestPerfComponentBase() {}
 };
 
@@ -61,7 +61,7 @@ public:
         {"Slink", "Link to the coreTestComponent to the South", { "coreTestComponent.coreTestComponentEvent", "" } }
     )
 
-    coreTestPerfComponentBase2(ComponentId_t id) : coreTestPerfComponentBase(id) {}
+    explicit coreTestPerfComponentBase2(ComponentId_t id) : coreTestPerfComponentBase(id) {}
     ~coreTestPerfComponentBase2() {}
 };
 

--- a/src/sst/core/testElements/coreTest_PortModule.h
+++ b/src/sst/core/testElements/coreTest_PortModule.h
@@ -68,7 +68,7 @@ public:
         { "install_on_send",  "Controls whether the PortModule is installed on the send or receive side.  Set to true to register on send and false to register on recieve.", "false" },
     )
 
-    TestPortModule(Params& params);
+    explicit TestPortModule(Params& params);
 
     // For serialization only
     TestPortModule() = default;

--- a/src/sst/core/testElements/coreTest_Serialization.cc
+++ b/src/sst/core/testElements/coreTest_Serialization.cc
@@ -361,7 +361,7 @@ class pointed_to_class : public SST::Core::Serialization::serializable
     int value = -1;
 
 public:
-    pointed_to_class(int val) : value(val) {}
+    explicit pointed_to_class(int val) : value(val) {}
     pointed_to_class() {}
 
     int  getValue() { return value; }
@@ -454,7 +454,7 @@ struct HandlerTest : public SST::Core::Serialization::serializable
 
     int value = -1;
 
-    HandlerTest(int in) : value(in) {}
+    explicit HandlerTest(int in) : value(in) {}
     HandlerTest() {}
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override { SST_SER(value); }
@@ -479,7 +479,7 @@ struct RecursiveSerializationTest : public SST::Core::Serialization::serializabl
     int                                                                            value;
 
     RecursiveSerializationTest() {}
-    RecursiveSerializationTest(int in) : value(in)
+    explicit RecursiveSerializationTest(int in) : value(in)
     {
         handler = new Handler<RecursiveSerializationTest, &RecursiveSerializationTest::call, float>(this, 8.9);
     }

--- a/src/sst/core/testElements/coreTest_SubComponent.h
+++ b/src/sst/core/testElements/coreTest_SubComponent.h
@@ -38,7 +38,7 @@ class SubCompInterface : public SST::SubComponent
 public:
     SST_ELI_REGISTER_SUBCOMPONENT_API(SST::CoreTestSubComponent::SubCompInterface)
 
-    SubCompInterface(ComponentId_t id) : SubComponent(id) {}
+    explicit SubCompInterface(ComponentId_t id) : SubComponent(id) {}
     SubCompInterface(ComponentId_t id, Params& UNUSED(params)) : SubComponent(id) {}
     SubCompInterface() : SubComponent() {}
     virtual ~SubCompInterface() {}
@@ -68,7 +68,7 @@ public:
     SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
     )
 
-    SubCompSlotInterface(ComponentId_t id) : SubCompInterface(id) {}
+    explicit SubCompSlotInterface(ComponentId_t id) : SubCompInterface(id) {}
     SubCompSlotInterface(ComponentId_t id, Params& UNUSED(params)) : SubCompInterface(id) {}
     virtual ~SubCompSlotInterface() {}
 
@@ -214,7 +214,7 @@ public:
     )
 
 
-    SubCompSendRecvInterface(ComponentId_t id) : SubCompInterface(id) {}
+    explicit SubCompSendRecvInterface(ComponentId_t id) : SubCompInterface(id) {}
     SubCompSendRecvInterface(ComponentId_t id, Params& UNUSED(params)) : SubCompInterface(id) {}
     virtual ~SubCompSendRecvInterface() {}
 

--- a/src/sst/core/testElements/message_mesh/enclosingComponent.h
+++ b/src/sst/core/testElements/message_mesh/enclosingComponent.h
@@ -28,7 +28,7 @@ class PortInterface : public SST::SubComponent
 public:
     SST_ELI_REGISTER_SUBCOMPONENT_API(SST::CoreTest::MessageMesh::PortInterface)
 
-    PortInterface(ComponentId_t id) : SubComponent(id) {}
+    explicit PortInterface(ComponentId_t id) : SubComponent(id) {}
     virtual ~PortInterface() {}
 
     /**
@@ -93,7 +93,7 @@ class RouteInterface : public SST::SubComponent
 public:
     SST_ELI_REGISTER_SUBCOMPONENT_API(SST::CoreTest::MessageMesh::RouteInterface, const std::vector<PortInterface*>&, int)
 
-    RouteInterface(ComponentId_t id) : SubComponent(id) {}
+    explicit RouteInterface(ComponentId_t id) : SubComponent(id) {}
     virtual ~RouteInterface() {}
 
     virtual void send(MessageEvent* ev, int incoming_port) = 0;

--- a/src/sst/core/threadsafe.h
+++ b/src/sst/core/threadsafe.h
@@ -164,7 +164,7 @@ class BoundedQueue
 
 public:
     // BoundedQueue(size_t maxSize) : dsize(maxSize)
-    BoundedQueue(size_t maxSize) : initialized(false) { initialize(maxSize); }
+    explicit BoundedQueue(size_t maxSize) : initialized(false) { initialize(maxSize); }
 
     BoundedQueue() : initialized(false) {}
 

--- a/src/sst/core/timeConverter.h
+++ b/src/sst/core/timeConverter.h
@@ -80,7 +80,7 @@ private:
     */
     SimTime_t factor;
 
-    TimeConverter(SimTime_t fact) { factor = fact; }
+    explicit TimeConverter(SimTime_t fact) { factor = fact; }
 };
 
 template <>

--- a/src/sst/core/uninitializedQueue.h
+++ b/src/sst/core/uninitializedQueue.h
@@ -26,7 +26,7 @@ public:
     /** Create a new Queue
      * @param message - Message to print when something attempts to use this Queue
      */
-    UninitializedQueue(const std::string& message);
+    explicit UninitializedQueue(const std::string& message);
     UninitializedQueue()           = default; // Only used for serialization
     ~UninitializedQueue() override = default;
 

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -268,7 +268,7 @@ public:
         /**
          * @param msg exception message displayed as-is without modification
          */
-        UnitAlgebraException(const std::string& msg);
+        explicit UnitAlgebraException(const std::string& msg);
     };
 
     /** Exception for when units are not recognized or are invalid
@@ -279,7 +279,7 @@ public:
         /**
          * @param type string containing invalid type
          */
-        InvalidUnitType(const std::string& type);
+        explicit InvalidUnitType(const std::string& type);
     };
 
     /** Exception for when number couldn't be parsed
@@ -290,7 +290,7 @@ public:
         /**
          * @param number string containing invalid number
          */
-        InvalidNumberString(const std::string& number);
+        explicit InvalidNumberString(const std::string& number);
     };
 
     /** Exception for when attempting operations between objects that do not have matching base units


### PR DESCRIPTION
Add `explicit` to constructors with a single parameter which should not perform implicit conversions. I built sst-core and sst-elements and got no build errors, but if some of the constructors need to perform implicit conversions, then `explicit` can be removed.
