### PR TITLE
Moved primary component functions into BaseComponent

### DIFF
--- a/src/sst/core/component.cc
+++ b/src/sst/core/component.cc
@@ -31,26 +31,6 @@ Component::Component(ComponentId_t id) :
     // currentlyLoadingSubComponent = my_info;
 }
 
-void
-Component::registerAsPrimaryComponent()
-{
-    // Nop for now.  Will put in complete semantics later
-}
-
-void
-Component::primaryComponentDoNotEndSim()
-{
-    int thread = Simulation_impl::getSimulation()->getRank().thread;
-    Simulation_impl::getSimulation()->getExit()->refInc(getId(), thread);
-}
-
-void
-Component::primaryComponentOKToEndSim()
-{
-    int thread = Simulation_impl::getSimulation()->getRank().thread;
-    Simulation_impl::getSimulation()->getExit()->refDec(getId(), thread);
-}
-
 
 void
 Component::serialize_order(SST::Core::Serialization::serializer& ser)

--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -50,47 +50,6 @@ public:
     explicit Component(ComponentId_t id);
     virtual ~Component() override = default;
 
-    /** Register as a primary component, which allows the component to
-        specify when it is and is not OK to end simulation.  The
-        simulator will not end simulation naturally (through use of
-        the Exit object) while any primary component has specified
-        primaryComponentDoNotEndSim().  However, it is still possible
-        for Actions other than Exit to end simulation.  Once all
-        primary components have specified
-        primaryComponentOKToEndSim(), the Exit object will trigger and
-        end simulation.
-
-    This must be called during simulation wireup (i.e during the
-    constructor for the component).  By default, the state of the
-    primary component is set to OKToEndSim.
-
-    If no component registers as a primary component, then the
-    Exit object will not be used for that simulation and
-    simulation termination must be accomplished through some other
-    mechanism (e.g. --stopAt flag, or some other Action object).
-
-        @sa Component::primaryComponentDoNotEndSim()
-        @sa Component::primaryComponentOKToEndSim()
-    */
-    void registerAsPrimaryComponent();
-
-    /** Tells the simulation that it should not exit.  The component
-    will remain in this state until a call to
-    primaryComponentOKToEndSim().
-
-        @sa Component::registerAsPrimaryComponent()
-        @sa Component::primaryComponentOKToEndSim()
-    */
-    void primaryComponentDoNotEndSim();
-
-    /** Tells the simulation that it is now OK to end simulation.
-    Simulation will not end until all primary components have
-    called this function.
-
-        @sa Component::registerAsPrimaryComponent()
-        @sa Component::primaryComponentDoNotEndSim()
-    */
-    void primaryComponentOKToEndSim();
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::Component)

