### PR TITLE
Provide std::this_thread::yield() as a default definition of sst_pause()

### DIFF
--- a/src/sst/core/threadsafe.h
+++ b/src/sst/core/threadsafe.h
@@ -19,6 +19,8 @@
 #define sst_pause() __asm__ __volatile__("yield")
 #elif defined(__PPC64__)
 #define sst_pause() __asm__ __volatile__("or 27, 27, 27" ::: "memory");
+#else
+#define sst_pause() std::this_thread::yield()
 #endif
 
 #include <atomic>


### PR DESCRIPTION
During a recent SST client build (which was probably misconfigured for other reasons), I found that the `sst_pause()` macro would not be defined if no predefined macros on supported architectures are detected, and so the build fails because `sst_pause()` is undefined and the `src/sst/core/threadsafe.h` header cannot be compiled.

```
/home/lkillough/sstcore-14.1.0/include/sst/core/threadsafe.h: In member function 'double SST::Core::ThreadSafe::Barrier::wait()':
/home/lkillough/sstcore-14.1.0/include/sst/core/threadsafe.h:102:25: error: 'sst_pause' was not declared in this scope
  102 |                         sst_pause();
      |                         ^~~~~~~~~
/home/lkillough/sstcore-14.1.0/include/sst/core/threadsafe.h: In member function 'void SST::Core::ThreadSafe::Spinlock::lock()':
/home/lkillough/sstcore-14.1.0/include/sst/core/threadsafe.h:141:13: error: 'sst_pause' was not declared in this scope
  141 |             sst_pause();
      |             ^~~~~~~~~
/home/lkillough/sstcore-14.1.0/include/sst/core/threadsafe.h: In member function 'T SST::Core::ThreadSafe::BoundedQueue<T>::remove()':
/home/lkillough/sstcore-14.1.0/include/sst/core/threadsafe.h:265:13: error: there are no arguments to 'sst_pause' that depend on a template parameter, so a declaration of 'sst_pause' must be available [-fpermissive]
  265 |             sst_pause();
      |             ^~~~~~~~~
```

This adds `std::this_thread::yield()` as a fallback default definition for `sst_pause()` if no lighter-weight methods are known for the target architecture.
```Diff
+ #else
+ #define sst_pause() std::this_thread::yield()
```

In a spin loop in `threadsafe.h`, `std::this_thread::yield()` is already used as the second "backing off" method, with `sst_pause()` being the first and `nanosleep()` being the third:
1. `sst_pause()`                   &lt;-- make this default to `std::this_thread::yield()` if no architecture-specific method exists
2. `std::this_thread::yield()`
3. `nanosleep()`

If falling back to `std::this_thread::yield()` is too heavyweight, then a default blank definition can be added, perhaps with a `#warning` message:
```Diff
+ #else
+ #warning "No architecture-specific definition of sst_pause() found -- making it a no-op"
+ #define sst_pause()
#endif
```

