### PR TITLE
Enforce minimum Python version of 3.9

### DIFF
--- a/config/sst_check_python.m4
+++ b/config/sst_check_python.m4
@@ -16,8 +16,8 @@ dnl check if user provided a specific python-config
 dnl search python3-config
   AS_IF([test $PYTHON_CONFIG_EXE = "no"],
     [AS_IF([test -n "$with_python"],
-        [AC_PATH_PROGS([PYTHON_CONFIG_EXE], ["python3-config" "python3.11-config" "python3.10-config" "python3.9-config" "python3.8-config" "python3.7-config" "python3.6-config"], ["no"], ["$with_python/bin"])],
-        [AC_PATH_PROGS([PYTHON_CONFIG_EXE], ["python3-config" "python3.11-config" "python3.10-config" "python3.9-config" "python3.8-config" "python3.7-config" "python3.6-config"], ["no"])])])
+        [AC_PATH_PROGS([PYTHON_CONFIG_EXE], ["python3-config" "python3.13-config" "python3.12-config" "python3.11-config" "python3.10-config" "python3.9-config"], ["no"], ["$with_python/bin"])],
+        [AC_PATH_PROGS([PYTHON_CONFIG_EXE], ["python3-config" "python3.13-config" "python3.12-config" "python3.11-config" "python3.10-config" "python3.9-config"], ["no"])])])
 
 dnl search python-config
   AS_IF([test $PYTHON_CONFIG_EXE = "no"],
@@ -44,8 +44,8 @@ dnl Assume a consistent naming convention for pythonX and pythonX-config
   AC_PATH_PROGS([PYTHON_EXE], ["$PYTHON_NAME"], [""], ["$PYTHON_PREFIX/bin"])
 
 
-dnl Error if python version < 3.6
-  AM_PYTHON_CHECK_VERSION([$PYTHON_EXE], [3.6], [PYTHON_VERSION3="yes"], [AC_MSG_ERROR([Python version must be >= 3.6])])
+dnl Error if python version < 3.9
+  AM_PYTHON_CHECK_VERSION([$PYTHON_EXE], [3.9], [PYTHON_VERSION3="yes"], [AC_MSG_ERROR([Python version must be >= 3.9])])
 
 dnl Python3.8+ doesn't link to lpython by default
   AM_PYTHON_CHECK_VERSION([$PYTHON_EXE], [3.8], [PYTHON_LIBS=`$PYTHON_CONFIG_EXE --libs --embed`], [])

--- a/experimental/CMakeLists.txt
+++ b/experimental/CMakeLists.txt
@@ -47,7 +47,7 @@ unset(_REQUIRED_CXX_STANDARD)
 # Don't change this path to SST_TOP_SRC_DIR cmake lives in experimental for now.
 list(APPEND CMAKE_MODULE_PATH ${sst-core_SOURCE_DIR}/cmake)
 
-find_package(Python 3.6 REQUIRED COMPONENTS Interpreter Development)
+find_package(Python 3.9 REQUIRED COMPONENTS Interpreter Development)
 find_package(Threads)
 
 option(SST_DISABLE_ZLIB "Use zlib compression library" OFF)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 cache_dir = "build/.mypy_cache"
 explicit_package_bases = true
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src/sst/core/testingframework"
-python_version = "3.6"
+python_version = "3.9"
 
 strict = true
 warn_unused_ignores = true
@@ -22,13 +22,12 @@ module = [
 ignore_missing_imports = true
 
 [tool.pyright]
-pythonVersion = "3.6"
+pythonVersion = "3.9"
 
 [tool.ruff]
 cache-dir = "build/.ruff_cache"
 line-length = 100
-# This should be 3.6 but is not supported with the newest versions of ruff.
-target-version = "py37"
+target-version = "py39"
 
 [tool.ruff.lint]
 ignore = [

--- a/src/sst/core/testingframework/sst_unittest_support.py
+++ b/src/sst/core/testingframework/sst_unittest_support.py
@@ -2180,7 +2180,7 @@ def os_extract_tar(tarfilepath: str, targetdir: str = ".") -> bool:
     try:
         this_tar = tarfile.open(tarfilepath)
         if sys.version_info.minor >= 12:
-            this_tar.extractall(targetdir, filter="data")  # type: ignore [call-arg]
+            this_tar.extractall(targetdir, filter="data")
         else:
             this_tar.extractall(targetdir)
         this_tar.close()


### PR DESCRIPTION
Part of #1376.  There should be follow-ups to:
- Modernize the Python code in the test framework to use 3.9 language constructs
- Remove any pre-3.9-specific CPython code from the source

This PR will fail if there are any jobs using pre-3.9 versions.