--- a/src/sst/core/componentExtension.cc
+++ b/src/sst/core/componentExtension.cc
@@ -18,7 +18,7 @@ namespace SST {
 ComponentExtension::ComponentExtension(ComponentId_t id) :
     BaseComponent(id)
 {
-    isExtension = true;
+    setAsExtension();
 }
 
 void

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -28,7 +28,6 @@ ComponentInfo::ComponentInfo(ComponentId_t id, const std::string& name) :
     link_map(nullptr),
     component(nullptr),
     params(nullptr),
-    portModules(nullptr),
     stat_configs_(nullptr),
     enabled_stat_names_(nullptr),
     enabled_all_stats_(false),
@@ -49,7 +48,6 @@ ComponentInfo::ComponentInfo() :
     link_map(nullptr),
     component(nullptr),
     params(nullptr),
-    portModules(nullptr),
     stat_configs_(nullptr),
     enabled_stat_names_(nullptr),
     enabled_all_stats_(false),
@@ -89,7 +87,6 @@ ComponentInfo::ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const
     link_map(nullptr),
     component(nullptr),
     params(/*new Params()*/ nullptr),
-    portModules(nullptr),
     stat_configs_(nullptr),
     enabled_stat_names_(nullptr),
     enabled_all_stats_(false),
@@ -184,7 +181,7 @@ ComponentInfo::~ComponentInfo()
 {
     if ( link_map ) delete link_map;
     if ( component ) {
-        component->my_info = nullptr;
+        component->my_info_ = nullptr;
         delete component;
     }
 

--- a/src/sst/core/exit.cc
+++ b/src/sst/core/exit.cc
@@ -24,88 +24,48 @@ namespace SST {
 
 Exit::Exit(int num_threads, bool single_rank) :
     Action(),
-    //     m_functor( new EventHandler<Exit,bool,Event*> (this,&Exit::handler ) ),
-    num_threads(num_threads),
-    m_refCount(0),
-    end_time(0),
-    single_rank(single_rank)
+    num_threads_(num_threads),
+    single_rank_(single_rank)
 {
     setPriority(EXITPRIORITY);
-    m_thread_counts = new unsigned int[num_threads];
-    for ( int i = 0; i < num_threads; i++ ) {
-        m_thread_counts[i] = 0;
+    thread_counts_ = new unsigned int[num_threads_];
+    for ( int i = 0; i < num_threads_; i++ ) {
+        thread_counts_[i] = 0;
     }
 }
 
 Exit::~Exit()
 {
-    m_idSet.clear();
+    delete[] thread_counts_;
 }
 
-bool
-Exit::refInc(ComponentId_t id, uint32_t thread)
+void
+Exit::refInc(uint32_t thread)
 {
-    std::lock_guard<Spinlock> lock(slock);
-    if ( m_idSet.find(id) != m_idSet.end() ) {
-        // CompMap_t comp_map = Simulation_impl::getSimulation()->getComponentMap();
-        // bool found_in_map = false;
-
-        // for(CompMap_t::iterator comp_map_itr = comp_map.begin();
-        //     comp_map_itr != comp_map.end();
-        //     ++comp_map_itr) {
-
-        //     if(comp_map_itr->second->getId() == id) {
-        //         found_in_map = true;
-        //         break;
-        //     }
-        // }
-
-        // if(found_in_map) {
-        //     _DBG( Exit, "component (%s) multiple increment\n",
-        //           Simulation_impl::getSimulation()->getComponent(id)->getName().c_str() );
-        // } else {
-        //     _DBG( Exit, "component in construction increments exit multiple times.\n" );
-        // }
-        return true;
-    }
-
-    m_idSet.insert(id);
-
-    ++m_refCount;
-    ++m_thread_counts[thread];
-
-    return false;
+    std::lock_guard<Spinlock> lock(slock_);
+    ++ref_count_;
+    ++thread_counts_[thread];
 }
 
-bool
-Exit::refDec(ComponentId_t id, uint32_t thread)
+void
+Exit::refDec(uint32_t thread)
 {
-    std::lock_guard<Spinlock> lock(slock);
-    if ( m_idSet.find(id) == m_idSet.end() ) {
-        Simulation_impl::getSimulation()->getSimulationOutput().verbose(CALL_INFO, 1, 1,
-            "component (%s) multiple decrement\n",
-            Simulation_impl::getSimulation()->getComponent(id)->getName().c_str());
-        return true;
+    std::lock_guard<Spinlock> lock(slock_);
+    if ( ref_count_ == 0 ) {
+        Simulation_impl::getSimulation()->getSimulationOutput().fatal(CALL_INFO, 1, "ref_count is already 0\n");
     }
 
-    if ( m_refCount == 0 ) {
-        Simulation_impl::getSimulation()->getSimulationOutput().fatal(CALL_INFO, 1, "refCount is already 0\n");
-        return true;
-    }
+    --ref_count_;
+    --thread_counts_[thread];
 
-    m_idSet.erase(id);
-
-    --m_refCount;
-    --m_thread_counts[thread];
-
-    if ( single_rank && num_threads == 1 && m_refCount == 0 ) {
-        end_time             = Simulation_impl::getSimulation()->getCurrentSimCycle();
+    if ( single_rank_ && num_threads_ == 1 && ref_count_ == 0 ) {
+        end_time_            = Simulation_impl::getSimulation()->getCurrentSimCycle();
         Simulation_impl* sim = Simulation_impl::getSimulation();
         sim->insertActivity(sim->getCurrentSimCycle() + 1, this);
     }
-    else if ( m_thread_counts[thread] == 0 ) {
+    else if ( thread_counts_[thread] == 0 ) {
         SimTime_t end_time_new = Simulation_impl::getSimulation()->getCurrentSimCycle();
-        if ( end_time_new > end_time ) end_time = end_time_new;
+        if ( end_time_new > end_time_ ) end_time_ = end_time_new;
         if ( Simulation_impl::getSimulation()->isIndependentThread() ) {
             // Need to exit just this thread, so we'll need to use a
             // StopAction
@@ -113,24 +73,19 @@ Exit::refDec(ComponentId_t id, uint32_t thread)
             sim->insertActivity(sim->getCurrentSimCycle(), new StopAction());
         }
     }
-
-    return false;
 }
 
 unsigned int
 Exit::getRefCount()
 {
-    return m_refCount;
+    return ref_count_;
 }
 
 void
 Exit::execute()
 {
-    check();
-
     // Only gets put into queue once, no need to reschedule
-    // SimTime_t next = Simulation_impl::getSimulation()->getCurrentSimCycle() + m_period->getFactor();
-    // Simulation_impl::getSimulation()->insertActivity(next, this);
+    check();
 }
 
 SimTime_t
@@ -139,25 +94,25 @@ Exit::computeEndTime()
 #ifdef SST_CONFIG_HAVE_MPI
     // Do an all_reduce to get the end_time
     SimTime_t end_value;
-    if ( !single_rank ) {
-        MPI_Allreduce(&end_time, &end_value, 1, MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
-        end_time = end_value;
+    if ( !single_rank_ ) {
+        MPI_Allreduce(&end_time_, &end_value, 1, MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
+        end_time_ = end_value;
     }
 #endif
-    if ( single_rank ) {
-        endSimulation(end_time);
+    if ( single_rank_ ) {
+        endSimulation(end_time_);
     }
-    return end_time;
+    return end_time_;
 }
 
 void
 Exit::check()
 {
-    int value = (m_refCount > 0);
+    int value = (ref_count_ > 0);
     int out;
 
 #ifdef SST_CONFIG_HAVE_MPI
-    if ( !single_rank ) {
+    if ( !single_rank_ ) {
         MPI_Allreduce(&value, &out, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
     }
     else {
@@ -166,44 +121,19 @@ Exit::check()
 #else
     out = value;
 #endif
-    global_count = out;
+    global_count_ = out;
     // If out is 0, then it's time to end
     if ( !out ) {
         computeEndTime();
     }
-    // else {
-    //     // Reinsert into TimeVortex.  We do this even when ending so that
-    //     // it will get deleted with the TimeVortex on termination.  We do
-    //     // this in case we exit with a StopEvent instead.  In that case,
-    //     // there is no way to know if the Exit object is deleted in the
-    //     // TimeVortex or not, so we just make sure it is always deleted
-    //     // there.
-    //     Simulation *sim = Simulation_impl::getSimulation();
-    //     SimTime_t next = sim->getCurrentSimCycle() +
-    //     sim->insertActivity( next, this );
-    // }
 }
 
-void
-Exit::serialize_order(SST::Core::Serialization::serializer& ser)
+std::string
+Exit::toString() const
 {
-    Action::serialize_order(ser);
-
-    SST_SER(num_threads);
-
-    if ( ser.mode() == SST::Core::Serialization::serializer::UNPACK ) {
-        m_thread_counts = new unsigned int[num_threads];
-    }
-
-    for ( int i = 0; i < num_threads; i++ ) {
-        SST_SER(m_thread_counts[i]);
-    }
-
-    SST_SER(m_refCount);
-    SST_SER(global_count);
-    SST_SER(m_idSet);
-    SST_SER(end_time);
-    SST_SER(single_rank);
+    std::stringstream buf;
+    buf << "Exit Action to be delivered at " << getDeliveryTime() << " with priority " << getPriority();
+    return buf.str();
 }
 
 } // namespace SST

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -1725,9 +1725,9 @@ Simulation_impl::checkpoint(const std::string& checkpoint_filename)
     SST_SER(output_directory);
     // Actions that may also be in TV
     SST_SER(real_time_);
-    if ( my_rank.thread == 0 ) {
-        SST_SER(m_exit);
-    }
+
+    // Exit created here in restart
+
     SST_SER(m_heartbeat);
 
     // Add statistics engine and associated state
@@ -1771,9 +1771,9 @@ Simulation_impl::checkpoint(const std::string& checkpoint_filename)
     SST_SER(output_directory);
     // Actions that may also be in TV
     SST_SER(real_time_);
-    if ( my_rank.thread == 0 ) {
-        SST_SER(m_exit);
-    }
+
+    // Exit created here in restart
+
     SST_SER(m_heartbeat);
 
     // Add shared StatisticOutput vector
@@ -1899,9 +1899,12 @@ Simulation_impl::restart(Config* cfg)
     SST_SER(output_directory);
     // Actions that may also be in TV
     SST_SER(real_time_);
+
+    // Create the Exit object
     if ( my_rank.thread == 0 ) {
-        SST_SER(m_exit);
+        m_exit = new Exit(num_ranks.thread, num_ranks.rank == 1);
     }
+
     initBarrier.wait();
 
     // Create new checkpoint object.  Needs to be done before SyncManager is reinitialized

--- a/src/sst/core/testElements/coreTest_SubComponent.h
+++ b/src/sst/core/testElements/coreTest_SubComponent.h
@@ -34,6 +34,27 @@ namespace SST::CoreTestSubComponent {
   depending on the configuration.
  */
 
+class SubCompEvent : public SST::Event
+{
+public:
+    SubCompEvent(bool last) :
+        Event(),
+        last(last)
+    {}
+
+    SubCompEvent() = default; // For serialization
+
+    bool last = false;
+
+    void serialize_order(SST::Core::Serialization::serializer& ser) override
+    {
+        Event::serialize_order(ser);
+        SST_SER(last);
+    }
+
+    ImplementSerializable(SubCompEvent);
+};
+
 class SubCompInterface : public SST::SubComponent
 {
 public:

--- a/tests/subcomponent_tests/refFiles/test_sc_2a.out
+++ b/tests/subcomponent_tests/refFiles/test_sc_2a.out
@@ -1,8 +1,6 @@
-# Creating simulation checkpoint at simulated time period of 2500 ns.
+# Creating simulation checkpoint at simulated time period of 2.5us.
 Sent an event, 14 more to send
 Sent an event, 14 more to send
-Got an event
-Got an event
 Sent an event, 13 more to send
 Sent an event, 13 more to send
 Got an event
@@ -28,7 +26,7 @@ Sent an event, 8 more to send
 Sent an event, 8 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00505 seconds)
+# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00836 seconds)
 Sent an event, 7 more to send
 Sent an event, 7 more to send
 Got an event
@@ -45,7 +43,7 @@ Sent an event, 4 more to send
 Sent an event, 4 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.01007 seconds)
+# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00924 seconds)
 Sent an event, 3 more to send
 Sent an event, 3 more to send
 Got an event
@@ -62,7 +60,9 @@ Sent an event, 0 more to send
 Sent an event, 0 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00516 seconds)
+# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00506 seconds)
+Got an event
+Got an event
  Loader0.numSent : Accumulator : Sum.u32 = 30; SumSQ.u32 = 30; Count.u64 = 30; Min.u32 = 1; Max.u32 = 1; 
  Loader1.numRecv : Accumulator : Sum.u32 = 30; SumSQ.u32 = 30; Count.u64 = 30; Min.u32 = 1; Max.u32 = 1; 
-Simulation is complete, simulated time: 10 us
+Simulation is complete, simulated time: 10.6 us

--- a/tests/subcomponent_tests/refFiles/test_sc_2u.out
+++ b/tests/subcomponent_tests/refFiles/test_sc_2u.out
@@ -1,8 +1,6 @@
-# Creating simulation checkpoint at simulated time period of 2500 ns.
+# Creating simulation checkpoint at simulated time period of 2.5us.
 Sent an event, 14 more to send
 Sent an event, 14 more to send
-Got an event
-Got an event
 Sent an event, 13 more to send
 Sent an event, 13 more to send
 Got an event
@@ -11,7 +9,7 @@ Sent an event, 12 more to send
 Sent an event, 12 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00183 seconds)
+# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00148 seconds)
 Sent an event, 11 more to send
 Sent an event, 11 more to send
 Got an event
@@ -28,7 +26,7 @@ Sent an event, 8 more to send
 Sent an event, 8 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00609 seconds)
+# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00405 seconds)
 Sent an event, 7 more to send
 Sent an event, 7 more to send
 Got an event
@@ -45,7 +43,7 @@ Sent an event, 4 more to send
 Sent an event, 4 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.01025 seconds)
+# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00429 seconds)
 Sent an event, 3 more to send
 Sent an event, 3 more to send
 Got an event
@@ -62,9 +60,11 @@ Sent an event, 0 more to send
 Sent an event, 0 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00467 seconds)
+# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00373 seconds)
+Got an event
+Got an event
  Loader0:mySubComp[0].numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader0.totalSent : Accumulator : Sum.u32 = 30; SumSQ.u32 = 30; Count.u64 = 30; Min.u32 = 1; Max.u32 = 1; 
  Loader0:mySubComp[1].numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader1.totalRecv : Accumulator : Sum.u32 = 30; SumSQ.u32 = 30; Count.u64 = 30; Min.u32 = 1; Max.u32 = 1; 
-Simulation is complete, simulated time: 10 us
+Simulation is complete, simulated time: 10.6 us

--- a/tests/subcomponent_tests/refFiles/test_sc_2u2a.out
+++ b/tests/subcomponent_tests/refFiles/test_sc_2u2a.out
@@ -1,12 +1,8 @@
-# Creating simulation checkpoint at simulated time period of 2500 ns.
+# Creating simulation checkpoint at simulated time period of 2.5us.
 Sent an event, 14 more to send
 Sent an event, 14 more to send
 Sent an event, 14 more to send
 Sent an event, 14 more to send
-Got an event
-Got an event
-Got an event
-Got an event
 Sent an event, 13 more to send
 Sent an event, 13 more to send
 Sent an event, 13 more to send
@@ -23,7 +19,7 @@ Got an event
 Got an event
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00231 seconds)
+# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00193 seconds)
 Sent an event, 11 more to send
 Sent an event, 11 more to send
 Sent an event, 11 more to send
@@ -56,7 +52,7 @@ Got an event
 Got an event
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00596 seconds)
+# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00323 seconds)
 Sent an event, 7 more to send
 Sent an event, 7 more to send
 Sent an event, 7 more to send
@@ -89,7 +85,7 @@ Got an event
 Got an event
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00703 seconds)
+# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00372 seconds)
 Sent an event, 3 more to send
 Sent an event, 3 more to send
 Sent an event, 3 more to send
@@ -122,9 +118,13 @@ Got an event
 Got an event
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00474 seconds)
+# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00355 seconds)
+Got an event
+Got an event
+Got an event
+Got an event
  Loader0:mySubComp[0].numSent : Accumulator : Sum.u32 = 30; SumSQ.u32 = 30; Count.u64 = 30; Min.u32 = 1; Max.u32 = 1; 
  Loader0:mySubComp[1].numSent : Accumulator : Sum.u32 = 30; SumSQ.u32 = 30; Count.u64 = 30; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp[0].numRecv : Accumulator : Sum.u32 = 30; SumSQ.u32 = 30; Count.u64 = 30; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp[1].numRecv : Accumulator : Sum.u32 = 30; SumSQ.u32 = 30; Count.u64 = 30; Min.u32 = 1; Max.u32 = 1; 
-Simulation is complete, simulated time: 10 us
+Simulation is complete, simulated time: 10.6 us

--- a/tests/subcomponent_tests/refFiles/test_sc_2u2u.out
+++ b/tests/subcomponent_tests/refFiles/test_sc_2u2u.out
@@ -1,12 +1,8 @@
-# Creating simulation checkpoint at simulated time period of 2500 ns.
+# Creating simulation checkpoint at simulated time period of 2.5us.
 Sent an event, 14 more to send
 Sent an event, 14 more to send
 Sent an event, 14 more to send
 Sent an event, 14 more to send
-Got an event
-Got an event
-Got an event
-Got an event
 Sent an event, 13 more to send
 Sent an event, 13 more to send
 Sent an event, 13 more to send
@@ -23,7 +19,7 @@ Got an event
 Got an event
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00300 seconds)
+# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00224 seconds)
 Sent an event, 11 more to send
 Sent an event, 11 more to send
 Sent an event, 11 more to send
@@ -56,7 +52,7 @@ Got an event
 Got an event
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00808 seconds)
+# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00411 seconds)
 Sent an event, 7 more to send
 Sent an event, 7 more to send
 Sent an event, 7 more to send
@@ -89,7 +85,7 @@ Got an event
 Got an event
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00902 seconds)
+# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00336 seconds)
 Sent an event, 3 more to send
 Sent an event, 3 more to send
 Sent an event, 3 more to send
