### PR TITLE
Bump clang-format requirement from v12 to v20

### DIFF
--- a/.github/workflows/PR_clang-format_test.yml
+++ b/.github/workflows/PR_clang-format_test.yml
@@ -16,7 +16,7 @@ on:
 #       Any changes to this script will not be run until it is merged into
 #       the main repo.
 
-# This script is used to do a quick and dirty clang-format v12 check on the
+# This script is used to do a quick and dirty clang-format v20 check on the
 # PR source repo to ensure it is formatted correctly.  It will initially set
 # the AT: WIP label to try to stop the Autottester from processing the PR, and
 # then perform the clang-format test using a 3rd party action.  It will then
@@ -67,12 +67,12 @@ jobs:
 
 #   Running the github action for clang format
     - name: Run Action clang-format-lint
-      uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 # v0.18.2
+      uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20
       with:
         source: './sst-core_source/'
         exclude: './sst-core_source/src/sst/core/libltdl ./sst-core_source/external ./sst-core_source/build'
         extensions: 'h,cc'
-        clangFormatVersion: 12
+        clangFormatVersion: 20
         inplace: False
 
 #############################################
@@ -116,7 +116,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '**CLANG-FORMAT TEST - FAILED** (on last commit): <br>Run > ./scripts/clang-format-test.sh using clang-format v12 to check formatting'
+              body: '**CLANG-FORMAT TEST - FAILED** (on last commit): <br>Run > ./scripts/clang-format-test.sh using clang-format v20 to check formatting'
             })
       if: ${{ failure() }}
 

--- a/scripts/clang-format-test.sh
+++ b/scripts/clang-format-test.sh
@@ -38,13 +38,13 @@ echo "Using clang-format ${CLANG_FORMAT_EXE} with arguments ${CLANG_FORMAT_ARG}.
 
 clang_format_version="$(${CLANG_FORMAT_EXE} --version)"
 currentver="$( ${CLANG_FORMAT_EXE} --version | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/' | sed 's/\.//g')"
-if [ "${currentver:=0}" -lt 1200 ]; then
-  echo "clang-format version is $clang_format_version. We require version 12."
+if [ "${currentver:=0}" -lt 2000 ]; then
+  echo "clang-format version is $clang_format_version. We require version 20."
   exit 1
 fi
 
-if [ "${currentver:=0}" -ge 1300 ]; then
-  echo "clang-format version is $clang_format_version. We require version 12."
+if [ "${currentver:=0}" -ge 2100 ]; then
+  echo "clang-format version is $clang_format_version. We require version 20."
   exit 1
 fi
 


### PR DESCRIPTION
The first part of https://github.com/sstsimulator/sst-core/issues/1236; actual formatting changes will come in a later PR.

(Redo of https://github.com/sstsimulator/sst-core/pull/1317)