### PR TITLE
Massage casting to remove warnings on GCC 14

### DIFF
--- a/src/sst/core/serialization/impl/serialize_insertable.h
+++ b/src/sst/core/serialization/impl/serialize_insertable.h
@@ -161,7 +161,7 @@ class serialize_impl<
                     SerOption::is_set(options, SerOption::as_ptr_elem) ? SerOption::as_ptr : SerOption::none;
                 // Iterate over references to elements, casting away any const in keys
                 for ( auto& e : obj )
-                    SST_SER((value_type&) e, opts);
+                    SST_SER(const_cast<value_type&>(reinterpret_cast<const value_type&>(e)), opts);
             }
             break;
         }
@@ -249,7 +249,9 @@ class serialize_impl<
                 // std::map, std::set, std::unordered_map std::unordered_set with non-simple keys
                 size_t i = 0;
                 for ( auto& e : obj )
-                    sst_ser_object(ser, (value_type&)e, SerOption::none, to_string(i++).c_str());
+                    sst_ser_object(
+                        ser, const_cast<value_type&>(reinterpret_cast<const value_type&>(e)), SerOption::none,
+                        to_string(i++).c_str());
             }
             ser.mapper().map_hierarchy_end();
             break;


### PR DESCRIPTION
When using C-style cast `(value_type&)e` to remove `const` from mapping keys (if any), GCC 14 reports a spurious warning about a user-defined conversion that might be expected to be called, but which isn't called.

> ./../../src/sst/core/serialization/impl/serialize_insertable.h:164:29: **warning: casting ‘std::pair<const int, long unsigned int>’ to ‘SST::Core::Serialization::serialize_impl<std::map<int, long unsigned int, std::less<int>, std::allocator<std::pair<const int, long unsigned int> > >, void>::value_type&’ {aka ‘std::pair<int, long unsigned int>&’} does not use ‘constexpr std::pair<_T1, _T2>::pair(const std::pair<_U1, _U2>&)** [with _U1 = const int; _U2 = long unsigned int; typename std::enable_if<(std::_PCC<((! std::is_same<_T1, _U1>::value) || (! std::is_same<_T2, _U2>::value)), _T1, _T2>::_ConstructiblePair<_U1, _U2>() && std::_PCC<((! std::is_same<_T1, _U1>::value) || (! std::is_same<_T2, _U2>::value)), _T1, _T2>::_ImplicitlyConvertiblePair<_U1, _U2>()), bool>::type <anonymous> = true; _T1 = int; _T2 = long unsigned int]’ **[-Wcast-user-defined]**
>
>  164 |                     SST_SER((value_type&) e, opts);

`value_type` in `serialize_insertable.h` is the `value_type` of the container, namely, the **value type of individual elements**, with `const` removed from the first element of a pair if the element type is a `std::pair<const KEY, VALUE>`.

We **already** remove the `const` from the key, by using `(value_type&)e`, but this causes a GCC 14 spurious warning about a conversion that we are not expecting to be called.

We do **NOT** need to split up the serialization into separate serialization of keys and values, for the `PACK` and `SIZE` modes. That will overly-complicate the code, which is already generalized to serialize any supported container by serializing its `value_type` elements in order. Only in `UNPACK` do we need to deserialize the key and value separately, to get in-place deserialization of values.

We simply need to use `reinterpret_cast` and `const_cast` explicitly, to prevent the GCC 14 warning:
```diff
-                    SST_SER((value_type&) e, opts);
+                    SST_SER(const_cast<value_type&>(reinterpret_cast<const value_type&>(e)), opts);
```
First, we `reinterpret_cast` the element to a `const value_type&`. This removes the `const` from the map `std::pair<const KEY, VALUE>`, if it exists, while keeping `const` on the upper level of the reference, in case `e`, the element itself, is a reference to `const`.

Then, we `const_cast` away the constness of the upper level of the reference, so that we can call serialization functions which expect a non-`const` reference to data.

Previously, the more concise `(value_type&)e` did this, but C++ purists like to stay away from C-style casts, and so we write the casts out explicitly now, which removes the spurious GCC warning about a conversion we never expected to occur anyway.