@@ -122,7 +118,11 @@ Got an event
 Got an event
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00951 seconds)
+# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00392 seconds)
+Got an event
+Got an event
+Got an event
+Got an event
  Loader0:mySubComp[0]:mySubCompSlot[0].numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader0.totalSent : Accumulator : Sum.u32 = 60; SumSQ.u32 = 60; Count.u64 = 60; Min.u32 = 1; Max.u32 = 1; 
  Loader0:mySubComp[0]:mySubCompSlot[1].numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
@@ -130,4 +130,4 @@ Got an event
  Loader0:mySubComp[1]:mySubCompSlot[1].numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader1.totalRecv : Accumulator : Sum.u32 = 45; SumSQ.u32 = 45; Count.u64 = 45; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp[1]:mySubCompSlot[0].numRecv : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
-Simulation is complete, simulated time: 10 us
+Simulation is complete, simulated time: 10.6 us

--- a/tests/subcomponent_tests/refFiles/test_sc_2ua.out
+++ b/tests/subcomponent_tests/refFiles/test_sc_2ua.out
@@ -1,8 +1,6 @@
-# Creating simulation checkpoint at simulated time period of 2500 ns.
+# Creating simulation checkpoint at simulated time period of 2.5us.
 Sent an event, 14 more to send
 Sent an event, 14 more to send
