### PR TITLE
Fix serialization to build in both mapped and un-mapped mode

### DIFF
--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -963,7 +963,7 @@ SerializeBaseComponentHelper::unpack_basecomponent(serializable_base*& s, serial
 }
 
 void
-SerializeBaseComponentHelper::map_basecomponent(serializable_base*& s, serializer& ser, const char* name)
+SerializeBaseComponentHelper::map_basecomponent(serializable_base*& s, serializer& ser, const std::string& name)
 {
     if ( nullptr == s ) return;
 

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -1124,7 +1124,7 @@ public:
 
     static void unpack_basecomponent(serializable_base*& s, serializer& ser);
 
-    static void map_basecomponent(serializable_base*& s, serializer& ser, const char* name);
+    static void map_basecomponent(serializable_base*& s, serializer& ser, const std::string& name);
 };
 
 } // namespace pvt

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -1149,19 +1149,10 @@ class serialize_impl<T*, std::enable_if_t<std::is_base_of_v<SST::BaseComponent, 
             pvt::SerializeBaseComponentHelper::unpack_basecomponent(sp, ser);
             break;
         case serializer::MAP:
-            // Add your code here
+            pvt::SerializeBaseComponentHelper::map_basecomponent(sp, ser, ser.getMapName());
             break;
         }
         s = static_cast<T*>(sp);
-    }
-
-    void operator()(T*& s, serializer& ser, const char* name)
-    {
-        // If it's not mapping mode, fall back on non-mapping mode.
-        if ( ser.mode() != serializer::MAP ) return (*this)(s, ser);
-
-        serializable_base* sp = static_cast<serializable_base*>(s);
-        pvt::SerializeBaseComponentHelper::map_basecomponent(sp, ser, name);
     }
 };
 

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -1157,6 +1157,9 @@ class serialize_impl<T*, std::enable_if_t<std::is_base_of_v<SST::BaseComponent, 
 
     void operator()(T*& s, serializer& ser, const char* name)
     {
+        // If it's not mapping mode, fall back on non-mapping mode.
+        if ( ser.mode() != serializer::MAP ) return (*this)(s, ser);
+
         serializable_base* sp = static_cast<serializable_base*>(s);
         pvt::SerializeBaseComponentHelper::map_basecomponent(sp, ser, name);
     }

--- a/src/sst/core/from_string.h
+++ b/src/sst/core/from_string.h
@@ -92,6 +92,27 @@ from_string(const std::string& input)
     return T(input);
 }
 
+template <class T>
+std::enable_if_t<std::is_enum_v<T>, T>
+from_string(const std::string& input)
+{
+    return static_cast<T>(from_string<std::underlying_type_t<T>>(input));
+}
+
+template <class T>
+std::enable_if_t<!std::is_enum_v<T>, std::string>
+to_string(const T& input)
+{
+    return std::to_string(input);
+}
+
+template <class T>
+std::enable_if_t<std::is_enum_v<T>, std::string>
+to_string(const T& input)
+{
+    return std::to_string(static_cast<std::underlying_type_t<T>>(input));
+}
+
 } // end namespace SST::Core
 
 #endif // SST_CORE_FROM_STRING_H

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -33,7 +33,7 @@
 namespace SST {
 
 void
-SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, SST::Core::Serialization::serializer& ser)
+SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer& ser)
 {
     // Need to treat Links and SelfLinks differently
     bool    self_link;
@@ -559,16 +559,9 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, SST::Core:
         }
         break;
     case serializer::MAP:
-        // This version of the function is not called in mapping mode.
+        // TODO: Implement Link mapping mode
         break;
     }
-}
-
-void
-SST::Core::Serialization::serialize_impl<Link*>::operator()(
-    Link*& UNUSED(s), SST::Core::Serialization::serializer& UNUSED(ser), const char* UNUSED(name))
-{
-    // TODO: Implement Link mapping mode
 }
 
 /**

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -43,7 +43,6 @@ class SST::Core::Serialization::serialize_impl<Link*>
     friend class serialize;
     // Function implemented in link.cc
     void operator()(Link*& s, SST::Core::Serialization::serializer& ser);
-    void operator()(Link*& s, SST::Core::Serialization::serializer& ser, const char* name);
 };
 
 

--- a/src/sst/core/serialization/impl/serialize_array.h
+++ b/src/sst/core/serialization/impl/serialize_array.h
@@ -81,7 +81,7 @@ raw_ptr(TPtr*& ptr)
    Version of serialize that works for statically allocated arrays of
    fundamental types and enums.
  */
