### PR TITLE
adding shared stats writing from JSON; Fix for JSON portion of Issue #1240

### DIFF
--- a/src/sst/core/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.cc
@@ -33,12 +33,14 @@ namespace {
 struct CompWrapper
 {
     SST::ConfigComponent const* comp;
+    std::map<SST::StatisticId_t, std::string> &sharedStatMap;
     bool                        output_parition_info;
 };
 
 struct SubCompWrapper
 {
     SST::ConfigComponent const* comp;
+    std::map<SST::StatisticId_t, std::string> &sharedStatMap;
 };
 
 struct LinkConfPair
@@ -50,6 +52,7 @@ struct LinkConfPair
 struct StatPair
 {
     std::pair<std::string, unsigned long> const& statkey;
+    std::map<SST::StatisticId_t, std::string> &sharedStatMap;
     SST::ConfigComponent const*                  comp;
 };
 
@@ -69,12 +72,22 @@ struct StatGroupParamPair
 void
 to_json(json::ordered_json& j, StatPair const& sp)
 {
-    auto const& name = sp.statkey.first;
-    j                = json::ordered_json { { "name", name } };
-
     auto* si = sp.comp->findStatistic(sp.statkey.second);
+    if( si->shared ){
+      if( sp.sharedStatMap.find(si->id) == sp.sharedStatMap.end() ) {
+        std::string name = "statObj" + std::to_string(sp.sharedStatMap.size()) + "_" + si->name;
+        sp.sharedStatMap[si->id].assign(name);
+        j                = json::ordered_json { { "name", name } };
+      }else{
+        std::string name = sp.sharedStatMap.find(si->id)->second;
+        j                = json::ordered_json { { "name", name } };
+      }
+    }else{
+      auto const& name = sp.statkey.first;
+      j                = json::ordered_json { { "name", name } };
+    }
     for ( auto const& parmItr : si->params.getKeys() ) {
-        j["params"][parmItr] = si->params.find<std::string>(parmItr);
+      j["params"][parmItr] = si->params.find<std::string>(parmItr);
     }
 }
 
@@ -93,11 +106,11 @@ to_json(json::ordered_json& j, SubCompWrapper const& comp_wrapper)
     }
 
     for ( auto const& scItr : comp->subComponents ) {
-        j["subcomponents"].push_back(SubCompWrapper { scItr });
+        j["subcomponents"].push_back(SubCompWrapper { scItr, comp_wrapper.sharedStatMap });
     }
 
     for ( auto const& pair : comp->enabledStatNames ) {
-        j["statistics"].push_back(StatPair { pair, comp });
+        j["statistics"].push_back(StatPair { pair, comp_wrapper.sharedStatMap, comp });
     }
 }
 
@@ -116,11 +129,11 @@ to_json(json::ordered_json& j, CompWrapper const& comp_wrapper)
     }
 
     for ( auto const& scItr : comp->subComponents ) {
-        j["subcomponents"].push_back(SubCompWrapper { scItr });
+        j["subcomponents"].push_back(SubCompWrapper { scItr, comp_wrapper.sharedStatMap });
     }
 
     for ( auto const& pair : comp->enabledStatNames ) {
-        j["statistics"].push_back(StatPair { pair, comp });
+        j["statistics"].push_back(StatPair { pair, comp_wrapper.sharedStatMap, comp });
     }
 
     if ( comp_wrapper.output_parition_info ) {
@@ -256,7 +269,7 @@ JSONConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph)
     if ( const_cast<ConfigComponentMap_t&>(compMap).size() == 0 ) { outputJson["components"]; }
 
     for ( const auto& compItr : compMap ) {
-        outputJson["components"].emplace_back(CompWrapper { compItr, cfg->output_partition() });
+        outputJson["components"].emplace_back(CompWrapper { compItr, sharedStatMap, cfg->output_partition() });
     }
 
     // no links exist in this rank