-Got an event
-Got an event
 Sent an event, 13 more to send
 Sent an event, 13 more to send
 Got an event
@@ -11,7 +9,7 @@ Sent an event, 12 more to send
 Sent an event, 12 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00216 seconds)
+# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00183 seconds)
 Sent an event, 11 more to send
 Sent an event, 11 more to send
 Got an event
@@ -28,7 +26,7 @@ Sent an event, 8 more to send
 Sent an event, 8 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00625 seconds)
+# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00328 seconds)
 Sent an event, 7 more to send
 Sent an event, 7 more to send
 Got an event
@@ -45,7 +43,7 @@ Sent an event, 4 more to send
 Sent an event, 4 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00519 seconds)
+# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00286 seconds)
 Sent an event, 3 more to send
 Sent an event, 3 more to send
 Got an event
@@ -62,9 +60,11 @@ Sent an event, 0 more to send
 Sent an event, 0 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00909 seconds)
+# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00338 seconds)
+Got an event
+Got an event
  Loader0:mySubComp[0].numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader0:mySubComp[1].numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp[0].numRecv : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp[1].numRecv : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
-Simulation is complete, simulated time: 10 us
+Simulation is complete, simulated time: 10.6 us

--- a/tests/subcomponent_tests/refFiles/test_sc_2uu.out
+++ b/tests/subcomponent_tests/refFiles/test_sc_2uu.out
@@ -1,8 +1,6 @@
-# Creating simulation checkpoint at simulated time period of 2500 ns.
+# Creating simulation checkpoint at simulated time period of 2.5us.
 Sent an event, 14 more to send
 Sent an event, 14 more to send
