### PR TITLE
Fix memory leaks in Clock

### DIFF
--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -33,8 +33,8 @@ class Clock : public Action
 {
 public:
     /** Create a new clock with a specified period */
-    Clock(TimeConverter* period, int priority = CLOCKPRIORITY);
-    ~Clock();
+    explicit Clock(TimeConverter* period, int priority = CLOCKPRIORITY);
+    ~Clock() = default;
 
     /**
        Base handler for clock functions.
@@ -102,10 +102,11 @@ public:
     std::string toString() const override;
 
 private:
-    /* using HandlerMap_t = std::list<Clock::HandlerBase*>; */
-    using StaticHandlerMap_t = std::vector<Clock::HandlerBase*>;
+    using StaticHandlerMap_t = std::vector<std::unique_ptr<Clock::HandlerBase>>;
 
-    Clock() {}
+    Clock()                        = default; // For serialization only
+    Clock(const Clock&)            = delete;
+    Clock& operator=(const Clock&) = delete;
 
     void execute() override;
 

--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -104,8 +104,8 @@ public:
 private:
     using StaticHandlerMap_t = std::vector<std::unique_ptr<Clock::HandlerBase>>;
 
-    Clock()                        = default; // For serialization only
-    Clock(const Clock&)            = delete;
+    Clock()             = default; // For serialization only
+    Clock(const Clock&) = delete;
     Clock& operator=(const Clock&) = delete;
 
     void execute() override;


### PR DESCRIPTION
This is another Valgrind-related memory leak fix, but because it is not as straightforward, it deserves a separate PR and more careful review.

There is a "definite leak" reported by Valgrind in `Clock::staticHandlerMap`, which is a vector of pointers to handlers, when running the `coreTest_Checkpoint` test.

To fix this leak, and to simplify the code, `staticHandlerMap` was changed from a vector of raw pointers to a vector of `std::unique_ptr`, so that when the class is destroyed and its member `staticHandlerMap` is destroyed, all of its pointers are deleted automatically. 

However, in `Clock::execute()`, the handler is executed, and if successful, the handler member in `staticHandlerMap` is erased. Previously it erased the raw pointer member without deleting it, while now we have to `release()` it from `std::unique_ptr` before the mapping entry gets erased, because the handler apparently uses the raw handler pointer elsewhere, passing it around and maybe adding it back to `staticHandlerMap` later. If we do not `release()` it and simply erase the `std::unique_ptr` entry, it will get `delete`d, which causes it not to work correctly (the previous code did not `delete` the raw pointer either).

On the surface, this change looks like it does not change the behavior, because it uses `std::unique_ptr` instead of raw pointers, and it has the same behavior as before, adding allocated handler pointers to `staticHandlerMap` and erasing them without deleting them when they are successfully executed. When the `Clock` is destroyed, any remaining members of `staticHandlerMap` are deleted and erased. So this change superficially looks like it uses smart pointers for better, simpler code without changing its behavior.

But I have seen "definite leak" Valgrind errors fixed by this change in `coreTest_Checkpoint`, so it has something to do with checkpoint/restart. I am not sure this solution is right. I wish that SST used smart pointers in more places, and that ownership semantics were better defined in APIs. There is this comment in the file, which indicates that `staticHandlerMap` is not serialized, which may have something to do with the leak in the `coreTest_Checkpoint` test:

```c++
void
Clock::serialize_order(SST::Core::Serialization::serializer& ser)
{
    Action::serialize_order(ser);

    // Won't serialize the handlers; they'll be re-registered at
    // restart
    ser& currentCycle;
    ser& period;
    ser& next;
    ser& scheduled;
}
```

"``Won't serialize the handlers; they'll be re-registered at restart``". Somehow turning the handler pointers into smart `std::unique_ptr`s is able to get rid of one of the leaks in `coreTest_Checkpoint`.

I suspect that when the checkpointing test does a serialization and Checkpointing, it discards the old value of `staticHandlerMap`, and that by making the pointers `std::unique_ptr`, they get `delete`d when the `staticHandlerMap` is erased/destroyed/whatever when the checkpoint/restart sequence happens, whereas before this change, the raw pointers to allocated memory simply got thrown away and caused a memory leak.
