### PR TITLE
add array serialization tests, fix bugs

### DIFF
--- a/src/sst/core/action.h
+++ b/src/sst/core/action.h
@@ -29,7 +29,7 @@ public:
     Action() {}
     ~Action() {}
 
-    bool isAction() final { return true; }
+    bool isAction() override final { return true; }
 
 protected:
     /** Called to signal to the Simulation object to end the simulation */

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -457,7 +457,7 @@ Link*
 BaseComponent::configureSelfLink(const std::string& name, TimeConverter* time_base, Event::HandlerBase* handler)
 {
     addSelfLink(name);
-    return configureLink(name, time_base, handler);
+    return configureLink(name, *time_base, handler);
 }
 
 Link*

--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -66,7 +66,8 @@ public:
        handler will be left in the clock list.
      */
     template <typename classT, typename dataT = void>
-    using Handler = SSTHandler<bool, Cycle_t, classT, dataT>;
+    using Handler [[deprecated("Handler has been deprecated. Please use Handler2 as it supports checkpointing.")]] =
+        SSTHandler<bool, Cycle_t, classT, dataT>;
 
     /**
        New style (checkpointable) SSTHandler

--- a/src/sst/core/event.h
+++ b/src/sst/core/event.h
@@ -58,7 +58,10 @@ public:
          new Event::Handler<classname, dataT>(this, &classname::function_name, data)
      */
     template <typename classT, typename dataT = void>
-    using Handler = SSTHandler<void, Event*, classT, dataT>;
+    using Handler
+        [[deprecated("Handler has been deprecated. Please use Handler2 instead as it supports checkpointing.")]] =
+            SSTHandler<void, Event*, classT, dataT>;
+
 
     /**
        New style (checkpointable) SSTHandler
@@ -119,9 +122,9 @@ public:
 
 #endif
 
-    bool isEvent() final { return true; }
+    bool isEvent() override final { return true; }
 
-    void copyAllDeliveryInfo(const Activity* act) final
+    void copyAllDeliveryInfo(const Activity* act) override final
     {
         Activity::copyAllDeliveryInfo(act);
         const Event* ev = static_cast<const Event*>(act);

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -213,7 +213,8 @@ public:
        handler will be removed from the clock list.
     */
     template <typename classT, typename dataT = void>
-    using Handler = SSTHandler<bool, int, classT, dataT>;
+    using Handler [[deprecated("Handler has been deprecated. Please use Handler2 as it supports checkpointing.")]] =
+        SSTHandler<bool, int, classT, dataT>;
 
     /**
        Used to create checkpointable handlers to notify the endpoint

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -97,7 +97,9 @@ public:
          new stdMem::Handler<classname, dataT>(this, &classname::function_name, data)
      */
     template <typename classT, typename dataT = void>
-    using Handler = SSTHandler<void, Request*, classT, dataT>;
+    using Handler
+        [[deprecated("Handler has been deprecated. Please use Handler2 instead as it supports checkpointing.")]] =
+            SSTHandler<void, Request*, classT, dataT>;
 
     /**
        Used to create checkpointable handlers for request handling.

--- a/src/sst/core/oneshot.h
+++ b/src/sst/core/oneshot.h
@@ -59,7 +59,9 @@ public:
          new OneShot::Handler<classname, dataT>(this, &classname::function_name, data)
      */
     template <typename classT, typename dataT = void>