-Got an event
-Got an event
 Sent an event, 13 more to send
 Sent an event, 13 more to send
 Got an event
@@ -11,7 +9,7 @@ Sent an event, 12 more to send
 Sent an event, 12 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00217 seconds)
+# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00167 seconds)
 Sent an event, 11 more to send
 Sent an event, 11 more to send
 Got an event
@@ -28,7 +26,7 @@ Sent an event, 8 more to send
 Sent an event, 8 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00555 seconds)
+# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00353 seconds)
 Sent an event, 7 more to send
 Sent an event, 7 more to send
 Got an event
@@ -45,7 +43,7 @@ Sent an event, 4 more to send
 Sent an event, 4 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00812 seconds)
+# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00409 seconds)
 Sent an event, 3 more to send
 Sent an event, 3 more to send
 Got an event
@@ -62,10 +60,12 @@ Sent an event, 0 more to send
 Sent an event, 0 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00446 seconds)
+# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00304 seconds)
+Got an event
+Got an event
  Loader0:mySubComp[0]:mySubCompSlot.numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader0.totalSent : Accumulator : Sum.u32 = 30; SumSQ.u32 = 30; Count.u64 = 30; Min.u32 = 1; Max.u32 = 1; 
  Loader0:mySubComp[1]:mySubCompSlot.numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp[0]:mySubCompSlot.numRecv : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp[1]:mySubCompSlot.numRecv : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
-Simulation is complete, simulated time: 10 us
+Simulation is complete, simulated time: 10.6 us

--- a/tests/subcomponent_tests/refFiles/test_sc_a.out
+++ b/tests/subcomponent_tests/refFiles/test_sc_a.out
@@ -1,11 +1,10 @@
-# Creating simulation checkpoint at simulated time period of 2500 ns.
+# Creating simulation checkpoint at simulated time period of 2.5us.
 Sent an event, 14 more to send
-Got an event
 Sent an event, 13 more to send
 Got an event
 Sent an event, 12 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00160 seconds)
+# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00156 seconds)
 Sent an event, 11 more to send
 Got an event
 Sent an event, 10 more to send
@@ -14,7 +13,7 @@ Sent an event, 9 more to send
 Got an event
 Sent an event, 8 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00535 seconds)
+# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00313 seconds)
 Sent an event, 7 more to send
 Got an event
 Sent an event, 6 more to send
@@ -23,7 +22,7 @@ Sent an event, 5 more to send
 Got an event
 Sent an event, 4 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00596 seconds)
+# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00332 seconds)
 Sent an event, 3 more to send
 Got an event
 Sent an event, 2 more to send
@@ -32,7 +31,8 @@ Sent an event, 1 more to send
 Got an event
 Sent an event, 0 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00620 seconds)
+# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00334 seconds)
+Got an event
  Loader0.numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader1.numRecv : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
-Simulation is complete, simulated time: 10 us
+Simulation is complete, simulated time: 10.6 us

--- a/tests/subcomponent_tests/refFiles/test_sc_u.out
+++ b/tests/subcomponent_tests/refFiles/test_sc_u.out
@@ -1,11 +1,10 @@
-# Creating simulation checkpoint at simulated time period of 2500 ns.
+# Creating simulation checkpoint at simulated time period of 2.5us.
 Sent an event, 14 more to send
-Got an event
 Sent an event, 13 more to send
 Got an event
 Sent an event, 12 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00148 seconds)
+# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00167 seconds)
 Sent an event, 11 more to send
 Got an event
 Sent an event, 10 more to send
@@ -14,7 +13,7 @@ Sent an event, 9 more to send
 Got an event
 Sent an event, 8 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00561 seconds)
+# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00354 seconds)
 Sent an event, 7 more to send
 Got an event
 Sent an event, 6 more to send
@@ -23,7 +22,7 @@ Sent an event, 5 more to send
 Got an event
 Sent an event, 4 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00582 seconds)
+# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00290 seconds)
 Sent an event, 3 more to send
 Got an event
 Sent an event, 2 more to send
@@ -32,7 +31,8 @@ Sent an event, 1 more to send
 Got an event
 Sent an event, 0 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00607 seconds)
+# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00292 seconds)
+Got an event
  Loader0:mySubComp.numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp.numRecv : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
-Simulation is complete, simulated time: 10 us
+Simulation is complete, simulated time: 10.6 us

--- a/tests/subcomponent_tests/refFiles/test_sc_u2a.out
+++ b/tests/subcomponent_tests/refFiles/test_sc_u2a.out
@@ -1,8 +1,6 @@
-# Creating simulation checkpoint at simulated time period of 2500 ns.
+# Creating simulation checkpoint at simulated time period of 2.5us.
 Sent an event, 14 more to send
 Sent an event, 14 more to send
-Got an event
-Got an event
 Sent an event, 13 more to send
 Sent an event, 13 more to send
 Got an event
@@ -11,7 +9,7 @@ Sent an event, 12 more to send
 Sent an event, 12 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00195 seconds)
+# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00170 seconds)
 Sent an event, 11 more to send
 Sent an event, 11 more to send
 Got an event
@@ -28,7 +26,7 @@ Sent an event, 8 more to send
 Sent an event, 8 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00522 seconds)
+# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00312 seconds)
 Sent an event, 7 more to send
 Sent an event, 7 more to send
 Got an event
@@ -45,7 +43,7 @@ Sent an event, 4 more to send
 Sent an event, 4 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00924 seconds)
+# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00425 seconds)
 Sent an event, 3 more to send
 Sent an event, 3 more to send
 Got an event
@@ -62,7 +60,9 @@ Sent an event, 0 more to send
 Sent an event, 0 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00534 seconds)
+# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00345 seconds)
+Got an event
+Got an event
  Loader0:mySubComp.numSent : Accumulator : Sum.u32 = 30; SumSQ.u32 = 30; Count.u64 = 30; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp.numRecv : Accumulator : Sum.u32 = 30; SumSQ.u32 = 30; Count.u64 = 30; Min.u32 = 1; Max.u32 = 1; 
-Simulation is complete, simulated time: 10 us
+Simulation is complete, simulated time: 10.6 us

--- a/tests/subcomponent_tests/refFiles/test_sc_u2u.out
+++ b/tests/subcomponent_tests/refFiles/test_sc_u2u.out
@@ -1,8 +1,6 @@
-# Creating simulation checkpoint at simulated time period of 2500 ns.
+# Creating simulation checkpoint at simulated time period of 2.5us.
 Sent an event, 14 more to send
 Sent an event, 14 more to send
-Got an event
-Got an event
 Sent an event, 13 more to send
 Sent an event, 13 more to send
 Got an event
@@ -11,7 +9,7 @@ Sent an event, 12 more to send
 Sent an event, 12 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00195 seconds)
+# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00164 seconds)
 Sent an event, 11 more to send
 Sent an event, 11 more to send
 Got an event
@@ -28,7 +26,7 @@ Sent an event, 8 more to send
 Sent an event, 8 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00629 seconds)
+# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00327 seconds)
 Sent an event, 7 more to send
 Sent an event, 7 more to send
 Got an event
@@ -45,7 +43,7 @@ Sent an event, 4 more to send
 Sent an event, 4 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00894 seconds)
+# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00383 seconds)
 Sent an event, 3 more to send
 Sent an event, 3 more to send
 Got an event
@@ -62,10 +60,12 @@ Sent an event, 0 more to send
 Sent an event, 0 more to send
 Got an event
 Got an event
-# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00467 seconds)
+# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00338 seconds)
+Got an event
+Got an event
  Loader0:mySubComp:mySubCompSlot[0].numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader0.totalSent : Accumulator : Sum.u32 = 30; SumSQ.u32 = 30; Count.u64 = 30; Min.u32 = 1; Max.u32 = 1; 
  Loader0:mySubComp:mySubCompSlot[1].numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp:mySubCompSlot[0].numRecv : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp:mySubCompSlot[1].numRecv : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
-Simulation is complete, simulated time: 10 us
+Simulation is complete, simulated time: 10.6 us

--- a/tests/subcomponent_tests/refFiles/test_sc_ua.out
+++ b/tests/subcomponent_tests/refFiles/test_sc_ua.out
@@ -1,11 +1,10 @@
-# Creating simulation checkpoint at simulated time period of 2500 ns.
+# Creating simulation checkpoint at simulated time period of 2.5us.
 Sent an event, 14 more to send
-Got an event
 Sent an event, 13 more to send
 Got an event
 Sent an event, 12 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00164 seconds)
+# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00160 seconds)
 Sent an event, 11 more to send
 Got an event
 Sent an event, 10 more to send
@@ -14,7 +13,7 @@ Sent an event, 9 more to send
 Got an event
 Sent an event, 8 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00716 seconds)
+# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00312 seconds)
 Sent an event, 7 more to send
 Got an event
 Sent an event, 6 more to send
@@ -23,7 +22,7 @@ Sent an event, 5 more to send
 Got an event
 Sent an event, 4 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00455 seconds)
+# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00316 seconds)
 Sent an event, 3 more to send
 Got an event
 Sent an event, 2 more to send
@@ -32,7 +31,8 @@ Sent an event, 1 more to send
 Got an event
 Sent an event, 0 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.01198 seconds)
+# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00333 seconds)
+Got an event
  Loader0:mySubComp.numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp.numRecv : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
-Simulation is complete, simulated time: 10 us
+Simulation is complete, simulated time: 10.6 us

--- a/tests/subcomponent_tests/refFiles/test_sc_uu.out
+++ b/tests/subcomponent_tests/refFiles/test_sc_uu.out
@@ -1,11 +1,10 @@
-# Creating simulation checkpoint at simulated time period of 2500 ns.
+# Creating simulation checkpoint at simulated time period of 2.5us.
 Sent an event, 14 more to send
-Got an event
 Sent an event, 13 more to send
 Got an event
 Sent an event, 12 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00166 seconds)
+# Simulation Checkpoint: Simulated Time 2.5 us (Real CPU time since last checkpoint 0.00138 seconds)
 Sent an event, 11 more to send
 Got an event
 Sent an event, 10 more to send
@@ -14,7 +13,7 @@ Sent an event, 9 more to send
 Got an event
 Sent an event, 8 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00635 seconds)
+# Simulation Checkpoint: Simulated Time 5 us (Real CPU time since last checkpoint 0.00268 seconds)
 Sent an event, 7 more to send
 Got an event
 Sent an event, 6 more to send
@@ -23,7 +22,7 @@ Sent an event, 5 more to send
 Got an event
 Sent an event, 4 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00702 seconds)
+# Simulation Checkpoint: Simulated Time 7.5 us (Real CPU time since last checkpoint 0.00291 seconds)
 Sent an event, 3 more to send
 Got an event
 Sent an event, 2 more to send
@@ -32,7 +31,8 @@ Sent an event, 1 more to send
 Got an event
 Sent an event, 0 more to send
 Got an event
-# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00486 seconds)
+# Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.00267 seconds)
+Got an event
  Loader0:mySubComp:mySubCompSlot.numSent : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
  Loader1:mySubComp:mySubCompSlot.numRecv : Accumulator : Sum.u32 = 15; SumSQ.u32 = 15; Count.u64 = 15; Min.u32 = 1; Max.u32 = 1; 
-Simulation is complete, simulated time: 10 us
+Simulation is complete, simulated time: 10.6 us

--- a/tests/subcomponent_tests/test_sc_2a.py
+++ b/tests/subcomponent_tests/test_sc_2a.py
@@ -12,7 +12,6 @@ import sst
 import sys
 
 # Define SST core options
-sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner", "self")
 
 verbose = 0
@@ -37,9 +36,9 @@ loader1.enableAllStatistics()
 
 # Set up links
 link0 = sst.Link("myLink0")
-link0.connect((loader0, "port0", "5ns"), (loader1, "port0", "5ns"))
+link0.connect((loader0, "port0", "1us"), (loader1, "port0", "1us"))
 link1 = sst.Link("myLink1")
-link1.connect((loader0, "port1", "5ns"), (loader1, "port1", "5ns"))
+link1.connect((loader0, "port1", "1us"), (loader1, "port1", "1us"))
 
 # Do the paritioning
 num_ranks = sst.getMPIRankCount()

--- a/tests/subcomponent_tests/test_sc_2u.py
+++ b/tests/subcomponent_tests/test_sc_2u.py
@@ -20,7 +20,6 @@ import sys
 ########################################################
 
 # Define SST core options
-sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner", "self")
 
 verbose = 0
@@ -63,10 +62,10 @@ sub1_1.setStatistic("numRecv", stat_recv)
 
 # Set up links
 link0 = sst.Link("myLink0")
-link0.connect((sub0_0, "sendPort", "5ns"), (sub1_0, "recvPort", "5ns"))
+link0.connect((sub0_0, "sendPort", "1us"), (sub1_0, "recvPort", "1us"))
 
 link1 = sst.Link("myLink1")
-link1.connect((sub0_1, "sendPort", "5ns"), (sub1_1, "recvPort", "5ns"))
+link1.connect((sub0_1, "sendPort", "1us"), (sub1_1, "recvPort", "1us"))
 
 # Do the paritioning
 num_ranks = sst.getMPIRankCount()

--- a/tests/subcomponent_tests/test_sc_2u2a.py
+++ b/tests/subcomponent_tests/test_sc_2u2a.py
@@ -12,7 +12,6 @@ import sst
 import sys
 
 # Define SST core options
-sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner","self")
 
 verbose = 0
@@ -58,16 +57,16 @@ sub1_1.enableAllStatistics()
 
 # Set up links
 link0_0 = sst.Link("myLink0_0")
-link0_0.connect((sub0_0, "slot_port0", "5ns"), (sub1_0, "slot_port0", "5ns"))
+link0_0.connect((sub0_0, "slot_port0", "1us"), (sub1_0, "slot_port0", "1us"))
 
 link0_1 = sst.Link("myLink0_1")
-link0_1.connect((sub0_1, "slot_port0", "5ns"), (sub1_1, "slot_port0", "5ns"))
+link0_1.connect((sub0_1, "slot_port0", "1us"), (sub1_1, "slot_port0", "1us"))
 
 link1_0 = sst.Link("myLink1_0")
-link1_0.connect((sub0_0, "slot_port1", "5ns"), (sub1_0, "slot_port1", "5ns"))
+link1_0.connect((sub0_0, "slot_port1", "1us"), (sub1_0, "slot_port1", "1us"))
 
 link1_1 = sst.Link("myLink1_1")
-link1_1.connect((sub0_1, "slot_port1", "5ns"), (sub1_1, "slot_port1", "5ns"))
+link1_1.connect((sub0_1, "slot_port1", "1us"), (sub1_1, "slot_port1", "1us"))
 
 
 # Do the paritioning

--- a/tests/subcomponent_tests/test_sc_2u2u.py
+++ b/tests/subcomponent_tests/test_sc_2u2u.py
@@ -21,7 +21,6 @@ import sys
 
 
 # Define SST core options
-sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner", "self")
 
 verbose = 0
@@ -91,16 +90,16 @@ sub1_1_1.setStatistic("numRecv", stat_recv)
 
 # Set up links
 link0_0 = sst.Link("myLink0_0")
-link0_0.connect((sub0_0_0, "sendPort", "5ns"), (sub1_0_0, "recvPort", "5ns"))
+link0_0.connect((sub0_0_0, "sendPort", "1us"), (sub1_0_0, "recvPort", "1us"))
 
 link0_1 = sst.Link("myLink0_1")
-link0_1.connect((sub0_0_1, "sendPort", "5ns"), (sub1_0_1, "recvPort", "5ns"))
+link0_1.connect((sub0_0_1, "sendPort", "1us"), (sub1_0_1, "recvPort", "1us"))
 
 link1_0 = sst.Link("myLink1_0")
-link1_0.connect((sub0_1_0, "sendPort", "5ns"), (sub1_1_0, "recvPort", "5ns"))
+link1_0.connect((sub0_1_0, "sendPort", "1us"), (sub1_1_0, "recvPort", "1us"))
 
 link1_1 = sst.Link("myLink1_1")
-link1_1.connect((sub0_1_1, "sendPort", "5ns"), (sub1_1_1, "recvPort", "5ns"))
+link1_1.connect((sub0_1_1, "sendPort", "1us"), (sub1_1_1, "recvPort", "1us"))
 
 # Do the paritioning
 num_ranks = sst.getMPIRankCount()

--- a/tests/subcomponent_tests/test_sc_2ua.py
+++ b/tests/subcomponent_tests/test_sc_2ua.py
@@ -12,7 +12,6 @@ import sst
 import sys
 
 # Define SST core options
-sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner","self")
 
 verbose = 0
@@ -54,10 +53,10 @@ sub1_1.enableAllStatistics()
 
 # Set up links
 link0 = sst.Link("myLink0")
-link0.connect((sub0_0, "slot_port0", "5ns"), (sub1_0, "slot_port0", "5ns"))
+link0.connect((sub0_0, "slot_port0", "1us"), (sub1_0, "slot_port0", "1us"))
 
 link1 = sst.Link("myLink1")
-link1.connect((sub0_1, "slot_port0", "5ns"), (sub1_1, "slot_port0", "5ns"))
+link1.connect((sub0_1, "slot_port0", "1us"), (sub1_1, "slot_port0", "1us"))
 
 
 # Do the paritioning