@@ -273,4 +286,6 @@ JSONConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph)
     // lifetime extension, but this temp is the careful way.
     std::string outputString = ss.str();
     fprintf(outputFile, "%s", outputString.c_str());
+
+    sharedStatMap.clear();
 }

--- a/src/sst/core/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.cc
@@ -32,15 +32,15 @@ JSONConfigGraphOutput::JSONConfigGraphOutput(const char* path) : ConfigGraphOutp
 namespace {
 struct CompWrapper
 {
-    SST::ConfigComponent const* comp;
-    std::map<SST::StatisticId_t, std::string> &sharedStatMap;
-    bool                        output_parition_info;
+    SST::ConfigComponent const*                comp;
+    std::map<SST::StatisticId_t, std::string>& sharedStatMap;
+    bool                                       output_parition_info;
 };
 
 struct SubCompWrapper
 {
-    SST::ConfigComponent const* comp;
-    std::map<SST::StatisticId_t, std::string> &sharedStatMap;
+    SST::ConfigComponent const*                comp;
+    std::map<SST::StatisticId_t, std::string>& sharedStatMap;
 };
 
 struct LinkConfPair
@@ -52,7 +52,7 @@ struct LinkConfPair
 struct StatPair
 {
     std::pair<std::string, unsigned long> const& statkey;
-    std::map<SST::StatisticId_t, std::string> &sharedStatMap;
+    std::map<SST::StatisticId_t, std::string>&   sharedStatMap;
     SST::ConfigComponent const*                  comp;
 };
 
@@ -73,21 +73,23 @@ void
 to_json(json::ordered_json& j, StatPair const& sp)
 {
     auto* si = sp.comp->findStatistic(sp.statkey.second);
-    if( si->shared ){
-      if( sp.sharedStatMap.find(si->id) == sp.sharedStatMap.end() ) {
-        std::string name = "statObj" + std::to_string(sp.sharedStatMap.size()) + "_" + si->name;
-        sp.sharedStatMap[si->id].assign(name);
+    if ( si->shared ) {
+        if ( sp.sharedStatMap.find(si->id) == sp.sharedStatMap.end() ) {
+            std::string name = "statObj" + std::to_string(sp.sharedStatMap.size()) + "_" + si->name;
+            sp.sharedStatMap[si->id].assign(name);
+            j = json::ordered_json { { "name", name } };
+        }
+        else {
+            std::string name = sp.sharedStatMap.find(si->id)->second;
+            j                = json::ordered_json { { "name", name } };
+        }
+    }
+    else {
+        auto const& name = sp.statkey.first;
         j                = json::ordered_json { { "name", name } };
-      }else{
-        std::string name = sp.sharedStatMap.find(si->id)->second;
-        j                = json::ordered_json { { "name", name } };
-      }
-    }else{
-      auto const& name = sp.statkey.first;
-      j                = json::ordered_json { { "name", name } };
     }
     for ( auto const& parmItr : si->params.getKeys() ) {
-      j["params"][parmItr] = si->params.find<std::string>(parmItr);
+        j["params"][parmItr] = si->params.find<std::string>(parmItr);
     }
 }
 

--- a/src/sst/core/cfgoutput/jsonConfigOutput.h
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.h
@@ -24,6 +24,7 @@ class JSONConfigGraphOutput : public ConfigGraphOutput
 public:
     JSONConfigGraphOutput(const char* path);
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
+
 private:
     std::map<SST::StatisticId_t, std::string> sharedStatMap;
 };

--- a/src/sst/core/cfgoutput/jsonConfigOutput.h
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.h
@@ -24,6 +24,8 @@ class JSONConfigGraphOutput : public ConfigGraphOutput
 public:
     JSONConfigGraphOutput(const char* path);
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
+private:
+    std::map<SST::StatisticId_t, std::string> sharedStatMap;
 };
 
 } // namespace SST::Core


### PR DESCRIPTION
Adds shared statistics writing from the JSON config writer.  Takes a similar approach to the Python writer.  This is the remainder of the fix for Issue #1240 
