### PR TITLE
Deprecate use of shared TimeConverter* objects

### DIFF
--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -512,7 +512,7 @@ BaseComponent::getSimulationOutput() const
 }
 
 SimTime_t
-BaseComponent::getCurrentSimTime(TimeConverter tc) const
+BaseComponent::getCurrentSimTime(TimeConverter& tc) const
 {
     return tc.convertFromCoreTime(sim_->getCurrentSimCycle());
 }

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -185,6 +185,12 @@ BaseComponent::registerClock(TimeConverter* tc, Clock::HandlerBase* handler, boo
 }
 
 Cycle_t
+BaseComponent::reregisterClock(TimeConverter& freq, Clock::HandlerBase* handler)
+{
+    return sim_->reregisterClock(freq, handler, CLOCKPRIORITY);
+}
+
+Cycle_t
 BaseComponent::reregisterClock(TimeConverter* freq, Clock::HandlerBase* handler)
 {
     return sim_->reregisterClock(freq, handler, CLOCKPRIORITY);
@@ -427,6 +433,13 @@ BaseComponent::addSelfLink(const std::string& name)
     // Set default time base to the component time base
     link->setDefaultTimeBase(my_info->defaultTimeBase);
     myLinks->insertLink(name, link);
+}
+
+Link*
+BaseComponent::configureSelfLink(const std::string& name, TimeConverter& time_base, Event::HandlerBase* handler)
+{
+    addSelfLink(name);
+    return configureLink(name, time_base, handler);
 }
 
 Link*

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -150,13 +150,16 @@ public:
 
        @param tc TimeConverter specifying the units
     */
-    SimTime_t getCurrentSimTime(TimeConverter* tc) const;
+    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'getCurrentSimTime(TimeConverter timebase)' "
+                 "(i.e., no pointer) instead.")]] SimTime_t
+              getCurrentSimTime(TimeConverter* tc) const;
+    SimTime_t getCurrentSimTime(TimeConverter tc) const;
 
     /**
        Return the simulated time since the simulation began in the
        default timebase
     */
-    inline SimTime_t getCurrentSimTime() const { return getCurrentSimTime(my_info->defaultTimeBase); }
+    inline SimTime_t getCurrentSimTime() const { return getCurrentSimTime(*(my_info->defaultTimeBase)); }
 
     /**
        Return the simulated time since the simulation began in
@@ -265,7 +268,12 @@ protected:
      * @param handler - Optional Handler to be called when an Event is received
      * @return A pointer to the configured link, or nullptr if an error occured.
      */
-    Link* configureLink(const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler = nullptr);
+
+    [[deprecated(
+        "Use of shared TimeConverter objects is deprecated. Use 'configureLink(const std::string& name, TimeConverter "
+        "time_base, EventHandlerBase* handler)' (i.e., no TimeConverter pointer) instead.")]] Link*
+          configureLink(const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler = nullptr);
+    Link* configureLink(const std::string& name, TimeConverter& time_base, Event::HandlerBase* handler = nullptr);
     /** Configure a Link
      * @param name - Port Name on which the link to configure is attached.
      * @param time_base - Time Base of the link as a string
@@ -294,7 +302,12 @@ protected:
      * @param handler - Optional Handler to be called when an Event is received
      * @return A pointer to the configured link, or nullptr if an error occured.
      */
-    Link* configureSelfLink(const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler = nullptr);
+    [[deprecated(
+        "Use of shared TimeConverter objects is deprecated. Use 'configureSelfLink(const std::string& name, "
+        "TimeConverter time_base, EventHandlerBase* handler)' (i.e., no TimeConverter pointer) instead.")]] Link*
+          configureSelfLink(const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler = nullptr);
+    Link* configureSelfLink(const std::string& name, TimeConverter time_base, Event::HandlerBase* handler = nullptr);
+
     /** Configure a SelfLink  (Loopback link)
      * @param name - Name of the self-link port
      * @param time_base - Time Base of the link as a string
@@ -346,10 +359,17 @@ protected:
         time base for all of the links connected to this component
         @return the TimeConverter object representing the clock frequency
     */
-    TimeConverter* registerClock(TimeConverter* tc, Clock::HandlerBase* handler, bool regAll = true);
+    [[deprecated(
+        "Use of shared TimeConverter objects is deprecated. Use 'registerClock(TimeConverter& tc, Clock::HandlerBase* "
+        "handler, bool regAll)' (i.e., no TimeConverter pointer) instead.")]] TimeConverter*
+                   registerClock(TimeConverter* tc, Clock::HandlerBase* handler, bool regAll = true);
+    TimeConverter* registerClock(TimeConverter& tc, Clock::HandlerBase* handler, bool regAll = true);
 
     /** Removes a clock handler from the component */