--- a/tests/subcomponent_tests/test_sc_2uu.py
+++ b/tests/subcomponent_tests/test_sc_2uu.py
@@ -12,7 +12,6 @@ import sst
 import sys
 
 # Define SST core options
-sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner","self")
 
 verbose = 0
@@ -60,10 +59,10 @@ sub1_1_0.enableAllStatistics()
 
 # Set up links
 link0 = sst.Link("myLink0")
-link0.connect((sub0_0_0, "sendPort", "5ns"), (sub1_0_0, "recvPort", "5ns"))
+link0.connect((sub0_0_0, "sendPort", "1us"), (sub1_0_0, "recvPort", "1us"))
 
 link1 = sst.Link("myLink1")
-link1.connect((sub0_1_0, "sendPort", "5ns"), (sub1_1_0, "recvPort", "5ns"))
+link1.connect((sub0_1_0, "sendPort", "1us"), (sub1_1_0, "recvPort", "1us"))
 
 
 # Do the paritioning

--- a/tests/subcomponent_tests/test_sc_a.py
+++ b/tests/subcomponent_tests/test_sc_a.py
@@ -12,7 +12,6 @@ import sst
 import sys
 
 # Define SST core options
-sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner","self")
 
 verbose = 0
@@ -35,7 +34,7 @@ loader1.enableAllStatistics()
 
 # Set up link
 link = sst.Link("myLink")
-link.connect((loader0, "port0", "5ns"), (loader1, "port0", "5ns"))
+link.connect((loader0, "port0", "1us"), (loader1, "port0", "1us"))
 
 # Do the paritioning
 num_ranks = sst.getMPIRankCount()

--- a/tests/subcomponent_tests/test_sc_u.py
+++ b/tests/subcomponent_tests/test_sc_u.py
@@ -12,7 +12,6 @@ import sst
 import sys
 
 # Define SST core options
-sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner","self")
 
 verbose = 0
@@ -39,7 +38,7 @@ sub1.enableAllStatistics()
 
 # Set up link
 link0 = sst.Link("myLink0")
-link0.connect((sub0, "sendPort", "5ns"), (sub1, "recvPort", "5ns"))
+link0.connect((sub0, "sendPort", "1us"), (sub1, "recvPort", "1us"))
 
 # Do the paritioning
 num_ranks = sst.getMPIRankCount()

--- a/tests/subcomponent_tests/test_sc_u2a.py
+++ b/tests/subcomponent_tests/test_sc_u2a.py
@@ -12,7 +12,6 @@ import sst
 import sys
 
 # Define SST core options
-sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner","self")
 
 verbose = 0
@@ -45,10 +44,10 @@ sub1.enableAllStatistics()
 
 # Set up links
 link0 = sst.Link("myLink0")
-link0.connect((sub0, "slot_port0", "5ns"), (sub1, "slot_port0", "5ns"))
+link0.connect((sub0, "slot_port0", "1us"), (sub1, "slot_port0", "1us"))
 
 link1 = sst.Link("myLink1")
-link1.connect((sub0, "slot_port1", "5ns"), (sub1, "slot_port1", "5ns"))
+link1.connect((sub0, "slot_port1", "1us"), (sub1, "slot_port1", "1us"))
 
 
 # Do the paritioning

--- a/tests/subcomponent_tests/test_sc_u2u.py
+++ b/tests/subcomponent_tests/test_sc_u2u.py
@@ -12,7 +12,6 @@ import sst
 import sys
 
 # Define SST core options
-sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner","self")
 
 verbose = 0
@@ -55,10 +54,10 @@ sub1_1.enableAllStatistics()
 
 # Set up links
 link0 = sst.Link("myLink0")
-link0.connect((sub0_0, "sendPort", "5ns"), (sub1_0, "recvPort", "5ns"))
+link0.connect((sub0_0, "sendPort", "1us"), (sub1_0, "recvPort", "1us"))
 
 link1 = sst.Link("myLink1")
-link1.connect((sub0_1, "sendPort", "5ns"), (sub1_1, "recvPort", "5ns"))
+link1.connect((sub0_1, "sendPort", "1us"), (sub1_1, "recvPort", "1us"))
 
 # Do the paritioning
 num_ranks = sst.getMPIRankCount()

--- a/tests/subcomponent_tests/test_sc_ua.py
+++ b/tests/subcomponent_tests/test_sc_ua.py
@@ -12,7 +12,6 @@ import sst
 import sys
 
 # Define SST core options
-sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner","self")
 
 verbose = 0
@@ -43,7 +42,7 @@ sub1.enableAllStatistics()
 
 # Set up links
 link = sst.Link("myLink1")
-link.connect((sub0, "slot_port0", "5ns"), (sub1, "slot_port0", "5ns"))
+link.connect((sub0, "slot_port0", "1us"), (sub1, "slot_port0", "1us"))
 
 
 # Do the paritioning

--- a/tests/subcomponent_tests/test_sc_uu.py
+++ b/tests/subcomponent_tests/test_sc_uu.py
@@ -12,7 +12,6 @@ import sst
 import sys
 
 # Define SST core options
-sst.setProgramOption("stop-at", "10us")
 sst.setProgramOption("partitioner","self")
 
 verbose = 0
@@ -44,7 +43,7 @@ sub1_0.enableAllStatistics()
 
 # Set up link
 link = sst.Link("myLink")
-link.connect((sub0_0, "sendPort", "5ns"), (sub1_0, "recvPort", "5ns"))
+link.connect((sub0_0, "sendPort", "1us"), (sub1_0, "recvPort", "1us"))
 
 
 # Do the paritioning


### PR DESCRIPTION
This allows SubComponents and ComponentExtensions access to the APIs.

Updated Exit object.
- BaseComponent now tracks current primary component exit state and provides errors and warnings when primaryComponent functions are called in unsupported ways
- Exit object no longer tracks the components that are registered with it
- Exit object is no longer serialized on checkpoint.  A new Exit object is created on restart and Components will reregister with the Exit object on restart if they are in the DoNotEndSim state.

