### PR TITLE
Fix enum warnings and make SerOption tests uniform

### DIFF
--- a/src/sst/core/serialization/impl/serialize_array.h
+++ b/src/sst/core/serialization/impl/serialize_array.h
@@ -85,7 +85,7 @@ struct serialize_impl_fixed_array
 {
     void operator()(OBJ_TYPE& ary, serializer& ser, ser_opt_t opt)
     {
-        ser_opt_t   elem_opt = opt & SerOption::as_ptr_elem ? SerOption::as_ptr : SerOption::none;
+        ser_opt_t   elem_opt = SerOption::is_set(opt, SerOption::as_ptr_elem) ? SerOption::as_ptr : SerOption::none;
         const auto& aPtr     = get_ptr(ary); // reference to ary if it's a pointer; &ary otherwise
         switch ( ser.mode() ) {
         case serializer::MAP:
@@ -148,7 +148,7 @@ class serialize_impl<pvt::array_wrapper<ELEM_T, SIZE_T>>
 {
     void operator()(pvt::array_wrapper<ELEM_T, SIZE_T>& ary, serializer& ser, ser_opt_t opt)
     {
-        ser_opt_t elem_opt = opt & SerOption::as_ptr_elem ? SerOption::as_ptr : SerOption::none;
+        ser_opt_t elem_opt = SerOption::is_set(opt, SerOption::as_ptr_elem) ? SerOption::as_ptr : SerOption::none;
         switch ( const auto mode = ser.mode() ) {
         case serializer::MAP:
             if constexpr ( !std::is_void_v<ELEM_T> ) {

--- a/src/sst/core/serialization/impl/serialize_insertable.h
+++ b/src/sst/core/serialization/impl/serialize_insertable.h
@@ -157,8 +157,8 @@ class serialize_impl<
                     SST_SER(e);
             }
             else {
-                ser_opt_t opts = 0;
-                if ( SerOption::is_set(options, SerOption::as_ptr_elem) ) opts = SerOption::as_ptr;
+                ser_opt_t opts =
+                    SerOption::is_set(options, SerOption::as_ptr_elem) ? SerOption::as_ptr : SerOption::none;
                 // Iterate over references to elements, casting away any const in keys
                 for ( auto& e : obj )
                     SST_SER((value_type&) e, opts);
@@ -172,8 +172,7 @@ class serialize_impl<
             size_t size;
             ser.unpack(size);
 
-            ser_opt_t opts = 0;
-            if ( SerOption::is_set(options, SerOption::as_ptr_elem) ) opts = SerOption::as_ptr;
+            ser_opt_t opts = SerOption::is_set(options, SerOption::as_ptr_elem) ? SerOption::as_ptr : SerOption::none;
 
             // Erase the container
             obj.clear();

--- a/src/sst/core/serialization/impl/serialize_tuple.h
+++ b/src/sst/core/serialization/impl/serialize_tuple.h
@@ -32,7 +32,7 @@ class serialize_impl<T<Ts...>, std::enable_if_t<is_same_template_v<T, std::tuple
     void operator()(T<Ts...>& t, serializer& ser, ser_opt_t options)
     {
         // Serialize each element of tuple or pair
-        ser_opt_t opt = (options & SerOption::as_ptr_elem) ? SerOption::as_ptr : 0;
+        ser_opt_t opt = SerOption::is_set(options, SerOption::as_ptr_elem) ? SerOption::as_ptr : SerOption::none;
         std::apply([&](auto&... e) { ((sst_ser_object(ser, e, opt)), ...); }, t);
     }
 


### PR DESCRIPTION
This fixes warnings about mixing `enum` and integers on GCC, and makes the `SerOption` tests uniform.
