### PR TITLE
Fix Valgrind memory errors

### DIFF
--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -34,6 +34,7 @@ ComponentInfo::ComponentInfo(ComponentId_t id, const std::string& name) :
     enabled_stat_names_(nullptr),
     enabled_all_stats_(false),
     all_stat_config_(nullptr),
+    statLoadLevel(0),
     coordinates(3, 0.0),
     subIDIndex(1),
     slot_name(""),
@@ -55,6 +56,7 @@ ComponentInfo::ComponentInfo() :
     enabled_stat_names_(nullptr),
     enabled_all_stats_(false),
     all_stat_config_(nullptr),
+    statLoadLevel(0),
     coordinates(3, 0.0),
     subIDIndex(1),
     slot_name(""),
@@ -170,9 +172,9 @@ ComponentInfo::ComponentInfo(ComponentInfo&& o) :
     stat_configs_(o.stat_configs_),
     all_stat_config_(o.all_stat_config_),
     statLoadLevel(o.statLoadLevel),
-    coordinates(o.coordinates),
+    coordinates(std::move(o.coordinates)),
     subIDIndex(o.subIDIndex),
-    slot_name(o.slot_name),
+    slot_name(std::move(o.slot_name)),
     slot_num(o.slot_num),
     share_flags(o.share_flags)
 {

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -369,6 +369,7 @@ private:
         id(id),
         graph(graph),
         name(name),
+        slot_num(0),
         type(type),
         weight(weight),
         rank(rank),

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -1234,6 +1234,11 @@ SSTPythonModelDefinition::SSTPythonModelDefinition(
     // Init the model
     initModel(script_file, verbosity, configObj, argc, argv);
 
+    // Free the arguments
+    for ( int i = 0; i < argc; ++i ) {
+        free(argv[i]);
+    }
+
     // Free the vector
     free(argv);
 }

--- a/src/sst/core/model/python/pymodel_comp.cc
+++ b/src/sst/core/model/python/pymodel_comp.cc
@@ -94,6 +94,7 @@ compInit(ComponentPy_t* self, PyObject* args, PyObject* UNUSED(kwds))
         char*         prefixed_name = gModel->addNamePrefix(name);
         ComponentId_t id            = gModel->addComponent(prefixed_name, type);
         obj                         = new PyComponent(self, id);
+        free(prefixed_name);
         gModel->getOutput()->verbose(
             CALL_INFO, 3, 0, "Creating component [%s] of type [%s]: id [%" PRIu64 "]\n", name, type, id);
     }

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -238,7 +238,7 @@ public:
     }
 
     /** Returns reference to the Component Info Map */
-    const ComponentInfoMap& getComponentInfoMap() { return compInfoMap; }
+    const ComponentInfoMap& getComponentInfoMap() const { return compInfoMap; }
 
     /** returns the component with the given ID */
     BaseComponent* getComponent(const ComponentId_t& id) const

--- a/src/sst/core/testElements/coreTest_Checkpoint.cc
+++ b/src/sst/core/testElements/coreTest_Checkpoint.cc
@@ -97,7 +97,18 @@ coreTestCheckpoint::coreTestCheckpoint(ComponentId_t id, Params& params) : Compo
     stat_null       = registerStatistic<uint32_t>("nullstat");
 }
 
-coreTestCheckpoint::~coreTestCheckpoint() {}
+coreTestCheckpoint::~coreTestCheckpoint()
+{
+    delete mersenne;
+    delete marsaglia;
+    delete xorshift;
+    delete dist_const;
+    delete dist_discrete;
+    delete dist_expon;
+    delete dist_gauss;
+    delete dist_poisson;
+    delete dist_uniform;
+}
 
 void
 coreTestCheckpoint::init(unsigned UNUSED(phase))

--- a/src/sst/core/testElements/coreTest_Checkpoint.h
+++ b/src/sst/core/testElements/coreTest_Checkpoint.h
@@ -138,20 +138,19 @@ private:
     Output*             output;
     int                 output_frequency;
 
