### PR TITLE
Add support for shutdown from interactive console

### DIFF
--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -54,6 +54,44 @@ SimpleDebugger::tokenize(std::vector<std::string>& tokens, const std::string& in
 }
 
 void
+SimpleDebugger::cmd_help(std::vector<std::string>& UNUSED(tokens))
+{
+    std::string help = "SimpleDebug Console Commands\n";
+    help.append("  Navigation: Navigate the current object map\n");
+    help.append("   - pwd: print the current working directory in the object map\n");
+    help.append("   - cd: change directory level in the object map\n");
+    help.append("   - ls: list the objects in the current level of the object map\n");
+
+    help.append("  Current State: Print information about the current simulation state\n");
+    help.append("   - time: print current simulation time in cycles\n");
+    help.append("   - print [-rN][<obj>]: print objects in the current level of the object map;\n");
+    help.append("                         if -rN is provided print recursive N levels (default N=4)\n");
+
+    help.append("  Modify State: Modify simulation variables\n");
+    help.append("   - set <obj> <value>: sets an object in the current scope to the provided value;\n");
+    help.append("                        object must be a \"fundamental type\" e.g. int \n");
+
+    help.append("  Watch Points: Manage watch points which break into interactive console when triggered\n");
+    help.append("   - watch: prints the current list of watch points and their associated indices\n");
+    help.append("     watch <var>: adds var to the watch list; triggered when value changes\n");
+    help.append("     watch <var> <comp> <val>: add var to watch list; triggered when comparison with val is true\n");
+    help.append("                 Valid <comp> operators: <, <=, >, >=, ==, !=\n");
+    help.append("   - unwatch <index>: removes the indexed watch point from the watch list;\n");
+    help.append("                 <index> is the associated index from the list of watch points\n");
+
+    help.append("  Execute: Execute the simulation for a specified duration\n");
+    help.append("   - run [TIME]: runs the simulation from the current point for TIME and then returns to\n");
+    help.append("                 interactive mode; if no time is given, the simulation runs to completion;\n");
+    help.append("                 TIME is of the format <Number><unit> e.g. 4us\n");
+
+    help.append("  Exit: Exit the interactive console\n");
+    help.append("   - exit or quit: exits the interactive console and resumes simulation execution\n");
+    help.append("   - shutdown: exits the interactive console and does a clean shutdown of the simulation\n");
+
+    printf("%s", help.c_str());
+}
+
+void
 SimpleDebugger::cmd_pwd(std::vector<std::string>& UNUSED(tokens))
 {
     // std::string path = obj_->getName();
@@ -374,6 +412,15 @@ SimpleDebugger::cmd_unwatch(std::vector<std::string>& tokens)
 }
 
 void
+SimpleDebugger::cmd_shutdown(std::vector<std::string>& UNUSED(tokens))
+{
+    simulationShutdown();
+    done = true;
+    printf("Exiting ObjectExplorer and shutting down simulation\n");
+    return;
+}
+
+void
 SimpleDebugger::dispatch_cmd(std::string cmd)
 {
     std::vector<std::string> tokens;
@@ -409,6 +456,12 @@ SimpleDebugger::dispatch_cmd(std::string cmd)
     }
     else if ( tokens[0] == "unwatch" ) {
         cmd_unwatch(tokens);
+    }
+    else if ( tokens[0] == "shutdown" ) {
+        cmd_shutdown(tokens);
+    }
+    else if ( tokens[0] == "help" ) {
+        cmd_help(tokens);
     }
     else {
         printf("Unknown command: %s\n", tokens[0].c_str());

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -66,6 +66,7 @@ private:
 
     std::vector<std::string> tokenize(std::vector<std::string>& tokens, const std::string& input);
 
+    void cmd_help(std::vector<std::string>& tokens);
     void cmd_pwd(std::vector<std::string>& tokens);
     void cmd_ls(std::vector<std::string>& tokens);
     void cmd_cd(std::vector<std::string>& tokens);
@@ -75,6 +76,7 @@ private:
     void cmd_run(std::vector<std::string>& tokens);
     void cmd_watch(std::vector<std::string>& tokens);
     void cmd_unwatch(std::vector<std::string>& tokens);
+    void cmd_shutdown(std::vector<std::string>& tokens);
 
     void dispatch_cmd(std::string cmd);
 };

--- a/src/sst/core/interactiveConsole.cc
+++ b/src/sst/core/interactiveConsole.cc
@@ -111,4 +111,11 @@ InteractiveConsole::getComponentObjectMap()
     return Simulation_impl::getSimulation()->getComponentObjectMap();
 }
 
+void
+InteractiveConsole::simulationShutdown()
+{
+    Simulation_impl::getSimulation()->interactiveShutdown();
+}
+
+
 } // namespace SST

--- a/src/sst/core/interactiveConsole.h
+++ b/src/sst/core/interactiveConsole.h
@@ -124,6 +124,8 @@ protected:
 
     SST::Core::Serialization::ObjectMap* getComponentObjectMap();
 
+    void simulationShutdown();
+
 private:
     InteractiveConsole(const InteractiveConsole&) = delete;
     InteractiveConsole& operator=(const InteractiveConsole&) = delete;

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -985,6 +985,14 @@ Simulation_impl::signalShutdown(bool abnormal)
     endSim = true;
 }
 
+void
+Simulation_impl::interactiveShutdown()
+{
+    shutdown_mode_ = SHUTDOWN_CLEAN;
+    endSim         = true;
+}
+
+
 // If this version is called, we need to set the end time in the exit
 // object as well
 void

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -412,6 +412,11 @@ public:
      */
     void signalShutdown(bool abnormal);
 
+    /** Interactive Shutdown
+     * Called when an interactive console needs to terminate SST
+     */
+    void interactiveShutdown();
+
     /** Normal Shutdown
      */
     void endSimulation();


### PR DESCRIPTION
Experimental - not required for 15.0 release

Add support to interactiveConsole for an interactiveShutdown function that exits the interactive console and does a clean shutdown of the simulation. This is modeled after the signalShutdown function in simulation.cc and tested in the simpleDebug prototype. 
---
Instructions for Issuing a Pull Request to sst-core
---------------------------------------------------

1 - Verify that the Pull Request is targeted to the **devel** branch of sstsimulator/sst-core

2 - Verify that Source branch is up to date with the devel branch of sst-core

3 - After submitting your Pull Request:
   * Automatic Testing will commence in a short while 
      * Pull Requests will be tested with the devel branches of the sst-elements and sst-sqe repositories
         * These branches are syncronized with the devel branch of sst-core.  This is why is it important to keep your source branch up to date.
      * If testing passes, the SST Core developers will review your changes and merge them or contact you for more information
         * Pull Requests from forks will not be automatically tested until the code is inspected.
         * Pull Requests from forks will not be automatically merged into the devel branch.
      * If testing fails, You will be notified of the test results.  
         * The Pull Request will be retested on a regular basis - Changes to the source branch can be made to correct problems
         
----
