### PR TITLE
Print diff on failure for tests that generate them

### DIFF
--- a/tests/testsuite_default_Checkpoint.py
+++ b/tests/testsuite_default_Checkpoint.py
@@ -170,6 +170,9 @@ class testcase_Checkpoint(SSTTestCase):
             StartsWithFilter("WARNING: No components are assigned") ]
 
         cmp_result = testing_compare_filtered_diff("NeedSomethingHere", outfile_cpt, reffile, True, filters_cpt)
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output from original checkpoint run {0} did not match reference file {1}".format(outfile_cpt, reffile))
 
         prefix_rst = teststr + "_rst"
@@ -198,6 +201,9 @@ class testcase_Checkpoint(SSTTestCase):
             StartsWithFilter("WARNING: No components are assigned") ]
 
         cmp_result = testing_compare_filtered_diff("PortModule", outfile_rst, reffile, True, filters_rst)
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile_rst, reffile))
 
         ## Optionally run from restart
@@ -215,4 +221,7 @@ class testcase_Checkpoint(SSTTestCase):
             CheckpointInfoFilter() ]
 
         cmp_result = testing_compare_filtered_diff("PortModule", outfile_cr, reffile, True, filters_cr)
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile_cr, reffile))

--- a/tests/testsuite_default_Component.py
+++ b/tests/testsuite_default_Component.py
@@ -60,5 +60,8 @@ class testcase_Component(SSTTestCase):
             testfile = errfile
 
         cmp_result = testing_compare_filtered_diff(testtype, testfile, reffile, sort=True, filters=[filter1,filter2])
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))
 

--- a/tests/testsuite_default_ComponentExtension.py
+++ b/tests/testsuite_default_ComponentExtension.py
@@ -57,5 +57,8 @@ class testcase_ComponentExtension(SSTTestCase):
             testfile = errfile
 
         cmp_result = testing_compare_filtered_diff(testtype, testfile, reffile, sort=True, filters=[filter1,filter2])
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))
 

--- a/tests/testsuite_default_Links.py
+++ b/tests/testsuite_default_Links.py
@@ -63,5 +63,8 @@ class testcase_Links(SSTTestCase):
             cmpfile = errfile
             filters.append(RemoveRegexFromLineFilter(r"FATAL: (\[[0-9]+:[0-9]+\])* "))
             cmp_result = testing_compare_filtered_diff("Links_{0}".format(testtype), errfile, reffile, rc == 0, filters)
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(cmpfile, reffile))
 

--- a/tests/testsuite_default_MemPoolTest.py
+++ b/tests/testsuite_default_MemPoolTest.py
@@ -53,4 +53,7 @@ class testcase_StatisticComponent(SSTTestCase):
         filter1 = StartsWithFilter("WARNING: No components are")
         filter2 = StartsWithFilter("#")
         cmp_result = testing_compare_filtered_diff(testtype, outfile, reffile, True, [filter1, filter2])
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))

--- a/tests/testsuite_default_Module.py
+++ b/tests/testsuite_default_Module.py
@@ -53,5 +53,8 @@ class testcase_Module(SSTTestCase):
             # Appears in multi-thread/rank runs since we just have one component, filter it out
             StartsWithFilter("WARNING: No components are") ]
         cmp_result = testing_compare_filtered_diff(testtype, outfile, reffile, True, filters)
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))
 

--- a/tests/testsuite_default_Output.py
+++ b/tests/testsuite_default_Output.py
@@ -72,6 +72,9 @@ class testcase_Output(SSTTestCase):
 
         if ( ranks == 1 and threads == 1 ):
             cmp_result = testing_compare_filtered_diff("tracefunction", outfile, reffile, False, filters)
+            if not cmp_result:
+                diffdata = testing_get_diff_data(testtype)
+                log_failure(diffdata)
             self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))
         else:
             cmp_result = True
@@ -82,6 +85,9 @@ class testcase_Output(SSTTestCase):
                     tf_filter.setPrefix("[{0}:{1}] ".format(r,t))
                     cmp_result &= testing_compare_filtered_diff("tracefunction", outfile, reffile, False, filters)
 
+            if not cmp_result:
+                diffdata = testing_get_diff_data(testtype)
+                log_failure(diffdata)
             self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))
             
                     

