### PR TITLE
Add -Wmissing-noreturn and [[noreturn]] to more functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ esac
 
 SST_CHECK_PICKY
 AS_IF([test "x$use_picky" = "xyes"],
-      [WARNFLAGS="-Wall -Wextra -Wvla -Wnon-virtual-dtor -Wsuggest-override"],
+      [WARNFLAGS="-Wall -Wextra -Wvla -Wnon-virtual-dtor -Wsuggest-override -Wmissing-noreturn"],
       [WARNFLAGS=""])
 CFLAGS="$CFLAGS $WARNFLAGS"
 CXXFLAGS="$CXXFLAGS $WARNFLAGS"

--- a/src/sst/core/model/element_python.cc
+++ b/src/sst/core/model/element_python.cc
@@ -36,6 +36,7 @@ SST_ELI_DEFINE_INFO_EXTERN(SSTElementPythonModule)
 
 // Utility function to parse the python exceptions from loading
 // modules and format and print them on abort.
+[[noreturn]]
 static void abortOnPyErr(uint32_t line, const char* file, const char* func, uint32_t exit_code, const char* format, ...)
     __attribute__((format(printf, 5, 6)));
 

--- a/src/sst/core/serialization/serializable_base.h
+++ b/src/sst/core/serialization/serializable_base.h
@@ -143,6 +143,7 @@ class serializable_type
 #define ImplementVirtualSerializable(obj)                                                                          \
                                                                                                                    \
 public:                                                                                                            \
+    [[noreturn]]                                                                                                   \
     static void throw_exc()                                                                                        \
     {                                                                                                              \
         ::SST::Core::Serialization::serializable_base::serializable_abort(__LINE__, __FILE__, __FUNCTION__, #obj); \
@@ -165,6 +166,7 @@ public:                                                                         
 #define NotSerializable(obj)                                                                                       \
                                                                                                                    \
 public:                                                                                                            \
+    [[noreturn]]                                                                                                   \
     static void throw_exc()                                                                                        \
     {                                                                                                              \
         ::SST::Core::Serialization::serializable_base::serializable_abort(__LINE__, __FILE__, __FUNCTION__, #obj); \


### PR DESCRIPTION
[Reported](https://github.com/tactcomplabs/rev/pull/371) by @kpgriesser 

This continues https://github.com/sstsimulator/sst-core/pull/1254 and adds `-Wmissing-noreturn` to warn about missing `[[noreturn]]` in the future.

