### PR TITLE
core: fix bug in tokenize() function

### DIFF
--- a/src/sst/core/stringize.h
+++ b/src/sst/core/stringize.h
@@ -64,6 +64,10 @@ tokenize(std::vector<std::string>& output, const std::string& input, const std::
         end   = input.find(delim, start);
     }
 
+    if ( input.empty() ) {
+        return;
+    }
+
     token = input.substr(start, end);
     if ( trim_ws ) trim(token);
     output.push_back(token);


### PR DESCRIPTION
If an empty string is passed as input, we fall through the loop but still do a push_back on the empty substring.
