### PR TITLE
inline InstantiateBuilderInfo<Base, T>::loaded variable

### DIFF
--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -130,14 +130,6 @@ protected:
     BuilderInfoImpl& operator=(const BuilderInfoImpl&) = delete;
 };
 
-template <class Base, class T>
-struct InstantiateBuilderInfo
-{
-    static bool isLoaded() { return loaded; }
-
-    static const bool loaded;
-};
-
 template <class Base>
 class InfoLibrary
 {
@@ -287,7 +279,12 @@ struct ElementsInfo
 };
 
 template <class Base, class T>
-const bool InstantiateBuilderInfo<Base, T>::loaded = ElementsInfo<Base>::template add<T>();
+struct InstantiateBuilderInfo
+{
+    static bool isLoaded() { return loaded; }
+
+    static inline const bool loaded = ElementsInfo<Base>::template add<T>();
+};
 
 struct InfoDatabase
 {


### PR DESCRIPTION
This makes the `InstantiateBuilderInfo<Base, T>::loaded` variable `inline` and moves the `InstantiateBuilderInfo<Base, T>` class definition down so that the `loaded` variable can be initialized inside the class definition.

Although the previous code did not have any ODR-violations (multiple definitions), this was probably because the template arguments were different in each file which `#include`d the header. With C++17 `inline` variables, this makes it safe from ODR violations even if the same template arguments are used in multiple `#include`s of this header file, and makes it simpler to define the variable in-class.

