### PR TITLE
Fix some warnings found in gcc 8.5-14.2

### DIFF
--- a/src/sst/core/action.h
+++ b/src/sst/core/action.h
@@ -29,7 +29,7 @@ public:
     Action() {}
     ~Action() {}
 
-    bool isAction() final { return true; }
+    bool isAction() override final { return true; }
 
 protected:
     /** Called to signal to the Simulation object to end the simulation */

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -457,7 +457,7 @@ Link*
 BaseComponent::configureSelfLink(const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler)
 {
     addSelfLink(name);
-    return configureLink(name, time_base, handler);
+    return configureLink(name, *time_base, handler);
 }
 
 Link*

--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -66,7 +66,8 @@ public:
        handler will be left in the clock list.
      */
     template <typename classT, typename dataT = void>
-    using Handler = SSTHandler<bool, Cycle_t, classT, dataT>;
+    using Handler [[deprecated("Handler has been deprecated. Please use Handler2 as it supports checkpointing.")]] =
+        SSTHandler<bool, Cycle_t, classT, dataT>;
 
     /**
        New style (checkpointable) SSTHandler

--- a/src/sst/core/event.h
+++ b/src/sst/core/event.h
@@ -119,9 +119,9 @@ public:
 
 #endif
 
-    bool isEvent() final { return true; }
+    bool isEvent() override final { return true; }
 
-    void copyAllDeliveryInfo(const Activity* act) final
+    void copyAllDeliveryInfo(const Activity* act) override final
     {
         Activity::copyAllDeliveryInfo(act);
         const Event* ev = static_cast<const Event*>(act);

--- a/src/sst/core/event.h
+++ b/src/sst/core/event.h
@@ -58,7 +58,10 @@ public:
          new Event::Handler<classname, dataT>(this, &classname::function_name, data)
      */
     template <typename classT, typename dataT = void>
-    using Handler = SSTHandler<void, Event*, classT, dataT>;
+    using Handler
+        [[deprecated("Handler has been deprecated. Please use Handler2 instead as it supports checkpointing.")]] =
+            SSTHandler<void, Event*, classT, dataT>;
+
 
     /**
        New style (checkpointable) SSTHandler

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -213,7 +213,8 @@ public:
        handler will be removed from the clock list.
     */
     template <typename classT, typename dataT = void>
-    using Handler = SSTHandler<bool, int, classT, dataT>;
+    using Handler [[deprecated("Handler has been deprecated. Please use Handler2 as it supports checkpointing.")]] =
+        SSTHandler<bool, int, classT, dataT>;
 
     /**
        Used to create checkpointable handlers to notify the endpoint

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -97,7 +97,9 @@ public:
          new stdMem::Handler<classname, dataT>(this, &classname::function_name, data)
      */
     template <typename classT, typename dataT = void>
-    using Handler = SSTHandler<void, Request*, classT, dataT>;
+    using Handler
+        [[deprecated("Handler has been deprecated. Please use Handler2 instead as it supports checkpointing.")]] =
+            SSTHandler<void, Request*, classT, dataT>;
 
     /**
        Used to create checkpointable handlers for request handling.

--- a/src/sst/core/oneshot.h
+++ b/src/sst/core/oneshot.h
@@ -59,7 +59,9 @@ public:
          new OneShot::Handler<classname, dataT>(this, &classname::function_name, data)
      */
     template <typename classT, typename dataT = void>
-    using Handler = SSTHandlerNoArgs<void, classT, dataT>;
+    using Handler
+        [[deprecated("Handler has been deprecated. Please use Handler2 instead as it supports checkpointing.")]] =
+            SSTHandlerNoArgs<void, classT, dataT>;
 
     /**
        Used to create checkpointable handlers for OneShot.  The callback function is

--- a/src/sst/core/serialization/impl/serialize_insertable.h
+++ b/src/sst/core/serialization/impl/serialize_insertable.h
@@ -206,12 +206,14 @@ class serialize_impl<
                         is_same_template_v<T, std::multiset> || is_same_template_v<T, std::unordered_multiset> ) {
                         typename OBJ::key_type key {};
                         // TODO: Figure out how to make as_ptr_elem work with sets
-                        SST_SER(key);
+                        opts = SerOption::none;
+                        SST_SER(key, opts);
                         obj.emplace(std::move(key));
                     }
                     else if constexpr ( is_vector_bool_v<OBJ> ) {
                         bool value {};
-                        SST_SER(value);
+                        opts = SerOption::none;
+                        SST_SER(value, opts);
                         obj.push_back(value);
                     }
                     else { // std::vector, std::deque, std::list

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -820,7 +820,7 @@ protected:
     T* addr_;
 
 public:
-    bool isContainer() final { return true; }
+    bool isContainer() override final { return true; }
 
     std::string getType() override { return demangle_name(typeid(T).name()); }
 

--- a/src/sst/core/ssthandler.h
+++ b/src/sst/core/ssthandler.h
@@ -1129,9 +1129,7 @@ using SSTHandlerBaseNoArgs = SSTHandlerBase<returnT, void>;
  * Handler class with user-data argument
  */
 template <typename returnT, typename argT, typename classT, typename dataT = void>