-    using Handler = SSTHandlerNoArgs<void, classT, dataT>;
+    using Handler
+        [[deprecated("Handler has been deprecated. Please use Handler2 instead as it supports checkpointing.")]] =
+            SSTHandlerNoArgs<void, classT, dataT>;
 
     /**
        Used to create checkpointable handlers for OneShot.  The callback function is

--- a/src/sst/core/serialization/impl/serialize_array.h
+++ b/src/sst/core/serialization/impl/serialize_array.h
@@ -97,10 +97,7 @@ struct serialize_impl_fixed_array
         case serializer::UNPACK:
             if constexpr ( std::is_pointer_v<OBJ_TYPE> ) {
                 // for pointers to fixed arrays, we allocate the storage
-                if constexpr ( std::is_same_v<OBJ_TYPE, ELEM_T(*)[SIZE]> )
-                    ary = new ELEM_T[SIZE];
-                else
-                    ary = new std::remove_pointer_t<OBJ_TYPE>;
+                ary = reinterpret_cast<OBJ_TYPE>(new std::remove_pointer_t<OBJ_TYPE>);
             }
             [[fallthrough]];
 

--- a/src/sst/core/serialization/impl/serialize_tuple.h
+++ b/src/sst/core/serialization/impl/serialize_tuple.h
@@ -26,10 +26,11 @@
 namespace SST::Core::Serialization {
 
 // Serialize tuples and pairs
-template <template <typename...> class T, typename... Ts>
-class serialize_impl<T<Ts...>, std::enable_if_t<is_same_template_v<T, std::tuple> || is_same_template_v<T, std::pair>>>
+template <typename T>
+class serialize_impl<
+    T, std::enable_if_t<is_same_type_template_v<T, std::tuple> || is_same_type_template_v<T, std::pair>>>
 {
-    void operator()(T<Ts...>& t, serializer& ser, ser_opt_t options)
+    void operator()(T& t, serializer& ser, ser_opt_t options)
     {
         // Serialize each element of tuple or pair
         ser_opt_t opt = SerOption::is_set(options, SerOption::as_ptr_elem) ? SerOption::as_ptr : SerOption::none;

--- a/src/sst/core/serialization/impl/serialize_utility.h
+++ b/src/sst/core/serialization/impl/serialize_utility.h
@@ -21,17 +21,19 @@
 
 namespace SST::Core::Serialization {
 
-// Whether two names are the same template. Similar to std::is_same.
+// Whether two names are the same template. Similar to std::is_same_v.
 template <template <typename...> class, template <typename...> class>
-struct is_same_template : std::false_type
-{};
+constexpr bool is_same_template_v = false;
 
 template <template <typename...> class T>
-struct is_same_template<T, T> : std::true_type
-{};
+constexpr bool is_same_template_v<T, T> = true;
 
-template <template <typename...> class A, template <typename...> class B>
-inline constexpr bool is_same_template_v = is_same_template<A, B>::value;
+// Whether a certain type is the same as a certain class template filled with arguments
+template <class, template <typename...> class>
+constexpr bool is_same_type_template_v = false;
+
+template <template <typename...> class T1, typename... T1ARGS, template <typename...> class T2>
+constexpr bool is_same_type_template_v<T1<T1ARGS...>, T2> = is_same_template_v<T1, T2>;
 
 } // namespace SST::Core::Serialization
 

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -820,7 +820,7 @@ protected:
     T* addr_;
 
 public:
-    bool isContainer() final { return true; }
+    bool isContainer() override final { return true; }
 
     std::string getType() override { return demangle_name(typeid(T).name()); }
 

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -131,7 +131,7 @@ public:
         switch ( mode_ ) {
         case SIZER:
             sizer_.add(sizeof(SIZE_T));
-            sizer_.add(size);
+            sizer_.add(size * sizeof(ELEM_T));
             break;
         case PACK:
             if ( buffer ) {

--- a/src/sst/core/ssthandler.h
+++ b/src/sst/core/ssthandler.h
@@ -1129,9 +1129,7 @@ using SSTHandlerBaseNoArgs = SSTHandlerBase<returnT, void>;
  * Handler class with user-data argument
  */
 template <typename returnT, typename argT, typename classT, typename dataT = void>