-template <class T, int N>
+template <class T, size_t N>
 class serialize_impl<T[N], std::enable_if_t<std::is_fundamental_v<T> || std::is_enum_v<T>>>
 {
     template <class A>
@@ -98,7 +98,7 @@ class serialize_impl<T[N], std::enable_if_t<std::is_fundamental_v<T> || std::is_
    Version of serialize that works for statically allocated arrays of
    non base types.
  */
-template <class T, int N>
+template <class T, size_t N>
 class serialize_impl<T[N], std::enable_if_t<!std::is_fundamental_v<T> && !std::is_enum_v<T>>>
 {
     template <class A>

--- a/src/sst/core/serialization/impl/serialize_array.h
+++ b/src/sst/core/serialization/impl/serialize_array.h
@@ -86,10 +86,10 @@ class serialize_impl<T[N], std::enable_if_t<std::is_fundamental_v<T> || std::is_
 {
     template <class A>
     friend class serialize;
-    void operator()(T arr[N], serializer& ser) { ser.array<T, N>(arr); }
-
-    void operator()(T UNUSED(arr[N]), serializer& UNUSED(ser), const char* UNUSED(name))
+    void operator()(T arr[N], serializer& ser)
     {
+        ser.array<T, N>(arr);
+
         // TODO: Implement mapping mode
     }
 };
@@ -108,10 +108,7 @@ class serialize_impl<T[N], std::enable_if_t<!std::is_fundamental_v<T> && !std::i
         for ( int i = 0; i < N; i++ ) {
             ser& arr[i];
         }
-    }
 
-    void operator()(T UNUSED(arr[N]), serializer& UNUSED(ser), const char* UNUSED(name))
-    {
         // TODO: Implement mapping mode
     }
 };
@@ -128,10 +125,10 @@ class serialize_impl<
 {
     template <class A>
     friend class serialize;
-    void operator()(pvt::ser_array_wrapper<T, IntType> arr, serializer& ser) { ser.binary(arr.bufptr, arr.sizeptr); }
-
-    void operator()(pvt::ser_array_wrapper<T, IntType> UNUSED(arr), serializer& UNUSED(ser), const char* UNUSED(name))
+    void operator()(pvt::ser_array_wrapper<T, IntType> arr, serializer& ser)
     {
+        ser.binary(arr.bufptr, arr.sizeptr);
+
         // TODO: Implement mapping mode
     }
 };
@@ -152,10 +149,7 @@ class serialize_impl<
         for ( int i = 0; i < arr.sizeptr; i++ ) {
             ser& arr[i];
         }
-    }
 
-    void operator()(pvt::ser_array_wrapper<T, IntType> UNUSED(arr), serializer& UNUSED(ser), const char* UNUSED(name))
-    {
         // TODO: Implement mapping mode
     }
 };
@@ -169,11 +163,10 @@ class serialize_impl<pvt::ser_array_wrapper<void, IntType>>
 {
     template <class A>
     friend class serialize;
-    void operator()(pvt::ser_array_wrapper<void, IntType> arr, serializer& ser) { ser.binary(arr.bufptr, arr.sizeptr); }
-
-    void
-    operator()(pvt::ser_array_wrapper<void, IntType> UNUSED(arr), serializer& UNUSED(ser), const char* UNUSED(name))
+    void operator()(pvt::ser_array_wrapper<void, IntType> arr, serializer& ser)
     {
+        ser.binary(arr.bufptr, arr.sizeptr);
+
         // TODO: Implement mapping mode
     }
 };
@@ -191,10 +184,10 @@ class serialize_impl<pvt::raw_ptr_wrapper<TPtr>>
 {
     template <class A>
     friend class serialize;
-    void operator()(pvt::raw_ptr_wrapper<TPtr> ptr, serializer& ser) { ser.primitive(ptr.bufptr); }
-
-    void operator()(pvt::raw_ptr_wrapper<TPtr> UNUSED(ptr), serializer& UNUSED(ser), const char* UNUSED(name))
+    void operator()(pvt::raw_ptr_wrapper<TPtr> ptr, serializer& ser)
     {
+        ser.primitive(ptr.bufptr);
+
         // TODO: Implement mapping mode
     }
 };

--- a/src/sst/core/serialization/impl/serialize_atomic.h
+++ b/src/sst/core/serialization/impl/serialize_atomic.h
@@ -53,14 +53,11 @@ public:
             break;
         }
         case serializer::MAP:
-            // The version of function not called in mapping mode
+        {
+            // TODO: Add support for mapping mode
             break;
         }
-    }
-
-    void operator()(Value& UNUSED(v), serializer& UNUSED(ser), const char* UNUSED(name))
-    {
-        // TODO: Add support for mapping mode
+        }
     }
 };
 

--- a/src/sst/core/serialization/impl/serialize_deque.h
+++ b/src/sst/core/serialization/impl/serialize_deque.h
@@ -64,14 +64,11 @@ public:
             break;
         }
         case serializer::MAP:
-            // The version of function not called in mapping mode
+        {
+            // TODO: Add support for mapping mode
             break;
         }
-    }
-
-    void operator()(Deque& UNUSED(v), serializer& UNUSED(ser), const char* UNUSED(name))
-    {
-        // TODO: Add support for mapping mode
+        }
     }
 };
 

--- a/src/sst/core/serialization/impl/serialize_list.h
+++ b/src/sst/core/serialization/impl/serialize_list.h
@@ -67,14 +67,11 @@ public:
             break;
         }
         case serializer::MAP:
-            // The version of function not called in mapping mode
+        {
+            // TODO: Add support for mapping mode
             break;
         }
-    }
-
-    void operator()(List& UNUSED(v), serializer& UNUSED(ser), const char* UNUSED(name))
-    {
-        // TODO: Add support for mapping mode
+        }
     }
 };
 

--- a/src/sst/core/serialization/impl/serialize_map.h
+++ b/src/sst/core/serialization/impl/serialize_map.h
@@ -77,14 +77,11 @@ public:
             break;
         }
         case serializer::MAP:
-            // The version of function not called in mapping mode
+        {
+            // TODO: Add support for mapping mode
             break;
         }
-    }
-
-    void operator()(Map& UNUSED(m), serializer& UNUSED(ser), const char* UNUSED(name))
-    {
-        // TODO: Add support for mapping mode
+        }
     }
 };
 
@@ -136,14 +133,11 @@ public:
             break;
         }
         case serializer::MAP:
-            // The version of function not called in mapping mode
+        {
+            // TODO: Add support for mapping mode
             break;
         }
-    }
-
-    void operator()(Map& UNUSED(m), serializer& UNUSED(ser), const char* UNUSED(name))
-    {
-        // TODO: Add support for mapping mode
+        }
     }
 };
 

--- a/src/sst/core/serialization/impl/serialize_multiset.h
+++ b/src/sst/core/serialization/impl/serialize_multiset.h
@@ -124,7 +124,7 @@ public:
         }
         case serializer::MAP:
         {
-        // TODO: Add support for mapping mode
+            // TODO: Add support for mapping mode
             break;
         }
         }

--- a/src/sst/core/serialization/impl/serialize_multiset.h
+++ b/src/sst/core/serialization/impl/serialize_multiset.h
@@ -123,14 +123,11 @@ public:
             break;
         }
         case serializer::MAP:
-            // The version of function not called in mapping mode
+        {
+        // TODO: Add support for mapping mode
             break;
         }
-    }
-
-    void operator()(MultiSet& UNUSED(v), serializer& UNUSED(ser), const char* UNUSED(name))
-    {
-        // TODO: Add support for mapping mode
+        }
     }
 };
 

--- a/src/sst/core/serialization/impl/serialize_priority_queue.h
+++ b/src/sst/core/serialization/impl/serialize_priority_queue.h
@@ -77,14 +77,11 @@ public:
             break;
         }
         case serializer::MAP:
-            // The version of function not called in mapping mode
+        {
+          // TODO: Add support for mapping mode
             break;
         }
-    }
-
-    void operator()(Pqueue& UNUSED(v), serializer& UNUSED(ser), const char* UNUSED(name))
-    {
-        // TODO: Add support for mapping mode
+        }
     }
 };
 

--- a/src/sst/core/serialization/impl/serialize_priority_queue.h
+++ b/src/sst/core/serialization/impl/serialize_priority_queue.h
@@ -78,7 +78,7 @@ public:
         }
         case serializer::MAP:
         {
-          // TODO: Add support for mapping mode
+            // TODO: Add support for mapping mode
             break;
         }
         }

--- a/src/sst/core/serialization/impl/serialize_set.h
+++ b/src/sst/core/serialization/impl/serialize_set.h
@@ -68,14 +68,11 @@ public:
             break;
         }
         case serializer::MAP:
-            // The version of function not called in mapping mode
+        {
+           // TODO: Add support for mapping mode
             break;
         }
-    }
-
-    void operator()(Set& UNUSED(v), serializer& UNUSED(ser), const char* UNUSED(name))
-    {
-        // TODO: Add support for mapping mode
+        }
     }
 };
 
@@ -123,14 +120,11 @@ public:
             break;
         }
         case serializer::MAP:
-            // The version of function not called in mapping mode
+        {
+            // TODO: Add support for mapping mode
             break;
         }
-    }
-
-    void operator()(Set& UNUSED(v), serializer& UNUSED(ser), const char* UNUSED(name))
-    {
-        // TODO: Add support for mapping mode
+        }
     }
 };
 

--- a/src/sst/core/serialization/impl/serialize_set.h
+++ b/src/sst/core/serialization/impl/serialize_set.h
@@ -69,7 +69,7 @@ public:
         }
         case serializer::MAP:
         {
-           // TODO: Add support for mapping mode
+            // TODO: Add support for mapping mode
             break;
         }
         }

--- a/src/sst/core/serialization/impl/serialize_string.h
+++ b/src/sst/core/serialization/impl/serialize_string.h
@@ -64,14 +64,14 @@ template <>
 class serialize_impl<std::string>
 {
 public:
-    void operator()(std::string& str, serializer& ser) { ser.string(str); }
-    void operator()(std::string& str, serializer& ser, const char* name)
+    void operator()(std::string& str, serializer& ser)
     {
-        // If it's not mapping mode, fall back on non-mapping mode.
-        if ( ser.mode() != serializer::MAP ) return (*this)(str, ser);
-
-        ObjectMapString* obj_map = new ObjectMapString(&str);
-        ser.mapper().map_primitive(name, obj_map);
+        if ( ser.mode() == serializer::MAP ) {
+            ObjectMapString* obj_map = new ObjectMapString(&str);
+            ser.mapper().map_primitive(ser.getMapName(), obj_map);
+            return;
+        }
+        ser.string(str);
     }
 };
 
