### PR TITLE
StandardMem Serialization

### DIFF
--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -142,7 +142,7 @@ public:
         Request(id_t rid, flags_t flags = 0) :
             id(rid),
             flags(flags) {} /* Responses share an ID with the matching request */
-        
+
         virtual ~Request() {}
 
         id_t getID() { return id; }
@@ -223,12 +223,13 @@ public:
 
         // Serialization
         ImplementVirtualSerializable(SST::Interfaces::StandardMem::Request);
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser) {
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
+        {
             SST_SER(id);
             SST_SER(flags);
             SST_SER(main_id);
         }
-        
+
     protected:
         id_t    id;
         flags_t flags;
@@ -308,7 +309,7 @@ public:
         uint32_t tid;   /* Thread ID */
 
         /* Serialization */
-        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -317,7 +318,7 @@ public:
             SST_SER(iPtr);
             SST_SER(tid);
         }
-        
+
         ImplementSerializable(SST::Interfaces::StandardMem::Read);
     };
 
@@ -382,7 +383,7 @@ public:
         /* Serialization */
         ReadResp() : Request(0, 0) {}
 
-        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -453,7 +454,7 @@ public:
         /* Serialization */
         Write() : Request(0, 0) {}
 
-        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -523,7 +524,7 @@ public:
         /* Serialization */
         WriteResp() : Request(0, 0) {}
 
-        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -588,7 +589,7 @@ public:
         /* Serialization */
         FlushAddr() : Request(0, 0) {}
 
-        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -643,7 +644,7 @@ public:
         uint32_t tid;   /* Thread ID */
 
         /* Serialization */
-        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(depth);
@@ -715,7 +716,7 @@ public:
         /* Serialization */
         FlushResp() : Request(0, 0) {}
 
-        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -783,7 +784,7 @@ public:
         /* Serialization */
         ReadLock() : Request(0, 0) {}
 
-        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -853,7 +854,7 @@ public:
         /* Serialization */
         WriteUnlock() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -923,7 +924,7 @@ public:
         /* Serialization */
         LoadLink() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -992,7 +993,7 @@ public:
         /* Serialization */
         StoreConditional() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -1060,7 +1061,7 @@ public:
         /* Serialization */
         MoveData() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pSrc);
@@ -1118,7 +1119,7 @@ public:
         /* Serialization */
         InvNotify() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -1227,7 +1228,7 @@ public:
         /* Serialization */
         CustomReq() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(data);
@@ -1320,7 +1321,7 @@ public:
         /* Serialization */
         CustomResp() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(data);
@@ -1362,9 +1363,9 @@ public:
         virtual SST::Event* convert(CustomResp* request)       = 0;
         virtual SST::Event* convert(InvNotify* request)        = 0;
 
-    /* Serialization */
-    virtual void serialize_order(SST::Core::Serialization::serializer& ser);
-    ImplementVirtualSerializable(RequestConverter);
+        /* Serialization */
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser);
+        ImplementVirtualSerializable(RequestConverter);
     };
 
     /* Class for implementation-specific handler functions */
@@ -1439,10 +1440,7 @@ public:
         SST::Output* out;
 
         /* Serialization */
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
-        {
-            SST_SER(out);
-        }
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) { SST_SER(out); }
         ImplementVirtualSerializable(RequestHandler);
     };
 

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -223,7 +223,7 @@ public:
 
         // Serialization
         ImplementVirtualSerializable(SST::Interfaces::StandardMem::Request);
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             SST_SER(id);
             SST_SER(flags);
@@ -309,7 +309,7 @@ public:
         uint32_t tid;   /* Thread ID */
 
         /* Serialization */
-        void serialize_order(SST::Core::Serialization::serializer& ser)
+        void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -383,7 +383,7 @@ public:
         /* Serialization */
         ReadResp() : Request(0, 0) {}
 
-        void serialize_order(SST::Core::Serialization::serializer& ser)
+        void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -454,7 +454,7 @@ public:
         /* Serialization */
         Write() : Request(0, 0) {}
 
-        void serialize_order(SST::Core::Serialization::serializer& ser)
+        void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -524,7 +524,7 @@ public:
         /* Serialization */
         WriteResp() : Request(0, 0) {}
 
-        void serialize_order(SST::Core::Serialization::serializer& ser)
+        void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -589,7 +589,7 @@ public:
         /* Serialization */
         FlushAddr() : Request(0, 0) {}
 
