### PR TITLE
GitHub Actions: Initial addition of free macOS runners

### DIFF
--- a/.github/scripts/compilers.bash
+++ b/.github/scripts/compilers.bash
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# compilers.bash: Common logic for compiling SST, specifically setting up
+# compiler environment variables.
+#
+# Note: some variables appear unused because this file is sourced, not
+# executed, in order to avoid polluting the environment.
+
+set -eo pipefail
+
+# To use this, the desired compiler must be registered with Spack (shown under
+# `spack compilers`).  However, it is not `spack load`ed into the environment,
+# but only its CC and CXX paths exported.
+source_compilers_nompi() {
+    local spack_compiler_spec="${1}"
+
+    # SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+    # TODO need to install Spack first.
+    # local compiler_paths
+    # compiler_paths="$(spack python "${SCRIPTDIR}"/spack_get_compilers.py --spec "${spack_compiler_spec}")"
+    # CC="$(echo "${compiler_paths}" | jq -r .c)"
+    # CXX="$(echo "${compiler_paths}" | jq -r .cxx)"
+    CC="$(command -v gcc)"
+    CXX="$(command -v g++)"
+    export CC
+    export CXX
+
+    if [[ -n "${CLANG_LIBCXX}" ]]; then
+        export CXXFLAGS="-stdlib=libc++"
+    fi
+
+    export CC
+    export CXX
+}
+
+source_compilers_mpi() {
+    local spack_compiler_spec="${1}"
+
+    source_compilers_nompi "${spack_compiler_spec}"
+
+    # local ompi_version="4.1.5"
+    # local ompi_loc
+    # shellcheck disable=SC2086
+    # TODO need to install Spack first.
+    # ompi_loc="$(spack location -i openmpi@${ompi_version} %${spack_compiler_spec})"
+    # export MPICC="${ompi_loc}"/bin/mpicc
+    # export MPICXX="${ompi_loc}"/bin/mpicxx
+    # export CPPFLAGS="-I${ompi_loc}/include"
+    MPICC="$(command -v mpicc)"
+    MPICXX="$(command -v mpicxx)"
+    export MPICC
+    export MPICXX
+}
+
+# delete '@' and '=' characters if present
+clean_suffix() {
+    local suffix="${1}"
+    local tmp="${suffix//@/}"
+    local cleaned="${tmp//=/}"
+    echo "${cleaned}"
+}
+
+# Handle the case where the Pin binary is on the path but the SST-specific
+# environment variable needed for the compile and link lines isn't present.
+# if [[ -z "${INTEL_PIN_DIRECTORY}" ]]; then
+#     pinloc="$(command -v pin)"
+#     if [[ -n "${pinloc}" ]]; then
+#         INTEL_PIN_DIRECTORY="$(dirname "$(dirname "${pinloc}")")"
+#         export INTEL_PIN_DIRECTORY
+#     fi
+# fi
+
+bear_make_install() {
+    if command -v bear >& /dev/null; then
+        "$(command -v bear)" -- make install
+    else
+        make install
+    fi
+}

--- a/.github/scripts/core_autotools_noflags_nodeps.sh
+++ b/.github/scripts/core_autotools_noflags_nodeps.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# core_autotools_noflags_nodeps.sh: Compile and install core, using the
+# Autotools build system, without explicitly specifying any additional build
+# dependencies at configure time.
+
+# shellcheck disable=SC2086
+# https://web.archive.org/web/20230401201759/https://wiki.bash-hackers.org/scripting/debuggingtips#making_xtrace_more_useful
+export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+set -x
+
+set -eo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}"/compilers.bash
+
+toolchain="${1}"
+
+source_compilers_mpi "${toolchain}"
+
+suffix="$(clean_suffix autotools_noflags_nodeps_${toolchain})"
+
+dir_src="${PWD}/sst-core"
+dir_build="${PWD}"/sst-core-build-${suffix}
+dir_install="${PWD}"/install_${suffix}
+
+\rm -rf "${dir_build}" || true
+\rm -rf "${dir_install}" || true
+
+pushd "${dir_src}"
+git clean -Xdf .
+./autogen.sh
+popd
+
+mkdir -p "${dir_build}"
+pushd "${dir_build}"
+
+INSTALL="$(command -v install) -p" "${dir_src}"/configure \
+       --prefix="${dir_install}"
+
+bear_make_install
+ln -fsv "${dir_build}"/compile_commands.json "${dir_src}"/compile_commands.json
+# no installation available
+# make html

