### PR TITLE
Generate JSON timing information at end of simulation

### DIFF
--- a/src/sst/core/CMakeLists.txt
+++ b/src/sst/core/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(
   module.cc
   sstpart.cc
   timeVortex.cc
+  timingOutput.cc
   profile/clockHandlerProfileTool.cc
   profile/componentProfileTool.cc
   profile/eventHandlerProfileTool.cc

--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -224,6 +224,8 @@ sst_core_sources = \
 	sstpart.cc \
 	sst_types.cc \
 	timeVortex.cc \
+	timingOutput.h \
+	timingOutput.cc \
 	serialization/objectMap.cc \
 	serialization/serializable_base.cc \
 	serialization/serializable.cc \

--- a/src/sst/core/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.cc
@@ -231,6 +231,7 @@ JSONConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph)
     outputJson["program_options"]["verbose"]                = std::to_string(cfg->verbose());
     outputJson["program_options"]["stop-at"]                = cfg->stop_at();
     outputJson["program_options"]["print-timing-info"]      = cfg->print_timing() ? "true" : "false";
+    outputJson["program_options"]["timing-info-json"]       = cfg->timing_json();
     // Ignore stopAfter for now
     // outputJson["program_options"]["stopAfter"] = cfg->stopAfterSec();
     outputJson["program_options"]["heartbeat-sim-period"]   = cfg->heartbeat_sim_period();

--- a/src/sst/core/cfgoutput/pythonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.cc
@@ -273,6 +273,7 @@ PythonConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph)
     fprintf(outputFile, "sst.setProgramOption(\"stop-at\", \"%s\")\n", cfg->stop_at().c_str());
     fprintf(
         outputFile, "sst.setProgramOption(\"print-timing-info\", \"%s\")\n", cfg->print_timing() ? "true" : "false");
+    fprintf(outputFile, "sst.setProgramOption(\"timing-info-json\", \"%s\")\n", cfg->timing_json().c_str());
     // Ignore stopAfter for now
     // fprintf(outputFile, "sst.setProgramOption(\"stopAfter\", \"%" PRIu32 "\")\n", cfg->stopAfterSec);
     fprintf(

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -415,7 +415,7 @@ Config::insertOptions()
         "Provide options to the python configuration script.  Additionally, any arguments provided after a final '-- ' "
         "will be appended to the model options (or used as the model options if --model-options was not specified).",
         model_options_, false, false, true);
-    DEF_FLAG_OPTVAL("print-timing-info", 0, "Print SST timing information", print_timing_, true);
+    DEF_FLAG_OPTVAL("print-timing-info", 0, "Print SST timing information", print_timing_, true, true, false);
     DEF_ARG(
         "timing-info-json", 0, "FILE", "Write SST timing information in JSON format", timing_json_, true, true, false);
     DEF_ARG("stop-at", 0, "TIME", "Set time at which simulation will end execution", stop_at_, true, true, false);

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -320,7 +320,7 @@ Config::merge_checkpoint_options(Config& other)
         if ( option.annotations.size() <= r_index || !option.annotations[r_index] ) continue;
 
         // Now see if we need to copy over the option.  We copy it if
-        // it wasn't set on the command line, or it isne't allowed to
+        // it wasn't set on the command line, or it isn't allowed to
         // be set on the command line for a restart.
         if ( !option.def->set_cmdline || option.annotations[x_index] ) {
             option.def->transfer(other.options[i].def);
@@ -416,6 +416,8 @@ Config::insertOptions()
         "will be appended to the model options (or used as the model options if --model-options was not specified).",
         model_options_, false, false, true);
     DEF_FLAG_OPTVAL("print-timing-info", 0, "Print SST timing information", print_timing_, true);
