### PR TITLE
Add override for virtual functions which are overriden

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
+# Enable warnings for non-virtual destructors and missing overrides; add override and virtual destructors to remove warnings
+f150d6f7db2d71f4a77720ee7e7a7385a57bf540 
+
 # Initial cmake-format fixes
 1c149870b806f5412c34c918cea96caa14720f3c

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ esac
 
 SST_CHECK_PICKY
 AS_IF([test "x$use_picky" = "xyes"],
-      [WARNFLAGS="-Wall -Wextra -Wvla"],
+      [WARNFLAGS="-Wall -Wextra -Wvla -Wnon-virtual-dtor -Wsuggest-override"],
       [WARNFLAGS=""])
 CFLAGS="$CFLAGS $WARNFLAGS"
 CXXFLAGS="$CXXFLAGS $WARNFLAGS"

--- a/src/sst/core/impl/timevortex/timeVortexPQ.cc
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.cc
@@ -153,7 +153,10 @@ public:
     TimeVortexPQ() : TimeVortexPQBase<false>() {} // For serialization only
     ~TimeVortexPQ() {}
 
-    void serialize_order(SST::Core::Serialization::serializer& ser) { TimeVortexPQBase<false>::serialize_order(ser); }
+    void serialize_order(SST::Core::Serialization::serializer& ser) override
+    {
+        TimeVortexPQBase<false>::serialize_order(ser);
+    }
 
     SST_ELI_EXPORT(TimeVortexPQ)
 };
@@ -175,7 +178,10 @@ public:
     TimeVortexPQ_ts() : TimeVortexPQBase<true>() {} // For serialization only
     ~TimeVortexPQ_ts() {}
 
-    void serialize_order(SST::Core::Serialization::serializer& ser) { TimeVortexPQBase<true>::serialize_order(ser); }
+    void serialize_order(SST::Core::Serialization::serializer& ser) override
+    {
+        TimeVortexPQBase<true>::serialize_order(ser);
+    }
 
     SST_ELI_EXPORT(TimeVortexPQ_ts)
 };

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -1523,7 +1523,10 @@ public:
     /**
      * Serialization function
      */
-    virtual void serialize_order(SST::Core::Serialization::serializer& ser) { SST::SubComponent::serialize_order(ser); }
+    void serialize_order(SST::Core::Serialization::serializer& ser) override
+    {
+        SST::SubComponent::serialize_order(ser);
+    }
 };
 
 } // namespace SST::Interfaces

--- a/src/sst/core/testElements/coreTest_ClockerComponent.h
+++ b/src/sst/core/testElements/coreTest_ClockerComponent.h
@@ -47,8 +47,8 @@ public:
     )
 
     coreTestClockerComponent(SST::ComponentId_t id, SST::Params& params);
-    void setup() {}
-    void finish() {}
+    void setup() override {}
+    void finish() override {}
 
 private:
     coreTestClockerComponent();                                                    // for serialization only

--- a/src/sst/core/testElements/coreTest_DistribComponent.h
+++ b/src/sst/core/testElements/coreTest_DistribComponent.h
@@ -57,8 +57,8 @@ public:
     )
 
     coreTestDistribComponent(SST::ComponentId_t id, SST::Params& params);
-    void finish();
-    void setup() {}
+    void finish() override;
+    void setup() override {}
 
 private:
     coreTestDistribComponent();                                                    // for serialization only

--- a/src/sst/core/testElements/coreTest_Links.h
+++ b/src/sst/core/testElements/coreTest_Links.h
@@ -53,8 +53,8 @@ public:
     coreTestLinks(SST::ComponentId_t id, SST::Params& params);
     ~coreTestLinks() = default;
 
-    void setup() {}
-    void finish() {}
+    void setup() override {}
+    void finish() override {}
 
 private:
     int my_id;

--- a/src/sst/core/testElements/coreTest_MessageGeneratorComponent.h
+++ b/src/sst/core/testElements/coreTest_MessageGeneratorComponent.h
@@ -50,8 +50,8 @@ public:
     )
 
     coreTestMessageGeneratorComponent(SST::ComponentId_t id, SST::Params& params);