-        void serialize_order(SST::Core::Serialization::serializer& ser)
+        void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -644,7 +644,7 @@ public:
         uint32_t tid;   /* Thread ID */
 
         /* Serialization */
-        void serialize_order(SST::Core::Serialization::serializer& ser)
+        void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(depth);
@@ -716,7 +716,7 @@ public:
         /* Serialization */
         FlushResp() : Request(0, 0) {}
 
-        void serialize_order(SST::Core::Serialization::serializer& ser)
+        void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -784,7 +784,7 @@ public:
         /* Serialization */
         ReadLock() : Request(0, 0) {}
 
-        void serialize_order(SST::Core::Serialization::serializer& ser)
+        void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -854,7 +854,7 @@ public:
         /* Serialization */
         WriteUnlock() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -924,7 +924,7 @@ public:
         /* Serialization */
         LoadLink() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -993,7 +993,7 @@ public:
         /* Serialization */
         StoreConditional() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -1061,7 +1061,7 @@ public:
         /* Serialization */
         MoveData() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pSrc);
@@ -1119,7 +1119,7 @@ public:
         /* Serialization */
         InvNotify() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(pAddr);
@@ -1228,7 +1228,7 @@ public:
         /* Serialization */
         CustomReq() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(data);
@@ -1321,7 +1321,7 @@ public:
         /* Serialization */
         CustomResp() : Request(0, 0) {}
 
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser)
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) override
         {
             StandardMem::Request::serialize_order(ser);
             SST_SER(data);
@@ -1364,7 +1364,7 @@ public:
         virtual SST::Event* convert(InvNotify* request)        = 0;
 
         /* Serialization */
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser);
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) override;
         ImplementVirtualSerializable(RequestConverter);
     };
 
@@ -1373,6 +1373,7 @@ public:
     {
     public:
         RequestHandler(SST::Output* o) : out(o) {}
+        RequestHandler() {}
         virtual ~RequestHandler() {}
 
         /* Built in command handlers */
@@ -1440,8 +1441,8 @@ public:
         SST::Output* out;
 
         /* Serialization */
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser) { SST_SER(out); }
-        ImplementVirtualSerializable(RequestHandler);
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) override { SST_SER(out); }
+        ImplementSerializable(RequestHandler);
     };
 
     /** Constructor, designed to be used via 'loadUserSubComponent' and 'loadAnonymousSubComponent'.

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -16,6 +16,7 @@
 
 #include "sst/core/link.h"
 #include "sst/core/params.h"
+#include "sst/core/serialization/serializable.h"
 #include "sst/core/sst_types.h"
 #include "sst/core/ssthandler.h"
 #include "sst/core/subcomponent.h"
@@ -97,6 +98,12 @@ public:
     template <typename classT, typename dataT = void>
     using Handler = SSTHandler<void, Request*, classT, dataT>;
 
+    // /**
+    //    New style (checkpointable) SSTHandler
+    // */
+    template <typename classT, auto funcT, typename dataT = void>
+    using Handler2 = SSTHandler2<void, Request*, classT, dataT, funcT>;
+
     class RequestConverter; // Convert request to SST::Event* according to type
     class RequestHandler;   // Handle a request according to type
 
@@ -109,7 +116,7 @@ public:
     /**
      * Base class for StandardMem commands
      */
-    class Request
+    class Request : public SST::Core::Serialization::serializable
     {
     public:
         using id_t    = uint64_t;
@@ -135,7 +142,7 @@ public:
         Request(id_t rid, flags_t flags = 0) :
             id(rid),
             flags(flags) {} /* Responses share an ID with the matching request */
-
+        
         virtual ~Request() {}
 
         id_t getID() { return id; }
@@ -214,6 +221,14 @@ public:
             return str.str();
         }
 
+        // Serialization
+        ImplementVirtualSerializable(SST::Interfaces::StandardMem::Request);
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) {
+            SST_SER(id);
+            SST_SER(flags);
+            SST_SER(main_id);
+        }
+        
     protected:
         id_t    id;
         flags_t flags;
@@ -255,6 +270,7 @@ public:
             tid(tid)
         {}
         virtual ~Read() {}
+        Read() : Request(0, 0) {}
 
         /** Create read response.
          * User must manually set read data on response if simulation is using actual data values
@@ -290,6 +306,19 @@ public:
         uint64_t size;  /* Number of bytes to read */
         Addr     iPtr;  /* Instruction pointer - optional metadata */
         uint32_t tid;   /* Thread ID */
