### PR TITLE
Add support for general handling of trivially serializable types

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -112,6 +112,7 @@ nobase_dist_sst_HEADERS = \
 	serialization/impl/packer.h \
 	serialization/impl/sizer.h \
 	serialization/impl/serialize_string.h \
+	serialization/impl/serialize_trivial.h \
 	serialization/impl/serialize_valarray.h \
 	serialization/impl/unpacker.h \
 	serialization/serializer.h \
@@ -228,6 +229,7 @@ sst_core_sources = \
 	serialization/statics.cc \
 	serialization/impl/mapper.cc \
 	serialization/impl/serialize_array.cc \
+	serialization/impl/serialize_trivial.cc \
 	sstinfo.h \
 	interfaces/TestEvent.cc \
 	interfaces/stdMem.cc \

--- a/src/sst/core/serialization/impl/serialize_array.cc
+++ b/src/sst/core/serialization/impl/serialize_array.cc
@@ -13,6 +13,8 @@
 
 #include "sst/core/serialization/serialize.h"
 
+#include <cstddef>
+
 namespace SST::Core::Serialization::pvt {
 
 void

--- a/src/sst/core/serialization/impl/serialize_trivial.cc
+++ b/src/sst/core/serialization/impl/serialize_trivial.cc
@@ -1,0 +1,206 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+
+#include "sst/core/serialization/serialize.h"
+
+#include <array>
+#include <bitset>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace SST::Core::Serialization::unittest {
+
+// Compile-time unit tests of trivially serializable types
+
+template <typename TYPE, bool EXPECTED>
+void
+trivially_serializable_test()
+{
+    static_assert(is_trivially_serializable_v<TYPE> == EXPECTED);
+}
+
+template <typename TYPE>
+void
+test_trivially_serializable_type_assumptions()
+{
+    static_assert(std::is_trivially_copyable_v<TYPE> && std::is_standard_layout_v<TYPE>);
+}
+
+template void trivially_serializable_test<std::byte, true>();
+template void trivially_serializable_test<int8_t, true>();
+template void trivially_serializable_test<uint8_t, true>();
+template void trivially_serializable_test<int16_t, true>();
+template void trivially_serializable_test<uint16_t, true>();
+template void trivially_serializable_test<int32_t, true>();
+template void trivially_serializable_test<uint32_t, true>();
+template void trivially_serializable_test<int64_t, true>();
+template void trivially_serializable_test<uint64_t, true>();
+template void trivially_serializable_test<float, true>();
+template void trivially_serializable_test<double, true>();
+template void trivially_serializable_test<long double, true>();
+
+enum class test_enum { X, Y, Z };
+enum class test_enum_int8_t : int8_t { X, Y, Z, A, B, C };
+enum class test_enum_uint8_t : uint8_t { X, Y, Z, A, B, C, J, K, L };
+enum class test_enum_int16_t : int16_t { X, Y, Z, A, B, C };
+enum class test_enum_uint16_t : uint16_t { X, Y, Z, A, B, C, J, K, L };
+enum class test_enum_int32_t : int32_t { X, Y, Z, A, B, C };
+enum class test_enum_uint32_t : uint32_t { X, Y, Z, A, B, C, J, K, L };
+enum class test_enum_int64_t : int64_t { X, Y, Z, A, B, C };
+enum class test_enum_uint64_t : uint64_t { X, Y, Z, A, B, C, J, K, L };
+
+template void trivially_serializable_test<test_enum, true>();
+template void trivially_serializable_test<test_enum_int8_t, true>();
+template void trivially_serializable_test<test_enum_uint8_t, true>();
+template void trivially_serializable_test<test_enum_int16_t, true>();
+template void trivially_serializable_test<test_enum_uint16_t, true>();
+template void trivially_serializable_test<test_enum_int32_t, true>();
+template void trivially_serializable_test<test_enum_uint32_t, true>();
+template void trivially_serializable_test<test_enum_int64_t, true>();
+template void trivially_serializable_test<test_enum_uint64_t, true>();
+
+struct test_complex_float
+{
+    float r, i;
+};
+struct test_complex_double
+{
+    double r, i;
+};
+
+template void trivially_serializable_test<test_complex_float, true>();
+template void trivially_serializable_test<test_complex_double, true>();
+template void trivially_serializable_test<std::complex<float>, true>();
+template void trivially_serializable_test<std::complex<double>, true>();
+
+struct test_complex_mix
+{
+    float _Complex cf;
+    double _Complex cd;
+    long double _Complex cl;
+    std::complex<double> cfa[10];
+};
+
+template void trivially_serializable_test<test_complex_mix, true>();
+
+struct test_complex_double_array
+{
+    test_complex_double ary[1000];
+};
+
+template void trivially_serializable_test<test_complex_double_array, true>();
+
+struct test_struct
+{
+    test_complex_float z[8];
+    std::bitset<100>   bs;
+    test_complex_float test_struct::* mem_ptr;
+    std::array<size_t, 100>           sizes;
+    union {
+        int   i;
+        float f;
+    };
+};
+
+template void trivially_serializable_test<test_struct, true>();
+
+union test_union_ptr_2nd {
+    uintptr_t iptr;
+    void*     ptr;
+};
+
+template void trivially_serializable_test<test_union_ptr_2nd, true>();
+
+// Tests of types which are not trivially serializable
+
+template void trivially_serializable_test<void, false>();
+template void trivially_serializable_test<void*, false>();
+
+typedef void (*fptr)(int, int);
+template void trivially_serializable_test<fptr, false>();
+
+typedef test_complex_double* test_complex_double_array_ptr[1000];
+template void                trivially_serializable_test<test_complex_double_array_ptr, false>();
+
+template void trivially_serializable_test<std::vector<int>, false>();
+
+struct test_struct_ref
+{
+    test_complex_float z[8];
+    double&            dref;
+};
+
+template void trivially_serializable_test<test_struct_ref, false>();
+
+struct test_struct_ptr
+{
+    int    i;
+    int*   iptr;
+    double d;
+};
+
+template void trivially_serializable_test<test_struct_ptr, false>();
+
+struct test_serialize_order
+{
+    std::complex<double> cfa[10];
+    void                 serialize_order(serializer& ser) { SST_SER(cfa); }
+};
+
+template void trivially_serializable_test<test_serialize_order, false>();
+
+struct test_mix
+{
+    test_complex_float z;
+    test_struct_ref    refs;
+};
+
+template void trivially_serializable_test<test_mix, false>();
+
+union test_union_ptr_1st {
+    void*     ptr;
+    uintptr_t iptr;
+};
+
+template void trivially_serializable_test<test_union_ptr_1st, false>();
+
+struct test_container_struct
+{
+    int                 size;
+    std::vector<double> v;
+};
+
+template void trivially_serializable_test<test_container_struct, false>();
+
+template void trivially_serializable_test<std::pair<int, int>, false>();
+
+template void trivially_serializable_test<std::tuple<float, float, float>, false>();
+
+// Test assumptions which are made by is_trivially_serializable_v<TYPE>
+template void test_trivially_serializable_type_assumptions<std::bitset<1>>();
+template void test_trivially_serializable_type_assumptions<std::bitset<8>>();
+template void test_trivially_serializable_type_assumptions<std::bitset<100>>();
+template void test_trivially_serializable_type_assumptions<std::bitset<200>>();
+template void test_trivially_serializable_type_assumptions<std::bitset<400>>();
+template void test_trivially_serializable_type_assumptions<std::bitset<800>>();
+template void test_trivially_serializable_type_assumptions<std::bitset<1600>>();
+
+template void test_trivially_serializable_type_assumptions<std::complex<float>>();
+template void test_trivially_serializable_type_assumptions<std::complex<double>>();
+template void test_trivially_serializable_type_assumptions<std::complex<long double>>();
+
+} // namespace SST::Core::Serialization::unittest

