### PR TITLE
Serialize arrays, making the code much simpler and more general

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -224,6 +224,7 @@ sst_core_sources = \
 	serialization/serializer.cc \
 	serialization/statics.cc \
 	serialization/impl/mapper.cc \
+	serialization/impl/serialize_array.cc \
 	sstinfo.h \
 	interfaces/TestEvent.cc \
 	interfaces/stdMem.cc \

--- a/src/sst/core/serialization/impl/mapper.cc
+++ b/src/sst/core/serialization/impl/mapper.cc
@@ -18,10 +18,7 @@
 
 #include <iostream>
 
-namespace SST {
-namespace Core {
-namespace Serialization {
-namespace pvt {
+namespace SST::Core::Serialization::pvt {
 
 void
 ser_mapper::map_primitive(const std::string& name, ObjectMap* map)
@@ -83,8 +80,4 @@ ser_mapper::setNextObjectReadOnly()
     next_item_read_only = true;
 }
 
-
-} // namespace pvt
-} // namespace Serialization
-} // namespace Core
-} // namespace SST
+} // namespace SST::Core::Serialization::pvt

--- a/src/sst/core/serialization/impl/serialize_array.cc
+++ b/src/sst/core/serialization/impl/serialize_array.cc
@@ -1,0 +1,37 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+
+#include "sst/core/serialization/serialize.h"
+
+namespace SST::Core::Serialization::pvt {
+
+void
+serialize_array(
+    serializer& ser, void* data, size_t size, void serialize_array_element(serializer& ser, void* data, size_t index))
+{
+    for ( size_t index = 0; index < size; ++index )
+        serialize_array_element(ser, data, index);
+}
+
+void
+serialize_array_map(
+    serializer& ser, void* data, size_t size, ObjectMap* map,
+    void serialize_array_map_element(serializer& ser, void* data, size_t index, const std::string& name))
+{
+    ser.mapper().map_hierarchy_start(ser.getMapName(), map);
+    for ( size_t index = 0; index < size; ++index )
+        serialize_array_map_element(ser, data, index, std::to_string(index));
+    ser.mapper().map_hierarchy_end();
+}
+
+} // namespace SST::Core::Serialization::pvt

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -818,7 +818,7 @@ protected:
     T* addr_;
 
 public:
-    bool isContainer() override { return true; }
+    bool isContainer() final { return true; }
 
     std::string getType() override { return demangle_name(typeid(T).name()); }
 

--- a/src/sst/core/serialization/serializer.cc
+++ b/src/sst/core/serialization/serializer.cc
@@ -103,4 +103,11 @@ serializer::report_object_map(ObjectMap* ptr)
     ser_pointer_map[reinterpret_cast<uintptr_t>(ptr->getAddr())] = reinterpret_cast<uintptr_t>(ptr);
 }
 