--- a/.github/scripts/core_autotools_noflags_nodeps_nompi.sh
+++ b/.github/scripts/core_autotools_noflags_nodeps_nompi.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# core_autotools_noflags_nodeps_nompi.sh: Compile and install core, using the
+# Autotools build system, without explicitly specifying any additional build
+# dependencies at configure time.  MPI is explicitly disabled.
+
+# shellcheck disable=SC2086
+# https://web.archive.org/web/20230401201759/https://wiki.bash-hackers.org/scripting/debuggingtips#making_xtrace_more_useful
+export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+set -x
+
+set -eo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}"/compilers.bash
+
+toolchain="${1}"
+
+source_compilers_nompi "${toolchain}"
+
+suffix="$(clean_suffix autotools_noflags_nodeps_nompi_${toolchain})"
+
+dir_src="${PWD}/sst-core"
+dir_build="${PWD}"/sst-core-build-${suffix}
+dir_install="${PWD}"/install_${suffix}
+
+\rm -rf "${dir_build}" || true
+\rm -rf "${dir_install}" || true
+
+pushd "${dir_src}"
+git clean -Xdf .
+./autogen.sh
+popd
+
+mkdir -p "${dir_build}"
+pushd "${dir_build}"
+
+INSTALL="$(command -v install) -p" "${dir_src}"/configure \
+       --disable-mpi \
+       --prefix="${dir_install}"
+
+bear_make_install
+ln -fsv "${dir_build}"/compile_commands.json "${dir_src}"/compile_commands.json
+# no installation available
+# make html

--- a/.github/scripts/elements_autotools_noflags_nodeps.sh
+++ b/.github/scripts/elements_autotools_noflags_nodeps.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# elements_autotools_noflags_nodeps.sh: TODO
+
+# shellcheck disable=SC2086
+# https://web.archive.org/web/20230401201759/https://wiki.bash-hackers.org/scripting/debuggingtips#making_xtrace_more_useful
+export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+set -x
+
+set -eo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}"/compilers.bash
+
+toolchain="${1}"
+
+source_compilers_mpi "${toolchain}"
+
+suffix="$(clean_suffix autotools_noflags_nodeps_${toolchain})"
+
+dir_src="${PWD}"/sst-elements
+dir_build="${PWD}"/sst-elements-build-${suffix}
+dir_core="${PWD}"/install_${suffix}
+dir_install="${dir_core}"
+
+\rm -rf "${dir_build}" || true
+# \rm -rf "${dir_install}" || true
+
+pushd "${dir_src}"
+git clean -Xdf .
+./autogen.sh
+popd
+
+mkdir -p "${dir_build}"
+pushd "${dir_build}"
+
+[ -n "${INTEL_PIN_DIRECTORY}" ] && PIN_TEXT="--with-pin=${INTEL_PIN_DIRECTORY}" || PIN_TEXT="--without-pin"
+INSTALL="$(command -v install) -p" "${dir_src}"/configure \
+       "${PIN_TEXT}" \
+       --prefix="${dir_install}" \
+       --with-sst-core="${dir_core}"
+
+bear_make_install
+ln -fsv "${dir_build}"/compile_commands.json "${dir_src}"/compile_commands.json

--- a/.github/scripts/elements_autotools_noflags_nodeps_nompi.sh
+++ b/.github/scripts/elements_autotools_noflags_nodeps_nompi.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# elements_autotools_noflags_nodeps_nompi.sh: TODO
+
+# shellcheck disable=SC2086
+# https://web.archive.org/web/20230401201759/https://wiki.bash-hackers.org/scripting/debuggingtips#making_xtrace_more_useful
+export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+set -x
+
+set -eo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}"/compilers.bash
+
+toolchain="${1}"
+
+source_compilers_nompi "${toolchain}"
+
+suffix="$(clean_suffix autotools_noflags_nodeps_nompi_${toolchain})"
+
+dir_src="${PWD}"/sst-elements
+dir_build="${PWD}"/sst-elements-build-${suffix}
+dir_core="${PWD}"/install_${suffix}
+dir_install="${dir_core}"
+
+\rm -rf "${dir_build}" || true
+# \rm -rf "${dir_install}" || true
+
+pushd "${dir_src}"
+git clean -Xdf .
+./autogen.sh
+popd
+
+mkdir -p "${dir_build}"
+pushd "${dir_build}"
+
+[ -n "${INTEL_PIN_DIRECTORY}" ] && PIN_TEXT="--with-pin=${INTEL_PIN_DIRECTORY}" || PIN_TEXT="--without-pin"
+INSTALL="$(command -v install) -p" "${dir_src}"/configure \
+       "${PIN_TEXT}" \
+       --with-sst-core="${dir_core}" \
+       --prefix="${dir_install}"
+
+bear_make_install
+ln -fsv "${dir_build}"/compile_commands.json "${dir_src}"/compile_commands.json