--- a/src/sst/core/serialization/impl/serialize_trivial.h
+++ b/src/sst/core/serialization/impl/serialize_trivial.h
@@ -1,0 +1,93 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_SERIALIZATION_IMPL_SERIALIZE_TRIVIAL_H
+#define SST_CORE_SERIALIZATION_IMPL_SERIALIZE_TRIVIAL_H
+
+#ifndef SST_INCLUDING_SERIALIZE_H
+#warning \
+    "The header file sst/core/serialization/impl/serialize_trivial.h should not be directly included as it is not part of the stable public API.  The file is included in sst/core/serialization/serialize.h"
+#endif
+
+#include "sst/core/serialization/impl/serialize_utility.h"
+#include "sst/core/serialization/serializer.h"
+
+#include <array>
+#include <type_traits>
+#include <utility>
+
+namespace SST::Core::Serialization {
+
+// Types excluded because they would cause ambiguity with more specialized methods
+template <typename T>
+struct is_trivially_serializable_excluded : std::is_array<T>
+{};
+
+template <typename T, size_t S>
+struct is_trivially_serializable_excluded<std::array<T, S>> : std::true_type
+{};
+
+template <size_t N>
+struct is_trivially_serializable_excluded<std::bitset<N>> : std::true_type
+{};
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Version of serialize that works for trivially serializable types which aren't excluded, and pointers thereof //
+//                                                                                                              //
+// Note that the pointer tracking happens at a higher level, and only if it is turned on. If it is not turned   //
+// on, then this only copies the value pointed to into the buffer. If multiple objects point to the same        //
+// location, they will each have an independent copy after deserialization.                                     //
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class T>
+class serialize_impl<T,
+    std::enable_if_t<std::conjunction_v<std::negation<is_trivially_serializable_excluded<std::remove_pointer_t<T>>>,
+        is_trivially_serializable<std::remove_pointer_t<T>>>>>
+{
+    void operator()(T& t, serializer& ser, ser_opt_t options)
+    {
+        switch ( const auto mode = ser.mode() ) {
+        case serializer::MAP:
+            // Right now only arithmetic and enum types are handled in mapping mode without custom serializer
+            if constexpr ( std::is_arithmetic_v<std::remove_pointer_t<T>> ||
+                           std::is_enum_v<std::remove_pointer_t<T>> ) {
+                ObjectMap* obj_map;
+                if constexpr ( std::is_pointer_v<T> )
+                    obj_map = new ObjectMapFundamental<std::remove_pointer_t<T>>(t);
+                else
+                    obj_map = new ObjectMapFundamental<T>(&t);
+                if ( SerOption::is_set(options, SerOption::map_read_only) ) ser.mapper().setNextObjectReadOnly();
+                ser.mapper().map_primitive(ser.getMapName(), obj_map);
+            }
+            else {
+                // TODO: Handle mapping mode for trivially serializable types without from_string() methods which do not
+                // define their own serialization methods.
+            }
+            break;
+
+        default:
+            if constexpr ( std::is_pointer_v<T> ) {
+                if ( mode == serializer::UNPACK ) t = new std::remove_pointer_t<T> {};
+                ser.primitive(*t);
+            }
+            else {
+                ser.primitive(t);
+            }
+            break;
+        }
+    }
+
+    SST_FRIEND_SERIALIZE();
+};
+
+} // namespace SST::Core::Serialization
+
+#endif // SST_CORE_SERIALIZATION_IMPL_SERIALIZE_TRIVIAL_H