+
+        /* Serialization */
+        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(pAddr);
+            SST_SER(vAddr);
+            SST_SER(size);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+        
+        ImplementSerializable(SST::Interfaces::StandardMem::Read);
     };
 
     /** Response to a Read */
@@ -349,6 +378,21 @@ public:
         std::vector<uint8_t> data;  /* Read data */
         Addr                 iPtr;  /* Instruction pointer - optional metadata */
         uint32_t             tid;   /* Thread ID */
+
+        /* Serialization */
+        ReadResp() : Request(0, 0) {}
+
+        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(pAddr);
+            SST_SER(vAddr);
+            SST_SER(size);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::Read);
     };
 
     /** Request to write data.
@@ -405,6 +449,23 @@ public:
         bool                 posted; /* Whether write is posted (requires no response) */
         Addr                 iPtr;   /* Instruction pointer - optional metadata */
         uint32_t             tid;    /* Thread ID */
+
+        /* Serialization */
+        Write() : Request(0, 0) {}
+
+        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(pAddr);
+            SST_SER(vAddr);
+            SST_SER(size);
+            SST_SER(data);
+            SST_SER(posted);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::Write);
     };
 
     /** Response to a Write */
@@ -458,6 +519,21 @@ public:
         uint64_t size;  /* Number of bytes to read */
         Addr     iPtr;  /* Instruction pointer - optional metadata */
         uint32_t tid;   /* Thread ID */
+
+        /* Serialization */
+        WriteResp() : Request(0, 0) {}
+
+        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(pAddr);
+            SST_SER(vAddr);
+            SST_SER(size);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::WriteResp);
     };
 
     /* Flush an address from cache
@@ -508,6 +584,23 @@ public:
                            L1 + L2, etc. */
         Addr     iPtr;  /* Instruction pointer */
         uint32_t tid;   /* Thread ID */
+
+        /* Serialization */
+        FlushAddr() : Request(0, 0) {}
+
+        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(pAddr);
+            SST_SER(vAddr);
+            SST_SER(size);
+            SST_SER(inv);
+            SST_SER(depth);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::FlushAddr);
     };
 
     /* Flush an entire cache
@@ -548,6 +641,17 @@ public:
                            L1 + L2, etc. */
         Addr     iPtr;  /* Instruction pointer */
         uint32_t tid;   /* Thread ID */
+
+        /* Serialization */
+        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(depth);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::FlushCache);
     };
 
     /** Response to a flush request.
@@ -607,6 +711,21 @@ public:
         uint64_t size;  /* Number of bytes to invalidate */
         Addr     iPtr;  /* Instruction pointer */
         uint32_t tid;   /* Thread ID */
+
+        /* Serialization */
+        FlushResp() : Request(0, 0) {}
+
+        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(pAddr);
+            SST_SER(vAddr);
+            SST_SER(size);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::FlushResp);
     };
 
     /**
@@ -660,6 +779,21 @@ public:
         uint64_t size;  /* Number of bytes to read */
         Addr     iPtr;  /* Instruction pointer - optional metadata */
         uint32_t tid;   /* Thread ID */
+
+        /* Serialization */
+        ReadLock() : Request(0, 0) {}
+
+        void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(pAddr);
+            SST_SER(vAddr);
+            SST_SER(size);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::ReadLock);
     };
 
     /* WriteUnlock writes a locked address
@@ -715,6 +849,23 @@ public:
         bool                 posted; /* Whether write is posted (requires no response) */
         Addr                 iPtr;   /* Instruction pointer - optional metadata */
         uint32_t             tid;    /* Thread ID */
+
+        /* Serialization */
+        WriteUnlock() : Request(0, 0) {}
+
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(pAddr);
+            SST_SER(vAddr);
+            SST_SER(size);
+            SST_SER(data);
+            SST_SER(posted);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::WriteUnlock);
     };
 
     /**
@@ -768,6 +919,21 @@ public:
         uint64_t size;  /* Number of bytes to read */
         Addr     iPtr;  /* Instruction pointer - optional metadata */
         uint32_t tid;   /* Thread ID */
