### PR TITLE
Move initilization of units in UnitAlgebra to main()

### DIFF
--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -47,6 +47,7 @@ REENABLE_WARNING
 #include "sst/core/timeLord.h"
 #include "sst/core/timeVortex.h"
 #include "sst/core/timingOutput.h"
+#include "sst/core/unitAlgebra.h"
 
 #include <cinttypes>
 #include <exception>
@@ -117,6 +118,22 @@ force_rank_sequential_stop(bool enable, const RankInfo& myRank, const RankInfo& 
     }
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
+}
+
+static void
+initialize_unitalgebra()
+{
+    Units::registerBaseUnit("s");
+    Units::registerBaseUnit("B");
+    Units::registerBaseUnit("b");
+    Units::registerBaseUnit("events");
+
+    Units::registerCompoundUnit("Hz", "1/s");
+    // Yes, I know it's wrong, but other people don't always realize that
+    Units::registerCompoundUnit("hz", "1/s");
+    Units::registerCompoundUnit("Bps", "B/s");
+    Units::registerCompoundUnit("bps", "b/s");
+    Units::registerCompoundUnit("event", "events");
 }
 
 static void
@@ -742,6 +759,8 @@ main(int argc, char* argv[])
 
     Simulation_impl::config.initialize(world_size.rank, myrank == 0);
     Config& cfg = Simulation_impl::config;
+
+    initialize_unitalgebra();
 
     // Current simulation time.  Needed to properly intialize
     // Simulation_impl object for restarts.

--- a/src/sst/core/statapi/statbase.cc
+++ b/src/sst/core/statapi/statbase.cc
@@ -243,9 +243,12 @@ StatisticBase::StatisticInfo::StatisticInfo()
     saved_stat_enabled_    = true;
     saved_output_enabled_  = true;
 
-    start_at_time_   = UnitAlgebra("0ns");
-    stop_at_time_    = UnitAlgebra("0ns");
-    collection_rate_ = UnitAlgebra("0ns");
+    // Since there is an instance of this class that is statically
+    // initialized, we can't use any units as they aren't initialized
+    // until main()
+    start_at_time_   = UnitAlgebra("0");
+    stop_at_time_    = UnitAlgebra("0");
+    collection_rate_ = UnitAlgebra("0");
 
     current_collection_count_   = 0;
     output_collection_count_    = 0;

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -49,9 +49,6 @@ private:
     static std::map<std::string, std::pair<Units, sst_big_num>> valid_compound_units;
     static std::map<unit_id_t, std::string>                     unit_strings;
     static unit_id_t                                            count;
-    static bool                                                 initialized;
-
-    static bool initialize();
 
     // Non-static data members and functions
     std::vector<unit_id_t> numerator;
@@ -114,7 +111,7 @@ private:
 public:
     void init(const std::string& val);
 
-    UnitAlgebra() {}
+    UnitAlgebra() = default;
     /**
      Create a new UnitAlgebra instance, and pre-populate with a parsed value.
 


### PR DESCRIPTION
Move initilization of units in UnitAlgebra to main() to avoid ordering issues during static initialization.  A consequence of this is that UnitAlgebras with units cannot be created until after they units are intialized in main().