-    void unregisterClock(TimeConverter* tc, Clock::HandlerBase* handler);
+    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'unregisterClock(TimeConverter& tc, "
+                 "Clock::HandlerBase* handler)' (i.e., no TimeConverter pointer) instead.")]] void
+         unregisterClock(TimeConverter* tc, Clock::HandlerBase* handler);
+    void unregisterClock(TimeConverter& tc, Clock::HandlerBase* handler);
 
     /** Reactivates an existing Clock and Handler
      * @return time of next time clock handler will fire
@@ -360,7 +380,10 @@ protected:
      * clocks can run a few extra cycles. As a result, the return value just prior to
      * simulation end may be greater than the value returned after simulation end.
      */
-    Cycle_t reregisterClock(TimeConverter* freq, Clock::HandlerBase* handler);
+    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'reregisterClock(TimeConverter& tc, "
+                 "Clock::HandlerBase* handler)' (i.e., no TimeConverter pointer) instead.")]] Cycle_t
+            reregisterClock(TimeConverter* freq, Clock::HandlerBase* handler);
+    Cycle_t reregisterClock(TimeConverter& freq, Clock::HandlerBase* handler);
 
     /** Returns the next Cycle that the TimeConverter would fire
         If called prior to the simulation run loop, next Cycle is 0.
@@ -369,7 +392,10 @@ protected:
         the simulation. See Note in reregisterClock() for additional guidance
         when calling this function after simulation ends.
      */
-    Cycle_t getNextClockCycle(TimeConverter* freq);
+    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'getNextClockCycle(TimeConverter tc)' (i.e., "
+                 "no TimeConverter pointer) instead.")]] Cycle_t
+            getNextClockCycle(TimeConverter* freq);
+    Cycle_t getNextClockCycle(TimeConverter freq);
 
     /** Registers a default time base for the component and optionally
         sets the the component's links to that timebase. Useful for
@@ -409,6 +435,11 @@ private:
        and checkpointing.
      */
     void registerClock_impl(TimeConverter* tc, Clock::HandlerBase* handler, bool regAll);
+
+    /**
+        Handles default timebase setup
+    */
+    Link* configureLink_impl(const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler = nullptr);
 
     template <typename T>
     Statistics::Statistic<T>*
@@ -1176,7 +1207,7 @@ class serialize_impl<T*, std::enable_if_t<std::is_base_of_v<SST::BaseComponent, 
         s = static_cast<T*>(sp);
     }
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 } // namespace Core::Serialization

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -153,7 +153,7 @@ public:
     [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'getCurrentSimTime(TimeConverter timebase)' "
                  "(i.e., no pointer) instead.")]] SimTime_t
               getCurrentSimTime(TimeConverter* tc) const;
-    SimTime_t getCurrentSimTime(TimeConverter tc) const;
+    SimTime_t getCurrentSimTime(TimeConverter& tc) const;
 
     /**
        Return the simulated time since the simulation began in the
@@ -306,7 +306,7 @@ protected:
         "Use of shared TimeConverter objects is deprecated. Use 'configureSelfLink(const std::string& name, "
         "TimeConverter time_base, EventHandlerBase* handler)' (i.e., no TimeConverter pointer) instead.")]] Link*
           configureSelfLink(const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler = nullptr);
-    Link* configureSelfLink(const std::string& name, TimeConverter time_base, Event::HandlerBase* handler = nullptr);
+    Link* configureSelfLink(const std::string& name, TimeConverter& time_base, Event::HandlerBase* handler = nullptr);
 
     /** Configure a SelfLink  (Loopback link)
      * @param name - Name of the self-link port
@@ -395,7 +395,7 @@ protected:
     [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'getNextClockCycle(TimeConverter tc)' (i.e., "
                  "no TimeConverter pointer) instead.")]] Cycle_t
             getNextClockCycle(TimeConverter* freq);
-    Cycle_t getNextClockCycle(TimeConverter freq);
+    Cycle_t getNextClockCycle(TimeConverter& freq);
 
     /** Registers a default time base for the component and optionally
         sets the the component's links to that timebase. Useful for

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -150,10 +150,10 @@ public:
 
        @param tc TimeConverter specifying the units
     */
-    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'getCurrentSimTime(TimeConverter timebase)' "
+    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'getCurrentSimTime(TimeConverter tc)' "
                  "(i.e., no pointer) instead.")]] SimTime_t
               getCurrentSimTime(TimeConverter* tc) const;
