### PR TITLE
Replace volatile counters with std::atomic types

### DIFF
--- a/src/sst/core/interprocess/tunneldef.h
+++ b/src/sst/core/interprocess/tunneldef.h
@@ -22,8 +22,10 @@
 
 #include "sst/core/interprocess/circularBuffer.h"
 
-#include <inttypes.h>
+#include <atomic>
+#include <cinttypes>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 namespace SST::Core::Interprocess {
@@ -33,10 +35,10 @@ extern uint32_t globalMMAPIPCCount;
 /* Internal bookkeeping */
 struct InternalSharedData
 {
-    volatile uint32_t expectedChildren;
-    size_t            shmSegSize;
-    size_t            numBuffers;
-    size_t            offsets[0]; // offset[0] points to user region, offset[1]... points to circular buffers
+    std::atomic_uint32_t expectedChildren;
+    size_t               shmSegSize;
+    size_t               numBuffers;
+    size_t               offsets[0]; // offset[0] points to user region, offset[1]... points to circular buffers
 };
 
 /**


### PR DESCRIPTION
Replace `volatile` counters with std::atomic types, except in one case where the assembly code is listed and analyzed and `volatile` is used for a timing delay.  `volatile` is [deprecated](https://www.youtube.com/watch?v=KJW_DLaVXIY).