### PR TITLE
Checkpoint global data into single globals file

### DIFF
--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -815,25 +815,25 @@ ConfigGraph::addSharedParam(const std::string& shared_set, const std::string& ke
 void
 ConfigGraph::setStatisticOutput(const std::string& name)
 {
-    stat_outputs_[0].type = name;
+    stats_config_->outputs[0].type = name;
 }
 
 void
 ConfigGraph::setStatisticOutputParams(const Params& p)
 {
-    stat_outputs_[0].params = p;
+    stats_config_->outputs[0].params = p;
 }
 
 void
 ConfigGraph::addStatisticOutputParameter(const std::string& param, const std::string& value)
 {
-    stat_outputs_[0].params.insert(param, value);
+    stats_config_->outputs[0].params.insert(param, value);
 }
 
 void
 ConfigGraph::setStatisticLoadLevel(uint8_t loadLevel)
 {
-    stat_load_level_ = loadLevel;
+    stats_config_->load_level = loadLevel;
 }
 
 void
@@ -1004,12 +1004,12 @@ ConfigGraph::getSubGraph(const std::set<uint32_t>& rank_set)
     }
 
     // Copy the statistic configuration to the sub-graph
-    graph->stat_outputs_ = this->stat_outputs_;
+    graph->stats_config_->outputs = this->stats_config_->outputs;
     /* Only need to copy StatGroups which are referenced in this subgraph */