+const std::string&
+serializer::getMapName() const
+{
+    if ( !mapContext ) throw std::invalid_argument("Internal error: Empty map name when map serialization requires it");
+    return mapContext->getName();
+}
+
 } // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -273,17 +273,15 @@ class ObjectMapContext
 {
     serializer&                   ser;
     const ObjectMapContext* const prevContext;
-    std::string                   name;
+    std::string const             name;
 
 public:
     ObjectMapContext(serializer& ser, std::string name) : ser(ser), prevContext(ser.mapContext), name(std::move(name))
     {
-        DIAG_DISABLE(dangling-pointer) // GCC 13 bug causes spurious warning
-        ser.mapContext = this;           // change the serializer's context to this new one
-        REENABLE_WARNING
+        DIAG_DISABLE(dangling-pointer); // GCC 13 bug causes spurious warning
+        ser.mapContext = this;          // change the serializer's context to this new one
+        REENABLE_WARNING;
     }
-    ObjectMapContext(serializer& ser, std::string_view name) : ObjectMapContext(ser, std::string(name)) {}
-    ObjectMapContext(serializer& ser, const char* name) : ObjectMapContext(ser, std::string(name)) {}
     ~ObjectMapContext() { ser.mapContext = prevContext; } // restore the serializer's old context
     const std::string& getName() const { return name; }
 }; // class ObjectMapContext

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -35,6 +35,7 @@
 namespace SST::Core::Serialization {
 
 class ObjectMap;
+class ObjectMapContext;
 
 /**
  * This class is basically a wrapper for objects to declare the order in
@@ -107,63 +108,46 @@ public:
         }
     }
 
-    template <class T, size_t N>
-    void array(T arr[N])
+    void raw(void* data, size_t size)
     {
         switch ( mode_ ) {
         case SIZER:
-        {
-            sizer_.add(sizeof(T) * N);
+            sizer_.add(size);
             break;
-        }
         case PACK:
-        {
-            char* charstr = packer_.next_str(N * sizeof(T));
-            ::memcpy(charstr, arr, N * sizeof(T));
+            memcpy(packer_.next_str(size), data, size);
             break;
-        }
         case UNPACK:
-        {
-            char* charstr = unpacker_.next_str(N * sizeof(T));
-            ::memcpy(arr, charstr, N * sizeof(T));
+            memcpy(data, unpacker_.next_str(size), size);
             break;
-        }
         case MAP:
             break;
         }
     }
 
-    template <typename T, typename Int>
-    void binary(T*& buffer, Int& size)
+    template <typename ELEM_T, typename SIZE_T>
+    void binary(ELEM_T*& buffer, SIZE_T& size)
     {
         switch ( mode_ ) {
         case SIZER:
-        {
-            sizer_.add(sizeof(Int));
+            sizer_.add(sizeof(SIZE_T));
             sizer_.add(size);
             break;
-        }
         case PACK:
-        {
             if ( buffer ) {
                 packer_.pack(size);
-                packer_.pack_buffer(buffer, size * sizeof(T));
+                packer_.pack_buffer(buffer, size * sizeof(ELEM_T));
             }
             else {
-                Int nullsize = 0;
+                SIZE_T nullsize = 0;
                 packer_.pack(nullsize);
             }
             break;
-        }
         case UNPACK:
-        {
             unpacker_.unpack(size);
-            if ( size != 0 ) { unpacker_.unpack_buffer(&buffer, size * sizeof(T)); }
-            else {
-                buffer = nullptr;
-            }
+            buffer = nullptr;
+            if ( size ) unpacker_.unpack_buffer(&buffer, size * sizeof(ELEM_T));
             break;
-        }
         case MAP:
             break;
         }
@@ -174,9 +158,7 @@ public:
     template <typename Int>
     void binary(void*& buffer, Int& size)
     {
-        char* tmp = (char*)buffer;
-        binary<char>(tmp, size);
-        buffer = tmp;
+        binary(reinterpret_cast<char*&>(buffer), size);
     }
 
     void string(std::string& str);
@@ -261,20 +243,8 @@ public:
 
     void report_object_map(ObjectMap* ptr);
 
-    void pushMapName(std::string name) { map_name.push(std::move(name)); }
-
-    const std::string& getMapName() const
-    {
-        if ( map_name.empty() || map_name.top().empty() )
-            throw std::invalid_argument("Internal error: Empty map name when map serialization requires it");
-        return map_name.top();
-    }
-
-    void popMapName()
-    {
-        getMapName(); // make sure name exists
-        map_name.pop();
-    }
+    // Get the map name
+    const std::string& getMapName() const;
 
 protected:
     // only one of these is going to be valid for this serializer
@@ -290,8 +260,33 @@ protected:
     // Used for unpacking and mapping
     std::map<uintptr_t, uintptr_t> ser_pointer_map;
     uintptr_t                      split_key;
-    std::stack<std::string>        map_name;
-};
+    const ObjectMapContext*        mapContext = nullptr;
+    friend class ObjectMapContext;
+}; // class serializer
+
+/**
+   ObjectMap context which is saved in a virtual stack when name or other information changes.
+   When ObjectMapContext is destroyed, the serializer goes back to the previous ObjectMapContext.
+ */
+
+class ObjectMapContext
+{
+    serializer&                   ser;
+    const ObjectMapContext* const prevContext;
+    std::string                   name;
+
+public:
+    ObjectMapContext(serializer& ser, std::string name) : ser(ser), prevContext(ser.mapContext), name(std::move(name))
+    {
+        DIAG_DISABLE(dangling-pointer) // GCC 13 bug causes spurious warning
+        ser.mapContext = this;         // change the serializer's context to this new one
+        REENABLE_WARNING
+    }
+    ObjectMapContext(serializer& ser, std::string_view name) : ObjectMapContext(ser, std::string(name)) {}
+    ObjectMapContext(serializer& ser, const char* name) : ObjectMapContext(ser, std::string(name)) {}
+    ~ObjectMapContext() { ser.mapContext = prevContext; } // restore the serializer's old context
+    const std::string& getName() const { return name; }
+}; // class ObjectMapContext
 
 } // namespace SST::Core::Serialization
 

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -279,7 +279,7 @@ public:
     ObjectMapContext(serializer& ser, std::string name) : ser(ser), prevContext(ser.mapContext), name(std::move(name))
     {
         DIAG_DISABLE(dangling-pointer); // GCC 13 bug causes spurious warning
-        ser.mapContext = this;          // change the serializer's context to this new one
+        ser.mapContext = this;            // change the serializer's context to this new one
         REENABLE_WARNING;
     }
     ~ObjectMapContext() { ser.mapContext = prevContext; } // restore the serializer's old context

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -279,7 +279,7 @@ public:
     ObjectMapContext(serializer& ser, std::string name) : ser(ser), prevContext(ser.mapContext), name(std::move(name))
     {
         DIAG_DISABLE(dangling-pointer) // GCC 13 bug causes spurious warning
-        ser.mapContext = this;         // change the serializer's context to this new one
+        ser.mapContext = this;           // change the serializer's context to this new one
         REENABLE_WARNING
     }
     ObjectMapContext(serializer& ser, std::string_view name) : ObjectMapContext(ser, std::string(name)) {}