-    SimTime_t getCurrentSimTime(TimeConverter& tc) const;
+    SimTime_t getCurrentSimTime(TimeConverter tc) const;
 
     /**
        Return the simulated time since the simulation began in the
@@ -273,7 +273,7 @@ protected:
         "Use of shared TimeConverter objects is deprecated. Use 'configureLink(const std::string& name, TimeConverter "
         "time_base, EventHandlerBase* handler)' (i.e., no TimeConverter pointer) instead.")]] Link*
           configureLink(const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler = nullptr);
-    Link* configureLink(const std::string& name, TimeConverter& time_base, Event::HandlerBase* handler = nullptr);
+    Link* configureLink(const std::string& name, TimeConverter time_base, Event::HandlerBase* handler = nullptr);
     /** Configure a Link
      * @param name - Port Name on which the link to configure is attached.
      * @param time_base - Time Base of the link as a string
@@ -306,7 +306,7 @@ protected:
         "Use of shared TimeConverter objects is deprecated. Use 'configureSelfLink(const std::string& name, "
         "TimeConverter time_base, EventHandlerBase* handler)' (i.e., no TimeConverter pointer) instead.")]] Link*
           configureSelfLink(const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler = nullptr);
-    Link* configureSelfLink(const std::string& name, TimeConverter& time_base, Event::HandlerBase* handler = nullptr);
+    Link* configureSelfLink(const std::string& name, TimeConverter time_base, Event::HandlerBase* handler = nullptr);
 
     /** Configure a SelfLink  (Loopback link)
      * @param name - Name of the self-link port
@@ -360,16 +360,16 @@ protected:
         @return the TimeConverter object representing the clock frequency
     */
     [[deprecated(
-        "Use of shared TimeConverter objects is deprecated. Use 'registerClock(TimeConverter& tc, Clock::HandlerBase* "
+        "Use of shared TimeConverter objects is deprecated. Use 'registerClock(TimeConverter tc, Clock::HandlerBase* "
         "handler, bool regAll)' (i.e., no TimeConverter pointer) instead.")]] TimeConverter*
                    registerClock(TimeConverter* tc, Clock::HandlerBase* handler, bool regAll = true);
-    TimeConverter* registerClock(TimeConverter& tc, Clock::HandlerBase* handler, bool regAll = true);
+    TimeConverter* registerClock(TimeConverter tc, Clock::HandlerBase* handler, bool regAll = true);
 
     /** Removes a clock handler from the component */
-    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'unregisterClock(TimeConverter& tc, "
+    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'unregisterClock(TimeConverter tc, "
                  "Clock::HandlerBase* handler)' (i.e., no TimeConverter pointer) instead.")]] void
          unregisterClock(TimeConverter* tc, Clock::HandlerBase* handler);
-    void unregisterClock(TimeConverter& tc, Clock::HandlerBase* handler);
+    void unregisterClock(TimeConverter tc, Clock::HandlerBase* handler);
 
     /** Reactivates an existing Clock and Handler
      * @return time of next time clock handler will fire
@@ -380,10 +380,10 @@ protected:
      * clocks can run a few extra cycles. As a result, the return value just prior to
      * simulation end may be greater than the value returned after simulation end.
      */
-    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'reregisterClock(TimeConverter& tc, "
+    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'reregisterClock(TimeConverter freq, "
                  "Clock::HandlerBase* handler)' (i.e., no TimeConverter pointer) instead.")]] Cycle_t
             reregisterClock(TimeConverter* freq, Clock::HandlerBase* handler);
-    Cycle_t reregisterClock(TimeConverter& freq, Clock::HandlerBase* handler);
+    Cycle_t reregisterClock(TimeConverter freq, Clock::HandlerBase* handler);
 
     /** Returns the next Cycle that the TimeConverter would fire
         If called prior to the simulation run loop, next Cycle is 0.
@@ -392,10 +392,11 @@ protected:
         the simulation. See Note in reregisterClock() for additional guidance
         when calling this function after simulation ends.
      */
-    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'getNextClockCycle(TimeConverter tc)' (i.e., "
-                 "no TimeConverter pointer) instead.")]] Cycle_t
+    [[deprecated(
+        "Use of shared TimeConverter objects is deprecated. Use 'getNextClockCycle(TimeConverter freq)' (i.e., "
+        "no TimeConverter pointer) instead.")]] Cycle_t
             getNextClockCycle(TimeConverter* freq);