-class [[deprecated(
-    "Handler has been deprecated.  Please use Handler2 instead as it supports checkpointing")]] SSTHandler :
-    public SSTHandlerBase<returnT, argT>
+class SSTHandler : public SSTHandlerBase<returnT, argT>
 {
 private:
     using PtrMember = returnT (classT::*)(argT, dataT);
@@ -1165,8 +1163,7 @@ public:
  * Event Handler class with no user-data.
  */
 template <typename returnT, typename argT, typename classT>
-class [[deprecated("Handler has been deprecated.  Please use Handler2 instead as it supports "
-                   "checkpointing")]] SSTHandler<returnT, argT, classT, void> : public SSTHandlerBase<returnT, argT>
+class SSTHandler<returnT, argT, classT, void> : public SSTHandlerBase<returnT, argT>
 {
 private:
     using PtrMember = returnT (classT::*)(argT);
@@ -1194,9 +1191,7 @@ public:
  * Event Handler class with user-data argument
  */
 template <typename returnT, typename classT, typename dataT = void>
-class [[deprecated(
-    "Handler has been deprecated.  Please use Handler2 instead as it supports checkpointing")]] SSTHandlerNoArgs :
-    public SSTHandlerBaseNoArgs<returnT>
+class SSTHandlerNoArgs : public SSTHandlerBaseNoArgs<returnT>
 {
 private:
     using PtrMember = returnT (classT::*)(dataT);
@@ -1230,8 +1225,7 @@ public:
  * Event Handler class with no user-data.
  */
 template <typename returnT, typename classT>
-class [[deprecated("Handler has been deprecated.  Please use Handler2 instead as it supports "
-                   "checkpointing")]] SSTHandlerNoArgs<returnT, classT, void> : public SSTHandlerBaseNoArgs<returnT>
+class SSTHandlerNoArgs<returnT, classT, void> : public SSTHandlerBaseNoArgs<returnT>
 {
 private:
     using PtrMember = returnT (classT::*)();

--- a/src/sst/core/testElements/coreTest_Serialization.cc
+++ b/src/sst/core/testElements/coreTest_Serialization.cc
@@ -76,11 +76,11 @@ struct checkSimpleSerializeDeserialize
 
     static bool check(TYPE data)
     {
-        TYPE obj;
         T    input;
         T    output;
 
         if constexpr ( std::is_pointer_v<T> ) {
+            TYPE obj;
             obj    = data;
             input  = &obj;
             output = nullptr;

--- a/src/sst/core/testElements/coreTest_Serialization.cc
+++ b/src/sst/core/testElements/coreTest_Serialization.cc
@@ -76,11 +76,11 @@ struct checkSimpleSerializeDeserialize
 
     static bool check(TYPE data)
     {
-        T input;
-        T output;
+        T    input;
+        T    output;
+        TYPE obj [[maybe_unused]];
 
         if constexpr ( std::is_pointer_v<T> ) {
-            TYPE obj;
             obj    = data;
             input  = &obj;
             output = nullptr;

--- a/src/sst/core/testElements/coreTest_Serialization.cc
+++ b/src/sst/core/testElements/coreTest_Serialization.cc
@@ -76,8 +76,8 @@ struct checkSimpleSerializeDeserialize
 
     static bool check(TYPE data)
     {
-        T    input;
-        T    output;
+        T input;
+        T output;
 
         if constexpr ( std::is_pointer_v<T> ) {
             TYPE obj;


### PR DESCRIPTION
Two types of compile warnings addressed: unused variables and missing override in functions marked final. 

While the missing override does not warn in all newer versions of gcc, it does warn in older ones that are still supported.