@@ -81,18 +81,16 @@ class serialize_impl<std::string*>
 public:
     void operator()(std::string*& str, serializer& ser)
     {
+        if ( ser.mode() == serializer::MAP ) {
+            ObjectMapString* obj_map = new ObjectMapString(str);
+            ser.mapper().map_primitive(ser.getMapName(), obj_map);
+            return;
+        }
+
         // Nullptr is checked for in serialize<T>(), so just serialize
         // as if it was non-pointer
         if ( ser.mode() == serializer::UNPACK ) { str = new std::string(); }
         ser.string(*str);
-    }
-    void operator()(std::string*& str, serializer& ser, const char* name)
-    {
-        // If it's not mapping mode, fall back on non-mapping mode.
-        if ( ser.mode() != serializer::MAP ) return (*this)(str, ser);
-
-        ObjectMapString* obj_map = new ObjectMapString(str);
-        ser.mapper().map_primitive(name, obj_map);
     }
 };
 

--- a/src/sst/core/serialization/impl/serialize_string.h
+++ b/src/sst/core/serialization/impl/serialize_string.h
@@ -67,6 +67,9 @@ public:
     void operator()(std::string& str, serializer& ser) { ser.string(str); }
     void operator()(std::string& str, serializer& ser, const char* name)
     {
+        // If it's not mapping mode, fall back on non-mapping mode.
+        if ( ser.mode() != serializer::MAP ) return (*this)(str, ser);
+
         ObjectMapString* obj_map = new ObjectMapString(&str);
         ser.mapper().map_primitive(name, obj_map);
     }
@@ -85,6 +88,9 @@ public:
     }
     void operator()(std::string*& str, serializer& ser, const char* name)
     {
+        // If it's not mapping mode, fall back on non-mapping mode.
+        if ( ser.mode() != serializer::MAP ) return (*this)(str, ser);
+
         ObjectMapString* obj_map = new ObjectMapString(str);
         ser.mapper().map_primitive(name, obj_map);
     }