-    Cycle_t getNextClockCycle(TimeConverter& freq);
+    Cycle_t getNextClockCycle(TimeConverter freq);
 
     /** Registers a default time base for the component and optionally
         sets the the component's links to that timebase. Useful for
@@ -439,7 +440,7 @@ private:
     /**
         Handles default timebase setup
     */
-    Link* configureLink_impl(const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler = nullptr);
+    Link* configureLink_impl(const std::string& name, SimTime_t time_base, Event::HandlerBase* handler = nullptr);
 
     template <typename T>
     Statistics::Statistic<T>*

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -690,6 +690,12 @@ Link::addSendLatency(int cycles, const std::string& timebase)
 }
 
 void
+Link::addSendLatency(SimTime_t cycles, TimeConverter timebase)
+{
+    latency += timebase.convertToCoreTime(cycles);
+}
+
+void
 Link::addSendLatency(SimTime_t cycles, TimeConverter* timebase)
 {
     latency += timebase->convertToCoreTime(cycles);
@@ -700,6 +706,12 @@ Link::addRecvLatency(int cycles, const std::string& timebase)
 {
     SimTime_t tb = Simulation_impl::getSimulation()->getTimeLord()->getSimCycles(timebase, "addOutputLatency");
     pair_link->latency += (cycles * tb);
+}
+
+void
+Link::addRecvLatency(SimTime_t cycles, TimeConverter timebase)
+{
+    pair_link->latency += timebase.convertToCoreTime(cycles);
 }
 
 void

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -42,7 +42,7 @@ class SST::Core::Serialization::serialize_impl<Link*>
     // Function implemented in link.cc
     void operator()(Link*& s, SST::Core::Serialization::serializer& ser, ser_opt_t options);
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 
@@ -134,7 +134,10 @@ public:
      * @param cycles Number of Cycles to be added
      * @param timebase Base Units of cycles
      */
-    void addSendLatency(SimTime_t cycles, TimeConverter* timebase);
+    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'addSendLatency(SimTime_t cycles, "
+                 "TimeConverter timebase)' (i.e., no pointer) instead.")]] void
+         addSendLatency(SimTime_t cycles, TimeConverter* timebase);
+    void addSendLatency(SimTime_t cycles, TimeConverter timebase);
 
     /** Set additional Latency to be added on to events coming in on this link.
      * @param cycles Number of Cycles to be added
@@ -146,7 +149,10 @@ public:
      * @param cycles Number of Cycles to be added
      * @param timebase Base Units of cycles
      */
-    void addRecvLatency(SimTime_t cycles, TimeConverter* timebase);
+    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'addRecvLatency(SimTime_t cycles, "
+                 "TimeConverter timebase)' (i.e., no pointer) instead.")]] void
+         addRecvLatency(SimTime_t cycles, TimeConverter* timebase);
+    void addRecvLatency(SimTime_t cycles, TimeConverter timebase);
 
     /** Set the callback function to be called when a message is
      * delivered. Not available for Polling links.
@@ -174,10 +180,23 @@ public:
      * @param tc - time converter to specify units for the additional delay
      * @param event - the Event to send
      */
-    inline void send(SimTime_t delay, TimeConverter* tc, Event* event)
+    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'send(SimTime_t delay, TimeConverter tc, "
+                 "Event* event)' instead.")]] inline void
+    send(SimTime_t delay, TimeConverter* tc, Event* event)
     {
-        send_impl(tc->convertToCoreTime(delay), event);
+        send(delay, *tc, event);
     }
+
+    /** Send an event over the link with additional delay. Sends an event
+     * over a link with an additional delay specified with a
+     * TimeConverter. I.e. the total delay is the link's delay + the
+     * additional specified delay.
+     * @param delay - additional delay
+     * @param tc - time converter to specify units for the additional delay
+     * @param event - the Event to send
+     */
+    inline void send(SimTime_t delay, TimeConverter tc, Event* event) { send_impl(tc.convertToCoreTime(delay), event); }
+
 
     /** Send an event with additional delay. Sends an event over a link
      * with additional delay specified by the Link's default
@@ -202,7 +221,7 @@ public:
      */
     Event* recv();
 
-    /** Manually set the default detaulTimeBase
+    /** Manually set the default defaultTimeBase
      * @param tc TimeConverter object for the timebase
      */
     void setDefaultTimeBase(TimeConverter* tc);

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -195,7 +195,10 @@ public:
      * @param tc - time converter to specify units for the additional delay
      * @param event - the Event to send
      */
