### PR TITLE
Fix #1262 by specifying intended base class

### DIFF
--- a/src/sst/core/testingframework/test_engine_unittest.py
+++ b/src/sst/core/testingframework/test_engine_unittest.py
@@ -595,7 +595,7 @@ class SSTTestSuite(TestSuiteBaseClass):  # type: ignore [misc, valid-type]
             # Ignore make_tests and wrap_results
             # continue using old super invocation to prevent
             # sstsimulator/sst-core#1262
-            super(unittest.TestSuite, self).__init__(suite)
+            super(unittest.TestSuite, self).__init__(suite) # type: ignore[name-defined]
         else:
             super().__init__(suite, make_tests, wrap_result)
 

--- a/src/sst/core/testingframework/test_engine_unittest.py
+++ b/src/sst/core/testingframework/test_engine_unittest.py
@@ -593,7 +593,9 @@ class SSTTestSuite(TestSuiteBaseClass):  # type: ignore [misc, valid-type]
         # concurrently.
         if not test_engine_globals.TESTENGINE_CONCURRENTMODE:
             # Ignore make_tests and wrap_results
-            super().__init__(suite)
+            # continue using old super invocation to prevent
+            # sstsimulator/sst-core#1262
+            super(unittest.TestSuite, self).__init__(suite)
         else:
             super().__init__(suite, make_tests, wrap_result)
 


### PR DESCRIPTION
Updating some of our `super()` calls caused this failure.  Restore the old code for the non-concurrent testing case.

Closes #1262 