--- a/src/sst/core/serialization/impl/serialize_tuple.h
+++ b/src/sst/core/serialization/impl/serialize_tuple.h
@@ -18,10 +18,10 @@
 #endif
 
 #include "sst/core/serialization/impl/serialize_utility.h"
-#include "sst/core/serialization/serialize.h"
 #include "sst/core/serialization/serializer.h"
 
 #include <tuple>
+#include <type_traits>
 
 namespace SST::Core::Serialization {
 

--- a/src/sst/core/serialization/impl/serialize_utility.h
+++ b/src/sst/core/serialization/impl/serialize_utility.h
@@ -17,23 +17,203 @@
     "The header file sst/core/serialization/impl/serialize_utility.h should not be directly included as it is not part of the stable public API.  The file is included in sst/core/serialization/serialize.h"
 #endif
 
+#include <bitset>
+#include <complex>
+#include <cstddef>
 #include <type_traits>
+#include <utility>
 
 namespace SST::Core::Serialization {
 
-// Whether two names are the same template. Similar to std::is_same_v.
-template <template <typename...> class, template <typename...> class>
+/////////////////////////////////////////////////////////////////////////
+// Whether two names are the same template. Similar to std::is_same_v. //
+/////////////////////////////////////////////////////////////////////////
+template <template <class...> class, template <class...> class>
 constexpr bool is_same_template_v = false;
 
-template <template <typename...> class T>
+template <template <class...> class T>
 constexpr bool is_same_template_v<T, T> = true;
 
-// Whether a certain type is the same as a certain class template filled with arguments
-template <class, template <typename...> class>
+template <template <class...> class T1, template <class...> class T2>
+using is_same_template = std::bool_constant<is_same_template_v<T1, T2>>;
+
+///////////////////////////////////////////////////////////////////////////////////////
+// Whether a type is the same as a certain class template filled with type arguments //
+///////////////////////////////////////////////////////////////////////////////////////
+template <class, template <class...> class>
 constexpr bool is_same_type_template_v = false;
 
-template <template <typename...> class T1, typename... T1ARGS, template <typename...> class T2>
+template <template <class...> class T1, class... T1ARGS, template <class...> class T2>
 constexpr bool is_same_type_template_v<T1<T1ARGS...>, T2> = is_same_template_v<T1, T2>;
+
+template <class T, template <class...> class TT>
+using is_same_type_template = std::bool_constant<is_same_type_template_v<T, TT>>;
+
+//////////////////////////////////////////////////
+// Compute the number of fields in an aggregate //
+//////////////////////////////////////////////////
+namespace pvt_nfields {
+
+// glob is convertible to any other type while initializing an aggregate
+// The conversion function is only used in decltype() so it does not need to be defined
+struct glob
+{
+    template <class T>
+    operator T() const;
+};
+
+// Whether N fields can be used to initialize an aggregate, i.e., number of aggregate fields >= N
+// If the type is not an aggregate, always returns false, so that nfields<C> returns 0.
+template <class C, class, bool = std::is_aggregate_v<C>, class = C>
+constexpr bool nfields_ge_impl = false;
+
+// Try to initialize N fields in an aggregate, with glob() automatically converting to each field's
+// type. If initialization fails, it is not an error (SFINAE) and this specialization won't apply.
+template <class C, size_t... I>
+constexpr bool nfields_ge_impl<C, std::index_sequence<I...>, true, decltype(C { (I, glob())... })> = true;
+
+// Whether the number of fields in an aggregate is greater than or equal to N
+template <class C, size_t N>
+constexpr bool nfields_ge = nfields_ge_impl<C, std::make_index_sequence<N>>;
+
+// Binary search in [L,H) for number of fields in aggregate. Stops at L when M == L.
+template <class C, size_t L, size_t H, size_t M = L + (H - L) / 2, bool = M != L>
+constexpr size_t b_search = L;
+
+// Next search is in [L,M)
+template <class C, size_t L, size_t H, size_t M, bool>
+constexpr size_t b_search_next = b_search<C, L, M>;
+
+// Next search is in [M,H)
+template <class C, size_t L, size_t H, size_t M>
+constexpr size_t b_search_next<C, L, H, M, true> = b_search<C, M, H>;
+
+// Choose [L,M) or [M,H) depending on whether nfields >= M
+template <class C, size_t L, size_t H, size_t M>
+constexpr size_t b_search<C, L, H, M, true> = b_search_next<C, L, H, M, nfields_ge<C, M>>;
+
+// Find an upper bound on the number of fields, doubling N as long as number of fields >= N
+template <class C, size_t N = 1, bool = true>
+constexpr size_t nfields = nfields<C, N * 2, nfields_ge<C, N * 2>>;
+
+// When the number of fields < N, perform binary search in [0,N)
+template <class C, size_t N>
+constexpr size_t nfields<C, N, false> = b_search<C, 0, N>;
+
+} // namespace pvt_nfields
+
+// The number of fields in an aggregate, initializable by { ... }. Returns 0 if the type is not aggregate.
+template <class C>
+constexpr size_t nfields = pvt_nfields::nfields<C>;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+// Template metaprogramming to determine if a type is trivially serializable - that it can be read //
+// and written as raw data without any special handling.                                           //
+//                                                                                                 //
+// It is one of these types:                                                                       //
+// - arithmetic (integral, floating-point)                                                         //
+// - enumeration (including std::byte)                                                             //
+// - member object pointer                                                                         //
+// - std::complex<T>, C99 _Complex                                                                 //
+// - std::bitset                                                                                   //
+// - trivially copyable, standard layout aggregate with trivially serializable members and no      //
+//   serialize_order() method                                                                      //
+//                                                                                                 //
+// An aggregate is a C-style array, std::array, or a class/struct/union with all-public non-static //
+// data members and direct bases, no user-provided, inherited or explicit constructors (C++17),    //
+// no user-declared or inherited constructors (C++20), and no virtual functions or virtual bases.  //
+//                                                                                                 //
+// Pointers are not considered trivially serializable since they have specific addresses which     //
+// are not portable across runs, and may require special tracking and allocation. Pointers to      //
+// member functions may have ABI-specific pointers to data which are not portable across runs.     //
+// But pointers to member objects are typed offsets within a class, and are portable across runs.  //
+//                                                                                                 //
+// Note: If an aggregate is a union, only the first member will be considered active, and thus     //
+// cannot be a pointer. Rather than ban unions entirely, pointers in unions are strongly           //
+// discouraged and can cause unexpected results.                                                   //
+//                                                                                                 //
+// Note: is_trivially_serializable<T> should return true if T is trivially serializable, even if   //
+// there exists a specialization for serialize_impl<T>. is_trivially_serialzable<T> is a trait     //
+// for trivial serializability in general, not a serialize_impl specialization test condition.     //
+// For example, it returns true for arrays of int, even if serialize_impl<int[N]> is specialized.  //
+//                                                                                                 //
+// For further reading on the meaning of "trivial":  https://isocpp.org/files/papers/P3279R0.html  //
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pvt_trivial {
+
+// Whether a type has no serialize_order() method
+template <class, class = void>
+struct has_no_serialize_order : std::true_type
+{};
+
+template <class T>
+struct has_no_serialize_order<T,
+    std::void_t<decltype(std::declval<T>().serialize_order(std::declval<class serializer&>()))>> : std::false_type
+{};
+
+// If it's not a trivially copyable, standard layout aggregate without a serialize_order() method, it needs to
+// be an integer, floating-point, enum or member object pointer, or one of the specializations listed later.
+// std::conjunction_v and std::disjunction_v are used to short-circuit and speed up instead of using && and ||.
+template <class C, bool = std::conjunction_v<std::is_aggregate<C>, std::is_trivially_copyable<C>,
+                       std::is_standard_layout<C>, has_no_serialize_order<C>>>
+constexpr bool is_trivially_serializable_v =
+    std::disjunction_v<std::is_arithmetic<C>, std::is_enum<C>, std::is_member_object_pointer<C>>;
+
+// glob_ts is convertible to any trivially serializable type
+struct glob_ts
+{
+    // The type of the conversion must be trivially serializable or the conversion fails
+    template <class C, class = std::enable_if_t<is_trivially_serializable_v<C>>>
+    operator C() const;
+};
+
+// Whether all fields of an aggregate type are trivially serializable
+template <class C, class, class = C>
+constexpr bool has_ts_fields = false;
+
+// Try to initialize N fields in an aggregate, with glob_ts() automatically converting to each field's
+// type. If conversion fails, it is not an error (SFINAE) and this specialization won't apply.
+template <class C, size_t... I>
+constexpr bool has_ts_fields<C, std::index_sequence<I...>, decltype(C { (I, glob_ts())... })> = true;
+
+// If it's a trivially copyable, standard layout aggregate, then all of its fields must be trivially serializable
+template <class C>
+constexpr bool is_trivially_serializable_v<C, true> = has_ts_fields<C, std::make_index_sequence<nfields<C>>>;
+
+// std::bitset is trivially serializable
+template <size_t N>
+constexpr bool is_trivially_serializable_v<std::bitset<N>, false> = true;
+
+// Complex numbers are trivially serializable
+template <class C>
+constexpr bool is_trivially_serializable_v<std::complex<C>, false> = true;
+
+#ifndef __STDC_NO_COMPLEX__
+template <>
+inline constexpr bool is_trivially_serializable_v<float _Complex, false> = true;
+
+template <>
+inline constexpr bool is_trivially_serializable_v<double _Complex, false> = true;
+
+template <>
+inline constexpr bool is_trivially_serializable_v<long double _Complex, false> = true;
+#endif
+
+// Other floating-point types not covered by std::is_floating_point
+#ifdef FLT16_MIN
+template <>
+inline constexpr bool is_trivially_serializable_v<_Float16, false> = true;
+#endif
+
+} // namespace pvt_trivial
+
+// Whether a type is trivially serializable
+template <class C>
+constexpr bool is_trivially_serializable_v = pvt_trivial::is_trivially_serializable_v<C>;
+
+template <class C>
+using is_trivially_serializable = std::bool_constant<is_trivially_serializable_v<C>>;
 
 } // namespace SST::Core::Serialization
 


### PR DESCRIPTION
Template metaprogramming to determine if a type is trivially serializable - that it can be read and written as raw data without any special handling.

The criteria are:
* It is one of these types:
    - arithmetic (integral, floating-point)
    - enumeration (including `std::byte`)
    - pointer-to-member-object (not pointer or pointer-to-member-function) 
    - `std::complex<T>`, C99 `_Complex`
    - `std::bitset<N>`
    - trivially copyable, standard layout aggregate type with trivially serializable members and no `serialize_order()` method
 
An aggregate is a C-style array, `std::array`, or a class/struct/union with all public non-static data members and direct bases, no user-provided, inherited or explicit constructors (C++17), no user-declared or inherited constructors (C++20), and no virtual functions or virtual bases.

Pointers are not considered trivially serializable since they have specific addresses which are not portable across runs, and may require special tracking and allocation. But pointers to member objects are typed offsets within a class, and are portable across runs. Pointers to member functions point to a static data structure which is not stable from run to run and is able to handle all contingencies of overriden and virtual functions.

Note: If an aggregate is a union, only the first member will be considered active, and thus cannot be a pointer. Rather than ban unions entirely, pointers in unions are strongly discouraged and can cause unexpected results.

Note: `is_trivially_serializable<T>` should return `true` if `T` is trivially serializable, even if there exists a specialization for `serialize_impl<T>`. `is_trivially_serialzable<T>` is a trait for trivial serializability in general, not a `serialize_impl` specialization test condition. For example, it returns `true` for arrays of `int`, even if `serialize_impl<int[N]>` is specialized.

For mapping mode, this does not change the current behavior, which only implements mapping mode for arithmetic and enumeration types which are trivially serializable. If mapping mode is required for an aggregate class type, a `to_string()` method and custom `serialize_impl` specializations are required.

`std::complex`, C99 `_Complex`, `_Float16` and `__float128` are supported as well, although some of them may need to be `#ifdef`'ed to not be included on certain platforms.

Array serialization uses the `is_trivially_serializable<>` trait, and calls the primitive serialization routines to serialize/deserialize the whole array as one group of bytes, if the element type is trivially serializable.

This uses C++ metaprogramming and reflection methods to determine whether an aggregate type contains any members which are not trivially serializable, such as pointers.