-    inline void send(SimTime_t delay, TimeConverter tc, Event* event) { send_impl(tc.convertToCoreTime(delay), event); }
+    inline void send(SimTime_t delay, TimeConverter& tc, Event* event)
+    {
+        send_impl(tc.convertToCoreTime(delay), event);
+    }
 
 
     /** Send an event with additional delay. Sends an event over a link

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -180,8 +180,9 @@ public:
      * @param tc - time converter to specify units for the additional delay
      * @param event - the Event to send
      */
-    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'send(SimTime_t delay, TimeConverter tc, "
-                 "Event* event)' instead.")]] inline void
+    [[deprecated(
+        "Use of shared TimeConverter objects is deprecated. Use 'send(SimTime_t delay, const TimeConverter& tc, "
+        "Event* event)' instead.")]] inline void
     send(SimTime_t delay, TimeConverter* tc, Event* event)
     {
         send(delay, *tc, event);
@@ -195,10 +196,7 @@ public:
      * @param tc - time converter to specify units for the additional delay
      * @param event - the Event to send
      */
-    inline void send(SimTime_t delay, TimeConverter& tc, Event* event)
-    {
-        send_impl(tc.convertToCoreTime(delay), event);
-    }
+    inline void send(SimTime_t delay, TimeConverter tc, Event* event) { send_impl(tc.convertToCoreTime(delay), event); }
 
 
     /** Send an event with additional delay. Sends an event over a link
@@ -228,6 +226,11 @@ public:
      * @param tc TimeConverter object for the timebase
      */
     void setDefaultTimeBase(TimeConverter* tc);
+
+    /** Manually set the default time base
+     * @param factor SimTime_T defining the timebase factor
+     */
+    void setDefaultTimeBase(SimTime_t factor) { defaultTimeBase = factor; }
 
     /** Return the default Time Base for this link
      * @return the default Time Base for this link

--- a/src/sst/core/portModule.cc
+++ b/src/sst/core/portModule.cc
@@ -90,9 +90,15 @@ PortModule::getSimulationOutput() const
 }
 
 SimTime_t
-PortModule::getCurrentSimTime(TimeConverter* tc) const
+PortModule::getCurrentSimTime(TimeConverter& tc) const
 {
     return component_->getCurrentSimTime(tc);
+}
+
+SimTime_t
+PortModule::getCurrentSimTime(TimeConverter* tc) const
+{
+    return component_->getCurrentSimTime(*tc);
 }
 
 SimTime_t

--- a/src/sst/core/portModule.h
+++ b/src/sst/core/portModule.h
@@ -231,7 +231,10 @@ protected:
 
        @param tc TimeConverter specifying the units
     */
-    SimTime_t getCurrentSimTime(TimeConverter* tc) const;
+    [[deprecated("Use of shared TimeConverter objects is deprecated. Use 'getCurrentSimTime(TimeConverter& timebase)' "
+                 "(i.e., no pointer) instead.")]] SimTime_t
+              getCurrentSimTime(TimeConverter* tc) const;
+    SimTime_t getCurrentSimTime(TimeConverter& tc) const;
 
     /**
        Return the simulated time since the simulation began in

--- a/src/sst/core/serialization/impl/serialize_adapter.h
+++ b/src/sst/core/serialization/impl/serialize_adapter.h
@@ -42,7 +42,30 @@ class serialize_impl<
         SST_SER(static_cast<S&>(v).c, options); // serialize the underlying container
     }
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
+};
+
+template <template <typename...> class T, typename... Ts>
+class serialize_impl<
+    T<Ts...>*, std::enable_if_t<
+                   is_same_template_v<T, std::stack> || is_same_template_v<T, std::queue> ||
+                   is_same_template_v<T, std::priority_queue>>>
+{
+    struct S : T<Ts...>
+    {
+        using T<Ts...>::c; // access protected container
+    };
+
+    void operator()(T<Ts...>*& v, serializer& ser, ser_opt_t options)
+    {
+        if ( ser.mode() == serializer::UNPACK ) {
+            v = new T<Ts...>();
+        }
+
+        SST_SER(static_cast<S&>(*v).c, options); // serialize the underlying container
+    }
+
+    SST_FRIEND_SERIALIZE();
 };
 
 } // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/impl/serialize_adapter.h
+++ b/src/sst/core/serialization/impl/serialize_adapter.h
@@ -58,9 +58,7 @@ class serialize_impl<
 
     void operator()(T<Ts...>*& v, serializer& ser, ser_opt_t options)
     {
-        if ( ser.mode() == serializer::UNPACK ) {
-            v = new T<Ts...>();
-        }
+        if ( ser.mode() == serializer::UNPACK ) { v = new T<Ts...>(); }
 
         SST_SER(static_cast<S&>(*v).c, options); // serialize the underlying container
     }

--- a/src/sst/core/serialization/impl/serialize_array.h
+++ b/src/sst/core/serialization/impl/serialize_array.h
@@ -120,26 +120,26 @@ struct serialize_impl_fixed_array
 template <typename ELEM_T, size_t SIZE>
 class serialize_impl<ELEM_T[SIZE]> : pvt::serialize_impl_fixed_array<ELEM_T[SIZE], ELEM_T, SIZE>
 {
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 template <typename ELEM_T, size_t SIZE>
 class serialize_impl<std::array<ELEM_T, SIZE>> : pvt::serialize_impl_fixed_array<std::array<ELEM_T, SIZE>, ELEM_T, SIZE>
 {
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 template <typename ELEM_T, size_t SIZE>
 class serialize_impl<ELEM_T (*)[SIZE]> : pvt::serialize_impl_fixed_array<ELEM_T (*)[SIZE], ELEM_T, SIZE>
 {
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 template <typename ELEM_T, size_t SIZE>
 class serialize_impl<std::array<ELEM_T, SIZE>*> :
     pvt::serialize_impl_fixed_array<std::array<ELEM_T, SIZE>*, ELEM_T, SIZE>
 {
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 // Serialize dynamic arrays
@@ -170,7 +170,7 @@ class serialize_impl<pvt::array_wrapper<ELEM_T, SIZE_T>>
         }
     }
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 /**
@@ -183,7 +183,7 @@ template <typename ELEM_T>
 struct serialize_impl<pvt::raw_ptr_wrapper<ELEM_T>>
 {
     void operator()(pvt::raw_ptr_wrapper<ELEM_T>& a, serializer& ser, ser_opt_t UNUSED(opt)) { ser.primitive(a.ptr); }
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 // Wrapper functions

--- a/src/sst/core/serialization/impl/serialize_atomic.h
+++ b/src/sst/core/serialization/impl/serialize_atomic.h
@@ -57,7 +57,7 @@ class serialize_impl<std::atomic<T>>
         }
     }
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 } // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/impl/serialize_insertable.h
+++ b/src/sst/core/serialization/impl/serialize_insertable.h
@@ -258,7 +258,36 @@ class serialize_impl<
         }
     }
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
+};
+
+// clang-format off
+template <template <typename...> class T, typename... Ts>
+class serialize_impl<
+    T<Ts...>*, std::enable_if_t<
+                  is_same_template_v< T, std::deque              > ||
+                  is_same_template_v< T, std::forward_list       > ||
+                  is_same_template_v< T, std::list               > ||
+                  is_same_template_v< T, std::map                > ||
+                  is_same_template_v< T, std::multimap           > ||
+                  is_same_template_v< T, std::multiset           > ||
+                  is_same_template_v< T, std::set                > ||
+                  is_same_template_v< T, std::unordered_map      > ||
+                  is_same_template_v< T, std::unordered_multimap > ||
+                  is_same_template_v< T, std::unordered_multiset > ||
+                  is_same_template_v< T, std::unordered_set      > ||
+                  is_same_template_v< T, std::vector             >
+                > >
+// clang-format on
+{
+    void operator()(T<Ts...>*& t, serializer& ser, ser_opt_t options)
+    {
+        if ( ser.mode() == serializer::UNPACK ) { t = new T<Ts...>(); }
+        SST_SER(*t, options);
+        // serialize_impl<T<Ts...>>()(*t, ser, options);
+    }
+
+    SST_FRIEND_SERIALIZE();
 };
 
 } // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/impl/serialize_string.h
+++ b/src/sst/core/serialization/impl/serialize_string.h
@@ -81,7 +81,7 @@ class serialize_impl<T, std::enable_if_t<std::is_same_v<std::remove_pointer_t<T>
         }
     }
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 } // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/impl/serialize_tuple.h
+++ b/src/sst/core/serialization/impl/serialize_tuple.h
@@ -36,7 +36,7 @@ class serialize_impl<T<Ts...>, std::enable_if_t<is_same_template_v<T, std::tuple
         std::apply([&](auto&... e) { ((sst_ser_object(ser, e, opt)), ...); }, t);
     }
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 } // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/serializable.h
+++ b/src/sst/core/serialization/serializable.h
@@ -68,7 +68,7 @@ class serialize_impl<T*, std::enable_if_t<std::is_base_of_v<serializable, T>>>
         s = static_cast<T*>(sp);
     }
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 template <class T>
@@ -110,7 +110,7 @@ class serialize_impl<T, std::enable_if_t<std::is_base_of_v<serializable, T>>>
         // For now mapping mode won't provide any data
     }
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 } // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -29,8 +29,8 @@
 
    NOTE: requires a semicolon after the call
  */
-#define SST_FRIEND_SERIALZE() \
-    template <class SER>      \
+#define SST_FRIEND_SERIALIZE() \
+    template <class SER>       \
     friend class pvt::serialize
 
 namespace SST {
@@ -366,7 +366,7 @@ public:
             ser.primitive(t);
         }
     }
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 /**
@@ -401,7 +401,7 @@ class serialize_impl<T*, std::enable_if_t<std::is_arithmetic_v<T> || std::is_enu
         }
         }
     }
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -298,20 +298,24 @@ public:
     TimeConverter* registerClock(const UnitAlgebra& freq, Clock::HandlerBase* handler, int priority);
 
     TimeConverter* registerClock(TimeConverter* tcFreq, Clock::HandlerBase* handler, int priority);
+    TimeConverter* registerClock(TimeConverter& tcFreq, Clock::HandlerBase* handler, int priority);
 
     // registerClock function used during checkpoint/restart
     void registerClock(SimTime_t factor, Clock::HandlerBase* handler, int priority);
 
     /** Remove a clock handler from the list of active clock handlers */
     void unregisterClock(TimeConverter* tc, Clock::HandlerBase* handler, int priority);
