### PR TITLE
Serialize std::bitset

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -101,6 +101,7 @@ nobase_dist_sst_HEADERS = \
 	serialization/impl/serialize_adapter.h \
 	serialization/impl/serialize_array.h \
 	serialization/impl/serialize_atomic.h \
+	serialization/impl/serialize_bitset.h \
 	serialization/impl/ser_buffer_accessor.h \
 	serialization/impl/serialize_insertable.h \
         serialization/impl/serialize_optional.h \

--- a/src/sst/core/serialization/impl/serialize_bitset.h
+++ b/src/sst/core/serialization/impl/serialize_bitset.h
@@ -1,0 +1,65 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_SERIALIZATION_IMPL_SERIALIZE_BITSET_H
+#define SST_CORE_SERIALIZATION_IMPL_SERIALIZE_BITSET_H
+
+#ifndef SST_INCLUDING_SERIALIZE_H
+#warning \
+    "The header file sst/core/serialization/impl/serialize_bitset.h should not be directly included as it is not part of the stable public API.  The file is included in sst/core/serialization/serialize.h"
+#endif
+
+#include "sst/core/serialization/serializer.h"
+
+#include <bitset>
+#include <cstddef>
+#include <type_traits>
+
+namespace SST::Core::Serialization {
+
+// Serialize std::bitset
+template <size_t N>
+class serialize_impl<std::bitset<N>>
+{
+    using T = std::bitset<N>;
+    void operator()(T& t, serializer& ser, ser_opt_t UNUSED(options))
+    {
+        switch ( ser.mode() ) {
+        case serializer::MAP:
+        {
+            // TODO: Should this be mapped as an array? It will have the same problems as std::vector<bool>
+            break;
+        }
+
+        default:
+            static_assert(std::is_trivially_copyable_v<T> && std::is_standard_layout_v<T>);
+            ser.primitive(t);
+            break;
+        }
+    }
+    SST_FRIEND_SERIALIZE();
+};
+
+template <size_t N>
+class serialize_impl<std::bitset<N>*>
+{
+    using T = std::bitset<N>;
+    void operator()(T*& t, serializer& ser, ser_opt_t UNUSED(options))
+    {
+        if ( ser.mode() == serializer::UNPACK ) t = new T {};
+        SST_SER(*t);
+    }
+    SST_FRIEND_SERIALIZE();
+};
+
+} // namespace SST::Core::Serialization
+
+#endif // SST_CORE_SERIALIZATION_IMPL_SERIALIZE_BITSET_H

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -512,6 +512,7 @@ sst_ser_or_helper(Args... args)
 #include "sst/core/serialization/impl/serialize_adapter.h"
 #include "sst/core/serialization/impl/serialize_array.h"
 #include "sst/core/serialization/impl/serialize_atomic.h"
+#include "sst/core/serialization/impl/serialize_bitset.h"
 #include "sst/core/serialization/impl/serialize_insertable.h"
 #include "sst/core/serialization/impl/serialize_optional.h"
 #include "sst/core/serialization/impl/serialize_string.h"

--- a/src/sst/core/testElements/coreTest_Serialization.cc
+++ b/src/sst/core/testElements/coreTest_Serialization.cc
@@ -24,6 +24,7 @@
 #include "sst/core/warnmacros.h"
 
 #include <array>
+#include <bitset>
 #include <deque>
 #include <forward_list>
 #include <list>
@@ -642,6 +643,11 @@ coreTestSerialization::coreTestSerialization(ComponentId_t id, Params& params) :
         checkSimpleSerializeDeserialize<float>::check_all(rng->nextUniform() * 1000, out, "float");
         checkSimpleSerializeDeserialize<double>::check_all(rng->nextUniform() * 1000000, out, "double");
         checkSimpleSerializeDeserialize<std::string>::check_all("test_string", out, "std::string");
+
+        checkSimpleSerializeDeserialize<std::bitset<1>>::check_all(rng->generateNextUInt64(), out, "std::bitset<1>");
+        checkSimpleSerializeDeserialize<std::bitset<10>>::check_all(rng->generateNextUInt64(), out, "std::bitset<10>");
+        checkSimpleSerializeDeserialize<std::bitset<100>>::check_all(
+            rng->generateNextUInt64(), out, "std::bitset<100>");
 
         passed = checkSimpleSerializeDeserialize<std::tuple<int32_t, int32_t, int32_t>>::check(
             std::tuple<int32_t, int32_t, int32_t>(


### PR DESCRIPTION
This serializes `std::bitset`, fixing https://github.com/sstsimulator/sst-core/issues/1347 with a solution very specific to `std::bitset` even though it might be able to be handled with trivial serialization in https://github.com/sstsimulator/sst-core/pull/1330.

(Even if https://github.com/sstsimulator/sst-core/pull/1330 is merged, there won't be any conflict, because `serialize_impl<std::bitset<N>>` is "more specialized" and constraining than `serialize_impl<T, std::enable_if_t<...>>` is.)

It leaves open the question of how to implement `std::bitset` mapping mode, and presents issues similar to `std::vector<bool>` with packed bits.