--- a/src/sst/core/serialization/impl/serialize_vector.h
+++ b/src/sst/core/serialization/impl/serialize_vector.h
@@ -79,18 +79,19 @@ class serialize_impl<std::vector<T>>
         case serializer::MAP:
         {
             const char* name = ser.getMapName();
-            if(name) {
-              ObjectMapVector<T>* obj_map = new ObjectMapVector<T>(&v);
-              ser.mapper().map_hierarchy_start(ser.getMapName(), obj_map);
-              for ( size_t i = 0; i < v.size(); ++i ) {
-                sst_map_object(ser, v[i], std::to_string(i).c_str());
-              }
-              ser.mapper().map_hierarchy_end();
-              return;
-            } else {
-              // If this version of operator() is called during mapping
-              // mode and the variable being mapped did not provide a
-              // name, no ObjectMap will be created.
+            if ( name ) {
+                ObjectMapVector<T>* obj_map = new ObjectMapVector<T>(&v);
+                ser.mapper().map_hierarchy_start(ser.getMapName(), obj_map);
+                for ( size_t i = 0; i < v.size(); ++i ) {
+                    sst_map_object(ser, v[i], std::to_string(i).c_str());
+                }
+                ser.mapper().map_hierarchy_end();
+                return;
+            }
+            else {
+                // If this version of operator() is called during mapping
+                // mode and the variable being mapped did not provide a
+                // name, no ObjectMap will be created.
             }
             break;
         }

--- a/src/sst/core/serialization/impl/serialize_vector.h
+++ b/src/sst/core/serialization/impl/serialize_vector.h
@@ -90,7 +90,8 @@ class serialize_impl<std::vector<T>>
 
     void operator()(Vector& v, serializer& ser, const char* name)
     {
-        if ( ser.mode() != serializer::MAP ) return operator()(v, ser);
+        // If it's not mapping mode, fall back on non-mapping mode.
+        if ( ser.mode() != serializer::MAP ) return (*this)(v, ser);
 
         ObjectMapVector<T>* obj_map = new ObjectMapVector<T>(&v);
         ser.mapper().map_hierarchy_start(name, obj_map);

--- a/src/sst/core/serialization/impl/serialize_vector.h
+++ b/src/sst/core/serialization/impl/serialize_vector.h
@@ -78,8 +78,8 @@ class serialize_impl<std::vector<T>>
         }
         case serializer::MAP:
         {
-            const char* name = ser.getMapName();
-            if ( name ) {
+            const std::string& name = ser.getMapName();
+            if ( !name.empty() ) {
                 ObjectMapVector<T>* obj_map = new ObjectMapVector<T>(&v);
                 ser.mapper().map_hierarchy_start(ser.getMapName(), obj_map);
                 for ( size_t i = 0; i < v.size(); ++i ) {

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -605,7 +605,7 @@ public:
 /**
    ObjectMap representing fundamental types, and classes treated as
    fundamental types.  In order for an object to be treated as a
-   fundamental, it must be printable using std::to_string() and
+   fundamental, it must be printable using SST::Core::to_string() and
    assignable using SST::Core::from_string(). If this is not true, it
    is possible to create a template specialization for the type
    desired to be treated as a fundamental.  The specialization will
@@ -625,7 +625,7 @@ public:
     /**
        Get the value of the object as a string
      */
-    virtual std::string get() override { return std::to_string(*addr_); }
+    virtual std::string get() override { return SST::Core::to_string(*addr_); }
 
     /**
        Set the value of the object represented as a string

--- a/src/sst/core/serialization/serializable.cc
+++ b/src/sst/core/serialization/serializable.cc
@@ -48,19 +48,19 @@ unpack_serializable(serializable_base*& s, serializer& ser)
     ser.unpack(cls_id);
     if ( cls_id == null_ptr_id ) { s = nullptr; }
     else {
-        s = SST::Core::Serialization::serializable_factory::get_serializable(cls_id);
+        s = serializable_factory::get_serializable(cls_id);
         ser.report_new_pointer(reinterpret_cast<uintptr_t>(s));
         s->serialize_order(ser);
     }
 }
 
 void
-map_serializable(serializable_base*& s, serializer& ser, const char* name)
+map_serializable(serializable_base*& s, serializer& ser)
 {
     if ( s ) {
-        SST::Core::Serialization::ObjectMap* obj_map = new SST::Core::Serialization::ObjectMapClass(s, s->cls_name());
+        ObjectMap* obj_map = new ObjectMapClass(s, s->cls_name());
         ser.report_object_map(obj_map);
-        ser.mapper().map_hierarchy_start(name, obj_map);
+        ser.mapper().map_hierarchy_start(ser.getMapName(), obj_map);
         s->serialize_order(ser);
         ser.mapper().map_hierarchy_end();
     }

--- a/src/sst/core/serialization/serializable.h
+++ b/src/sst/core/serialization/serializable.h
@@ -73,6 +73,9 @@ class serialize_impl<T*, std::enable_if_t<std::is_base_of_v<SST::Core::Serializa
 
     void operator()(T*& s, serializer& ser, const char* name)
     {
+        // If it's not mapping mode, fall back on non-mapping mode.
+        if ( ser.mode() != serializer::MAP ) return (*this)(s, ser);
+
         serializable_base* sp = static_cast<serializable_base*>(s);
         switch ( ser.mode() ) {
         case serializer::SIZER:

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -391,7 +391,7 @@ sst_map_object(serializer& ser, T& t, const char* name)
     // temporarily set the map name and run the serializer
     ser.setMapName(name);
     serialize<T>()(t, ser);
-    ser.setMapName(nullptr);
+    ser.setMapName("");
 }
 
 // Serialization macros for checkpoint/debug serialization

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -262,10 +262,10 @@ public:
         ser_pointer_map[reinterpret_cast<uintptr_t>(ptr->getAddr())] = reinterpret_cast<uintptr_t>(ptr);
     }
 
-    void        setMapName(const char* name) { map_name = name; }
-    const char* getMapName() const
+    void               setMapName(std::string name) { map_name = std::move(name); }
+    const std::string& getMapName() const
     {
-        if ( !map_name ) throw std::invalid_argument("NULL map name when map serialization requires it");
+        if ( map_name.empty() ) throw std::invalid_argument("Empty map name when map serialization requires it");
         return map_name;
     }
 
@@ -283,8 +283,7 @@ protected:
     // Used for unpacking and mapping
     std::map<uintptr_t, uintptr_t> ser_pointer_map;
     uintptr_t                      split_key;
-
-    const char* map_name = nullptr;
+    std::string                    map_name;
 };
 
 } // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -105,7 +105,7 @@ public:
         }
     }
 
-    template <class T, int N>
+    template <class T, size_t N>
     void array(T arr[N])
     {
         switch ( mode_ ) {
@@ -262,6 +262,13 @@ public:
         ser_pointer_map[reinterpret_cast<uintptr_t>(ptr->getAddr())] = reinterpret_cast<uintptr_t>(ptr);
     }
 
+    void        setMapName(const char* name) { map_name = name; }
+    const char* getMapName() const
+    {
+        if ( !map_name ) throw std::invalid_argument("NULL map name when map serialization requires it");
+        return map_name;
+    }
+
 protected:
     // only one of these is going to be valid for this serializer
     // not very good class design, but a little more convenient
@@ -276,6 +283,8 @@ protected:
     // Used for unpacking and mapping
     std::map<uintptr_t, uintptr_t> ser_pointer_map;
     uintptr_t                      split_key;
+
+    const char* map_name = nullptr;
 };
 
 } // namespace SST::Core::Serialization

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -653,7 +653,7 @@ class serialize_impl<Statistics::Statistic<T>*>
 {
     template <class A>
     friend class serialize;
-    void operator()(Statistics::Statistic<T>*& s, serializer& ser, const char* UNUSED(name) = nullptr)
+    void operator()(Statistics::Statistic<T>*& s, serializer& ser)
     {
         // For sizer and pack, need to get the information needed
         // to create a new statistic of the correct type on unpack.
@@ -691,15 +691,12 @@ class serialize_impl<Statistics::Statistic<T>*>
             break;
         }
         case serializer::MAP:
+        {
             // Mapping mode not supported for stats
             break;
         }
+        }
     }
-
-    // void operator()(Statistics::Statistic<T>*& UNUSED(s), serializer& UNUSED(ser), const char* UNUSED(name))
-    // {
-    //     // Mapping mode not supported for stats
-    // }
 };
 
 } // namespace Core::Serialization

--- a/src/sst/core/testElements/coreTest_Checkpoint.cc
+++ b/src/sst/core/testElements/coreTest_Checkpoint.cc
@@ -208,32 +208,30 @@ void
 coreTestCheckpoint::serialize_order(SST::Core::Serialization::serializer& ser)
 {
     SST::Component::serialize_order(ser);
-    SST_SER(link_left)
-    SST_SER(link_right)
-    SST_SER(self_link)
-    SST_SER(clock_handler)
-    SST_SER(clock_tc)
-    SST_SER(duty_cycle)
-    SST_SER(duty_cycle_count)
-    SST_SER(counter)
-    SST_SER(test_string); // Make sure semicolon is a no-op
+    SST_SER(link_left);
+    SST_SER(link_right);
+    SST_SER(self_link);
+    SST_SER(clock_handler);
+    SST_SER(clock_tc);
+    SST_SER(duty_cycle);
+    SST_SER(duty_cycle_count);
     SST_SER(counter);
     SST_SER(test_string);
     SST_SER(output);
     SST_SER(output_frequency);
-    SST_SER(mersenne)
-    SST_SER(marsaglia)
-    SST_SER(xorshift)
-    SST_SER(dist_const)
-    SST_SER(dist_discrete)
-    SST_SER(dist_expon)
-    SST_SER(dist_gauss)
-    SST_SER(dist_poisson)
-    SST_SER(dist_uniform)
-    SST_SER(stat_eventcount)
-    SST_SER(stat_rng)
-    SST_SER(stat_dist)
-    SST_SER(stat_null)
+    SST_SER(mersenne);
+    SST_SER(marsaglia);
+    SST_SER(xorshift);
+    SST_SER(dist_const);
+    SST_SER(dist_discrete);
+    SST_SER(dist_expon);
+    SST_SER(dist_gauss);
+    SST_SER(dist_poisson);
+    SST_SER(dist_uniform);
+    SST_SER(stat_eventcount);
+    SST_SER(stat_rng);
+    SST_SER(stat_dist);
+    SST_SER(stat_null);
 }
 
 

--- a/src/sst/core/testElements/coreTest_Checkpoint.h
+++ b/src/sst/core/testElements/coreTest_Checkpoint.h
@@ -47,7 +47,7 @@ private:
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {
         Event::serialize_order(ser);
-        SST_SER(counter)
+        SST_SER(counter);
     }
 
     ImplementSerializable(SST::CoreTestCheckpoint::coreTestCheckpointEvent);

--- a/src/sst/core/testElements/coreTest_Component.cc
+++ b/src/sst/core/testElements/coreTest_Component.cc
@@ -162,21 +162,21 @@ void
 coreTestComponent::serialize_order(SST::Core::Serialization::serializer& ser)
 {
     SST::CoreTestComponent::coreTestComponentBase2::serialize_order(ser);
-    SST_SER(workPerCycle)
-    SST_SER(commFreq)
-    SST_SER(commSize)
-    SST_SER(neighbor)
+    SST_SER(workPerCycle);
+    SST_SER(commFreq);
+    SST_SER(commSize);
+    SST_SER(neighbor);
 
-    SST_SER(rng)
-    SST_SER(N)
-    SST_SER(S)
-    SST_SER(E)
-    SST_SER(W)
+    SST_SER(rng);
+    SST_SER(N);
+    SST_SER(S);
+    SST_SER(E);
+    SST_SER(W);
 
-    SST_SER(countN)
-    SST_SER(countS)
-    SST_SER(countE)
-    SST_SER(countW)
+    SST_SER(countN);
+    SST_SER(countS);
+    SST_SER(countE);
+    SST_SER(countW);
 }
 
 // Element Library / Serialization stuff

--- a/src/sst/core/testElements/coreTest_Module.cc
+++ b/src/sst/core/testElements/coreTest_Module.cc
@@ -152,8 +152,8 @@ void
 coreTestModuleLoader::serialize_order(SST::Core::Serialization::serializer& ser)
 {
     Component::serialize_order(ser);
-    SST_SER(output)
-    SST_SER(rng_max_count)
-    SST_SER(rng_count)
-    SST_SER(rng_module)
+    SST_SER(output);
+    SST_SER(rng_max_count);
+    SST_SER(rng_count);
+    SST_SER(rng_module);
 }

--- a/src/sst/core/testElements/coreTest_SharedObjectComponent.cc
+++ b/src/sst/core/testElements/coreTest_SharedObjectComponent.cc
@@ -362,25 +362,25 @@ void
 coreTestSharedObjectsComponent::serialize_order(SST::Core::Serialization::serializer& ser)
 {
     Component::serialize_order(ser);
-    SST_SER(out)
-    SST_SER(test_array)
-    SST_SER(test_array)
-    SST_SER(test_bool_array)
-    SST_SER(test_map)
-    SST_SER(test_set)
-    SST_SER(myid)
-    SST_SER(num_entities)
-    SST_SER(count)
-    SST_SER(check)
-    SST_SER(late_write)
-    SST_SER(pub)
-    SST_SER(late_initialize)
-    SST_SER(checkpoint)
+    SST_SER(out);
+    SST_SER(test_array);
+    SST_SER(test_array);
+    SST_SER(test_bool_array);
+    SST_SER(test_map);
+    SST_SER(test_set);
+    SST_SER(myid);
+    SST_SER(num_entities);
+    SST_SER(count);
+    SST_SER(check);
+    SST_SER(late_write);
+    SST_SER(pub);
+    SST_SER(late_initialize);
+    SST_SER(checkpoint);
 
-    if ( test_array ) SST_SER(array)
-    if ( test_bool_array ) SST_SER(bool_array)
-    if ( test_map ) SST_SER(map)
-    if ( test_set ) SST_SER(set)
+    if ( test_array ) SST_SER(array);
+    if ( test_bool_array ) SST_SER(bool_array);
+    if ( test_map ) SST_SER(map);
+    if ( test_set ) SST_SER(set);
 }
 
 } // namespace SST::CoreTestSharedObjectsComponent

--- a/src/sst/core/testElements/coreTest_SubComponent.h
+++ b/src/sst/core/testElements/coreTest_SubComponent.h
@@ -117,8 +117,8 @@ public:
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {
         SST::Component::serialize_order(ser);
-        SST_SER(count)
-        SST_SER(subComps)
+        SST_SER(count);
+        SST_SER(subComps);
     }
     ImplementSerializable(SST::CoreTestSubComponent::SubComponentLoader)
 
@@ -159,7 +159,7 @@ public:
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {
         SubCompSlotInterface::serialize_order(ser);
-        SST_SER(subComps)
+        SST_SER(subComps);
     }
     ImplementSerializable(SST::CoreTestSubComponent::SubCompSlot)
 
@@ -258,11 +258,11 @@ public:
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {
         SubCompSendRecvInterface::serialize_order(ser);
-        SST_SER(link)
-        SST_SER(nToSend)
-        SST_SER(nMsgSent)
-        SST_SER(totalMsgSent)
-        SST_SER(out)
+        SST_SER(link);
+        SST_SER(nToSend);
+        SST_SER(nMsgSent);
+        SST_SER(totalMsgSent);
+        SST_SER(out);
     }
     ImplementSerializable(SST::CoreTestSubComponent::SubCompSender)
 
@@ -316,8 +316,8 @@ public:
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {
         SubCompSendRecvInterface::serialize_order(ser);
-        SST_SER(link)
-        SST_SER(nMsgReceived)
+        SST_SER(link);
+        SST_SER(nMsgReceived);
         SST_SER(out);
     }
     ImplementSerializable(SST::CoreTestSubComponent::SubCompReceiver)

--- a/src/sst/core/timeConverter.h
+++ b/src/sst/core/timeConverter.h
@@ -72,7 +72,7 @@ class SST::Core::Serialization::serialize_impl<TimeConverter*>
     template <class A>
     friend class serialize;
     // Function implemented in timeLord.cc
-    void operator()(TimeConverter*& s, SST::Core::Serialization::serializer& ser, const char* name = nullptr);
+    void operator()(TimeConverter*& s, serializer& ser);
 };
 
 } // namespace SST

--- a/src/sst/core/timeLord.cc
+++ b/src/sst/core/timeLord.cc
@@ -234,8 +234,7 @@ public:
 
 
 void
-serialize_impl<TimeConverter*>::operator()(
-    TimeConverter*& s, SST::Core::Serialization::serializer& ser, const char* name)
+serialize_impl<TimeConverter*>::operator()(TimeConverter*& s, serializer& ser)
 {
     SimTime_t factor = 0;
 
@@ -265,9 +264,11 @@ serialize_impl<TimeConverter*>::operator()(
         break;
     }
     case serializer::MAP:
+    {
         ObjectMap* obj_map = new ObjectMapFundamental<TimeConverter*>(&s);
-        ser.mapper().map_primitive(name, obj_map);
+        ser.mapper().map_primitive(ser.getMapName(), obj_map);
         break;
+    }
     }
 }
 

--- a/src/sst/core/timeVortex.h
+++ b/src/sst/core/timeVortex.h
@@ -70,10 +70,10 @@ void unpack_timevortex(TimeVortex*& s, SST::Core::Serialization::serializer& ser
 template <>
 class SST::Core::Serialization::serialize_impl<TimeVortex*>
 {
-
     template <class A>
     friend class serialize;
-    void operator()(TimeVortex*& s, SST::Core::Serialization::serializer& ser, const char *UNUSED(name) = nullptr)
+
+    void operator()(TimeVortex*& s, SST::Core::Serialization::serializer& ser)
     {
         switch ( ser.mode() ) {
         case serializer::SIZER:

--- a/src/sst/core/timeVortex.h
+++ b/src/sst/core/timeVortex.h
@@ -73,7 +73,7 @@ class SST::Core::Serialization::serialize_impl<TimeVortex*>
 
     template <class A>
     friend class serialize;
-    void operator()(TimeVortex*& s, SST::Core::Serialization::serializer& ser)
+    void operator()(TimeVortex*& s, SST::Core::Serialization::serializer& ser, const char *UNUSED(name) = nullptr)
     {
         switch ( ser.mode() ) {
         case serializer::SIZER:

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -468,6 +468,9 @@ class serialize_impl<UnitAlgebra>
 
     void operator()(UnitAlgebra& ua, serializer& ser, const char* name)
     {
+        // If it's not mapping mode, fall back on non-mapping mode.
+        if ( ser.mode() != serializer::MAP ) return (*this)(ua, ser);
+
         ObjectMap* obj_map = new ObjectMapFundamental<UnitAlgebra>(&ua);
         ser.mapper().map_primitive(name, obj_map);
     }

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -404,8 +404,7 @@ operator<<(std::ostream& os, const Units& r)
 }
 
 
-namespace Core {
-namespace Serialization {
+namespace Core::Serialization {
 
 template <>
 class ObjectMapFundamental<UnitAlgebra> : public ObjectMap
@@ -461,25 +460,17 @@ class serialize_impl<UnitAlgebra>
             ua.serialize_order(ser);
             break;
         case serializer::MAP:
-            // Add your code here
+        {
+            ObjectMap* obj_map = new ObjectMapFundamental<UnitAlgebra>(&ua);
+            ser.mapper().map_primitive(ser.getMapName(), obj_map);
             break;
         }
-    }
-
-    void operator()(UnitAlgebra& ua, serializer& ser, const char* name)
-    {
-        // If it's not mapping mode, fall back on non-mapping mode.
-        if ( ser.mode() != serializer::MAP ) return (*this)(ua, ser);
-
-        ObjectMap* obj_map = new ObjectMapFundamental<UnitAlgebra>(&ua);
-        ser.mapper().map_primitive(name, obj_map);
+        }
     }
 };
 
 
-} // namespace Serialization
-} // namespace Core
-
+} // namespace Core::Serialization
 
 } // namespace SST
 


### PR DESCRIPTION
Fixes https://github.com/tactcomplabs/sst-tools/issues/5 (cross-repo).

Remove the `name` parameter from serialization `operator()(T&, serializer& ser, const char* name)`, since it makes it too complicated, and caused compilation errors. It would be better to store mapped information in the `serializer` class state than to pass mapped `name` arguments at every level of the call hierarchy and to need to split the serialization  functions into mapped and non-mapped versions.

Add `ser.setMapName()` and `ser.getMapName()` to set and get mapped names, which are only used in certain places ~~(right now it's just a `const char*` pointer, but it can be turned into a `std::string` if necessary)~~. The `SST_SER()` macro will call the `sst_map_object()` function, which will set the quoted variable name to be used in the map before the serialization call, and clear the name after the serialization call, so that the name does not need to be passed around in every call.

`operator()` functions which used to be duplicated with a mapped and a non-mapped version, the mapped version of which was only valid in `serializer::MAP` mode, are now combined into one where the `serializer::MAP` mode, already handled in a `switch` statement, expects `getMapName()` to return the name.

Rewrite the default `serialize_impl<>` class to use modern C++ techniques like `if constexpr` and `decltype(auto)`. `tPtr` is a `const` reference variable which refers to either `t` or `&t` depending on whether `t` is a pointer or not, so that pointer and non-pointer code can be merged into one, by using the `tPtr` pointer to make method calls, and `tPtr` also reflects the new value of `t` when `t` is a pointer which gets assigned to in `UNPACK` mode. The `dependent_false` template is not needed anymore, since we can simply use a single `static_assert()` at the top of our function to assert that the type, with any top-level pointer removed, is a non-polymorphic class type.

Write a generalized `SST::Core::to_string()` which operates like `std::to_string` and also handles enumeration types, and generalize `SST::Core::from_string()`  to handle enumeration types. Right now, enumeration types are inputted and outputted as integers of the underlying type. There were build errors when the mapped and non-mapped serialization codes were merged, because the mapped code depended on `std::to_string` which isn't defined for enumeration types but which was depended on when the `serialize_impl` for "fundamental and `enum` types" created a mapping object.

For array serialization templates, use `size_t` instead of `int` for the size of the array.

The Core tests pass, and Elements builds, but there are some Elements test failures which need investigating and fixing.