+    void unregisterClock(TimeConverter& tc, Clock::HandlerBase* handler, int priority);
 
     /** Reactivate an existing clock and handler.
      * @return time when handler will next fire
      */
     Cycle_t reregisterClock(TimeConverter* tc, Clock::HandlerBase* handler, int priority);
+    Cycle_t reregisterClock(TimeConverter& tc, Clock::HandlerBase* handler, int priority);
 
-    /** Returns the next Cycle that the TImeConverter would fire. */
+    /** Returns the next Cycle that the TimeConverter would fire. */
     Cycle_t getNextClockCycle(TimeConverter* tc, int priority = CLOCKPRIORITY);
+    Cycle_t getNextClockCycle(TimeConverter& tc, int priority = CLOCKPRIORITY);
 
     /** Gets the clock the handler is registered with, represented by it's factor
      *

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -699,7 +699,7 @@ class serialize_impl<Statistics::Statistic<T>*>
         }
     }
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 } // namespace Core::Serialization

--- a/src/sst/core/testElements/coreTest_Checkpoint.cc
+++ b/src/sst/core/testElements/coreTest_Checkpoint.cc
@@ -54,10 +54,11 @@ coreTestCheckpoint::coreTestCheckpoint(ComponentId_t id, Params& params) : Compo
     // reregister clock
     clock_handler = new Clock::Handler2<coreTestCheckpoint, &coreTestCheckpoint::handleClock>(this);
 
-    TimeConverter* core_tc = registerClock(freq, clock_handler);
+    // TimeConverter* core_tc = registerClock(freq, clock_handler);
+    clock_tc         = registerClock(freq, clock_handler);
     // Get a local copy of the clock_tc so we aren't using core's
-    TimeConverter  local_tc(core_tc);
-    clock_tc         = local_tc;
+    // TimeConverter  local_tc(core_tc);
+    // clock_tc         = local_tc;
     duty_cycle       = params.find<int>("clock_duty_cycle", 10);
     duty_cycle_count = duty_cycle;
 

--- a/src/sst/core/testElements/coreTest_Checkpoint.cc
+++ b/src/sst/core/testElements/coreTest_Checkpoint.cc
@@ -53,7 +53,7 @@ coreTestCheckpoint::coreTestCheckpoint(ComponentId_t id, Params& params) : Compo
     // Need to keep a pointer to the clock handler so we can
     // reregister clock
     clock_handler = new Clock::Handler2<coreTestCheckpoint, &coreTestCheckpoint::handleClock>(this);
-    clock_tc      = registerClock(freq, clock_handler);
+    clock_tc      = TimeConverter(registerClock(freq, clock_handler));
 
     duty_cycle       = params.find<int>("clock_duty_cycle", 10);
     duty_cycle_count = duty_cycle;

--- a/src/sst/core/testElements/coreTest_Checkpoint.cc
+++ b/src/sst/core/testElements/coreTest_Checkpoint.cc
@@ -53,8 +53,11 @@ coreTestCheckpoint::coreTestCheckpoint(ComponentId_t id, Params& params) : Compo
     // Need to keep a pointer to the clock handler so we can
     // reregister clock
     clock_handler = new Clock::Handler2<coreTestCheckpoint, &coreTestCheckpoint::handleClock>(this);
-    clock_tc      = TimeConverter(registerClock(freq, clock_handler));
 
+    TimeConverter* core_tc = registerClock(freq, clock_handler);
+    // Get a local copy of the clock_tc so we aren't using core's
+    TimeConverter  local_tc(core_tc);
+    clock_tc         = local_tc;
     duty_cycle       = params.find<int>("clock_duty_cycle", 10);
     duty_cycle_count = duty_cycle;
 

--- a/src/sst/core/testElements/coreTest_Checkpoint.h
+++ b/src/sst/core/testElements/coreTest_Checkpoint.h
@@ -129,7 +129,7 @@ private:
     SST::Link*          link_left;
     SST::Link*          link_right;
     SST::Link*          self_link;
-    TimeConverter*      clock_tc;
+    TimeConverter       clock_tc;
     Clock::HandlerBase* clock_handler;
     int                 duty_cycle;       // Used to count clock on and off cycles
     int                 duty_cycle_count; // Used to count clock on and off cycles

--- a/src/sst/core/timeConverter.h
+++ b/src/sst/core/timeConverter.h
@@ -32,9 +32,18 @@ class TimeConverter
 public:
     /**
        Create a new TimeConverter object from a TimeConverter*
+       Use this to create a local TimeConverter from a TimeConverter*
+       returned by the BaseComponent and other public APIs.
        @param tc TimeConverter to initialize factor from
      */