--- a/tests/testsuite_default_ParamComponent.py
+++ b/tests/testsuite_default_ParamComponent.py
@@ -47,4 +47,7 @@ class testcase_ParamComponent(SSTTestCase):
         filter2 = StartsWithFilter("#")
         ws_filter = IgnoreWhiteSpaceFilter()
         cmp_result = testing_compare_filtered_diff(testtype, outfile, reffile, True, [filter1, filter2, ws_filter])
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))

--- a/tests/testsuite_default_PerfComponent.py
+++ b/tests/testsuite_default_PerfComponent.py
@@ -45,6 +45,9 @@ class testcase_PerfComponent(SSTTestCase):
         
         # Perform the test of the standard simulation output
         cmp_result = testing_compare_sorted_diff(testtype, outfile, reffile)
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))
 
         #save off the performance data

--- a/tests/testsuite_default_PortModule.py
+++ b/tests/testsuite_default_PortModule.py
@@ -208,6 +208,9 @@ class testcase_PortModule(SSTTestCase):
             filter1 = StartsWithFilter("#")
                 
             cmp_result = testing_compare_filtered_diff("PortModule", outfile, reffile, True, filter1)
+            if not cmp_result:
+                diffdata = testing_get_diff_data(testtype)
+                log_failure(diffdata)
             self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))
         else:
             # Need to rerun from the checkpoint, then compare this output against the reffile
@@ -221,4 +224,7 @@ class testcase_PortModule(SSTTestCase):
             filter1.apply_to_out_file = False
                 
             cmp_result = testing_compare_filtered_diff("PortModule", outfile, reffile, True, filter1)
+            if not cmp_result:
+                diffdata = testing_get_diff_data(testtype)
+                log_failure(diffdata)
             self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))

--- a/tests/testsuite_default_Serialization.py
+++ b/tests/testsuite_default_Serialization.py
@@ -90,4 +90,7 @@ class testcase_Serialization(SSTTestCase):
         # Perform the test
         filter1 = StartsWithFilter("WARNING: No components are")
         cmp_result = testing_compare_filtered_diff("serialization", outfile, reffile, True, [filter1])
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))

--- a/tests/testsuite_default_StatisticsComponent.py
+++ b/tests/testsuite_default_StatisticsComponent.py
@@ -72,13 +72,22 @@ class testcase_StatisticComponent(SSTTestCase):
 
         filters = [ StartsWithFilter("WARNING: No components are"), StartsWithFilter("#") ]
         cmp_result = testing_compare_filtered_diff(testtype, outfile, reffile, True, filters)
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))
 
         filter2 = StartsWithFilter("ComponentName, StatisticName,")
         cmp_result = testing_compare_filtered_diff(testtype, out_group_stat_file_csv, ref_group_stat_file_csv, True, [filter2])
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(out_group_stat_file_csv, ref_group_stat_file_csv))
 
         cmp_result = testing_compare_filtered_diff(testtype, out_group_stat_file_txt, ref_group_stat_file_txt, True)
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(out_group_stat_file_txt, ref_group_stat_file_txt))
 
         # Generate raw H5 output

--- a/tests/testsuite_default_SubComponent.py
+++ b/tests/testsuite_default_SubComponent.py
@@ -97,5 +97,8 @@ class testcase_SubComponent(SSTTestCase):
             StartsWithFilter("WARNING: No components are"),
             CheckpointInfoFilter() ]
         cmp_result = testing_compare_filtered_diff(testtype, outfile, reffile, sort=True, filters=filters)
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))
 

--- a/tests/testsuite_default_config_input_output.py
+++ b/tests/testsuite_default_config_input_output.py
@@ -101,4 +101,7 @@ class testcase_Config_input_output(SSTTestCase):
 
         # Perform the test
         cmp_result = testing_compare_sorted_diff(testtype, outfile_ref, outfile_check)
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile_ref, outfile_check))

--- a/tests/testsuite_default_partitioner.py
+++ b/tests/testsuite_default_partitioner.py
@@ -59,4 +59,7 @@ class testcase_Partitioners(SSTTestCase):
 
         # Perform the test
         cmp_result = testing_compare_sorted_diff(testtype, outfile_ref, outfile_check)
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile_ref, outfile_check))