--- a/.github/scripts/install_os_level_dependencies.sh
+++ b/.github/scripts/install_os_level_dependencies.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# install_os_level_dependencies.sh: Install dependencies at the operating
+# system level needed for GitHub Actions CI runs.
+
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+if command -v brew; then
+    brew install \
+         autoconf \
+         automake \
+         ccache \
+         coreutils \
+         doxygen \
+         libtool \
+         ncurses \
+         open-mpi \
+         pygments
+    python -m pip install blessings
+elif command -v dnf >/dev/null 2>&1; then
+    dnf upgrade -y
+elif command -v apt-get; then
+    sudo apt-get -y update
+    sudo apt-get -y install \
+         autoconf \
+         automake \
+         doxygen \
+         libopenmpi-dev \
+         libtool-bin \
+         python3-blessings \
+         python3-pygments
+elif command -v pacman >/dev/null 2>&1; then
+    pacman -Syu --noconfirm
+    pacman -S --noconfirm \
+           autoconf \
+           automake \
+           ccache \
+           gcc \
+           make \
+           ncurses \
+           openmpi \
+           python \
+           wget
+fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,38 @@
+---
+name: sst-core build/install/test
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+
+concurrency:
+  group: build-and-test-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  # Jobs depend on the output of pre-checks to run.
+  # Cancels new workflows if prior runs were successful (same tree hash)
+  pre-checks:
+    runs-on: ubuntu-24.04
+    # actions: write needed by skip-duplicate-actions
+    permissions:
+      actions: write
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1
+        with:
+          skip_after_successful_duplicate: 'true'
+  macos-14:
+    needs: pre-checks
+    if: ${{ needs.pre-checks.outputs.should_skip != 'true' }}
+    uses:
+      ./.github/workflows/free-macos-14.yml
+  macos-15:
+    needs: pre-checks
+    if: ${{ needs.pre-checks.outputs.should_skip != 'true' }}
+    uses:
+      ./.github/workflows/free-macos-15.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,33 @@ name: ci
 on:
   push:
   pull_request:
+    types:
+      - opened
+      - synchronize
 
 concurrency:
   group: ci-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   prechecks:
     uses: ./.github/workflows/pre-commit.yml
   all-prechecks:
     needs: [prechecks]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Success
+        run: "true"
+  tests:
+    needs: [all-prechecks]
+    uses: ./.github/workflows/build_and_test.yml
+    permissions:
+      actions: write
+  all-tests:
+    needs: [tests]
+    runs-on: ubuntu-24.04
     steps:
       - name: Success
         run: "true"

--- a/.github/workflows/free-macos-14.yml
+++ b/.github/workflows/free-macos-14.yml
@@ -1,0 +1,84 @@
+---
+name: Build/test on macOS 14
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  macos-14:
+    runs-on: macos-14
+    steps:
+
+      - name: Clone core
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          path: sst-core
+          persist-credentials: false
+
+      - name: Clone elements
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          path: sst-elements
+          persist-credentials: false
+          ref: devel
+          repository: sstsimulator-at2/sst-elements
+
+      - name: Install system-level dependencies
+        run: |
+          sst-core/.github/scripts/install_os_level_dependencies.sh
+
+      - name: Install and configure ccache
+        uses: hendrikmuhs/ccache-action@63069e3931dedbf3b63792097479563182fe70d1  # v1.2
+        with:
+          append-timestamp: false
+          create-symlink: true
+          key: >-
+            ccache-${{ github.job }}
+          max-size: "2GB"
+          verbose: 2
+
+      - name: Set environment variables
+        run: |
+          MAKEFLAGS="-j$(nproc)"
+          echo "MAKEFLAGS=${MAKEFLAGS}" >> "${GITHUB_ENV}"
+          echo "TERM=dumb" >> "${GITHUB_ENV}"
+
+      - name: Compile core
+        run: |
+          # TODO the argument does nothing as long as Spack is unavailable
+          sst-core/.github/scripts/core_autotools_noflags_nodeps.sh gcc
+
+      - name: Test core
+        run: |
+          install_autotools_noflags_nodeps_gcc/bin/sst-test-core
+
+      - name: Save sst_test_outputs after core tests
+        uses: actions/upload-artifact@v4
+        with:
+          name: sst_test_outputs_core_free-macos-14
+          path: sst_test_outputs
+          compression-level: 9
+          if-no-files-found: error
+          retention-days: 5
+        if: ${{ !cancelled() }}
+
+      - name: Compile elements
+        run: |
+          # TODO the argument does nothing as long as Spack is unavailable
+          sst-core/.github/scripts/elements_autotools_noflags_nodeps.sh gcc
+
+      - name: Test elements
+        run: |
+          install_autotools_noflags_nodeps_gcc/bin/sst-test-elements
+
+      - name: Save sst_test_outputs after elements tests
+        uses: actions/upload-artifact@v4
+        with:
+          name: sst_test_outputs_elements_free-macos-14
+          path: sst_test_outputs
+          compression-level: 9
+          if-no-files-found: error
+          retention-days: 5
+        if: ${{ !cancelled() }}