-    TimeConverter(TimeConverter* tc) : factor(tc->getFactor()) {}
+    TimeConverter(TimeConverter* tc) : factor(tc->factor) {}
+
+    /**
+       Do not directly invoke this constructor from Components to get
+       a TimeConverter. Instead, use the BaseComponent API functions and the constructor
+       that uses a TimeConverter* to create a TimeConverter.
+     */
+    TimeConverter() {}
 
     /**
        Converts from the component's view to the core's view of time.
@@ -64,7 +73,6 @@ public:
      * Elements. This was moved to public due to needing to support ObjectMaps.
      */
     ~TimeConverter() {}
-    TimeConverter() {} // Only needed to simplify serialization
 
 private:
     /**

--- a/src/sst/core/timeConverter.h
+++ b/src/sst/core/timeConverter.h
@@ -31,6 +31,12 @@ class TimeConverter
 
 public:
     /**
+       Create a new TimeConverter object from a TimeConverter*
+       @param tc TimeConverter to initialize factor from
+     */
+    TimeConverter(TimeConverter* tc) : factor(tc->getFactor()) {}
+
+    /**
        Converts from the component's view to the core's view of time.
        @param time time to convert to core time
      */
@@ -53,6 +59,13 @@ public:
      */
     UnitAlgebra getPeriod() const; // Implemented in timeLord.cc
 