-    void setup() {}
-    void finish()
+    void setup() override {}
+    void finish() override
     {
         fprintf(stdout, "Component completed at: %" PRIu64 " milliseconds\n", (uint64_t)getCurrentSimTimeMilli());
     }

--- a/src/sst/core/testElements/coreTest_ParamComponent.h
+++ b/src/sst/core/testElements/coreTest_ParamComponent.h
@@ -58,8 +58,8 @@ public:
 
     coreTestParamComponent(SST::ComponentId_t id, SST::Params& params);
     ~coreTestParamComponent() {}
-    void setup() {}
-    void finish() {}
+    void setup() override {}
+    void finish() override {}
 
 private:
     coreTestParamComponent();                                                  // for serialization only

--- a/src/sst/core/testElements/coreTest_PerfComponent.h
+++ b/src/sst/core/testElements/coreTest_PerfComponent.h
@@ -99,8 +99,8 @@ public:
     coreTestPerfComponent(SST::ComponentId_t id, SST::Params& params);
     ~coreTestPerfComponent();
 
-    void setup() {}
-    void finish() { printf("Perf Test Component Finished.\n"); }
+    void setup() override {}
+    void finish() override { printf("Perf Test Component Finished.\n"); }
 
 private:
     coreTestPerfComponent();                                                 // for serialization only

--- a/src/sst/core/testElements/coreTest_RNGComponent.h
+++ b/src/sst/core/testElements/coreTest_RNGComponent.h
@@ -56,8 +56,8 @@ public:
 
     coreTestRNGComponent(SST::ComponentId_t id, SST::Params& params);
     ~coreTestRNGComponent();
-    void setup() {}
-    void finish() {}
+    void setup() override {}
+    void finish() override {}
 
 private:
     coreTestRNGComponent();                                                // for serialization only

--- a/src/sst/core/testElements/coreTest_StatisticsComponent.h
+++ b/src/sst/core/testElements/coreTest_StatisticsComponent.h
@@ -60,8 +60,8 @@ public:
     )
 
     StatisticsComponentInt(ComponentId_t id, Params& params);
-    void setup() {}
-    void finish() {}
+    void setup() override {}
+    void finish() override {}
 
 private:
     StatisticsComponentInt();
@@ -121,8 +121,8 @@ public:
     )
 
     StatisticsComponentFloat(ComponentId_t id, Params& params);
-    void setup() {}
-    void finish() {}
+    void setup() override {}
+    void finish() override {}
 
 private:
     StatisticsComponentFloat();

--- a/src/sst/core/testElements/message_mesh/enclosingComponent.h
+++ b/src/sst/core/testElements/message_mesh/enclosingComponent.h
@@ -107,8 +107,8 @@ public:
 
     EnclosingComponent(ComponentId_t id, Params& params);
 
-    void setup();
-    void finish();
+    void setup() override;
+    void finish() override;
 
 private:
     void handleEvent(SST::Event* ev, int port);
@@ -188,7 +188,7 @@ public:
     MessagePort(ComponentId_t id, Params& params);
     ~MessagePort() {}
 
-    void send(MessageEvent* ev);
+    void send(MessageEvent* ev) override;
     void handleEvent(Event* ev);
 
 private:

--- a/src/sst/core/watchPoint.h
+++ b/src/sst/core/watchPoint.h
@@ -34,6 +34,7 @@ public:
     {
     public:
         virtual bool check() = 0;
+        virtual ~Logic()     = default;
     };
 
     WatchPoint(const std::string& name, Core::Serialization::ObjectMapComparison* obj) :


### PR DESCRIPTION
Add `override` for virtual functions which are overriden (as warned by `-Wsuggest-override`).

`virtual` could be removed wherever `override` was used. `override` implies `virtual`, but it was felt that leaving `virtual`, which is at the beginning, would make it more readable. If `virtual` existed before, it was not removed simply because `override` was added, but if neither `virtual` nor `override` existed and `override` applied because the function was virtual in a base class, then only `override` was added.