+
+        /* Serialization */
+        LoadLink() : Request(0, 0) {}
+
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(pAddr);
+            SST_SER(vAddr);
+            SST_SER(size);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::LoadLink);
     };
 
     /* StoreConditional checks if a write to a prior LoadLink address will be atomic,
@@ -822,6 +988,22 @@ public:
         std::vector<uint8_t> data;  /* Written data */
         Addr                 iPtr;  /* Instruction pointer - optional metadata */
         uint32_t             tid;   /* Thread ID */
+
+        /* Serialization */
+        StoreConditional() : Request(0, 0) {}
+
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(pAddr);
+            SST_SER(vAddr);
+            SST_SER(size);
+            SST_SER(data);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::StoreConditional);
     };
 
     /* Explicit data movement */
@@ -874,6 +1056,24 @@ public:
         bool     posted; /* True if a response is needed */
         Addr     iPtr;   /* Instruction pointer */
         uint32_t tid;    /* Thread ID */
+
+        /* Serialization */
+        MoveData() : Request(0, 0) {}
+
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(pSrc);
+            SST_SER(vSrc);
+            SST_SER(pDst);
+            SST_SER(vDst);
+            SST_SER(size);
+            SST_SER(posted);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::MoveData);
     };
 
     /** Notifies endpoint that an address has been invalidated from the L1.
@@ -914,6 +1114,21 @@ public:
         uint64_t size;  /* Number of bytes invalidated */
         Addr     iPtr;  /* Instruction pointer */
         uint32_t tid;   /* Thread ID */
+
+        /* Serialization */
+        InvNotify() : Request(0, 0) {}
+
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(pAddr);
+            SST_SER(vAddr);
+            SST_SER(size);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::InvNotify);
     };
 
     /* This class can be inherited to create custom events that can be handled in a limited fashion by existing
@@ -1008,6 +1223,19 @@ public:
         CustomData* data; /* Custom class that holds data for this event */
         Addr        iPtr; /* Instruction pointer */
         uint32_t    tid;  /* Thread ID */
+
+        /* Serialization */
+        CustomReq() : Request(0, 0) {}
+
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(data);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::CustomReq);
     };
 
     class CustomResp : public Request
@@ -1088,10 +1316,23 @@ public:
         CustomData* data; /* Custom class that holds data for this event */
         Addr        iPtr; /* Instruction pointer */
         uint32_t    tid;  /* Thread ID */
+
+        /* Serialization */
+        CustomResp() : Request(0, 0) {}
+
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            StandardMem::Request::serialize_order(ser);
+            SST_SER(data);
+            SST_SER(iPtr);
+            SST_SER(tid);
+        }
+
+        ImplementSerializable(SST::Interfaces::StandardMem::CustomResp);
     };
 
     /* Class for implementation-specific converter functions */
-    class RequestConverter
+    class RequestConverter : public SST::Core::Serialization::serializable
     {
     public:
         RequestConverter() {}
@@ -1120,10 +1361,14 @@ public:
         virtual SST::Event* convert(CustomReq* request)        = 0;
         virtual SST::Event* convert(CustomResp* request)       = 0;
         virtual SST::Event* convert(InvNotify* request)        = 0;
+
+    /* Serialization */
+    virtual void serialize_order(SST::Core::Serialization::serializer& ser);
+    ImplementVirtualSerializable(RequestConverter);
     };
 
     /* Class for implementation-specific handler functions */
-    class RequestHandler
+    class RequestHandler : public SST::Core::Serialization::serializable
     {
     public:
         RequestHandler(SST::Output* o) : out(o) {}
@@ -1192,6 +1437,13 @@ public:
         }
 
         SST::Output* out;
+
+        /* Serialization */
+        virtual void serialize_order(SST::Core::Serialization::serializer& ser) 
+        {
+            SST_SER(out);
+        }
+        ImplementVirtualSerializable(RequestHandler);
     };
 
     /** Constructor, designed to be used via 'loadUserSubComponent' and 'loadAnonymousSubComponent'.

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -1364,7 +1364,7 @@ public:
         virtual SST::Event* convert(InvNotify* request)        = 0;
 
         /* Serialization */
-        virtual void serialize_order(SST::Core::Serialization::serializer& ser) override;
+        virtual void serialize_order(SST::Core::Serialization::serializer& UNUSED(ser)) override {}
         ImplementVirtualSerializable(RequestConverter);
     };
 


### PR DESCRIPTION
Updates all classes within stdMem.h to be checkpointable (`Request`, `RequestConverter`, and `RequestHandler`), also adds a `Handler2` to `StandardMem`.