### PR DESCRIPTION
This rewrites the array serialization, adding support for `std::array` and dynamically allocated arrays of types besides arithmetic and `enum`.

It still supports the existing wrapper classes `SST::Core:Serialization::array(ptr, size)` and `SST::Core::Serialization::raw_ptr(ptr)` which, when serialized, serialize a dynamic array and a `void*` raw pointer, respectively.

`ser& SST::Core::Serialization::array(ptr, size)` during deserialization, will get `size` and allocate `ptr` with `new ELEM_T[size]` where `ELEM_T` is the type that `ptr` points to.

`std::array<ELEM_T,SIZE>` and `ELEM_T[SIZE]`, and pointers to them, are handled with the same templated class. A pointer to a fixed array, like `int (*aptr)[10]`, will be allocated when deserialized.

-----

The old `serializer::array()` function was renamed `serializer::raw()` and no longer uses the parameter syntax `array(T a[N])` because `a` is turned into a pointer, and it cannot match array arguments that way (it would need to use `array(T (&a)[N])` to match a reference to an array). `serializer::raw()` just takes a `void*` and `size_t` and reads/writes the raw data.

-----

Right now the code potentially leaks because it does not call `delete` or `delete[]` on the original pointer before calling `new` or `new[]` to set it. This may need to be fixed but if the pointer is uninitialized, it could pose a problem. If the serialization documentation says that pointers must be initialized to `nullptr` or some value returned by `new` or `new[]` before serializing them, this would help.

-----

The code has been written in such a way as to reduce code size across a large number of types and fixed array sizes, by separating out the parts which depend on the element type and the array size. Where there is a template dependency on the element type or a fixed array size (which is a part of the type), it is necessary to include templated code, and trying to split it out much further would not be beneficial -- I've tried abstracting it out in different ways, and this current way produces a small number of Lines of Code (LOC) while still not making template instantiations grow the code size too large. `if constexpr` is used to make parts of the code conditional and optimized out where possible.

-----

All existing Core and Elements test pass; I did not see where in the tests where array serialization was tested. We may need to add it, particularly for `std::array`.

-----

An `ObjectMapContext` class has been created which can be used to push options for mapping mode on the stack without having to use `std::stack` or any other containers. A pointer in the `serializer` class points to the current `ObjectMapContext`. The creation of a new `ObjectMapContext` points the serializer to it and saves the old context. When destroyed, it automatically restores the old context. A spurious compiler warning about pointers to local variables had to be suppressed (I verified a Bugzilla was submitted against it on GCC 13, which is my current compiler).
```c++
template <class T>
void
sst_map_object(serializer& ser, T& t, std::string_view name = "")
{
    if ( ser.mode() == serializer::MAP ) {
        if ( !name.empty() ) { // Do nothing if name is empty
            // A new ObjectMapContext is created with name and ser points to it
            ObjectMapContext c(ser, name); 
            serialize<T>()(t, ser);
           // c is destroyed and ser's old context is restored
        }
    }
    else {
        serialize<T>()(t, ser);
    }
}
```
Even though `ObjectMapContext` is lightweight and doesn't dynamically allocate memory (except for `std::string`), it still does not need to be used in the non-mapping mode, as shown in the code above. Besides the `name` string, other attributes can be added later and will be accessible through accessor functions in the `serializer` class without having to pass them in every serialization call. Even if you have a bitwise `flags` option passed in macros, it doesn't have to be passed in every function call, just passed to an `ObjectMapContext` constructor and then adding a method to return it (if attributes like flags apply to more than mapping mode, a different name like `SerializerContext` can be used). If performance is a concern with multiple pointer dereferences, `ObjectMapContext` can store any attributes passed to it directly into the `serializer` class (and restore the old one upon destruction).

-----

Because the `SST::Core::Serialization::array(ptr, size)` wrapper class is passed at the time of serialization and is an Rvalue, universal/forwarding references are used, but within the serialization code, the reference is treated as an Lvalue reference so that functions which expect Lvalue references can be called:
```c++
template<typename T>
void operator&(serializer& ser, T&& t)    // T may be plain type or Lvalue reference to it; t is a Rvalue or Lvalue reference
{
   // t is used locally as an Lvalue to call functions which expect Lvalue references
}
```
As the serialization code is changed to use macros, the functions that get called need to support serializing Rvalue references as well as Lvalue references in case wrappers are used. The old code used a kludgy workaround by providing its own overloads for `operator&(ser, SST::Core::Serialization::array ary)` which accepted wrapper classes by value instead of the usual Lvalue reference. But with universal/forwarding references at the top level, and then using the reference name as an Lvalue, that's not necessary.

Cc: @kpgriesser 
