### PR TITLE
Replace incorrect usage of std::is_fundamental with std::is_arithmetic

### DIFF
--- a/src/sst/core/from_string.h
+++ b/src/sst/core/from_string.h
@@ -99,14 +99,16 @@ from_string(const std::string& input)
     return static_cast<T>(from_string<std::underlying_type_t<T>>(input));
 }
 
+///////////////////////////////////////////////////////////////////////////////
+
 template <class T>
 std::enable_if_t<!std::is_enum_v<T>, std::string>
 to_string(const T& input)
 {
-    if constexpr ( std::is_fundamental_v<T> )
+    if constexpr ( std::is_arithmetic_v<T> )
         return std::to_string(input);
     else
-        return typeid(T).name(); // For now, return a string if the type isn't fundamental or handled elsewhere
+        return typeid(T).name(); // For now, return a string if the type isn't handled elsewhere
 }
 
 template <class T>
@@ -116,6 +118,7 @@ to_string(const T& input)
     return std::to_string(static_cast<std::underlying_type_t<T>>(input));
 }
 
+// for std::string no-op, or class types which define operator std::string()
 inline std::string
 to_string(std::string s)
 {

--- a/src/sst/core/serialization/impl/serialize_array.h
+++ b/src/sst/core/serialization/impl/serialize_array.h
@@ -82,10 +82,10 @@ raw_ptr(TPtr*& ptr)
 
 /**
    Version of serialize that works for statically allocated arrays of
-   fundamental types and enums.
+   arithmetic types and enums.
  */
 template <class T, size_t N>
-class serialize_impl<T[N], std::enable_if_t<std::is_fundamental_v<T> || std::is_enum_v<T>>>
+class serialize_impl<T[N], std::enable_if_t<std::is_arithmetic_v<T> || std::is_enum_v<T>>>
 {
     template <class A>
     friend class serialize;
@@ -102,7 +102,7 @@ class serialize_impl<T[N], std::enable_if_t<std::is_fundamental_v<T> || std::is_
    non base types.
  */
 template <class T, size_t N>
-class serialize_impl<T[N], std::enable_if_t<!std::is_fundamental_v<T> && !std::is_enum_v<T>>>
+class serialize_impl<T[N], std::enable_if_t<!std::is_arithmetic_v<T> && !std::is_enum_v<T>>>
 {
     template <class A>
     friend class serialize;
@@ -120,11 +120,10 @@ class serialize_impl<T[N], std::enable_if_t<!std::is_fundamental_v<T> && !std::i
 
 /**
    Version of serialize that works for dynamically allocated arrays of
-   fundamental types and enums.
+   arithmetic types and enums.
  */
 template <class T, class IntType>
-class serialize_impl<
-    pvt::ser_array_wrapper<T, IntType>, std::enable_if_t<std::is_fundamental_v<T> || std::is_enum_v<T>>>
+class serialize_impl<pvt::ser_array_wrapper<T, IntType>, std::enable_if_t<std::is_arithmetic_v<T> || std::is_enum_v<T>>>
 {
     template <class A>
     friend class serialize;
@@ -142,7 +141,7 @@ class serialize_impl<
  */
 template <class T, class IntType>
 class serialize_impl<
-    pvt::ser_array_wrapper<T, IntType>, std::enable_if_t<!std::is_fundamental_v<T> && !std::is_enum_v<T>>>
+    pvt::ser_array_wrapper<T, IntType>, std::enable_if_t<!std::is_arithmetic_v<T> && !std::is_enum_v<T>>>
 {
     template <class A>
     friend class serialize;

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -280,11 +280,11 @@ public:
 
 
 /**
-   Version of serialize that works for fundamental types and enums.
+   Version of serialize that works for arithmetic and enum types.
  */
 
 template <class T>
-class serialize_impl<T, std::enable_if_t<std::is_fundamental_v<T> || std::is_enum_v<T>>>
+class serialize_impl<T, std::enable_if_t<std::is_arithmetic_v<T> || std::is_enum_v<T>>>
 {
 public:
     void operator()(T& t, serializer& ser)
@@ -300,15 +300,14 @@ public:
 };
 
 /**
-   Version of serialize that works for pointers to fundamental types
-   and enums. Note that the pointer tracking happens at a higher
-   level, and only if it is turned on.  If it is not turned on, then
-   this only copies the value pointed to into the buffer.  If multiple
-   objects point to the same location, they will each have an
-   independent copy after deserialization.
+   Version of serialize that works for pointers to arithmetic and enum types.
+   Note that the pointer tracking happens at a higher level, and only if it is
+   turned on. If it is not turned on, then this only copies the value pointed
+   to into the buffer. If multiple objects point to the same location, they
+   will each have an independent copy after deserialization.
  */
 template <class T>
-class serialize_impl<T*, std::enable_if_t<std::is_fundamental_v<T> || std::is_enum_v<T>>>
+class serialize_impl<T*, std::enable_if_t<std::is_arithmetic_v<T> || std::is_enum_v<T>>>
 {
     template <typename>
     friend class serialize;

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -318,12 +318,11 @@ private:
 /**
  \class StatisticCollector
  * Base type that creates the virtual addData(...) interface
- * Used for distinguishing fundamental types (collected by value)
+ * Used for distinguishing arithmetic types (collected by value)
  * and composite struct types (collected by reference)
  */
-template <class T, bool = std::is_fundamental_v<T>>
-struct StatisticCollector
-{};
+template <class T, bool = std::is_arithmetic_v<T>>
+struct StatisticCollector;
 
 template <class T>
 struct StatisticCollector<T, true>

--- a/src/sst/core/statapi/statnull.h
+++ b/src/sst/core/statapi/statnull.h
@@ -34,9 +34,8 @@ namespace SST::Statistics {
 
     @tparam T A template for holding the main data type of this statistic
 */
-template <class T, bool = std::is_fundamental_v<T>>
-class NullStatisticBase
-{};
+template <class T, bool = std::is_arithmetic_v<T>>
+class NullStatisticBase;
 
 template <class T>
 class NullStatisticBase<T, true> : public Statistic<T>
@@ -137,11 +136,8 @@ public:
     static bool isLoaded() { return loaded_; }
 
 private:
-    static bool loaded_;
+    inline static bool loaded_ = true;
 };
-
-template <class T>
-bool NullStatistic<T>::loaded_ = true;
 
 template <>
 class NullStatistic<void> : public Statistic<void>


### PR DESCRIPTION
Replace all uses of the word and type traits `fundamental` with `arithmetic`, because `fundamental` is the wrong description -- the wrong named requirement -- for its uses.

--------

In C++ nomenclature and [`<type_traits>`](https://en.cppreference.com/w/cpp/header/type_traits), there are [different type categories](https://en.cppreference.com/w/cpp/language/type):
- Integral, `std::is_integral`: All signed and unsigned integer and `char` types, including `bool`
- Floating-point, `std::is_floating_point`: `float`, `double`, `long double`, extensions like `_Float16`
- Enumeration, `std::is_enum`: Scoped (`enum class`) and unscoped (`enum`) enumeration types
- Pointer, `std::is_pointer`: A pointer to an object or function, like `T*` or `void (*)()`
- Null pointer, `std::is_null_pointer`: `std::nullptr_t`, `decltype(nullptr)`, the type of a null pointer constant
- `void`, `std::is_void`
- Class, `std::is_class`
- Union, `std::is_union`
- Array, `std::is_array`
- Function, `std::is_function`
- Lvalue reference, `std::is_lvalue_reference`
- Rvalue reference, `std::is_rvalue_reference`
- Member object pointer, `std::is_member_object_pointer`
- Member function pointer, `std::is_member_function_pointer`

Composite type categories:
- Arithmetic, `std::is_arithmetic`: Integral and floating-point
- Scalar, `std::is_scalar`: Arithmetic, enumeration, pointer, pointer-to-member, and `std::nullptr_t`
    - not a reference, function, array, class, union, or `void`
- Object, `std::is_object`: Scalar, array, class or union
    - not a reference, function or `void`
- Reference, `std::is_reference`: Lvalue or Rvalue reference
- Member pointer, `std::is_member_pointer`: A pointer to a class member object or function
- Fundamental, `std::is_fundamental`: Arithmetic, `std::nullptr_t` and `void`.
    - The word _fundamental_ is used in the sense of the word _elemental_: That the type cannot be broken down any further into smaller pieces, like a pointer and its pointee, a class and its members, an enumeration and its underlying integral type, etc.
- Compound, `std::is_compound`: Array, class, union, enumeration, function, pointer to {object, function, member}, reference
    - The opposite of fundamental

--------

The word "Fundamental", and `std::is_fundamental`, `std::is_fundamental_v`, etc. were used incorrectly, when the correct term is _Arithmetic_: Integral types (including `char` and `bool`) and Floating-point types.

In places where "Fundamental" was used, I do not think that null pointer constants and `void` intended to be included:
  - "Yes, I'd like to serialize a `void` object. Oh wait, I can't declare one, much less pass it to a function!!!"
  - "I'd like to serialize a null pointer constant, not a general pointer to an object or function. I realize that it can only have one value, but there are cases where I'd like to call a serialization function or instantiate a template with `std::nullptr_t` when normally a pointer to an object or function is required, and well, you don't consider those object and function pointers to be fundamental types anyway."

All cases of the word `fundamental` have been replaced with `arithmetic`, preserving case, and the phrase `a fundamental` has been replaced with `an arithmetic`.

It should be remembered that although the word "fundamental" sounds cool, like "Well, it's a fundamental type in the C++ language -- that sounds cool, so we'll handle it", the word "fundamental" is not used casually in the C++ language definition: It means a built-in type which cannot be broken down into smaller components like a pointer and its pointee can, and it includes `std::nullptr_t` and `void`. That is almost certainly not the intended use of the word "fundamental" in SST. "Arithmetic" is the better word, and is the C++ language type category for integral and floating-point, with `std::is_arithmetic` being the `<type_traits>` trait for it.