+    /**
+     * TimeConverter* returned by the core should *never* be deleted by
+     * Elements. This was moved to public due to needing to support ObjectMaps.
+     */
+    ~TimeConverter() {}
+    TimeConverter() {} // Only needed to simplify serialization
+
 private:
     /**
        Factor for converting between core and component time
@@ -60,10 +73,15 @@ private:
     SimTime_t factor;
 
     TimeConverter(SimTime_t fact) { factor = fact; }
+};
 
-    ~TimeConverter() {}
+template <>
+class SST::Core::Serialization::serialize_impl<TimeConverter>
+{
+    // Function implemented in timeLord.cc
+    void operator()(TimeConverter& s, serializer& ser, ser_opt_t options);
 
-    TimeConverter() {} // Only needed to simplify serialization
+    SST_FRIEND_SERIALIZE();
 };
 
 template <>
@@ -72,7 +90,7 @@ class SST::Core::Serialization::serialize_impl<TimeConverter*>
     // Function implemented in timeLord.cc
     void operator()(TimeConverter*& s, serializer& ser, ser_opt_t options);
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 } // namespace SST

--- a/src/sst/core/timeVortex.h
+++ b/src/sst/core/timeVortex.h
@@ -86,7 +86,7 @@ class SST::Core::Serialization::serialize_impl<TimeVortex*>
         }
     }
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 } // namespace SST

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -455,7 +455,7 @@ class serialize_impl<UnitAlgebra>
         }
     }
 
-    SST_FRIEND_SERIALZE();
+    SST_FRIEND_SERIALIZE();
 };
 
 


### PR DESCRIPTION
Deprecates use of shared TimeConverter* objects in link/clock/simtime calls that use them

Also:
* Adds support for serializing std container pointers 
* Fixes some remaining VLA warnings
* Changes SST_FRIEND_SERIALZE to SST_FRIEND_SERIALIZE