+    DEF_ARG(
+        "timing-info-json", 0, "FILE", "Write SST timing information in JSON format", timing_json_, true, true, false);
     DEF_ARG("stop-at", 0, "TIME", "Set time at which simulation will end execution", stop_at_, true, true, false);
     DEF_ARG("exit-after", 0, "TIME",
         "Set the maximum wall time after which simulation will end execution.  Time is specified in hours, minutes and "

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -168,7 +168,7 @@ private:
     SST_CONFIG_DECLARE_OPTION(uint32_t, num_threads, 1, &StandardConfigParsers::from_string<uint32_t>);
 
     /**
-       Name of the SDL file to use to genearte the simulation
+       Name of the SDL file to use to generate the simulation
     */
     SST_CONFIG_DECLARE_OPTION(std::string, configFile, "NONE", &StandardConfigParsers::from_string<std::string>);
 
@@ -182,6 +182,11 @@ private:
        Print SST timing information after the run
     */
     SST_CONFIG_DECLARE_OPTION(bool, print_timing, false, &StandardConfigParsers::flag_default_true);
+
+    /**
+        Print SST timing information to JSON file
+    */
+    SST_CONFIG_DECLARE_OPTION(std::string, timing_json, "NONE", &StandardConfigParsers::from_string<std::string>);
 
     /**
        Simulated cycle to stop the simulation at
@@ -211,7 +216,7 @@ private:
             std::placeholders::_2));
 
     /**
-       The directory to be used for writting output files
+       The directory to be used for writing output files
     */
     SST_CONFIG_DECLARE_OPTION(std::string, output_directory, "", &StandardConfigParsers::from_string<std::string>);
 

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -186,7 +186,7 @@ private:
     /**
         Print SST timing information to JSON file
     */
-    SST_CONFIG_DECLARE_OPTION(std::string, timing_json, "NONE", &StandardConfigParsers::from_string<std::string>);
+    SST_CONFIG_DECLARE_OPTION(std::string, timing_json, "", &StandardConfigParsers::from_string<std::string>);
 
     /**
        Simulated cycle to stop the simulation at

--- a/src/sst/core/configBase.h
+++ b/src/sst/core/configBase.h
@@ -188,7 +188,7 @@ struct OptionDefinitionImpl : OptionDefinition
 
        @param val Initialization value of the underlying value
 
-       @param paraser Function used to parse the value of the option
+       @param parser Function used to parse the value of the option
 
        @param ext_help Function called to print extended help for the
        option
@@ -495,7 +495,7 @@ private:                                           \
 
 /**
    Struct that holds all the getopt_long options along with the
-   docuementation for the option
+   documentation for the option
 */
 
 struct LongOption
@@ -533,7 +533,7 @@ struct AnnotationInfo
 
   FLAG - value is either true or false.  FLAG defaults to no arguments allowed
   ARG - value is a string.  ARG defaults to required argument
-  OPTVAL - Takes an optional paramater
+  OPTVAL - Takes an optional parameter
 
   longName - multicharacter name referenced using --
   shortName - single character name referenced using -

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -1275,30 +1275,29 @@ main(int argc, char* argv[])
     const uint64_t global_max_io_out = maxOutputOperations();
 
     if ( myRank.rank == 0 && (cfg.verbose() || cfg.print_timing() || cfg.timing_json() != "") ) {
-        std::unique_ptr<TimingOutput> timingOutput =
-            std::make_unique<TimingOutput>(g_output, cfg.verbose() || cfg.print_timing());
-        if ( cfg.timing_json() != "" ) timingOutput->setJSON(cfg.timing_json());
+        TimingOutput timingOutput(g_output, cfg.verbose() || cfg.print_timing());
+        if ( cfg.timing_json() != "" ) timingOutput.setJSON(cfg.timing_json());
 
-        timingOutput->set(TimingOutput::Key::LOCAL_MAX_RSS, local_max_rss);
-        timingOutput->set(TimingOutput::Key::GLOBAL_MAX_RSS, global_max_rss);
-        timingOutput->set(TimingOutput::Key::LOCAL_MAX_PF, local_max_pf);
-        timingOutput->set(TimingOutput::Key::GLOBAL_PF, global_pf);
-        timingOutput->set(TimingOutput::Key::GLOBAL_MAX_IO_IN, global_max_io_in);
-        timingOutput->set(TimingOutput::Key::GLOBAL_MAX_IO_OUT, global_max_io_out);
-        timingOutput->set(TimingOutput::Key::GLOBAL_MAX_SYNC_DATA_SIZE, global_max_sync_data_size);
-        timingOutput->set(TimingOutput::Key::GLOBAL_SYNC_DATA_SIZE, global_sync_data_size);
-        timingOutput->set(TimingOutput::Key::MAX_MEMPOOL_SIZE, (uint64_t)max_mempool_size);
-        timingOutput->set(TimingOutput::Key::GLOBAL_MEMPOOL_SIZE, (uint64_t)global_mempool_size);
-        timingOutput->set(TimingOutput::Key::MAX_BUILD_TIME, max_build_time);
-        timingOutput->set(TimingOutput::Key::MAX_RUN_TIME, max_run_time);
-        timingOutput->set(TimingOutput::Key::MAX_TOTAL_TIME, max_total_time);
-        timingOutput->set(TimingOutput::Key::SIMULATED_TIME_UA, threadInfo[0].simulated_time);
-        timingOutput->set(TimingOutput::Key::GLOBAL_ACTIVE_ACTIVITIES, (uint64_t)global_active_activities);
-        timingOutput->set(TimingOutput::Key::GLOBAL_CURRENT_TV_DEPTH, global_current_tv_depth);
-        timingOutput->set(TimingOutput::Key::GLOBAL_MAX_TV_DEPTH, global_max_tv_depth);
-        timingOutput->set(TimingOutput::Key::RANKS, (uint64_t)world_size.rank);
-        timingOutput->set(TimingOutput::Key::THREADS, (uint64_t)world_size.thread);
-        timingOutput->generate();
+        timingOutput.set(TimingOutput::Key::LOCAL_MAX_RSS, local_max_rss);
+        timingOutput.set(TimingOutput::Key::GLOBAL_MAX_RSS, global_max_rss);
+        timingOutput.set(TimingOutput::Key::LOCAL_MAX_PF, local_max_pf);
+        timingOutput.set(TimingOutput::Key::GLOBAL_PF, global_pf);
+        timingOutput.set(TimingOutput::Key::GLOBAL_MAX_IO_IN, global_max_io_in);
+        timingOutput.set(TimingOutput::Key::GLOBAL_MAX_IO_OUT, global_max_io_out);
+        timingOutput.set(TimingOutput::Key::GLOBAL_MAX_SYNC_DATA_SIZE, global_max_sync_data_size);
+        timingOutput.set(TimingOutput::Key::GLOBAL_SYNC_DATA_SIZE, global_sync_data_size);
+        timingOutput.set(TimingOutput::Key::MAX_MEMPOOL_SIZE, (uint64_t)max_mempool_size);
+        timingOutput.set(TimingOutput::Key::GLOBAL_MEMPOOL_SIZE, (uint64_t)global_mempool_size);
+        timingOutput.set(TimingOutput::Key::MAX_BUILD_TIME, max_build_time);
+        timingOutput.set(TimingOutput::Key::MAX_RUN_TIME, max_run_time);
+        timingOutput.set(TimingOutput::Key::MAX_TOTAL_TIME, max_total_time);
+        timingOutput.set(TimingOutput::Key::SIMULATED_TIME_UA, threadInfo[0].simulated_time);
+        timingOutput.set(TimingOutput::Key::GLOBAL_ACTIVE_ACTIVITIES, (uint64_t)global_active_activities);
+        timingOutput.set(TimingOutput::Key::GLOBAL_CURRENT_TV_DEPTH, global_current_tv_depth);
+        timingOutput.set(TimingOutput::Key::GLOBAL_MAX_TV_DEPTH, global_max_tv_depth);
+        timingOutput.set(TimingOutput::Key::RANKS, (uint64_t)world_size.rank);
+        timingOutput.set(TimingOutput::Key::THREADS, (uint64_t)world_size.thread);
+        timingOutput.generate();
     }
 
 #ifdef SST_CONFIG_HAVE_MPI

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -46,6 +46,7 @@ REENABLE_WARNING
 #include "sst/core/threadsafe.h"
 #include "sst/core/timeLord.h"
 #include "sst/core/timeVortex.h"
+#include "sst/core/timingOutput.h"
 
 #include <cinttypes>
 #include <exception>
@@ -1265,6 +1266,7 @@ main(int argc, char* argv[])
     global_active_activities  = active_activities;
 #endif
 
+    // These functions invoke MPI_Allreduce
     const uint64_t local_max_rss     = maxLocalMemSize();
     const uint64_t global_max_rss    = maxGlobalMemSize();
     const uint64_t local_max_pf      = maxLocalPageFaults();
@@ -1272,55 +1274,31 @@ main(int argc, char* argv[])
     const uint64_t global_max_io_in  = maxInputOperations();
     const uint64_t global_max_io_out = maxOutputOperations();
 
-    if ( myRank.rank == 0 && (cfg.verbose() || cfg.print_timing()) ) {
-        std::string ua_buffer;
-        ua_buffer = format_string("%" PRIu64 "KB", local_max_rss);
-        UnitAlgebra max_rss_ua(ua_buffer);
+    if ( myRank.rank == 0 && (cfg.verbose() || cfg.print_timing() || cfg.timing_json() != "") ) {
+        std::unique_ptr<TimingOutput> timingOutput =
+            std::make_unique<TimingOutput>(g_output, cfg.verbose() || cfg.print_timing());
+        if ( cfg.timing_json() != "" ) timingOutput->setJSON(cfg.timing_json());
 
-        ua_buffer = format_string("%" PRIu64 "KB", global_max_rss);
-        UnitAlgebra global_rss_ua(ua_buffer);
-
-        ua_buffer = format_string("%" PRIu64 "B", global_max_sync_data_size);
-        UnitAlgebra global_max_sync_data_size_ua(ua_buffer);
-
-        ua_buffer = format_string("%" PRIu64 "B", global_sync_data_size);
-        UnitAlgebra global_sync_data_size_ua(ua_buffer);
-
-        ua_buffer = format_string("%" PRIu64 "B", max_mempool_size);
-        UnitAlgebra max_mempool_size_ua(ua_buffer);
-
-        ua_buffer = format_string("%" PRIu64 "B", global_mempool_size);
-        UnitAlgebra global_mempool_size_ua(ua_buffer);
-
-        g_output.output("\n");
-        g_output.output("\n");
-        g_output.output("------------------------------------------------------------\n");
-        g_output.output("Simulation Timing Information (Wall Clock Times):\n");
-        g_output.output("  Build time:                      %f seconds\n", max_build_time);
-        g_output.output("  Run loop time:                   %f seconds\n", max_run_time);
-        g_output.output("  Total time:                      %f seconds\n", max_total_time);
-        g_output.output("\n");
-        g_output.output(
-            "Simulated time:                    %s\n", threadInfo[0].simulated_time.toStringBestSI().c_str());
-        g_output.output("\n");
-        g_output.output("Simulation Resource Information:\n");
-        g_output.output("  Max Resident Set Size:           %s\n", max_rss_ua.toStringBestSI().c_str());
-        g_output.output("  Approx. Global Max RSS Size:     %s\n", global_rss_ua.toStringBestSI().c_str());
-        g_output.output("  Max Local Page Faults:           %" PRIu64 " faults\n", local_max_pf);
-        g_output.output("  Global Page Faults:              %" PRIu64 " faults\n", global_pf);
-        g_output.output("  Max Output Blocks:               %" PRIu64 " blocks\n", global_max_io_out);
-        g_output.output("  Max Input Blocks:                %" PRIu64 " blocks\n", global_max_io_in);
-        g_output.output("  Max mempool usage:               %s\n", max_mempool_size_ua.toStringBestSI().c_str());
-        g_output.output("  Global mempool usage:            %s\n", global_mempool_size_ua.toStringBestSI().c_str());
-        g_output.output("  Global active activities:        %" PRIu64 " activities\n", global_active_activities);
-        g_output.output("  Current global TimeVortex depth: %" PRIu64 " entries\n", global_current_tv_depth);
-        g_output.output("  Max TimeVortex depth:            %" PRIu64 " entries\n", global_max_tv_depth);
-        g_output.output(
-            "  Max Sync data size:              %s\n", global_max_sync_data_size_ua.toStringBestSI().c_str());
-        g_output.output("  Global Sync data size:           %s\n", global_sync_data_size_ua.toStringBestSI().c_str());
-        g_output.output("------------------------------------------------------------\n");
-        g_output.output("\n");
-        g_output.output("\n");
+        timingOutput->set(TimingOutput::Key::LOCAL_MAX_RSS, local_max_rss);
+        timingOutput->set(TimingOutput::Key::GLOBAL_MAX_RSS, global_max_rss);
+        timingOutput->set(TimingOutput::Key::LOCAL_MAX_PF, local_max_pf);
+        timingOutput->set(TimingOutput::Key::GLOBAL_PF, global_pf);
+        timingOutput->set(TimingOutput::Key::GLOBAL_MAX_IO_IN, global_max_io_in);
+        timingOutput->set(TimingOutput::Key::GLOBAL_MAX_IO_OUT, global_max_io_out);
+        timingOutput->set(TimingOutput::Key::GLOBAL_MAX_SYNC_DATA_SIZE, global_max_sync_data_size);
+        timingOutput->set(TimingOutput::Key::GLOBAL_SYNC_DATA_SIZE, global_sync_data_size);
+        timingOutput->set(TimingOutput::Key::MAX_MEMPOOL_SIZE, (uint64_t)max_mempool_size);
+        timingOutput->set(TimingOutput::Key::GLOBAL_MEMPOOL_SIZE, (uint64_t)global_mempool_size);
+        timingOutput->set(TimingOutput::Key::MAX_BUILD_TIME, max_build_time);
+        timingOutput->set(TimingOutput::Key::MAX_RUN_TIME, max_run_time);
+        timingOutput->set(TimingOutput::Key::MAX_TOTAL_TIME, max_total_time);
+        timingOutput->set(TimingOutput::Key::SIMULATED_TIME_UA, threadInfo[0].simulated_time);
+        timingOutput->set(TimingOutput::Key::GLOBAL_ACTIVE_ACTIVITIES, (uint64_t)global_active_activities);
+        timingOutput->set(TimingOutput::Key::GLOBAL_CURRENT_TV_DEPTH, global_current_tv_depth);
+        timingOutput->set(TimingOutput::Key::GLOBAL_MAX_TV_DEPTH, global_max_tv_depth);
+        timingOutput->set(TimingOutput::Key::RANKS, (uint64_t)world_size.rank);
+        timingOutput->set(TimingOutput::Key::THREADS, (uint64_t)world_size.thread);
+        timingOutput->generate();
     }
 
 #ifdef SST_CONFIG_HAVE_MPI

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -331,6 +331,8 @@ getProgramOptions(PyObject* UNUSED(self), PyObject* UNUSED(args))
     PyDict_SetItem(dict, SST_ConvertToPythonString("num-threads"), SST_ConvertToPythonLong(cfg->num_threads()));
     PyDict_SetItem(dict, SST_ConvertToPythonString("sdl-file"), SST_ConvertToPythonString(cfg->configFile().c_str()));
     PyDict_SetItem(dict, SST_ConvertToPythonString("print-timing-info"), SST_ConvertToPythonBool(cfg->print_timing()));
+    PyDict_SetItem(
+        dict, SST_ConvertToPythonString("timing-info-json"), SST_ConvertToPythonString(cfg->timing_json().c_str()));
     PyDict_SetItem(dict, SST_ConvertToPythonString("stop-at"), SST_ConvertToPythonString(cfg->stop_at().c_str()));
     PyDict_SetItem(dict, SST_ConvertToPythonString("exit-after"), SST_ConvertToPythonLong(cfg->exit_after()));
     PyDict_SetItem(

--- a/src/sst/core/timingOutput.cc
+++ b/src/sst/core/timingOutput.cc
@@ -1,0 +1,153 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+//
+
+#include "sst/core/timingOutput.h"
+
+#include "sst/core/simulation_impl.h"
+#include "sst/core/stringize.h"
+
+#include "nlohmann/json.hpp"
+
+#include <sys/ioctl.h>
+
+namespace json = ::nlohmann;
+
+namespace SST {
+namespace Core {
+
+TimingOutput::TimingOutput(const SST::Output& output, bool printEnable) :
+    output_(output),
+    printEnable_(printEnable),
+    jsonEnable_(false)
+{}
+
+void
+TimingOutput::setJSON(const std::string& path)
+{
+    SST::Util::Filesystem filesystem = Simulation_impl::filesystem;
+    outputFile                       = filesystem.fopen(path, "wt");
+    if ( outputFile == nullptr )
+        output_.fatal(CALL_INFO, -1, "Could not open %s\n", path.c_str());
+    else
+        jsonEnable_ = true;
+}
+
+void
+TimingOutput::set(Key key, const uint64_t v)
+{
+    // output_.output("%s %" PRId64 "\n", key2cstr.at(key), v);
+    u64map_[key] = v;
+}
+
+void
+TimingOutput::set(Key key, UnitAlgebra v)
+{
+    // output_.output("%s %s\n", key2cstr.at(key), v.toStringBestSI().c_str());
+    uamap_[key] = v;
+}
+
+void
+TimingOutput::set(Key key, double v)
+{
+    // output_.output("%s %f\n", key2cstr.at(key), v);
+    dmap_[key] = v;
+}
+
+TimingOutput::~TimingOutput()
+{
+    if ( outputFile ) fclose(outputFile);
+}
+
+
+void
+TimingOutput::generate()
+{
+    if ( printEnable_ ) renderText();
+    if ( jsonEnable_ ) renderJSON();
+}
+
+void
+TimingOutput::renderText()
+{
+    std::string ua_buffer;
+    ua_buffer = format_string("%" PRIu64 "KB", u64map_.at(Key::LOCAL_MAX_RSS));
+    UnitAlgebra max_rss_ua(ua_buffer);
+
+    ua_buffer = format_string("%" PRIu64 "KB", u64map_.at(Key::GLOBAL_MAX_RSS));
+    UnitAlgebra global_rss_ua(ua_buffer);
+
+    ua_buffer = format_string("%" PRIu64 "B", u64map_.at(Key::GLOBAL_MAX_SYNC_DATA_SIZE));
+    UnitAlgebra global_max_sync_data_size_ua(ua_buffer);
+
+    ua_buffer = format_string("%" PRIu64 "B", u64map_.at(Key::GLOBAL_SYNC_DATA_SIZE));
+    UnitAlgebra global_sync_data_size_ua(ua_buffer);
+
+    ua_buffer = format_string("%" PRIu64 "B", u64map_.at(Key::MAX_MEMPOOL_SIZE));
+    UnitAlgebra max_mempool_size_ua(ua_buffer);
+
+    ua_buffer = format_string("%" PRIu64 "B", u64map_.at(GLOBAL_MEMPOOL_SIZE));
+    UnitAlgebra global_mempool_size_ua(ua_buffer);
+
+    output_.output("\n");
+    output_.output("\n");
+    output_.output("------------------------------------------------------------\n");
+    output_.output("Simulation Timing Information (Wall Clock Times):\n");
+    output_.output("  Build time:                      %f seconds\n", dmap_.at(MAX_BUILD_TIME));
+    output_.output("  Run loop time:                   %f seconds\n", dmap_.at(MAX_RUN_TIME));
+    output_.output("  Total time:                      %f seconds\n", dmap_.at(MAX_TOTAL_TIME));
+    output_.output("\n");
+    output_.output("Simulated time:                    %s\n", uamap_.at(SIMULATED_TIME_UA).toStringBestSI().c_str());
+    output_.output("\n");
+    output_.output("Simulation Resource Information:\n");
+    output_.output("  Max Resident Set Size:           %s\n", max_rss_ua.toStringBestSI().c_str());
+    output_.output("  Approx. Global Max RSS Size:     %s\n", global_rss_ua.toStringBestSI().c_str());
+    output_.output("  Max Local Page Faults:           %" PRIu64 " faults\n", u64map_.at(LOCAL_MAX_PF));
+    output_.output("  Global Page Faults:              %" PRIu64 " faults\n", u64map_.at(GLOBAL_PF));
+    output_.output("  Max Output Blocks:               %" PRIu64 " blocks\n", u64map_.at(GLOBAL_MAX_IO_OUT));
+    output_.output("  Max Input Blocks:                %" PRIu64 " blocks\n", u64map_.at(GLOBAL_MAX_IO_IN));
+    output_.output("  Max mempool usage:               %s\n", max_mempool_size_ua.toStringBestSI().c_str());
+    output_.output("  Global mempool usage:            %s\n", global_mempool_size_ua.toStringBestSI().c_str());
+    output_.output("  Global active activities:        %" PRIu64 " activities\n", u64map_.at(GLOBAL_ACTIVE_ACTIVITIES));
+    output_.output("  Current global TimeVortex depth: %" PRIu64 " entries\n", u64map_.at(GLOBAL_CURRENT_TV_DEPTH));
+    output_.output("  Max TimeVortex depth:            %" PRIu64 " entries\n", u64map_.at(GLOBAL_MAX_TV_DEPTH));
+    output_.output("  Max Sync data size:              %s\n", global_max_sync_data_size_ua.toStringBestSI().c_str());
+    output_.output("  Global Sync data size:           %s\n", global_sync_data_size_ua.toStringBestSI().c_str());
+    output_.output("------------------------------------------------------------\n");
+    output_.output("\n");
+    output_.output("\n");
+}
+
+void
+TimingOutput::renderJSON()
+{
+    json::ordered_json json_o;
+    for ( auto kv : u64map_ ) {
+        // std::cout << key2cstr.at(kv.first) << " = " << std::dec << kv.second << std::endl;
+        json_o["timing-info"][key2cstr.at(kv.first)] = kv.second;
+    }
+    for ( auto kv : dmap_ ) {
+        json_o["timing-info"][key2cstr.at(kv.first)] = kv.second;
+    }
+    for ( auto kv : uamap_ ) {
+        json_o["timing-info"][key2cstr.at(kv.first)] = kv.second.toStringBestSI().c_str();
+    }
+
+    std::stringstream ss;
+    ss << std::setw(2) << json_o << std::endl;
+
+    // Avoid potential lifetime issues
+    std::string outputString = ss.str();
+    fprintf(outputFile, "%s", outputString.c_str());
+}
+
+} // namespace Core
+} // namespace SST

--- a/src/sst/core/timingOutput.h
+++ b/src/sst/core/timingOutput.h
@@ -1,0 +1,99 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_TIMING_OUTPUT_H
+#define SST_CORE_TIMING_OUTPUT_H
+
+#include "sst/core/output.h"
+#include "sst/core/unitAlgebra.h"
+#include "sst/core/util/filesystem.h"
+
+#include <map>
+
+namespace SST::Core {
+
+/**
+ * Outputs configuration data to a specified file path.
+ */
+class TimingOutput
+{
+public:
+    /** Timing Parameters
+     */
+    enum Key {
+        LOCAL_MAX_RSS,             // Max Resident Set Size (kB)
+        GLOBAL_MAX_RSS,            // Approx. Global Max RSS Size (kB)
+        LOCAL_MAX_PF,              // Max Local Page Faults
+        GLOBAL_PF,                 // Global Page Faults
+        GLOBAL_MAX_IO_IN,          // Max Output Blocks
+        GLOBAL_MAX_IO_OUT,         // Max Input Blocks
+        GLOBAL_MAX_SYNC_DATA_SIZE, // Max Sync data size
+        GLOBAL_SYNC_DATA_SIZE,     // Global Sync data size
+        MAX_MEMPOOL_SIZE,          // Max mempool usage (bytes)
+        GLOBAL_MEMPOOL_SIZE,       // Global mempool usage (bytes)
+        MAX_BUILD_TIME,            // Build time (wallclock seconds)
+        MAX_RUN_TIME,              // Run loop time (wallclock seconds)
+        MAX_TOTAL_TIME,            // Total time (wallclock seconds)
+        SIMULATED_TIME_UA,         // Simulated time ( Algebra seconds string. eg. "10 us" )
+        GLOBAL_ACTIVE_ACTIVITIES,  // Global active activities
+        GLOBAL_CURRENT_TV_DEPTH,   // Current global TimeVortex depth
+        GLOBAL_MAX_TV_DEPTH,       // Max TimeVortex depth
+        RANKS,                     // MPI ranks
+        THREADS,                   // Threads
+    };
+
+    const std::map<Key, const char*> key2cstr = {
+        { LOCAL_MAX_RSS, "local_max_rss" },
+        { GLOBAL_MAX_RSS, "global_max_rss" },
+        { LOCAL_MAX_PF, "local_max_pf" },
+        { GLOBAL_PF, "global_pf" },
+        { GLOBAL_MAX_IO_IN, "global_max_io_in" },
+        { GLOBAL_MAX_IO_OUT, "global_max_io_out" },
+        { GLOBAL_MAX_SYNC_DATA_SIZE, "global_max_sync_data_size" },
+        { GLOBAL_SYNC_DATA_SIZE, "global_sync_data_size" },
+        { MAX_MEMPOOL_SIZE, "max_mempool_size" },
+        { GLOBAL_MEMPOOL_SIZE, "global_mempool_size" },
+        { MAX_BUILD_TIME, "max_build_time" },
+        { MAX_RUN_TIME, "max_run_time" },
+        { MAX_TOTAL_TIME, "max_total_time" },
+        { SIMULATED_TIME_UA, "simulated_time_ua" },
+        { GLOBAL_ACTIVE_ACTIVITIES, "global_active_activities" },
+        { GLOBAL_CURRENT_TV_DEPTH, "global_current_tv_depth" },
+        { GLOBAL_MAX_TV_DEPTH, "global_max_tv_depth" },
+        { RANKS, "ranks" },
+        { THREADS, "threads" },
+    };
+
+    TimingOutput(const SST::Output& output, bool printEnable);
+    virtual ~TimingOutput();
+    void setJSON(const std::string& path);
+    void generate();
+    void renderText();
+    void renderJSON();
+
+    void set(Key key, uint64_t v);
+    void set(Key key, UnitAlgebra v);
+    void set(Key key, double v);
+
+private:
+    SST::Output output_;
+    bool        printEnable_;
+    bool        jsonEnable_;
+
+    std::map<Key, uint64_t>    u64map_    = {};
+    std::map<Key, UnitAlgebra> uamap_     = {};
+    std::map<Key, double>      dmap_      = {};
+    FILE*                      outputFile = nullptr;
+};
+
+} // namespace SST::Core
+
+#endif // SST_CORE_TIMING_OUTPUT_H

--- a/tests/refFiles/test_TimingInfo.out
+++ b/tests/refFiles/test_TimingInfo.out
@@ -1,0 +1,17 @@
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Perf Test Component Finished.
+Simulation is complete, simulated time: 10 us

--- a/tests/testsuite_default_TimingInfo.py
+++ b/tests/testsuite_default_TimingInfo.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2009-2025 NTESS. Under the terms
+# of Contract DE-NA0003525 with NTESS, the U.S.
+# Government retains certain rights in this software.
+#
+# Copyright (c) 2009-2025, NTESS
+# All rights reserved.
+#
+# This file is part of the SST software package. For license
+# information, see the LICENSE file in the top level directory of the
+# distribution.
+
+import json
+import os
+from sst_unittest import *
+from sst_unittest_support import *
+
+
+class testcase_TimingInfo(SSTTestCase):
+
+    def setUp(self):
+        super(type(self), self).setUp()
+        # Put test based setup code here. it is called once before every test
+
+    def tearDown(self):
+        # Put test based teardown code here. it is called once after every test
+        super(type(self), self).tearDown()
+
+#####
+
+    def test_TimingInfo(self):
+        self.timing_info_test_template("JSONTimingInfo")
+
+#####
+
+    def timing_info_test_template(self, testtype):
+        testsuitedir = self.get_testsuite_dir()
+        outdir = test_output_get_run_dir()
+
+        sdlfile = "{0}/test_PerfComponent.py".format(testsuitedir)
+        reffile = "{0}/refFiles/test_TimingInfo.out".format(testsuitedir)
+        outfile = "{0}/test_TimingInfo.out".format(outdir)
+        jsonfile = "{0}/test_TimingInfo.json".format(outdir)
+
+        self.run_sst(sdlfile, outfile, other_args=f"--timing-info-json={jsonfile}")
+        
+        # Perform the test of the standard simulation output
+        cmp_result = testing_compare_sorted_diff(testtype, outfile, reffile)
+        self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))
+
+        # Verify well formed JSON and navigate Key-Value pairs
+        jsonDict = {}
+        try:
+            with open(jsonfile) as f:
+                jsonDict = json.load(f)
+        except FileNotFoundError:
+            self.assertFalse(True, f"Could not load json timing info file {jsonfile}")
+
+        timingInfo = jsonDict['timing-info']
+
+        timing_keys = [
+            "local_max_rss",
+            "global_max_rss",
+            "local_max_pf",
+            "global_pf",
+            "global_max_io_in",
+            "global_max_io_out",
+            "global_max_sync_data_size",
+            "global_sync_data_size",
+            "max_mempool_size",
+            "global_mempool_size",
+            "global_active_activities",
+            "global_current_tv_depth",
+            "global_max_tv_depth",
+            "max_build_time",
+            "max_run_time",
+            "max_total_time",
+            "simulated_time_ua",
+            "ranks",
+            "threads",
+        ]
+        
+        # Check keys exists
+        for k in timing_keys:
+            self.assertTrue(k in timingInfo, f"JSON data is missing key: {k}")
+
+        # Check no spurious keys
+        for k in timingInfo.keys():
+            self.assertTrue(k in timing_keys, f"JSON data contains an unknown key: {k}")
+
+


### PR DESCRIPTION
Added a new command line option `--timing-info-json=FILE` to write timing information into a JSON formatted file. Moved the code to print the timing information to `stdout` from main.cc and into a new file where that data is captured as key-value pairs and then can be printed as text and/or as JSON depending on the command line options. 

Added test case to verify well formed json is generated with the expected keys.