--- a/tests/testsuite_default_profiling.py
+++ b/tests/testsuite_default_profiling.py
@@ -71,4 +71,7 @@ class testcase_Profiling(SSTTestCase):
 
         # Perform the test
         cmp_result = testing_compare_sorted_diff(testtype, checkfile, reffile)
+        if not cmp_result:
+            diffdata = testing_get_diff_data(testtype)
+            log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(outfile, reffile))


### PR DESCRIPTION
Redo of https://github.com/sstsimulator/sst-core/pull/1377

Part of https://github.com/sstsimulator/sst-core/issues/1061.

I think a better implementation, and the one I started with, is to have the core functions return the diff result lines rather than a success flag.  The problem with doing this is that the current functions return true if there is no diff (success), but truthiness of a Python collection is true if it holds things (there is a diff) and false if empty (there is no diff).  This means that every single `testing_compare*` usage needs to have its logic flipped and is a breaking change for users.

Instead I saw in `testsuite_default_UnitAlgebra.py` that the diff lines are read from a file and printed before the respective assertion if it is going to fail, so I copied that idea.

Attached is the original implementation patch for posterity.

---

```patch
diff --git src/sst/core/testingframework/sst_unittest_support.py src/sst/core/testingframework/sst_unittest_support.py
index 4bc0d584..332e5398 100644
--- src/sst/core/testingframework/sst_unittest_support.py
+++ src/sst/core/testingframework/sst_unittest_support.py
@@ -1426,7 +1426,7 @@ def testing_compare_filtered_diff(
     sort: bool = False,
     filters: Union[LineFilter, List[LineFilter]] = list(),
     do_statistics_comparison: bool = False,
-) -> bool:
+) -> List[str]:
     """Filter, optionally sort and then compare 2 files for a difference.

         Args:
@@ -1439,8 +1439,10 @@ def testing_compare_filtered_diff(
               in order, but will break early if any filter returns None

         Returns:
-            (bool) True if the 2 sorted files match
-
+            (list[str]) The contents of a possible diff.  If the list is empty,
+              the files were identical after applying the optional sort and filters.
+              Evaluating the output as a boolean will give True if there were any
+              differences and False if there were none.
     """

     check_param_type("test_name", test_name, str)
@@ -1452,32 +1454,34 @@ def testing_compare_filtered_diff(

     if not os.path.isfile(outfile):
         log_error("Cannot diff files: Out File {0} does not exist".format(outfile))
-        return False
+        return []

     if not os.path.isfile(reffile):
         log_error("Cannot diff files: Ref File {0} does not exist".format(reffile))
-        return False
+        return []

     # Read in the output and reference files, and optionally sorting them
     out_lines = _read_and_filter(outfile, filters, sort, False)
     ref_lines = _read_and_filter(reffile, filters, sort, True)

-    # Get the diff between the files
-    diff = difflib.unified_diff(out_lines,ref_lines,outfile,reffile,n=1)
+    # Get the diff between the files.  We exhaust the diff generator
+    # immediately in order to always work with the list of diff lines.
+    # Because of truthiness
+    # (https://docs.python.org/3/library/stdtypes.html#truth-value-testing),
+    # an empty list (no differences) will evaluate as false and one with
+    # elements (differences between files) will evaluate as true.
+    diff = list(difflib.unified_diff(out_lines, ref_lines, outfile, reffile, n=1))

-    # Write the diff to a file and count the number of lines of output
-    # to determine if they matched or not (the output of the diff is a
-    # generator, so the only way to see if it's empty is to start to
-    # write the data).
+    # Write the diff to a file; it can later be recalled using the
+    # `testing_get_diff_data` function.
     diff_file = "{1}/{0}_diff_file".format(test_name, test_output_get_tmp_dir())
-    count = 0
     with open(diff_file, "w") as fp:
-        for line in diff:
-            fp.write(line)
-            count += 1
+        fp.write("\n".join(diff))
+
+    # Files are the same if there were no lines of diff output (the list is
+    # empty).
+    return diff

-    # Files are the same if there were no lines of diff output
-    return count == 0

 ###

```