-    RNG::Random*             mersenne;
-    RNG::Random*             marsaglia;
-    RNG::Random*             xorshift;
-    RNG::RandomDistribution* dist_const;
-    RNG::RandomDistribution* dist_discrete;
-    RNG::RandomDistribution* dist_expon;
-    RNG::RandomDistribution* dist_gauss;
-    RNG::RandomDistribution* dist_poisson;
-    RNG::RandomDistribution* dist_uniform;
-
-    Statistic<uint32_t>* stat_eventcount;
-    Statistic<uint32_t>* stat_rng;
-    Statistic<double>*   stat_dist;
-    Statistic<uint32_t>* stat_null;
+    RNG::Random*             mersenne        = nullptr;
+    RNG::Random*             marsaglia       = nullptr;
+    RNG::Random*             xorshift        = nullptr;
+    RNG::RandomDistribution* dist_const      = nullptr;
+    RNG::RandomDistribution* dist_discrete   = nullptr;
+    RNG::RandomDistribution* dist_expon      = nullptr;
+    RNG::RandomDistribution* dist_gauss      = nullptr;
+    RNG::RandomDistribution* dist_poisson    = nullptr;
+    RNG::RandomDistribution* dist_uniform    = nullptr;
+    Statistic<uint32_t>*     stat_eventcount = nullptr;
+    Statistic<uint32_t>*     stat_rng        = nullptr;
+    Statistic<double>*       stat_dist       = nullptr;
+    Statistic<uint32_t>*     stat_null       = nullptr;
 };
 
 } // namespace SST::CoreTestCheckpoint


### PR DESCRIPTION
This fixes some Valgrind memory errors:
1. In `ConfigComponent`, `slot_num` and `statLoadLevel` were not being initialized (maybe because they only apply in some cases -- a `slot_num` comment says "Only valid for subcomponents") and when `ConfigComponent` is serialized, it causes Valgrind to report an uninitialized memory read. This change simply adds `slot_num(0)` and `statLoadLevel(0)` to the constructors to initialize them to `0` and avoid uninitialized memory reads.
2. In the `SSTPythonModelDefinition` constructor, an `argv` array is `malloc()`ed and then each of the argument pointers are separately `malloc()`ed. But then when it finishes, it only `free()`s the `argv` array, but not its individual arguments.
3. In `pymodel_comp.cc`, `compInit()` allocates a string by calling `gModel->addNamePrefix(name)` and then passes it as a `char*` to `gModel->addComponent()`, which constructs a `std::string` copy of it by implicitly converting the `char*` argument to `std::string`. But then it is not freed. It would have been better if `addNamePrefix()` returned a `std::string` which automatically gets destroyed, but it would be too much work to change and test changing this API, so the pointer returned by `addComponent()` is `free()`ed after it is converted to a `std::string` in the call to `addComponent()`.
4. In `CoreTestCheckPoint`, random number generators are initialized with `new` during construction, but are not `delete`d in the destructor. As a precaution, all pointers to allocated memory are default-initialized to `nullptr` before the constructor body begins, so that they can be passed to `delete` even if they never got initialized with `new` (say, if an exception was thrown in the constructor). There is another memory leak in `CoreTestCheckPoint::clock_handler`, but because of how it is handled during checkpoint/restart, it is not as simple as `delete`-ing it in the destructor, since it is re-initialized strangely during checkpoint/restart and the `CoreTestCheckPoint` is not completely destroyed and re-constructed during checkpoint/restart phases, but it is left in a partial state and re-initialized. So this leak, which is reported as a "definite leak" by Valgrind, will require a better solution. Since this `CoreTestCheckPoint` does not appear to be a part of main Core but rather testing, and the leaks were found with Valgrind while running `sst-test-core`, it is lower priority that these leaks be fixed.

As a bonus, but not fixing any memory errors, `ComponentInfo` already had an explicitly-defined move constructor, but it did not use `std::move()` on two of its `std::string` and `std::vector` members, so `std::move()` was added so that the `std::string` and `std::vector` have shallow moves instead of deep copies.

Also `Simulation_impl::getComponentInfoMap()`, which returns the Component Info Map, was marked `const`, since it is best practice that getters should be `const`.