### PR TITLE
Update GitHub Actions runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/PR_clang-format_test.yml
+++ b/.github/workflows/PR_clang-format_test.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         python-version: [3.8]
     name: Test:${{ matrix.os }}/PY-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/PR_cmake-format_test.yml
+++ b/.github/workflows/PR_cmake-format_test.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         python-version: [3.8]
     name: Test:${{ matrix.os }}/PY-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fix the intentional Ubuntu 20.04 brownouts (https://github.com/actions/runner-images/issues/11101) due to end of life.

The installation of the tools on these runners doesn't actually depend on the runner itself as long as it's Linux, so this is safe.