--- a/.github/workflows/free-macos-15.yml
+++ b/.github/workflows/free-macos-15.yml
@@ -1,0 +1,84 @@
+---
+name: Build/test on macOS 15
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  macos-15:
+    runs-on: macos-15
+    steps:
+
+      - name: Clone core
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          path: sst-core
+          persist-credentials: false
+
+      - name: Clone elements
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          path: sst-elements
+          persist-credentials: false
+          ref: devel
+          repository: sstsimulator-at2/sst-elements
+
+      - name: Install system-level dependencies
+        run: |
+          sst-core/.github/scripts/install_os_level_dependencies.sh
+
+      - name: Install and configure ccache
+        uses: hendrikmuhs/ccache-action@63069e3931dedbf3b63792097479563182fe70d1  # v1.2
+        with:
+          append-timestamp: false
+          create-symlink: true
+          key: >-
+            ccache-${{ github.job }}
+          max-size: "2GB"
+          verbose: 2
+
+      - name: Set environment variables
+        run: |
+          MAKEFLAGS="-j$(nproc)"
+          echo "MAKEFLAGS=${MAKEFLAGS}" >> "${GITHUB_ENV}"
+          echo "TERM=dumb" >> "${GITHUB_ENV}"
+
+      - name: Compile core
+        run: |
+          # TODO the argument does nothing as long as Spack is unavailable
+          sst-core/.github/scripts/core_autotools_noflags_nodeps.sh gcc
+
+      - name: Test core
+        run: |
+          install_autotools_noflags_nodeps_gcc/bin/sst-test-core
+
+      - name: Save sst_test_outputs after core tests
+        uses: actions/upload-artifact@v4
+        with:
+          name: sst_test_outputs_core_free-macos-14
+          path: sst_test_outputs
+          compression-level: 9
+          if-no-files-found: error
+          retention-days: 5
+        if: ${{ !cancelled() }}
+
+      - name: Compile elements
+        run: |
+          # TODO the argument does nothing as long as Spack is unavailable
+          sst-core/.github/scripts/elements_autotools_noflags_nodeps.sh gcc
+
+      - name: Test elements
+        run: |
+          install_autotools_noflags_nodeps_gcc/bin/sst-test-elements
+
+      - name: Save sst_test_outputs after elements tests
+        uses: actions/upload-artifact@v4
+        with:
+          name: sst_test_outputs_elements_free-macos-14
+          path: sst_test_outputs
+          compression-level: 9
+          if-no-files-found: error
+          retention-days: 5
+        if: ${{ !cancelled() }}

--- a/.github/workflows/free-macos-15.yml
+++ b/.github/workflows/free-macos-15.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Save sst_test_outputs after core tests
         uses: actions/upload-artifact@v4
         with:
-          name: sst_test_outputs_core_free-macos-14
+          name: sst_test_outputs_core_free-macos-15
           path: sst_test_outputs
           compression-level: 9
           if-no-files-found: error
@@ -76,7 +76,7 @@ jobs:
       - name: Save sst_test_outputs after elements tests
         uses: actions/upload-artifact@v4
         with:
-          name: sst_test_outputs_elements_free-macos-14
+          name: sst_test_outputs_elements_free-macos-15
           path: sst_test_outputs
           compression-level: 9
           if-no-files-found: error


### PR DESCRIPTION
First part of #1053.

There is no AT2 here, just the free runners.  Almost everything needs to be refactored and cleaned up, but this shows how building, testing, and uploading test outputs works.