-class [[deprecated(
-    "Handler has been deprecated.  Please use Handler2 instead as it supports checkpointing")]] SSTHandler :
-    public SSTHandlerBase<returnT, argT>
+class SSTHandler : public SSTHandlerBase<returnT, argT>
 {
 private:
     using PtrMember = returnT (classT::*)(argT, dataT);
@@ -1165,8 +1163,7 @@ public:
  * Event Handler class with no user-data.
  */
 template <typename returnT, typename argT, typename classT>
-class [[deprecated("Handler has been deprecated.  Please use Handler2 instead as it supports "
-                   "checkpointing")]] SSTHandler<returnT, argT, classT, void> : public SSTHandlerBase<returnT, argT>
+class SSTHandler<returnT, argT, classT, void> : public SSTHandlerBase<returnT, argT>
 {
 private:
     using PtrMember = returnT (classT::*)(argT);
@@ -1194,9 +1191,7 @@ public:
  * Event Handler class with user-data argument
  */
 template <typename returnT, typename classT, typename dataT = void>
-class [[deprecated(
-    "Handler has been deprecated.  Please use Handler2 instead as it supports checkpointing")]] SSTHandlerNoArgs :
-    public SSTHandlerBaseNoArgs<returnT>
+class SSTHandlerNoArgs : public SSTHandlerBaseNoArgs<returnT>
 {
 private:
     using PtrMember = returnT (classT::*)(dataT);
@@ -1230,8 +1225,7 @@ public:
  * Event Handler class with no user-data.
  */
 template <typename returnT, typename classT>
-class [[deprecated("Handler has been deprecated.  Please use Handler2 instead as it supports "
-                   "checkpointing")]] SSTHandlerNoArgs<returnT, classT, void> : public SSTHandlerBaseNoArgs<returnT>
+class SSTHandlerNoArgs<returnT, classT, void> : public SSTHandlerBaseNoArgs<returnT>
 {
 private:
     using PtrMember = returnT (classT::*)();

--- a/src/sst/core/testElements/coreTest_Serialization.cc
+++ b/src/sst/core/testElements/coreTest_Serialization.cc
@@ -40,8 +40,8 @@ namespace SST::CoreTestSerialization {
 using SST::Core::Serialization::get_size;
 
 template <typename T>
-static void
-serializeDeserialize(T& input, T& output, bool with_tracking = false)
+void
+serializeDeserialize(T&& input, T&& output, bool with_tracking = false)
 {
     // Set up serializer and buffers
     char*                                buffer;
@@ -76,9 +76,9 @@ struct checkSimpleSerializeDeserialize
 
     static bool check(TYPE data)
     {
-        TYPE obj;
         T    input;
         T    output;
+        TYPE obj [[maybe_unused]];
 
         if constexpr ( std::is_pointer_v<T> ) {
             obj    = data;
@@ -220,6 +220,57 @@ checkContainerSerializeDeserialize(T*& data)
     return true;
 };
 
+// Arrays
+
+template <typename>
+constexpr size_t array_size = 0;
+
+template <typename T, size_t S>
+constexpr size_t array_size<T[S]> = S;
+
+template <typename T, size_t S>
+constexpr size_t array_size<std::array<T, S>> = S;
+
+template <typename T>
+bool
+checkFixedArraySerializeDeserialize(T& data)
+{
+    T result;
+    serializeDeserialize(data, result);
+
+    for ( size_t i = 0; i < array_size<std::remove_pointer_t<T>>; ++i ) {
+        if constexpr ( std::is_pointer_v<T> ) {
+            if ( (*data)[i] != (*result)[i] ) return false;
+        }
+        else {
+            if ( data[i] != result[i] ) return false;
+        }
+    }
+    if constexpr ( std::is_pointer_v<T> ) delete[] result;
+    return true;
+};
+
+template <typename T>
+bool
+checkArraySerializeDeserialize(T* data, size_t dataSize)
+{
+    using SST::Core::Serialization::array;
+
+    T*     result     = nullptr;
+    size_t resultSize = ~size_t {};
+
+    serializeDeserialize(array(data, dataSize), array(result, resultSize));
+
+    if ( resultSize != dataSize ) return false;
+
+    for ( size_t i = 0; i < dataSize; ++i ) {
+        if ( data[i] != result[i] ) return false;
+    }
+
+    delete[] result;
+
+    return true;
+};
 
 // For ordered but non-iterable contaienrs
 template <typename T>
@@ -557,6 +608,47 @@ coreTestSerialization::coreTestSerialization(ComponentId_t id, Params& params) :
         checkSimpleSerializeDeserialize<float*>::check_all(rng->nextUniform() * 1000, out, "float*");
         checkSimpleSerializeDeserialize<double*>::check_all(rng->nextUniform() * 1000000, out, "double*");
         checkSimpleSerializeDeserialize<std::string*>::check_all("test_string", out, "std::string*");
+    }
+    else if ( test == "array" ) {
+        {
+            int32_t array_in[10];
+            for ( size_t i = 0; i < 10; ++i )
+                array_in[i] = rng->generateNextInt32();
+            passed = checkFixedArraySerializeDeserialize(array_in);
+            if ( !passed ) out.output("ERROR: int32_t[10] did not serialize/deserialize properly\n");
+        }
+        {
+            std::array<int32_t, 10> array_in;
+            for ( size_t i = 0; i < 10; ++i )
+                array_in[i] = rng->generateNextInt32();
+            passed = checkFixedArraySerializeDeserialize(array_in);
+            if ( !passed ) out.output("ERROR: std::array<int32_t, 10> did not serialize/deserialize properly\n");
+        }
+        {
+            int32_t(*array_in)[10] = reinterpret_cast<int32_t(*)[10]>(new int32_t[10]);
+            for ( size_t i = 0; i < 10; ++i )
+                (*array_in)[i] = rng->generateNextInt32();
+            passed = checkFixedArraySerializeDeserialize(array_in);
+            if ( !passed ) out.output("ERROR: int32_t[10] did not serialize/deserialize properly\n");
+            delete[] array_in;
+        }
+        {
+            std::array<int32_t, 10>* array_in = new std::array<int32_t, 10>;
+            for ( size_t i = 0; i < 10; ++i )
+                (*array_in)[i] = rng->generateNextInt32();
+            passed = checkFixedArraySerializeDeserialize(array_in);
+            if ( !passed ) out.output("ERROR: std::array<int32_t, 10> did not serialize/deserialize properly\n");
+            delete array_in;
+        }
+        {
+            size_t   size     = 100;
+            int32_t* array_in = new int32_t[size];
+            for ( size_t i = 0; i < size; ++i )
+                array_in[i] = rng->generateNextInt32();
+            passed = checkArraySerializeDeserialize(array_in, size);
+            if ( !passed ) out.output("ERROR: std::array<int32_t, %zu> did not serialize/deserialize properly\n", size);
+            delete[] array_in;
+        }
     }
     else if ( test == "ordered_containers" ) {
         // Ordered Containers

--- a/tests/testsuite_default_Serialization.py
+++ b/tests/testsuite_default_Serialization.py
@@ -36,6 +36,9 @@ class testcase_Serialization(SSTTestCase):
     def test_Serialization_pod_ptr(self):
         self.serialization_test_template("pod_ptr")
 
+    def test_Serialization_array(self):
+        self.serialization_test_template("array")
+
     def test_Serialization_ordered_containers(self):
         self.serialization_test_template("ordered_containers")
 
@@ -82,4 +85,3 @@ class testcase_Serialization(SSTTestCase):
         filter1 = StartsWithFilter("WARNING: No components are")
         cmp_result = testing_compare_filtered_diff("serialization", outfile, reffile, True, [filter1])
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))
-


### PR DESCRIPTION
This adds array serialization tests, and fixes two bugs:
1. `serializer::binary( buffer, size )` did not properly compute `SIZER` with `size * sizeof(ELEM_T)` -- it only used `size` for the `SIZER` computation of the array size. **This should be patched into SST 15 if possible.**
2. If a pointer to a fixed-size array, such as `int (*ary)[10]` was serialized, it was not properly allocated, leading to compilation errors in the template instantiation of `serialize_impl`.

The `serializeDeserialize()` function was modified slightly to take universal references, so that it can work with `array(ptr, size)` wrappers which are rvalue expressions but contain lvalue references inside.
