### PR TITLE
Add [[noreturn]] to non-virtual functions which do not return

### DIFF
--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -758,7 +758,8 @@ protected:
         @param format Format string.  All valid formats for printf are available.
         @param ... Arguments for format.
      */
-    void fatal(uint32_t line, const char* file, const char* func, int exit_code, const char* format, ...) const
+    [[noreturn]] void
+    fatal(uint32_t line, const char* file, const char* func, int exit_code, const char* format, ...) const
         __attribute__((format(printf, 6, 7)));
 
     /** Convenience function for testing for and reporting fatal
@@ -858,8 +859,9 @@ private:
     }
 
     // Utility function used by fatal and sst_assert
-    void
-    vfatal(uint32_t line, const char* file, const char* func, int exit_code, const char* format, va_list arg) const;
+    [[noreturn]] void
+    vfatal(uint32_t line, const char* file, const char* func, int exit_code, const char* format, va_list arg) const
+        __attribute__((format(printf, 6, 0)));
 
     // Get the statengine from Simulation_impl
     StatisticProcessingEngine* getStatEngine();

--- a/src/sst/core/factory.h
+++ b/src/sst/core/factory.h
@@ -309,7 +309,7 @@ public:
 private:
     friend int ::main(int argc, char** argv);
 
-    void notFound(const std::string& baseName, const std::string& type, const std::string& errorMsg);
+    [[noreturn]] void notFound(const std::string& baseName, const std::string& type, const std::string& errorMsg);
 
     Factory(const std::string& searchPaths);
     ~Factory();

--- a/src/sst/core/serialization/serializable_base.h
+++ b/src/sst/core/serialization/serializable_base.h
@@ -129,7 +129,7 @@ public:
 
 protected:
     enum cxn_flag_t { ConstructorFlag };
-    static void serializable_abort(uint32_t line, const char* file, const char* func, const char* obj);
+    [[noreturn]] static void serializable_abort(uint32_t line, const char* file, const char* func, const char* obj);
 };
 
 

--- a/src/sst/core/sstconfigtool.cc
+++ b/src/sst/core/sstconfigtool.cc
@@ -21,7 +21,7 @@
 #include <map>
 #include <string>
 
-void
+[[noreturn]] void
 print_usage(FILE* output)
 {
     fprintf(output, "sst-config\n");

--- a/src/sst/core/statapi/statengine.h
+++ b/src/sst/core/statapi/statengine.h
@@ -132,7 +132,8 @@ private:
     void handleStatisticEngineStopTimeEvent(SimTime_t timeFactor);
 
     void addStatisticToCompStatMap(StatisticBase* Stat, StatisticFieldInfo::fieldType_t fieldType);
-    void castError(const std::string& type, const std::string& statName, const std::string& fieldName);
+
+    [[noreturn]] void castError(const std::string& type, const std::string& statName, const std::string& fieldName);
 
 private:
     using StatArray_t   = std::vector<StatisticBase*>;           /*!< Array of Statistics */


### PR DESCRIPTION
Add `[[noreturn]]` to non-virtual functions which do not return, such as calling `Output::fatal()`.

(If the function is virtual, then `[[noreturn]]` has little benefit unless the function is marked as `final`, which is dangerous to do because SST Elements and other client code might override SST Core classes, and without a careful analysis of which functions and classes are really `final` in SST Core, it is too risky to add `final` to functions or classes, so `[[noreturn]]` is left off of virtual functions.)