-    for ( auto& kv : this->stat_groups_ ) {
+    for ( auto& kv : this->stats_config_->groups ) {
         for ( auto& id : kv.second.components ) {
             if ( graph->containsComponent(id) ) {
-                graph->stat_groups_.insert(std::make_pair(kv.first, kv.second));
+                graph->stats_config_->groups.insert(std::make_pair(kv.first, kv.second));
                 break;
             }
         }
@@ -1193,12 +1193,13 @@ ConfigGraph::splitGraph(const std::set<uint32_t>& orig_rank_set, const std::set<
     comps_.filter(filter);
 
     // Copy the statistic configuration to the sub-graph
-    graph->stat_outputs_ = this->stat_outputs_;
+    graph->stats_config_->outputs = this->stats_config_->outputs;
 
     // Need to copy statgroups contained in new graph and remove
     // statgroups that are no longer needed in original graph
     // for ( auto& kv : this->statGroups ) {
-    for ( auto it = this->stat_groups_.begin(); it != this->stat_groups_.end(); /* increment in loop body */ ) {
+    for ( auto it = this->stats_config_->groups.begin(); it != this->stats_config_->groups.end();
+        /* increment in loop body */ ) {
         bool copy   = false;
         bool remove = true;
         for ( auto& id : it->second.components ) {
@@ -1220,12 +1221,12 @@ ConfigGraph::splitGraph(const std::set<uint32_t>& orig_rank_set, const std::set<
 
         // See if we need to copy into new graph
         if ( copy ) {
-            graph->stat_groups_.insert(std::make_pair(it->first, it->second));
+            graph->stats_config_->groups.insert(std::make_pair(it->first, it->second));
         }
 
         // See if we need to remove from the original graph.
         if ( remove ) {
-            it = this->stat_groups_.erase(it);
+            it = this->stats_config_->groups.erase(it);
         }
         else {
             ++it;

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -16,6 +16,7 @@
 #include "sst/core/event.h"
 #include "sst/core/factory.h"
 #include "sst/core/initQueue.h"
+#include "sst/core/linkPair.h"
 #include "sst/core/pollingLinkQueue.h"
 #include "sst/core/profile/eventHandlerProfileTool.h"
 #include "sst/core/simulation_impl.h"
@@ -74,6 +75,15 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
     // 2 - SelfLink
     // 3 - Sync Link Pair
     int16_t type;
+
+    Simulation_impl* sim = Simulation_impl::getSimulation();
+
+    // In order to uniquely identify links on restart, we need to
+    // track the rank of the link and its pair link.  For regular
+    // links, they are the same, but for sync link pairs, the pair
+    // link will be on a different rank.  For self links, this
+    // information isn't needed
+    RankInfo my_rank = sim->getRank();
 
     switch ( ser.mode() ) {
     case serializer::SIZER:
@@ -145,187 +155,119 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
             return;
         } // if ( self_link )
 
-        // Check to see if this is a SYNC link pair.  If so, we will
-        // serialize all the info together so we can do the
-        // registerLink() calls on deserialization.  The serialization
-        // call will always be on the non-sync link of the pair.
-        if ( s->pair_link->type == Link::SYNC ) {
-            type = 3;
+        /*
+          If this isn't a self link, then we need to keep unique
+          identifiers for both this link and its pair link.  This
+          information will be used at restart to reconnect the links.
+
+          The unique identifiers are created using the MPI rank and
+          pointer of the link cast as a uintptr_t.
+
+          For SYNC links, we will only store the data for the
+          component side link, and recreate the sync link on
+          restart. This is need to support repartitioned restarts, as
+          links may change between regular and sync links depending on
+          how the graph is repartitioned.
+         */
+        if ( !self_link ) {
+            // Need to track the whether this is a sync link pair or
+            // not because where the data comes from will be slightly
+            // differnt
+            bool is_sync = s->pair_link->type == Link::SYNC;
+            type         = is_sync ? 3 : 1;
             SST_SER(type);
 
-            // MULTI-PARELLEL RESTART: When supporting different
-            // restart parallelism, will also need to store the rank
-            // of the links in order to have unique identifies for
-            // each link.  For pair links on another rank, we will use
-            // the delivery_info field as the pointer part of the tag
-            // (this is the uintptr_t representation of the link
-            // pointer on the remote rank).  This will also require
-            // that the remote rank be stored somewhere in the link
-            // object.  The most likely place is in the tag, since
-            // this field is essentially unused when the link is
-            // connected to a sync object (No ordering in the
-            // SyncQueue and the real tag will be added on the remote
-            // side).
+            /*
+              Unique Identifiers
+            */
 
-            // No need to keep pointers as tags since we'll have all
-            // the data in the serialization stream
+            // My unique id is constructred from my rank and pointer.
+            // However, if this is a sync link, the other side only
+            // has my pair pointer, so use that one as my tag.
+            SST_SER(my_rank);
+            uintptr_t ptr;
+            if ( is_sync )
+                ptr = reinterpret_cast<uintptr_t>(s->pair_link);
+            else
+                ptr = reinterpret_cast<uintptr_t>(s);
+            SST_SER(ptr);
 
-            // Store info for the non-sync link
+            if ( is_sync ) {
+                // The unique ID for the remote links is constructed from
+                // the rank of the remote pair link and its pointer on
+                // that rank.  The remote pointer is stored in
+                // delivery_info and we can get the remote rank from the
+                // sync queue.
+                SyncQueue* q  = dynamic_cast<SyncQueue*>(s->send_queue);
+                RankInfo   ri = q->getToRank();
+                SST_SER(ri);
+                SST_SER(s->delivery_info);
+            }
+            else {
+                // Unique ID for my pair link is my rank and pair_link
+                // pointer.  Rank is already stored, just store pair
+                // pointer
+                uintptr_t pair_ptr = reinterpret_cast<uintptr_t>(s->pair_link);
+                SST_SER(pair_ptr);
+            }
+
+            /*
+              Store the metadata for this link
+            */
             SST_SER(s->type);
             SST_SER(s->mode);
             SST_SER(s->tag);
 
+            /*
+              Store handler for handler links, or store the contents
+              of the PollingLinkQueue for polling links
+             */
             if ( s->type == Link::POLL ) {
                 // If I'm a polling link, I need to serialize my
-                // pair's send_queue.  For HANDLER and SYNC links, the
-                // send_queue will be reinitialized after restart.
+                // pair's send_queue (which is really my receive
+                // queue).  For HANDLER and SYNC links, the send_queue
+                // will be reinitialized after restart.
                 PollingLinkQueue* queue = dynamic_cast<PollingLinkQueue*>(s->pair_link->send_queue);
                 // PollingLinkQueues don't work with the serialization
                 // functions.  Call things directly.
                 queue->serialize_order(ser);
             }
+            else {
+                // Store the handler for this link.
 
-            // Now serialize the handler
-            Event::HandlerBase* handler = reinterpret_cast<Event::HandlerBase*>(s->pair_link->delivery_info);
+                // Need to serialize both the uintptr_t stored in
+                // pair_link->delivery_info and the pointer because
+                // we'll need the numerical value of the pointer as a
+                // tag when restarting.
+                Event::HandlerBase* handler = reinterpret_cast<Event::HandlerBase*>(s->pair_link->delivery_info);
 
-            // Need to serialize both the uintptr_t
-            // (delivery_info) and the pointer because we'll need
-            // the numerical value of the pointer as a tag when
-            // restarting.
-            SST_SER(s->pair_link->delivery_info);
-            SST_SER(handler);
+                // Tag for handler
+                SST_SER(s->pair_link->delivery_info);
+                // Actual handler
+                SST_SER(handler);
+            }
 
+            /*
+              Store timing info for link
+             */
             SST_SER(s->defaultTimeBase);
             SST_SER(s->latency);
+            // If part of a sync pair, need to save the pair_link's
+            // latency in case Link::addRecvLatency() was called.
+            // This will be added to the new pair_link on restart.
+            if ( is_sync ) SST_SER(s->pair_link->latency);
 
-            // Store data for sync link
+            /*
+              Serialize any serializable attached tools
 
-            // We'll need the pointer of the synclink in order to
-            // generate a globally unique name for
-            // SyncManager::registerLink().
-            uintptr_t ptr = reinterpret_cast<uintptr_t>(s->pair_link);
-            SST_SER(ptr);
-
-            SST_SER(s->pair_link->type);
-            SST_SER(s->pair_link->mode);
-            SST_SER(s->pair_link->tag);
-
-            // No need to store queue info, it will be reintialized by
-            // the registerLink() call on restart
-
-            // Just put in the delivery_info directly, this is the
-            // pointer to the link on the other parition
-            SST_SER(s->delivery_info);
-
-            // Need to store my rank info and the rank info for
-            // the other partition.  This information will be used
-            // to create a unique name for connecting things on
-            // restart
-            RankInfo ri = Simulation_impl::getSimulation()->getRank();
-            SST_SER(ri);
-
-            // Get the remote rank from my pairs send queue (which
-            // is a sync queue)
-            SyncQueue* q = dynamic_cast<SyncQueue*>(s->send_queue);
-            ri           = q->getToRank();
-            SST_SER(ri);
-
-            SST_SER(s->pair_link->defaultTimeBase);
-            SST_SER(s->pair_link->latency);
-
-            // Need to serialize anything in the AttachPoint. Not all
-            // tool types will be serializable, so will need to check
-            // by using dynamic_cast<serializable*>.  Just create a
-            // new vector with only the serializable elements and
-            // serialize that.  On restart, those will be the only
-            // ones that get attached, unless there is another
-            // specified on the command line.
-
-            // // Determine how many serializable tools there are
-            Link::ToolList tools;
-            if ( s->attached_tools ) {
-                for ( auto x : *s->attached_tools ) {
-                    if ( dynamic_cast<SST::Core::Serialization::serializable*>(x.first) ) {
-                        tools.push_back(x);
-                    }
-                }
-            }
-            size_t tool_count = tools.size();
-            SST_SER(tool_count);
-            if ( tool_count > 0 ) {
-                // Serialize each tool, then call
-                // serializeEventAttachPointKey() to serialize any
-                // data associated with the key
-                for ( auto x : tools ) {
-                    SST::Core::Serialization::serializable* obj =
-                        dynamic_cast<SST::Core::Serialization::serializable*>(x.first);
-                    SST_SER(obj);
-                    x.first->serializeEventAttachPointKey(ser, x.second);
-                }
-            }
-
-            // Serialize all the events sent on/to this Link
-            serialize_events(ser, s->pair_link->delivery_info);
-        }
-        else {
-            // Regular link
-            type = 1;
-            SST_SER(type);
-
-            // Need to put a uintptr_t in for my pointer and my pair's
-            // pointer.  This will be used to identify link
-            // connections on restart
-
-            uintptr_t ptr = reinterpret_cast<uintptr_t>(s);
-            SST_SER(ptr);
-            ptr = reinterpret_cast<uintptr_t>(s->pair_link);
-            SST_SER(ptr);
-
-            // Store some of the data we'll need to make decisions
-            // during unpacking
-            SST_SER(s->type);
-            SST_SER(s->mode);
-            SST_SER(s->tag);
-
-            if ( s->type == Link::POLL ) {
-                // If I'm a polling link, I need to serialize my
-                // pair's send_queue.  For HANDLER and SYNC links, the
-                // send_queue will be reinitialized after restart
-                PollingLinkQueue* queue = dynamic_cast<PollingLinkQueue*>(s->pair_link->send_queue);
-                // PollingLinkQueues don't work with the serialization
-                // functions.  Call things directly.
-                queue->serialize_order(ser);
-            }
-
-            // My handler is stored in pair_link->delivery_info
-
-            // First serialize the pointer tag so we can fix
-            // things up after restart
-
-            // Now serialize the handler
-            Event::HandlerBase* handler = reinterpret_cast<Event::HandlerBase*>(s->pair_link->delivery_info);
-
-            // Need to serialize both the uintptr_t
-            // (delivery_info) and the pointer because we'll need
-            // the numerical value of the pointer as a tag when
-            // restarting.
-            SST_SER(s->pair_link->delivery_info);
-            SST_SER(handler);
-
-            SST_SER(s->defaultTimeBase);
-            SST_SER(s->latency);
-
-            // s->pair_link - tag stored above
-            // s->current_time is automatically set on construction so
-            // no need to serialize
-
-            // Need to serialize anything in the AttachPoint. Not all
-            // tool types will be serializable, so will need to check
-            // by using dynamic_cast<serializable*>.  Just create a
-            // new vector with only the serializable elements and
-            // serialize that.  On restart, those will be the only
-            // ones that get attached, unless there is another
-            // specified on the command line.
+              Need to serialize anything in the AttachPoint. Not all
+              tool types will be serializable, so will need to check
+              by using dynamic_cast<serializable*>.  Just create a new
+              vector with only the serializable elements and serialize
+              that.  On restart, those will be the only ones that get
+              attached, unless there is another specified on the
+              command line.
+            */
 
             // Determine how many serializable tools there are
             Link::ToolList tools;
@@ -349,9 +291,13 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
                     x.first->serializeEventAttachPointKey(ser, x.second);
                 }
             }
-            // Serialize all the events sent on/to this Link
+
+            /*
+              Serialize all the events targeting this Link
+             */
             serialize_events(ser, s->pair_link->delivery_info);
-        }
+        } // if ( !self_link )
+
         break;
     case serializer::UNPACK:
         SST_SER(type);
@@ -377,20 +323,16 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
             SST_SER(handler);
             s->delivery_info = reinterpret_cast<uintptr_t>(handler);
 
-            Simulation_impl::getSimulation()->event_handler_restart_tracking[delivery_info] = s->delivery_info;
+            sim->event_handler_restart_tracking[delivery_info] = s->delivery_info;
 
             SST_SER(s->defaultTimeBase);
             SST_SER(s->latency);
-            // s->pair_link not needed for SelfLinks
-            // s->current_time is automatically set on construction so
-            // no need to serialize
+
             SST_SER(s->type);
             SST_SER(s->mode);
             SST_SER(s->tag);
-            // Profile tools not yet supported
-            // SST_SER(s->profile_tools);
 
-            s->send_queue = Simulation_impl::getSimulation()->getTimeVortex();
+            s->send_queue = sim->getTimeVortex();
 
             // Need to restore any Tool in the AttachPoint.
             size_t tool_count;
@@ -412,186 +354,150 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
 
             serialize_events(ser, s->delivery_info, s->send_queue);
         }
-        else if ( type == 3 ) {
-            // Sync link
+        /*
+          If this isn't a self link, then we need to determine if this
+          is a sync link or a regular link with the potentially new
+          repartioning on restart.
 
-            // Need to create both links in the pair
-            s = new Link();
-            ser.unpacker().report_new_pointer(reinterpret_cast<uintptr_t>(s));
-
-            Link* pair_link      = new Link();
-            s->pair_link         = pair_link;
-            pair_link->pair_link = s;
-
-            // Get data for non-sync link
-            SST_SER(s->type);
-            SST_SER(s->mode);
-            SST_SER(s->tag);
-
-            // Get the send_queue.  It goes in my pair_link
-            if ( s->type == Link::POLL ) {
-                // If I'm a polling link, need to deserialize my
-                // pair's send_queue. For now, I will store it in my
-                // own send_queue variable and swap once we have both
-                // links.
-                PollingLinkQueue* queue;
-                // PollingLinkQueues don't work with the serialization
-                // functions.  Call things directly.
-                // SST_SER(queue);
-                queue = new PollingLinkQueue();
-                queue->serialize_order(ser);
-                pair_link->send_queue = queue;
-            }
-            else {
-                pair_link->send_queue = Simulation_impl::getSimulation()->getTimeVortex();
-            }
-
-            // Get delivery_info (handler). It goes in my pair link
-            uintptr_t delivery_info;
-            SST_SER(delivery_info);
-
-            Event::HandlerBase* handler;
-            SST_SER(handler);
-            pair_link->delivery_info = reinterpret_cast<uintptr_t>(handler);
-
-            Simulation_impl::getSimulation()->event_handler_restart_tracking[delivery_info] = pair_link->delivery_info;
-
-            // Get defaultTimeBase and latency
-            SST_SER(s->defaultTimeBase);
-            SST_SER(s->latency);
-
-            // Now get data from the sync side of the link
-            uintptr_t my_tag;
-            SST_SER(my_tag);
-
-            SST_SER(pair_link->type);
-            SST_SER(pair_link->mode);
-            SST_SER(pair_link->tag);
-
-            // Get the delivery info for the sync.  This is the
-            // pointer to the link on the remote partition
-            SST_SER(delivery_info);
-
-
-            RankInfo local_rank;
-            RankInfo remote_rank;
-            SST_SER(local_rank);
-            SST_SER(remote_rank);
-
-            // Need to reregister with the SyncManager, but first need to create a unique name
-            std::string    uname = s->createUniqueGlobalLinkName(local_rank, my_tag, remote_rank, delivery_info);
-            ActivityQueue* sync_q =
-                Simulation_impl::getSimulation()->syncManager->registerLink(remote_rank, local_rank, uname, pair_link);
-            // SyncQueue goes in the non-sync link
-            s->send_queue = sync_q;
-
-            SST_SER(pair_link->defaultTimeBase);
-            SST_SER(pair_link->latency);
-
-            // Need to restore any Tool in the AttachPoint.
-            size_t tool_count;
-            SST_SER(tool_count);
-            if ( tool_count > 0 ) {
-                s->attached_tools = new Link::ToolList();
-                for ( size_t i = 0; i < tool_count; ++i ) {
-                    SST::Core::Serialization::serializable* tool;
-                    uintptr_t                               key;
-                    SST_SER(tool);
-                    Link::AttachPoint* ap = dynamic_cast<Link::AttachPoint*>(tool);
-                    ap->serializeEventAttachPointKey(ser, key);
-                    s->attached_tools->emplace_back(ap, key);
-                }
-            }
-            else {
-                s->attached_tools = nullptr;
-            }
-
-            // We always have our pair link since we serialized it
-            // with us.  Need to send the events on the pair's
-            // send_queue, with the delivery_info stored there. If
-            // this happens to be a PollingLinkQueue, then nothing
-            // will actually get sent since no events would have been
-            // serialized at this point in Link serialization.
-            serialize_events(ser, pair_link->delivery_info, pair_link->send_queue);
-        }
+          We do this by querying the Simulation_impl object to see if
+          the pair link is on the same partition or not.  If it is, it
+          is a regular link, otherwise it is part of a sync link pair.
+        */
         else {
-            // Regular link
+            bool is_orig_sync = type == 3;
 
-            // Pull out the tags for the two links
+            /*
+              Unique identifiers
+
+              Get the ranks and tags for this link and its pair link
+             */
+            RankInfo my_restart_rank = sim->getRank();
+
             uintptr_t my_tag;
-            uintptr_t pair_tag;
+            RankInfo  my_rank;
 
+            uintptr_t pair_tag;
+            RankInfo  pair_rank;
+
+
+            SST_SER(my_rank);
             SST_SER(my_tag);
+
+            if ( is_orig_sync ) {
+                SST_SER(pair_rank);
+            }
+            else {
+                pair_rank = my_rank;
+            }
             SST_SER(pair_tag);
 
-            s = new Link();
-            ser.unpacker().report_new_pointer(reinterpret_cast<uintptr_t>(s));
-            Link* pair_link = nullptr;
+            /*
+              Determine current sync state
+             */
+            RankInfo pair_restart_rank = sim->getRankForLinkOnRestart(pair_rank.rank, pair_tag);
 
-            // Need to check to see if my pair link has been unpacked
-            auto& link_tracker = Simulation_impl::getSimulation()->link_restart_tracking;
-            if ( link_tracker.count(pair_tag) ) {
-                pair_link = link_tracker[pair_tag];
-                link_tracker.erase(pair_tag);
+            // If pair_restart_rank.rank == UNASSIGNED, then we have
+            // the same paritioning as the checkpoint and the ranks
+            // for both links are the same
+            if ( pair_restart_rank.rank == RankInfo::UNASSIGNED ) pair_restart_rank = pair_rank;
 
-                // Set pair link
-                s->pair_link = pair_link;
+            bool is_restart_sync = (my_restart_rank != pair_restart_rank);
 
-                // Set my neighbor's pair link
-                pair_link->pair_link = s;
+            /*
+              Create or get link from tracker
+
+              See if the link has already been created by its pair. If
+              not, create a LinkPair.  This link will be the left link
+              of the pair.
+             */
+            auto&                     link_tracker   = sim->link_restart_tracking;
+            std::pair<int, uintptr_t> my_unique_id   = std::make_pair(my_rank.rank, my_tag);
+            std::pair<int, uintptr_t> pair_unique_id = std::make_pair(pair_rank.rank, pair_tag);
+
+            if ( !is_restart_sync && link_tracker.count(my_unique_id) ) {
+                // Get my link and erase it from the map
+                s = link_tracker[my_unique_id];
+                link_tracker.erase(my_unique_id);
             }
             else {
-                link_tracker[my_tag] = s;
+                // Create a link pair and set s to the left link
+                LinkPair links;
+                s = links.getLeft();
+
+                // Set latency to zero (it defaults to 1) so that the
+                // addition below works properly
+                s->setLatency(0);
+                s->pair_link->setLatency(0);
+
+                // Put my pair link in the tracking map
+                link_tracker[pair_unique_id] = s->pair_link;
             }
 
-
+            /*
+              Get the metadata for the link
+             */
             SST_SER(s->type);
             SST_SER(s->mode);
             SST_SER(s->tag);
 
+            /*
+              Get handler for handler links, or restore the contents
+              of the PollingLinkQueue for polling links
+             */
             if ( s->type == Link::POLL ) {
-                // If I'm a polling link, need to deserialize my
-                // pair's send_queue. For now, I will store it in my
-                // own send_queue variable and swap once we have both
-                // links.
+                // If I'm a polling link, I need to serialize my
+                // pair's send_queue (which is really my receive
+                // queue).  For HANDLER and SYNC links, the send_queue
+                // will be reinitialized after restart.
                 PollingLinkQueue* queue;
                 // PollingLinkQueues don't work with the serialization
                 // functions.  Call things directly.
                 queue = new PollingLinkQueue();
                 queue->serialize_order(ser);
-                s->send_queue = queue;
-            }
-            else {
-                s->send_queue = Simulation_impl::getSimulation()->getTimeVortex();
-            }
-
-            uintptr_t delivery_info;
-            SST_SER(delivery_info);
-
-            Event::HandlerBase* handler;
-            SST_SER(handler);
-            s->delivery_info = reinterpret_cast<uintptr_t>(handler);
-
-            Simulation_impl::getSimulation()->event_handler_restart_tracking[delivery_info] = s->delivery_info;
-
-
-            // If we have a pair link already, swap delivery_info and
-            // send_queue
-            if ( pair_link ) {
-                uintptr_t temp              = s->delivery_info;
-                s->delivery_info            = s->pair_link->delivery_info;
-                s->pair_link->delivery_info = temp;
-
-                // Swap the queues
-                ActivityQueue* queue     = s->send_queue;
-                s->send_queue            = s->pair_link->send_queue;
                 s->pair_link->send_queue = queue;
             }
+            else {
+                // Set the send_queue to the TimeVortex
+                s->pair_link->send_queue = sim->getTimeVortex();
 
+                // Restore the handler for this link.
+                uintptr_t delivery_info;
+                SST_SER(delivery_info);
+
+                Event::HandlerBase* handler;
+                SST_SER(handler);
+                s->pair_link->delivery_info = reinterpret_cast<uintptr_t>(handler);
+
+                // Report the handler for tracking
+                sim->event_handler_restart_tracking[delivery_info] = s->pair_link->delivery_info;
+            }
+
+            /*
+              Get the timing info
+             */
             SST_SER(s->defaultTimeBase);
-            SST_SER(s->latency);
 
-            // Need to restore any Tool in the AttachPoint.
+            // Get the latency. We need to add it to what's already
+            // there, because our pair_link deserialization may have
+            // added latency in the case of a sync link where
+            // Link::addRecvLatency() was called.
+            SimTime_t latency;
+            SST_SER(latency);
+            s->latency += latency;
+
+            // If originally part of a sync pair, need to restore the
+            // pair_link's latency in case Link::addRecvLatency() was
+            // called. We will add this latency to the pair_link
+            // latency because this link pair may no longer be a sync
+            // pair and may already have non-zero latency.
+            if ( is_orig_sync ) {
+                SST_SER(latency);
+                s->pair_link->latency += latency;
+            }
+
+            /*
+              Restore attached tools
+            */
             size_t tool_count;
             SST_SER(tool_count);
             if ( tool_count > 0 ) {
@@ -608,13 +514,33 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
             else {
                 s->attached_tools = nullptr;
             }
-            // If we have a pair_link, delivery_info and queue will be
-            // there.  If not, then this link is still holding them.
-            if ( pair_link ) {
-                serialize_events(ser, pair_link->delivery_info, pair_link->send_queue);
-            }
-            else {
-                serialize_events(ser, s->delivery_info, s->send_queue);
+
+            /*
+              Deserialize the events targetting this link
+             */
+
+            // Need to send the events on the pair's send_queue, with
+            // the delivery_info stored there. If this happens to be a
+            // PollingLinkQueue, then nothing will actually get sent
+            // since no events would have been serialized at this
+            // point in Link serialization.
+            serialize_events(ser, s->pair_link->delivery_info, s->pair_link->send_queue);
+
+            // Need to finish initializing the links if this is now a
+            // sync link.
+            if ( is_restart_sync ) {
+                s->pair_link->type = Link::SYNC;
+                s->pair_link->mode = s->mode;
+                s->pair_link->tag  = s->tag;
+
+                s->pair_link->defaultTimeBase = 1;
+
+                // Need to register with the SyncManager, but first
+                // need to create a unique name
+                std::string    uname = s->createUniqueGlobalLinkName(my_rank, my_tag, pair_rank, pair_tag);
+                ActivityQueue* sync_q =
+                    sim->syncManager->registerLink(pair_restart_rank, my_restart_rank, uname, s->pair_link);
+                s->send_queue = sync_q;
             }
         }
         break;

--- a/src/sst/core/linkPair.h
+++ b/src/sst/core/linkPair.h
@@ -36,6 +36,19 @@ public:
         right->pair_link = left;
     }
 
+    /** Create a new LinkPair.  This is used on restart.
+     * @param order Value used to enforce the link order.
+     */
+    LinkPair() :
+        left(new Link()),
+        right(new Link())
+    {
+        my_id = -1;
+
+        left->pair_link  = right;
+        right->pair_link = left;
+    }
+
     /** Create a new LinkPair.  This is used when the endpoints are in different partitions.
      * @param order Value used to enforce the link order.
      * @param remote_tag Used to look up the correct link on the other side.

--- a/src/sst/core/shared/sharedObject.h
+++ b/src/sst/core/shared/sharedObject.h
@@ -21,6 +21,9 @@
 #include <mutex>
 #include <string>
 
+/* Forward declare for Friendship */
+extern int main(int argc, char** argv);
+
 namespace SST {
 
 class Simulation_impl;
@@ -213,7 +216,7 @@ protected:
     ImplementVirtualSerializable(SharedObjectData);
 };
 
-class SharedObjectDataManager : public SST::Core::Serialization::serializable
+class SharedObjectDataManager //: public SST::Core::Serialization::serializable
 {
 
     std::map<std::string, SharedObjectData*> shared_data;
@@ -267,8 +270,7 @@ public:
 
     void updateState(bool finalize);
 
-    void serialize_order(SST::Core::Serialization::serializer& ser) override { SST_SER(shared_data); }
-    ImplementSerializable(SST::Shared::SharedObjectDataManager)
+    void serialize_order(SST::Core::Serialization::serializer& ser) { SST_SER(shared_data); }
 };
 
 class SharedObject : public SST::Core::Serialization::serializable
@@ -288,6 +290,10 @@ public:
 
 protected:
     friend class SST::Simulation_impl;
+
+    // To enable main to initialize manager on restart
+    friend int ::main(int argc, char** argv);
+
     static SharedObjectDataManager manager;
 
     void incPublishCount(SharedObjectData* data) { data->incPublishCount(); }

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -214,7 +214,7 @@ public:
      */
     void processGraphInfo(ConfigGraph& graph, const RankInfo& myRank, SimTime_t min_part);
 
-    int  initializeStatisticEngine(ConfigGraph& graph);
+    int  initializeStatisticEngine(StatsConfig* stats_config);
     int  prepareLinks(ConfigGraph& graph, const RankInfo& myRank, SimTime_t min_part);
     int  performWireUp(ConfigGraph& graph, const RankInfo& myRank, SimTime_t min_part);
     void exchangeLinkInfo();
@@ -285,7 +285,6 @@ public:
     BaseComponent* getComponent(const ComponentId_t& id) const
     {
         ComponentInfo* i = compInfoMap.getByID(id);
-        // CompInfoMap_t::const_iterator i = compInfoMap.find(id);
         if ( nullptr != i ) {
             return i->getComponent();
         }
@@ -299,7 +298,6 @@ public:
     ComponentInfo* getComponentInfo(const ComponentId_t& id) const
     {
         ComponentInfo* i = compInfoMap.getByID(id);
-        // CompInfoMap_t::const_iterator i = compInfoMap.find(id);
         if ( nullptr != i ) {
             return i;
         }
@@ -481,7 +479,6 @@ public:
     std::vector<SimTime_t>  interThreadLatencies;
     SimTime_t               interThreadMinLatency = MAX_SIMTIME_T;
     SyncManager*            syncManager;
-    // ThreadSync*      threadSync;
     ComponentInfoMap        compInfoMap;
     clockMap_t              clockMap;
     static Exit*            m_exit;
@@ -650,7 +647,8 @@ public:
     std::string                    globalOutputFileName = "";
 
     // Config object used by the simulation
-    static Config config;
+    static Config       config;
+    static StatsConfig* stats_config_;
 
     void printSimulationState();
 

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -416,6 +416,14 @@ public:
         int checkpoint_id, const std::string& registry_filename, const std::string& globals_filename);
     void restart();
 
+    /**
+       Function used to get the rank for a link on restart.  A rank of
+       -1 on the return means that the paritioning stayed the same
+       between checkpoint and restart and the original rank info
+       stored in the checkpoint should be used.
+     */
+    RankInfo getRankForLinkOnRestart(int UNUSED(rank), uintptr_t UNUSED(tag)) { return RankInfo(); }
+
     void initialize_interactive_console(const std::string& type);
 
     /** Factory used to generate the simulation components */
@@ -640,11 +648,11 @@ public:
     static std::vector<Simulation_impl*>                         instanceVec_;
 
     /******** Checkpoint/restart tracking data structures ***********/
-    std::map<uintptr_t, Link*>     link_restart_tracking;
-    std::map<uintptr_t, uintptr_t> event_handler_restart_tracking;
-    uint32_t                       checkpoint_id_       = 0;
-    std::string                    checkpoint_prefix_   = "";
-    std::string                    globalOutputFileName = "";
+    std::map<std::pair<int, uintptr_t>, Link*> link_restart_tracking;
+    std::map<uintptr_t, uintptr_t>             event_handler_restart_tracking;
+    uint32_t                                   checkpoint_id_       = 0;
+    std::string                                checkpoint_prefix_   = "";
+    std::string                                globalOutputFileName = "";
 
     // Config object used by the simulation
     static Config       config;

--- a/src/sst/core/statapi/statengine.cc
+++ b/src/sst/core/statapi/statengine.cc
@@ -39,10 +39,10 @@ StatisticProcessingEngine::StatisticProcessingEngine() :
 
 
 void
-StatisticProcessingEngine::static_setup(ConfigGraph* graph)
+StatisticProcessingEngine::static_setup(StatsConfig* stats_config)
 {
     // Outputs are per MPI rank, so have to be static data
-    for ( auto& cfg : graph->getStatOutputs() ) {
+    for ( auto& cfg : stats_config->outputs ) {
         m_statOutputs.push_back(createStatisticOutput(cfg));
     }
 }
@@ -65,15 +65,15 @@ StatisticProcessingEngine::stat_outputs_simulation_end()
 
 
 void
-StatisticProcessingEngine::setup(Simulation_impl* sim, ConfigGraph* graph)
+StatisticProcessingEngine::setup(Simulation_impl* sim, StatsConfig* stats_config)
 {
     m_sim = sim;
 
     m_SimulationStarted = false;
-    m_statLoadLevel     = graph->getStatLoadLevel();
+    m_statLoadLevel     = stats_config->load_level;
 
     m_defaultGroup.output = m_statOutputs[0];
-    for ( auto& cfg : graph->getStatGroups() ) {
+    for ( auto& cfg : stats_config->groups ) {
         m_statGroups.emplace_back(cfg.second, this);
     }
 }

--- a/src/sst/core/statapi/statengine.h
+++ b/src/sst/core/statapi/statengine.h
@@ -39,6 +39,7 @@ class ConfigGraph;
 class ConfigStatGroup;
 class ConfigStatOutput;
 class Params;
+struct StatsConfig;
 
 namespace Statistics {
 
@@ -87,7 +88,7 @@ public:
     /** Called to setup the StatOutputs, which are shared across all
        the StatEngines on the same MPI rank.
      */
-    static void static_setup(ConfigGraph* graph);
+    static void static_setup(StatsConfig* stats_config);
 
     /** Called to notify StatOutputs that simulation has started
      */
@@ -106,7 +107,7 @@ private:
     friend void ::finalize_statEngineConfig();
 
     StatisticProcessingEngine();
-    void setup(Simulation_impl* sim, ConfigGraph* graph);
+    void setup(Simulation_impl* sim, StatsConfig* stats_config);
     void restart(Simulation_impl* sim);
     ~StatisticProcessingEngine();
 


### PR DESCRIPTION
All information in Simulation_impl is now regenerated on restart.  This will allow for repartitioned restarts.