### PR TITLE
Reorganize code into regions in main()

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -223,6 +223,7 @@ sst_core_sources = \
 	module.cc \
 	realtime.cc \
 	sstpart.cc \
+	sst_mpi.cc \
 	sst_types.cc \
 	timeVortex.cc \
 	timingOutput.h \

--- a/src/sst/core/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.cc
@@ -230,7 +230,7 @@ JSONConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph)
     // Put in the program options
     outputJson["program_options"]["verbose"]                = std::to_string(cfg->verbose());
     outputJson["program_options"]["stop-at"]                = cfg->stop_at();
-    outputJson["program_options"]["print-timing-info"]      = cfg->print_timing() ? "true" : "false";
+    outputJson["program_options"]["print-timing-info"]      = std::to_string(cfg->print_timing());
     outputJson["program_options"]["timing-info-json"]       = cfg->timing_json();
     // Ignore stopAfter for now
     // outputJson["program_options"]["stopAfter"] = cfg->stopAfterSec();

--- a/src/sst/core/cfgoutput/pythonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.cc
@@ -371,8 +371,7 @@ PythonConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph)
     fprintf(outputFile, "# (These reflect the settings from original run and are not necessary in all files)\n");
     fprintf(outputFile, "sst.setProgramOption(\"verbose\", \"%" PRIu32 "\")\n", cfg->verbose());
     fprintf(outputFile, "sst.setProgramOption(\"stop-at\", \"%s\")\n", cfg->stop_at().c_str());
-    fprintf(
-        outputFile, "sst.setProgramOption(\"print-timing-info\", \"%s\")\n", cfg->print_timing() ? "true" : "false");
+    fprintf(outputFile, "sst.setProgramOption(\"print-timing-info\", \"%d\")\n", cfg->print_timing());
     fprintf(outputFile, "sst.setProgramOption(\"timing-info-json\", \"%s\")\n", cfg->timing_json().c_str());
     // Ignore stopAfter for now
     // fprintf(outputFile, "sst.setProgramOption(\"stopAfter\", \"%" PRIu32 "\")\n", cfg->stopAfterSec);

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -80,7 +80,7 @@ Config::ext_help_timebase()
     msg.append("Time in SST core is represented by a 64-bit unsigned integer.  By default, each count of that "
                "value represents 1ps of time.  The timebase option allows you to set that atomic core timebase to "
                "a different value.\n ");
-    msg.append("There are two things to balance when determing a timebase to use:\n\n");
+    msg.append("There are two things to balance when determining a timebase to use:\n\n");
     msg.append("1) The shortest time period or fastest clock frequency you want to represent:\n");
     msg.append("  It is recommended that the core timebase be set to ~1000x smaller than the shortest time period "
                "(fastest frequency) in your simulation.  For the default 1ps timebase, clocks in the 1-10GHz range "
@@ -415,7 +415,12 @@ Config::insertOptions()
         "Provide options to the python configuration script.  Additionally, any arguments provided after a final '-- ' "
         "will be appended to the model options (or used as the model options if --model-options was not specified).",
         model_options_, false, false, true);
-    DEF_FLAG_OPTVAL("print-timing-info", 0, "Print SST timing information", print_timing_, true, true, false);
+    DEF_ARG_OPTVAL("print-timing-info", 0, "LEVEL",
+        "Print SST timing information.  Can supply an optional level to control the granularity of timing information. "
+        "Level = 0 turns all timing info off, level = 1 will print total runtime, as well as other performance data. "
+        "Level >= 2 will print increasing granularity of performance data. If specified with no level, then the level "
+        "will be set to 2.",
+        print_timing_, true, true, false);
     DEF_ARG(
         "timing-info-json", 0, "FILE", "Write SST timing information in JSON format", timing_json_, true, true, false);
     DEF_ARG("stop-at", 0, "TIME", "Set time at which simulation will end execution", stop_at_, true, true, false);
@@ -468,8 +473,8 @@ Config::insertOptions()
     DEF_ARG("dot-verbosity", 0, "INT", "Amount of detail to include in the dot graph output", dot_verbosity_, true,
         false, true);
     DEF_ARG_OPTVAL("output-partition", 0, "FILE",
-        "File to write SST component partitioning information.  When used without an argument and in conjuction with "
-        "--output-json or --output-config options, will cause paritition information to be added to graph output.",
+        "File to write SST component partitioning information.  When used without an argument and in conjunction with "
+        "--output-json or --output-config options, will cause partition information to be added to graph output.",
         output_partition_, true, false, false);
 
     /* Advanced Features */

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -49,7 +49,7 @@ int check_unitalgebra_store_string(std::string valid_units, std::string& var, st
 class Config : public ConfigShared, public SST::Core::Serialization::serializable
 {
 
-private:
+public:
     // Main creates the config object
     friend int ::main(int argc, char** argv);
     friend class SSTModelDescription;
@@ -181,7 +181,8 @@ private:
     /**
        Print SST timing information after the run
     */
-    SST_CONFIG_DECLARE_OPTION(bool, print_timing, false, &StandardConfigParsers::flag_default_true);
+    SST_CONFIG_DECLARE_OPTION(int, print_timing, 0,
+        std::bind(&StandardConfigParsers::from_string_default<int>, std::placeholders::_1, std::placeholders::_2, 2));
 
     /**
         Print SST timing information to JSON file
@@ -617,10 +618,11 @@ public:
     /** Print to stdout the current configuration */
     void print();
 
+    void merge_checkpoint_options(Config& other);
+
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::Config);
 
-    void merge_checkpoint_options(Config& other);
 
 protected:
     std::string getUsagePrelude() override;

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -60,6 +60,7 @@ public:
      */
     Config();
 
+private:
     /**
        Initial Config object created with default constructor
      */

--- a/src/sst/core/factory.h
+++ b/src/sst/core/factory.h
@@ -33,12 +33,14 @@ class StatisticOutput;
 class StatisticBase;
 } // namespace Statistics
 
+class Config;
 class Module;
 class Component;
 class BaseComponent;
 class SubComponent;
 class ElemLoader;
 class SSTElementPythonModule;
+class SSTModelDescription;
 
 /**
  * Class for instantiating Components, Links and the like out
@@ -48,6 +50,8 @@ class Factory
 {
 public:
     static Factory* getFactory() { return instance; }
+
+    static Factory* createFactory(const std::string& searchPaths);
 
     /** Get a list of allowed ports for a given component type.
      * @param type - Name of component in lib.name format
@@ -314,13 +318,17 @@ public:
      */
     bool isProfilePointValid(const std::string& type, const std::string& point);
 
+    static SSTModelDescription* createModelDescription(
+        const std::string& type, const std::string& input_file, int verbose, Config& cfg, double start_time);
+
+    explicit Factory(const std::string& searchPaths);
+
 private:
     friend int ::main(int argc, char** argv);
 
     [[noreturn]]
     void notFound(const std::string& baseName, const std::string& type, const std::string& errorMsg);
 
-    explicit Factory(const std::string& searchPaths);
     ~Factory();
 
     Factory(const Factory&)            = delete; // Don't Implement
@@ -340,12 +348,12 @@ private:
     ElemLoader* loader;
     std::string loadingComponentType;
 
-    std::pair<std::string, std::string> parseLoadName(const std::string& wholename);
+    static std::pair<std::string, std::string> parseLoadName(const std::string& wholename);
 
     std::recursive_mutex factoryMutex;
 
 protected:
-    Output& out;
+    static Output out;
 };
 
 } // namespace SST

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -190,7 +190,7 @@ do_graph_wireup(ConfigGraph* graph, SST::Simulation_impl* sim, const RankInfo& m
     sim->performWireUp(*graph, myRank, min_part);
 }
 
-// Functions to do shared (static) initialization and notificaion for
+// Functions to do shared (static) initialization and notification for
 // stats engines.  Right now, the StatGroups are per MPI rank and
 // everything else in StatEngine is per partition.
 static void
@@ -296,7 +296,7 @@ doParallelCapableGraphOutput(ConfigGraph* graph, const RankInfo& myRank, const R
 }
 
 static void
-start_graph_creation(ConfigGraph*& graph, Factory* factory, const RankInfo& world_size, const RankInfo& myRank)
+start_graph_creation(ConfigGraph*& graph, const RankInfo& world_size, const RankInfo& myRank)
 {
     Config&                  cfg    = Simulation_impl::config;
     // Get a list of all the available SSTModelDescriptions
@@ -338,8 +338,8 @@ start_graph_creation(ConfigGraph*& graph, Factory* factory, const RankInfo& worl
         }
 
         if ( myRank.rank == 0 || cfg.parallel_load() ) {
-            modelGen.reset(factory->Create<SSTModelDescription>(
-                model_name, cfg.configFile(), cfg.verbose(), &cfg, sst_get_cpu_time()));
+            modelGen.reset(
+                Factory::createModelDescription(model_name, cfg.configFile(), cfg.verbose(), cfg, sst_get_cpu_time()));
         }
     }
 
@@ -474,7 +474,7 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
         //     // Write out any data structures needed for all checkpoints
         // }
     }
-    // Wait for all checkpointing files to be initialzed
+    // Wait for all checkpointing files to be initialized
     barrier.wait();
 
     double start_build = sst_get_cpu_time();
@@ -541,7 +541,7 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
         // revisit this in the future.  This is easy to see when running
         // sst-benchmark with 1024 components and multiple threads.  At
         // time of adding this code, the difference in delete times was
-        // 3-5 minutes versuses less than a second.
+        // 3-5 minutes versus less than a second.
         for ( uint32_t i = 0; i < info.world_size.thread; ++i ) {
             if ( i == info.myRank.thread ) {
                 do_link_preparation(info.graph, sim, info.myRank, info.min_part);
@@ -578,11 +578,9 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
     start_run       = sst_get_cpu_time();
     info.build_time = start_run - start_build;
 
-#ifdef SST_CONFIG_HAVE_MPI
     if ( tid == 0 && info.world_size.rank > 1 ) {
-        MPI_Barrier(MPI_COMM_WORLD);
+        SST_MPI_Barrier(MPI_COMM_WORLD);
     }
-#endif
 
     if ( !restart ) {
         barrier.wait();
@@ -629,10 +627,21 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
             }
             barrier.wait();
 
+            if ( tid == 0 ) {
+                Simulation_impl::basicPerf.endRegion("construct");
+                Simulation_impl::basicPerf.endRegion("build");
+
+                Simulation_impl::basicPerf.beginRegion("execute");
+            }
+
+
+            if ( tid == 0 ) Simulation_impl::basicPerf.beginRegion("init");
             sim->initialize();
             barrier.wait();
+            if ( tid == 0 ) Simulation_impl::basicPerf.endRegion("init");
 
             /* Run Set */
+            if ( tid == 0 ) Simulation_impl::basicPerf.beginRegion("setup");
             sim->setup();
             barrier.wait();
 
@@ -641,13 +650,48 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
             barrier.wait();
 
             sim->prepare_for_run();
+            if ( tid == 0 ) Simulation_impl::basicPerf.endRegion("setup");
+        } // end !RUNMODE == INIT
+        else {
+            // Need to all all the regions that were skipped because
+            // RUNMODE was set to INIT
+            if ( tid == 0 ) {
+                Simulation_impl::basicPerf.endRegion("construct");
+                Simulation_impl::basicPerf.endRegion("build");
+
+                Simulation_impl::basicPerf.beginRegion("execute");
+
+                Simulation_impl::basicPerf.beginRegion("init");
+                Simulation_impl::basicPerf.endRegion("init");
+
+                Simulation_impl::basicPerf.beginRegion("setup");
+                Simulation_impl::basicPerf.endRegion("setup");
+            }
         }
     } // end if !restart
+    else {
+        // Just need to add all the regions that were skipped to the
+        // basicPerf object
+        if ( tid == 0 ) {
+            Simulation_impl::basicPerf.endRegion("construct");
+            Simulation_impl::basicPerf.endRegion("build");
+
+            Simulation_impl::basicPerf.beginRegion("execute");
+
+            Simulation_impl::basicPerf.beginRegion("init");
+            Simulation_impl::basicPerf.endRegion("init");
+
+            Simulation_impl::basicPerf.beginRegion("setup");
+            Simulation_impl::basicPerf.endRegion("setup");
+        }
+    }
 
     /* Run Simulation */
     if ( cfg.runMode() == SimulationRunMode::RUN || cfg.runMode() == SimulationRunMode::BOTH ) {
+        if ( tid == 0 ) Simulation_impl::basicPerf.beginRegion("run");
         sim->run();
         barrier.wait();
+        if ( tid == 0 ) Simulation_impl::basicPerf.endRegion("run");
 
         /* Adjust clocks at simulation end to
          * reflect actual simulation end if that
@@ -656,15 +700,32 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
         sim->adjustTimeAtSimEnd();
         barrier.wait();
 
+        if ( tid == 0 ) Simulation_impl::basicPerf.beginRegion("complete");
         sim->complete();
         barrier.wait();
+        if ( tid == 0 ) Simulation_impl::basicPerf.endRegion("complete");
 
+        if ( tid == 0 ) Simulation_impl::basicPerf.beginRegion("finish");
         sim->finish();
         barrier.wait();
 
         /* Tell stat outputs simulation is done */
         do_statoutput_end_simulation(info.myRank);
         barrier.wait();
+        if ( tid == 0 ) Simulation_impl::basicPerf.endRegion("finish");
+    }
+    else {
+        // For RUNMODE set to INIT
+        if ( tid == 0 ) {
+            Simulation_impl::basicPerf.beginRegion("run");
+            Simulation_impl::basicPerf.endRegion("run");
+
+            Simulation_impl::basicPerf.beginRegion("complete");
+            Simulation_impl::basicPerf.endRegion("complete");
+
+            Simulation_impl::basicPerf.beginRegion("finish");
+            Simulation_impl::basicPerf.endRegion("finish");
+        }
     }
 
     info.simulated_time = sim->getEndSimTime();
@@ -727,9 +788,120 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
     delete sim;
 }
 
+void
+restart_graph_gen(SimTime_t& cpt_currentSimCycle, int& cpt_currentPriority)
+{
+    Config& cfg = Simulation_impl::config;
+
+    // Need to get the number of ranks and threads in the original checkpoint run
+    RankInfo cpt_ranks;
+
+    SST::Core::Serialization::serializer ser;
+    ser.enable_pointer_tracking();
+    std::vector<char> restart_data_buffer;
+
+    std::ifstream fs(cfg.configFile());
+    if ( !fs.is_open() ) {
+        if ( fs.bad() ) {
+            fprintf(stderr, "Unable to open checkpoint file [%s]: badbit set\n", cfg.configFile().c_str());
+            SST_Exit(-1);
+        }
+        if ( fs.fail() ) {
+            fprintf(stderr, "Unable to open checkpoint file [%s]: %s\n", cfg.configFile().c_str(), strerror(errno));
+            SST_Exit(-1);
+        }
+        fprintf(stderr, "Unable to open checkpoint file [%s]: unknown error\n", cfg.configFile().c_str());
+        SST_Exit(-1);
+    }
+
+    std::string line;
+
+    // Look for the line that has the global data file
+    std::string globals_filename;
+    std::string search_str("** (globals): ");
+    while ( std::getline(fs, line) ) {
+        // Look for lines starting with "** (globals):", then get the filename.
+        size_t pos = line.find(search_str);
+        if ( pos == 0 ) {
+            // Get the file name
+            globals_filename = line.substr(search_str.length());
+            break;
+        }
+    }
+    fs.close();
+
+    // Need to open the globals file
+    std::ifstream fs_globals(globals_filename);
+    if ( !fs_globals.is_open() ) {
+        if ( fs_globals.bad() ) {
+            fprintf(stderr, "Unable to open checkpoint globals file [%s]: badbit set\n", globals_filename.c_str());
+            SST_Exit(-1);
+        }
+        if ( fs_globals.fail() ) {
+            fprintf(
+                stderr, "Unable to open checkpoint globals file [%s]: %s\n", globals_filename.c_str(), strerror(errno));
+            SST_Exit(-1);
+        }
+        fprintf(stderr, "Unable to open checkpoint globals file [%s]: unknown error\n", globals_filename.c_str());
+        SST_Exit(-1);
+    }
+
+    size_t size;
+
+    fs_globals.read(reinterpret_cast<char*>(&size), sizeof(size));
+    restart_data_buffer.resize(size);
+    fs_globals.read(restart_data_buffer.data(), size);
+    fs_globals.close();
+
+    Config cpt_config;
+
+    ser.start_unpacking(restart_data_buffer.data(), size);
+
+    SST_SER(cpt_config);
+    cfg.merge_checkpoint_options(cpt_config);
+
+    SST_SER(cpt_ranks.rank);
+    SST_SER(cpt_ranks.thread);
+    SST_SER(cpt_currentSimCycle);
+    SST_SER(cpt_currentPriority);
+
+    // Deserialization continues after factory initialization below
+
+    ////// Initialize global data //////
+    if ( cfg.num_ranks() != cpt_ranks.rank || cfg.num_threads() != cpt_ranks.thread ) {
+        g_output.fatal(CALL_INFO, 1,
+            "Rank or thread counts do not match checkpoint. "
+            "Checkpoint requires %" PRIu32 " ranks and %" PRIu32 " threads\n",
+            cpt_ranks.rank, cpt_ranks.thread);
+    }
+
+    // On restart runs, need to reinitialize the loaded libraries
+    // and SharedObject::manager
+    Factory* factory = Factory::createFactory(cfg.getLibPath());
+
+    // Get set of loaded libraries
+    std::set<std::string> libnames;
+    SST_SER(libnames);
+
+    factory->loadUnloadedLibraries(libnames);
+
+    // Initialize SharedObjectManager
+    Simulation_impl::serializeSharedObjectManager(ser);
+    // SST_SER(SST::Shared::SharedObject::manager);
+
+    // Get the stats config
+    SST_SER(Simulation_impl::stats_config_);
+
+    // Done with restart_data_buffer
+    restart_data_buffer.clear();
+}
+
+// #include "sst/core/configGraph.h"
 int
 main(int argc, char* argv[])
 {
+    using SST::Util::BasicPerfTracker;
+
 #ifdef SST_CONFIG_HAVE_MPI
     // Initialize MPI
     MPI_Init(&argc, &argv);
@@ -743,29 +915,50 @@ main(int argc, char* argv[])
     RankInfo myRank(myrank, 0);
 #else
     int      myrank = 0;
+    int      mysize = 1;
     RankInfo world_size(1, 1);
     RankInfo myRank(0, 0);
 #endif
 
+    // Initialize the performance tracker
+    Simulation_impl::basicPerf.initialize(myrank, mysize);
+
+    // Mark the start of the full run region
+    Simulation_impl::basicPerf.beginRegion("total");
+
     /************************************************************************************
-        Here are the major phases of simulation as represented in main():
-            1 - Config object intialization
-            2 - Graph creation
-            3 - Graph Partitioning
-            4 - Build simulation data structures and run
+      Here are the major phases of simulation as represented in main()
+      and its corresponding functions.  Each of these regions will
+      track performance stats using the BasicPerfTracker. Note that
+      things are synchronized between each of these phases, so only
+      thread 0 will track time.
+
+          1 - Config object initialization (performance not tracked)
+          2 - Build phase
+            a - Graph processing
+              1 - Model Generation (ConfigGraph build)
+              2 - Graph Partitioning
+              3 - Graph distribution
+            b - Simulation object construction
+          3 - Execution phase
+            a - init()
+            b - setup()
+            c - run()
+            d - complete()
+            e - finish()
+          4 - Destruct the simulation objects
     *************************************************************************************/
 
-    /******** Config Object Initialization ********/
+    /**************************************************************************
+      1 - Config Object Initialization
 
+        During Config Object Initialization, the command line is
+        parsed and the Config object is initialized
+    ***************************************************************************/
     Simulation_impl::config.initialize(world_size.rank, myrank == 0);
     Config& cfg = Simulation_impl::config;
 
     initialize_unitalgebra();
-
-    // Current simulation time.  Needed to properly intialize
-    // Simulation_impl object for restarts.
-    SimTime_t cpt_currentSimCycle = 0;
-    int       cpt_currentPriority = 0;
 
     // All ranks parse the command line
     auto ret_value = cfg.parseCmdLine(argc, argv);
@@ -778,159 +971,105 @@ main(int argc, char* argv[])
         return 0;
     }
 
+    /**************************************************************************
+      2 - Build phase
+
+        Build reads the input file and creates the simulation objects
+        in preparation for the execution phase.
+
+        Sub-phases:
+        a - ConfigGraph processing
+        b - Simulation object construction
+    ***************************************************************************/
+    Simulation_impl::basicPerf.beginRegion("build");
+
+    /**************************************************************************
+      2.a - ConfigGraph Processing
+
+        The purpose of graph processing is to create the ConfigGraph
+        object, finalize the Config object (model generation can
+        change Config options) and ensure that each rank has the data
+        it needs to construct the simulation objects.  This phase also
+        initializes the Factory at the appropriate time. This
+        includes:
+
+        1 - Model generation. Generate the ConfigGraph, finalize the
+            Config object and decide if this is a restart or regular
+            run
+
+        2 - Partition the graph.  This phase is skipped for serial
+            jobs, normal jobs that were loaded in parallel, and for
+            restarted jobs that have no repartitioning.
+
+        3 - Distribute the graph.  This phase splits up the graph and
+            distributes it to all the ranks.  This phase is skipped
+            for serial jobs, normal jobs that were loaded in parallel,
+            and for restarted jobs that have no repartitioning.
+
+        Outputs:
+
+          - Config object with finalized options set
+          - Distributed ConfigGraph and Config objects
+          - Factory object initialized
+          - Output object initialized
+          - TimeLord initialized
+          - Set currentSimCycle and currentPriority to use for
+            Simulation object construction.
+    ***************************************************************************/
+    Simulation_impl::basicPerf.beginRegion("graph-processing");
+
+    // Need to ensure that the input file exists
+
+    // If we are doing a parallel load with a file per rank, add the
+    // rank number to the file name before the extension
+    if ( cfg.parallel_load() && cfg.parallel_load_mode_multi() && world_size.rank != 1 ) {
+        addRankToFileName(cfg.configFile_.value, myRank.rank);
+    }
+
+    if ( cfg.checkConfigFile() == false ) {
+        return -1; /* checkConfigFile provides error message */
+    }
+
+    // Current simulation time.  Needed to properly initialize
+    // Simulation_impl object for restarts.
+    SimTime_t cpt_currentSimCycle = 0;
+    int       cpt_currentPriority = 0;
+
+
+    /**************************************************************************
+      2.a.1 - Model generation
+
+        Creates the ConfigGraph, merges any program options set in the
+        SDL file and/or carried over from a checkpoint.  This stage
+        will also determine the currentSimCycle and currentPriority,
+        which is 0, 0 for a normal run and read from the checkpoint
+        for a restart run. This phase also initializes the Factory at
+        the appropriate time (regular and restart runs need to do it
+        at slightly different times).
+
+        Outputs of this phase are the Config object with finalized
+        options set, the ConfigGraph (if needed), and currentSimCycle
+        and currentPriority to use for Simulation object construction.
+        The ConfigGraph isn't needed for restart runs that use the
+        original partitioning.
+    ***************************************************************************/
+    Simulation_impl::basicPerf.beginRegion("model-generation");
+
     // Check to see if we are doing a restart from a checkpoint
     bool restart = cfg.load_from_checkpoint();
 
-    // Need to get the number of ranks and threads in the original checkpoint run
-    RankInfo cpt_ranks;
-
-    // Variables used on restart. They are used across if statements,
-    // so need to be declared here.
-    SST::Core::Serialization::serializer ser;
-    ser.enable_pointer_tracking();
-    std::vector<char> restart_data_buffer;
-
-    // On a restart, get the Config options from the checkpoint run
-    // and merge them with the current Config option based on the
-    // annotations for what passes through a checkpoint to a restart
-    // and what doesn't
-    if ( restart ) {
-        // Need to open the registry file
-        if ( cfg.checkConfigFile() == false ) {
-            return -1; /* checkConfigFile provides error message */
-        }
-
-        std::ifstream fs(cfg.configFile());
-        if ( !fs.is_open() ) {
-            if ( fs.bad() ) {
-                fprintf(stderr, "Unable to open checkpoint file [%s]: badbit set\n", cfg.configFile().c_str());
-                return -1;
-            }
-            if ( fs.fail() ) {
-                fprintf(stderr, "Unable to open checkpoint file [%s]: %s\n", cfg.configFile().c_str(), strerror(errno));
-                return -1;
-            }
-            fprintf(stderr, "Unable to open checkpoint file [%s]: unknown error\n", cfg.configFile().c_str());
-            return -1;
-        }
-
-        std::string line;
-
-        // Look for the line that has the global data file
-        std::string globals_filename;
-        std::string search_str("** (globals): ");
-        while ( std::getline(fs, line) ) {
-            // Look for lines starting with "** (globals):", then get the filename.
-            size_t pos = line.find(search_str);
-            if ( pos == 0 ) {
-                // Get the file name
-                globals_filename = line.substr(search_str.length());
-                break;
-            }
-        }
-        fs.close();
-
-        // Need to open the globals file
-        std::ifstream fs_globals(globals_filename);
-        if ( !fs_globals.is_open() ) {
-            if ( fs_globals.bad() ) {
-                fprintf(stderr, "Unable to open checkpoint globals file [%s]: badbit set\n", globals_filename.c_str());
-                return -1;
-            }
-            if ( fs_globals.fail() ) {
-                fprintf(stderr, "Unable to open checkpoint globals file [%s]: %s\n", globals_filename.c_str(),
-                    strerror(errno));
-                return -1;
-            }
-            fprintf(stderr, "Unable to open checkpoint globals file [%s]: unknown error\n", globals_filename.c_str());
-            return -1;
-        }
-
-        size_t size;
-
-        fs_globals.read(reinterpret_cast<char*>(&size), sizeof(size));
-        restart_data_buffer.resize(size);
-        fs_globals.read(restart_data_buffer.data(), size);
-        fs_globals.close();
-
-        Config cpt_config;
-
-        ser.start_unpacking(restart_data_buffer.data(), size);
-
-        SST_SER(cpt_config);
-        cfg.merge_checkpoint_options(cpt_config);
-
-        SST_SER(cpt_ranks.rank);
-        SST_SER(cpt_ranks.thread);
-        SST_SER(cpt_currentSimCycle);
-        SST_SER(cpt_currentPriority);
-
-        // Deserialization continues after factory initialization below
-
-        ////// Initialize global data //////
-        if ( cfg.num_ranks() != cpt_ranks.rank || cfg.num_threads() != cpt_ranks.thread ) {
-            g_output.fatal(CALL_INFO, 1,
-                "Rank or thread counts do not match checkpoint. "
-                "Checkpoint requires %" PRIu32 " ranks and %" PRIu32 " threads\n",
-                cpt_ranks.rank, cpt_ranks.thread);
-        }
-
-
-    } // if ( restart )
-    else {
-        // If we are doing a parallel load with a file per rank, add the
-        // rank number to the file name before the extension
-        if ( cfg.parallel_load() && cfg.parallel_load_mode_multi() && world_size.rank != 1 ) {
-            addRankToFileName(cfg.configFile_.value, myRank.rank);
-        }
-
-        // Check to see if the config file exists
-        if ( cfg.checkConfigFile() == false ) {
-            return -1; /* checkConfigFile provides error message */
-        }
-    }
-
-    /******** ConfigGraph Creation ********/
-
-    // Create the factory.  This may be needed to load an external model definition
-    Factory* factory = new Factory(cfg.getLibPath());
-
-
-    ////// Start ConfigGraph Creation //////
-
-    double       start    = sst_get_cpu_time();
     ConfigGraph* graph    = nullptr;
     SimTime_t    min_part = 0xffffffffffffffffl;
 
-    // Get the memory before we create the graph
-    const uint64_t pre_graph_create_rss = maxGlobalMemSize();
-    uint64_t       comp_count           = 0;
+    // Count of the number of components
+    uint64_t comp_count = 0;
 
-    // Variable for the start time for graph generation
-    double start_graph_gen = sst_get_cpu_time();
-
-    // If we aren't restarting, need to create the graph
-    if ( !restart ) {
-        start_graph_creation(graph, factory, world_size, myRank);
+    if ( restart ) {
+        restart_graph_gen(cpt_currentSimCycle, cpt_currentPriority);
     }
     else {
-        // On restart runs, need to reinitialize the loaded libraries
-        // and SharedObject::manager
-
-        // Get set of loaded libraries
-        std::set<std::string> libnames;
-        SST_SER(libnames);
-
-        factory->loadUnloadedLibraries(libnames);
-
-        // Initialize SharedObjectManager
-        SST_SER(SST::Shared::SharedObject::manager);
-
-        // Get thes stats config
-        SST_SER(Simulation_impl::stats_config_);
-
-        // Done with restart_data_buffer
-        restart_data_buffer.clear();
+        Factory::createFactory(cfg.getLibPath());
+        start_graph_creation(graph, world_size, myRank);
     }
 
     //// Initialize global data that needed to wait until Config was
@@ -953,7 +1092,8 @@ main(int argc, char* argv[])
     // For regular runs, need to check the ConfigGraph and finalize things
     if ( !restart ) {
 
-        // Cleanup after graph creation
+        // Cleanup after graph creation, but only if rank participated
+        // in graph construction
         if ( myRank.rank == 0 || cfg.parallel_load() ) {
 
             graph->postCreationCleanup();
@@ -964,34 +1104,19 @@ main(int argc, char* argv[])
             }
         }
 
-        // If verbose level is high enough, compute the total number
-        // components in the simulation.  NOTE: if parallel-load is
-        // enabled, then the parittioning won't actually happen and all
-        // ranks already have their parts of the graph.
-        if ( cfg.verbose() >= 1 ) {
-            if ( !cfg.parallel_load() && myRank.rank == 0 ) {
-                comp_count = graph->getNumComponents();
-            }
-#ifdef SST_CONFIG_HAVE_MPI
-            else if ( cfg.parallel_load() ) {
-                uint64_t my_count = graph->getNumComponentsInMPIRank(myRank.rank);
-                MPI_Allreduce(&my_count, &comp_count, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
-            }
-#endif
+        // Compute the total number components in the simulation.
+        if ( !cfg.parallel_load() && myRank.rank == 0 ) {
+            comp_count = graph->getNumComponents();
         }
+        else if ( cfg.parallel_load() ) {
+            uint64_t my_count = graph->getNumComponentsInMPIRank(myRank.rank);
+            SST_MPI_Allreduce(&my_count, &comp_count, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
+        }
+        Simulation_impl::basicPerf.addMetric("component count", comp_count);
     }
 
-    double graph_gen_time = sst_get_cpu_time() - start_graph_gen;
 
-    if ( myRank.rank == 0 ) {
-        g_output.verbose(CALL_INFO, 1, 0, "# ------------------------------------------------------------\n");
-        g_output.verbose(CALL_INFO, 1, 0, "# Graph construction took %f seconds.\n", graph_gen_time);
-        if ( !restart ) g_output.verbose(CALL_INFO, 1, 0, "# Graph contains %" PRIu64 " components\n", comp_count);
-    }
-
-    ////// End ConfigGraph Creation //////
-
-    // Set up the Filesystem object with the output directory
+    // Set up the Filesystem object with the specified output directory
     bool out_dir_okay = Simulation_impl::filesystem.setBasePath(cfg.output_directory());
     if ( !out_dir_okay ) {
         fprintf(stderr,
@@ -1001,11 +1126,50 @@ main(int argc, char* argv[])
         return -1;
     }
 
-    /******** Graph Partitioning ********/
+    Simulation_impl::basicPerf.endRegion("model-generation");
 
-    double graph_partitioning_start = sst_get_cpu_time();
+    if ( myRank.rank == 0 ) {
+        // Get the global and max memory usage.  These calls will generate
+        // implicit collectives so all ranks have to call them
+        uint64_t global_mem_begin = Simulation_impl::basicPerf.getGlobalTotalRegionBeginMemSize("model-generation");
+        uint64_t global_mem_end   = Simulation_impl::basicPerf.getGlobalTotalRegionEndMemSize("model-generation");
+        int64_t  global_mem_diff  = global_mem_end - global_mem_begin;
+        std::pair<uint64_t, int> max_mem = Simulation_impl::basicPerf.getGlobalMaxRegionEndMemSize("model-generation");
+
+        double graph_gen_time = Simulation_impl::basicPerf.getRegionDuration("model-generation");
+        g_output.verbose(CALL_INFO, 1, 0, "# ------------------------------------------------------------\n");
+        g_output.verbose(CALL_INFO, 1, 0, "# Graph construction took %f seconds.\n", graph_gen_time);
+        g_output.verbose(CALL_INFO, 1, 0, "# Global memory use is %" PRIu64 "kb (raised %" PRIi64 "kb)\n",
+            global_mem_end, global_mem_diff);
+        if ( world_size.rank > 1 )
+            g_output.verbose(
+                CALL_INFO, 1, 0, "# Max memory use is %" PRIu64 "kb (rank %d)\n", max_mem.first, max_mem.second);
+        if ( !restart ) g_output.verbose(CALL_INFO, 1, 0, "# Graph contains %" PRIu64 " components\n", comp_count);
+        g_output.verbose(CALL_INFO, 1, 0, "# ------------------------------------------------------------\n");
+    }
+
+    /******** End Model Generation ********/
+
+
+    /**************************************************************************
+      2.a.2 - Graph Partitioning
+
+        Partitions the graph.  This phase is skipped for serial
+        jobs, normal jobs that were loaded in parallel, and for
+        restarted jobs that have no repartitioning.
+
+        3 - Distribute the graph.  This phase splits up the graph and
+            distributes it to all the ranks.  This phase is skipped
+            for serial jobs, normal jobs that were loaded in parallel,
+            and for restarted jobs that have no repartitioning.
+
+        Outputs of this phase are the Config object with finalized
+        options set, a distributed ConfigGraph, and currentSimCycle
+        and currentPriority to use for Simulation object construction.
+    ***************************************************************************/
 
     // For now, nothing to do in the restart path
+    Simulation_impl::basicPerf.beginRegion("graph-partitioning");
     if ( !restart ) {
 #ifdef SST_CONFIG_HAVE_MPI
         // If we did a parallel load, check to make sure that all the
@@ -1027,7 +1191,7 @@ main(int argc, char* argv[])
         if ( world_size.rank == 1 && world_size.thread == 1 ) cfg.partitioner_ = "sst.single";
 
         // Run the partitioner
-        start_partitioning(world_size, myRank, factory, graph);
+        start_partitioning(world_size, myRank, Factory::getFactory(), graph);
 
         ////// End Partitioning //////
 
@@ -1050,7 +1214,6 @@ main(int argc, char* argv[])
                     }
                 }
             }
-#ifdef SST_CONFIG_HAVE_MPI
 
             // Fix for case that probably doesn't matter in practice, but
             // does come up during some specific testing.  If there are no
@@ -1062,10 +1225,9 @@ main(int argc, char* argv[])
             //     min_part = Simulation_impl::getTimeLord()->getSimCycles("1us","");
             // }
 
-            MPI_Allreduce(&local_min_part, &min_part, 1, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
+            SST_MPI_Allreduce(&local_min_part, &min_part, 1, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
             // Comms::broadcast(min_part, 0);
-#endif
-        }
+        } // if ( world_size > 1 )
         ////// End Calculate Minimum Partitioning //////
 
         ////// Write out the graph, if requested //////
@@ -1076,8 +1238,20 @@ main(int argc, char* argv[])
                 doParallelCapableGraphOutput(graph, myRank, world_size);
             }
         }
+    }
+    Simulation_impl::basicPerf.endRegion("graph-partitioning");
 
-        ////// Broadcast Graph //////
+    /**************************************************************************
+      2.a.3 - Graph Distribution
+
+        Distribute the graph.  This phase splits up the graph and
+        distributes it to all the ranks.  This phase is skipped for
+        serial jobs, normal jobs that were loaded in parallel, and for
+        restarted jobs that have no repartitioning.
+    ***************************************************************************/
+    Simulation_impl::basicPerf.beginRegion("graph-distribution");
+
+    if ( !restart ) {
 #ifdef SST_CONFIG_HAVE_MPI
         if ( world_size.rank > 1 && !cfg.parallel_load() ) {
             try {
@@ -1140,40 +1314,39 @@ main(int argc, char* argv[])
             }
         }
 #endif
-
         ////// End Broadcast Graph //////
         if ( cfg.parallel_output() ) {
             doParallelCapableGraphOutput(graph, myRank, world_size);
         }
     } // end if ( !restart )
-    else {
-        // Set up the Filesystem object with the output directory
-        bool out_dir_okay = Simulation_impl::filesystem.setBasePath(cfg.output_directory());
-        if ( !out_dir_okay ) {
-            fprintf(stderr,
-                "ERROR: Directory specified with --output-directory (%s) is not valid.  Most likely causes are that "
-                "the "
-                "user does not have permissions to write to this path, or a file of the same name exists.\n",
-                cfg.output_directory().c_str());
-            return -1;
-        }
-    }
-
-    double         partitioning_time     = sst_get_cpu_time() - graph_partitioning_start;
-    const uint64_t post_graph_create_rss = maxGlobalMemSize();
+    Simulation_impl::basicPerf.endRegion("graph-distribution");
+    Simulation_impl::basicPerf.endRegion("graph-processing");
 
     if ( myRank.rank == 0 ) {
-        g_output.verbose(CALL_INFO, 1, 0, "# Graph partitioning and output took %lg seconds.\n", partitioning_time);
-        g_output.verbose(CALL_INFO, 1, 0, "# Graph construction and partition raised RSS by %" PRIu64 " KB\n",
-            (post_graph_create_rss - pre_graph_create_rss));
+        // Get the global and max memory usage.  These calls will generate
+        // implicit collectives so all ranks have to call them
+        uint64_t global_mem_begin = Simulation_impl::basicPerf.getGlobalTotalRegionBeginMemSize("graph-partitioning");
+        uint64_t global_mem_end   = Simulation_impl::basicPerf.getGlobalTotalRegionEndMemSize("graph-distribution");
+        uint64_t global_mem_diff  = global_mem_end - global_mem_begin;
+        std::pair<uint64_t, int> max_mem =
+            Simulation_impl::basicPerf.getGlobalMaxRegionEndMemSize("graph-distribution");
+
+        double graph_gen_time = Simulation_impl::basicPerf.getRegionDuration("graph-distribution");
+        g_output.verbose(CALL_INFO, 1, 0, "# ------------------------------------------------------------\n");
+        g_output.verbose(
+            CALL_INFO, 1, 0, "# Graph partitioning, output and distribution took %f seconds.\n", graph_gen_time);
+        g_output.verbose(CALL_INFO, 1, 0, "# Global memory use is %" PRIu64 "kb (raised %" PRIi64 "kb)\n",
+            global_mem_end, global_mem_diff);
+        if ( world_size.rank > 1 )
+            g_output.verbose(
+                CALL_INFO, 1, 0, "# Max memory use is %" PRIu64 "kb (rank %d)\n", max_mem.first, max_mem.second);
         g_output.verbose(CALL_INFO, 1, 0, "# ------------------------------------------------------------\n");
 
         // Output the partition information if user requests it
         dump_partition(graph, world_size);
     }
 
-
-    /******** Create Simulation ********/
+    /******** Register signal handlers, if not disabled ********/
     if ( cfg.enable_sig_handling() ) {
         g_output.verbose(CALL_INFO, 1, 0, "Signal handlers will be registered for USR1, USR2, INT, ALRM, and TERM\n");
         RealTimeManager::installSignalHandlers();
@@ -1183,10 +1356,47 @@ main(int argc, char* argv[])
         g_output.verbose(CALL_INFO, 1, 0, "Signal handlers are disabled by user input\n");
     }
 
+    /**************************************************************************
+      2.b - Simulation Construction
 
+        The purpose of simulation construction is to create all the
+        objects needed to run the simulation.
+
+        This region begins in the main thread, but ends after all
+        other threads have been started.
+
+        Outputs:
+
+          - Simulation objects ready for execution
+    ***************************************************************************/
+
+    /**************************************************************************
+      Phases that start/stop in other parts of the code:
+
+      NOTE: These regions happen in the threads, so only thread 0 will
+      record stats.  This will give a good estimate because the
+      threads are either explicitly or implicitly synchronized between
+      each region.
+
+        3 - Execute
+
+          The execute phase happens entirely in the threaded portion
+          of the code.  Each thread executes the start_simulation()
+          function, and start_simulation() makes calls into the
+          Simulation object.  Those regions are detailed in the
+          corresponding code sections.
+
+        4 - Destruct
+
+          The destruct phase happens entirely in the threaded portion
+          of the code.
+    ***************************************************************************/
     Core::ThreadSafe::Barrier mainBarrier(world_size.thread);
 
-    Simulation_impl::factory    = factory;
+    Simulation_impl::basicPerf.beginRegion("construct");
+
+    // Initialize Simulation object data members and barriers
+    Simulation_impl::factory    = Factory::getFactory();
     Simulation_impl::sim_output = g_output;
     Simulation_impl::resizeBarriers(world_size.thread);
     CheckpointAction::barrier.resize(world_size.thread);
@@ -1204,13 +1414,12 @@ main(int argc, char* argv[])
         threadInfo[i].min_part      = min_part;
     }
 
-    double end_serial_build = sst_get_cpu_time();
-
     /* Block signals for all threads */
     sigset_t maskset;
     sigfillset(&maskset);
     pthread_sigmask(SIG_BLOCK, &maskset, nullptr);
 
+    // Start the remaining threads for the simulation
     try {
         Output::setThreadID(std::this_thread::get_id(), 0);
         for ( uint32_t i = 1; i < world_size.thread; i++ ) {
@@ -1221,7 +1430,10 @@ main(int argc, char* argv[])
 
         /* Unblock signals on thread 0 */
         pthread_sigmask(SIG_UNBLOCK, &maskset, NULL);
+        // Call start_simulation for the main thread
         start_simulation(0, threadInfo[0], mainBarrier, cpt_currentSimCycle, cpt_currentPriority);
+
+        // Join all the threads when the execute phase is done
         for ( uint32_t i = 1; i < world_size.thread; i++ ) {
             threads[i].join();
         }
@@ -1231,8 +1443,9 @@ main(int argc, char* argv[])
     catch ( std::exception& e ) {
         g_output.fatal(CALL_INFO, -1, "Error encountered during simulation: %s\n", e.what());
     }
+    Simulation_impl::basicPerf.endRegion("execute");
 
-    double total_end_time = sst_get_cpu_time();
+    Simulation_impl::basicPerf.endRegion("total");
 
     for ( uint32_t i = 1; i < world_size.thread; i++ ) {
         threadInfo[0].simulated_time = std::max(threadInfo[0].simulated_time, threadInfo[i].simulated_time);
@@ -1244,11 +1457,9 @@ main(int argc, char* argv[])
         threadInfo[0].sync_data_size += threadInfo[i].sync_data_size;
     }
 
-    double build_time = (end_serial_build - start) + threadInfo[0].build_time;
-    double run_time   = threadInfo[0].run_time;
-    double total_time = total_end_time - start;
-
-    double max_run_time = 0, max_build_time = 0, max_total_time = 0;
+    double max_run_time   = Simulation_impl::basicPerf.getRegionDuration("run");
+    double max_build_time = Simulation_impl::basicPerf.getRegionDuration("build");
+    double max_total_time = Simulation_impl::basicPerf.getRegionDuration("total");
 
     uint64_t local_max_tv_depth      = threadInfo[0].max_tv_depth;
     uint64_t global_max_tv_depth     = 0;
@@ -1264,9 +1475,6 @@ main(int argc, char* argv[])
 #ifdef SST_CONFIG_HAVE_MPI
     uint64_t local_sync_data_size = threadInfo[0].sync_data_size;
 
-    MPI_Allreduce(&run_time, &max_run_time, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
-    MPI_Allreduce(&build_time, &max_build_time, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
-    MPI_Allreduce(&total_time, &max_total_time, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
     MPI_Allreduce(&local_max_tv_depth, &global_max_tv_depth, 1, MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
     MPI_Allreduce(&local_current_tv_depth, &global_current_tv_depth, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
     MPI_Allreduce(&local_sync_data_size, &global_max_sync_data_size, 1, MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
@@ -1275,9 +1483,6 @@ main(int argc, char* argv[])
     MPI_Allreduce(&mempool_size, &global_mempool_size, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
     MPI_Allreduce(&active_activities, &global_active_activities, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
 #else
-    max_build_time            = build_time;
-    max_run_time              = run_time;
-    max_total_time            = total_time;
     global_max_tv_depth       = local_max_tv_depth;
     global_current_tv_depth   = local_current_tv_depth;
     global_max_sync_data_size = 0;
@@ -1295,30 +1500,34 @@ main(int argc, char* argv[])
     const uint64_t global_max_io_in  = maxInputOperations();
     const uint64_t global_max_io_out = maxOutputOperations();
 
-    if ( myRank.rank == 0 && (cfg.verbose() || cfg.print_timing() || cfg.timing_json() != "") ) {
-        TimingOutput timingOutput(g_output, cfg.verbose() || cfg.print_timing());
-        if ( cfg.timing_json() != "" ) timingOutput.setJSON(cfg.timing_json());
+    // if ( myRank.rank == 0 && (cfg.verbose() || cfg.print_timing() || cfg.timing_json() != "") ) {
+    if ( cfg.verbose() || cfg.print_timing() || cfg.timing_json() != "" ) {
+        if ( myRank.rank == 0 ) {
+            int          timing_verbose = cfg.print_timing() == 0 ? (cfg.verbose() > 0 ? 2 : 0) : cfg.print_timing();
+            TimingOutput timingOutput(g_output, timing_verbose);
+            if ( cfg.timing_json() != "" ) timingOutput.setJSON(cfg.timing_json());
 
-        timingOutput.set(TimingOutput::Key::LOCAL_MAX_RSS, local_max_rss);
-        timingOutput.set(TimingOutput::Key::GLOBAL_MAX_RSS, global_max_rss);
-        timingOutput.set(TimingOutput::Key::LOCAL_MAX_PF, local_max_pf);
-        timingOutput.set(TimingOutput::Key::GLOBAL_PF, global_pf);
-        timingOutput.set(TimingOutput::Key::GLOBAL_MAX_IO_IN, global_max_io_in);
-        timingOutput.set(TimingOutput::Key::GLOBAL_MAX_IO_OUT, global_max_io_out);
-        timingOutput.set(TimingOutput::Key::GLOBAL_MAX_SYNC_DATA_SIZE, global_max_sync_data_size);
-        timingOutput.set(TimingOutput::Key::GLOBAL_SYNC_DATA_SIZE, global_sync_data_size);
-        timingOutput.set(TimingOutput::Key::MAX_MEMPOOL_SIZE, (uint64_t)max_mempool_size);
-        timingOutput.set(TimingOutput::Key::GLOBAL_MEMPOOL_SIZE, (uint64_t)global_mempool_size);
-        timingOutput.set(TimingOutput::Key::MAX_BUILD_TIME, max_build_time);
-        timingOutput.set(TimingOutput::Key::MAX_RUN_TIME, max_run_time);
-        timingOutput.set(TimingOutput::Key::MAX_TOTAL_TIME, max_total_time);
-        timingOutput.set(TimingOutput::Key::SIMULATED_TIME_UA, threadInfo[0].simulated_time);
-        timingOutput.set(TimingOutput::Key::GLOBAL_ACTIVE_ACTIVITIES, (uint64_t)global_active_activities);
-        timingOutput.set(TimingOutput::Key::GLOBAL_CURRENT_TV_DEPTH, global_current_tv_depth);
-        timingOutput.set(TimingOutput::Key::GLOBAL_MAX_TV_DEPTH, global_max_tv_depth);
-        timingOutput.set(TimingOutput::Key::RANKS, (uint64_t)world_size.rank);
-        timingOutput.set(TimingOutput::Key::THREADS, (uint64_t)world_size.thread);
-        timingOutput.generate();
+            timingOutput.set(TimingOutput::Key::LOCAL_MAX_RSS, local_max_rss);
+            timingOutput.set(TimingOutput::Key::GLOBAL_MAX_RSS, global_max_rss);
+            timingOutput.set(TimingOutput::Key::LOCAL_MAX_PF, local_max_pf);
+            timingOutput.set(TimingOutput::Key::GLOBAL_PF, global_pf);
+            timingOutput.set(TimingOutput::Key::GLOBAL_MAX_IO_IN, global_max_io_in);
+            timingOutput.set(TimingOutput::Key::GLOBAL_MAX_IO_OUT, global_max_io_out);
+            timingOutput.set(TimingOutput::Key::GLOBAL_MAX_SYNC_DATA_SIZE, global_max_sync_data_size);
+            timingOutput.set(TimingOutput::Key::GLOBAL_SYNC_DATA_SIZE, global_sync_data_size);
+            timingOutput.set(TimingOutput::Key::MAX_MEMPOOL_SIZE, (uint64_t)max_mempool_size);
+            timingOutput.set(TimingOutput::Key::GLOBAL_MEMPOOL_SIZE, (uint64_t)global_mempool_size);
+            timingOutput.set(TimingOutput::Key::MAX_BUILD_TIME, max_build_time);
+            timingOutput.set(TimingOutput::Key::MAX_RUN_TIME, max_run_time);
+            timingOutput.set(TimingOutput::Key::MAX_TOTAL_TIME, max_total_time);
+            timingOutput.set(TimingOutput::Key::SIMULATED_TIME_UA, threadInfo[0].simulated_time);
+            timingOutput.set(TimingOutput::Key::GLOBAL_ACTIVE_ACTIVITIES, (uint64_t)global_active_activities);
+            timingOutput.set(TimingOutput::Key::GLOBAL_CURRENT_TV_DEPTH, global_current_tv_depth);
+            timingOutput.set(TimingOutput::Key::GLOBAL_MAX_TV_DEPTH, global_max_tv_depth);
+            timingOutput.set(TimingOutput::Key::RANKS, (uint64_t)world_size.rank);
+            timingOutput.set(TimingOutput::Key::THREADS, (uint64_t)world_size.thread);
+            timingOutput.generate();
+        }
     }
 
 #ifdef SST_CONFIG_HAVE_MPI

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -1155,6 +1155,12 @@ Simulation_impl::notifySignal()
 }
 
 void
+Simulation_impl::serializeSharedObjectManager(SST::Core::Serialization::serializer& ser)
+{
+    SST_SER(SST::Shared::SharedObject::manager);
+}
+
+void
 Simulation_impl::printStatus(bool fullStatus)
 {
     Output out("SimStatus: @R:@t:", 0, 0, Output::STDERR);
@@ -2176,6 +2182,8 @@ Core::ThreadSafe::Spinlock Simulation_impl::cross_thread_lock;
 TimeConverter              Simulation_impl::minPartTC;
 SimTime_t                  Simulation_impl::minPart;
 std::string                Simulation_impl::checkpoint_directory_ = "";
+
+Util::BasicPerfTracker Simulation_impl::basicPerf;
 
 
 /* Define statics (Simulation) */

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -24,6 +24,7 @@
 #include "sst/core/sst_types.h"
 #include "sst/core/statapi/statengine.h"
 #include "sst/core/unitAlgebra.h"
+#include "sst/core/util/basicPerf.h"
 #include "sst/core/util/filesystem.h"
 
 #include <atomic>
@@ -201,13 +202,15 @@ public:
     /** Sets an internal flag for signaling the simulation. Used by signal handler & thread 0. */
     static void notifySignal();
 
+    static void serializeSharedObjectManager(SST::Core::Serialization::serializer& ser);
+
+    /******** Core only API *************/
+
     /** Insert an activity to fire at a specified time */
     void insertActivity(SimTime_t time, Activity* ev);
 
     /** Return the exit event */
     Exit* getExit() const { return m_exit; }
-
-    /******** Core only API *************/
 
     /** Processes the ConfigGraph to pull out any need information
      * about relationships among the threads
@@ -443,6 +446,8 @@ public:
     static Core::ThreadSafe::Barrier exitBarrier;
     static Core::ThreadSafe::Barrier finishBarrier;
     static std::mutex                simulationMutex;
+
+    static Util::BasicPerfTracker basicPerf;
 
     // Support for crossthread links
     static Core::ThreadSafe::Spinlock cross_thread_lock;

--- a/src/sst/core/sst_mpi.cc
+++ b/src/sst/core/sst_mpi.cc
@@ -1,0 +1,52 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+
+#include "sst/core/sst_mpi.h"
+
+#include <cstring>
+
+int
+SST_MPI_Allreduce(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op UNUSED_WO_MPI(op),
+    MPI_Comm UNUSED_WO_MPI(comm))
+{
+#ifdef SST_CONFIG_HAVE_MPI
+    return MPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm);
+#else
+    // For no MPI, the datatypes are #defined to be the size of the type
+    std::memcpy(recvbuf, sendbuf, datatype * count);
+    return 0;
+#endif
+}
+
+int
+SST_MPI_Barrier(MPI_Comm UNUSED_WO_MPI(comm))
+{
+#ifdef SST_CONFIG_HAVE_MPI
+    return MPI_Barrier(comm);
+#else
+    return 0;
+#endif
+}
+
+
+int
+SST_MPI_Allgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
+    int UNUSED_WO_MPI(recvcount), MPI_Datatype UNUSED_WO_MPI(recvtype), MPI_Comm UNUSED_WO_MPI(comm))
+{
+#ifdef SST_CONFIG_HAVE_MPI
+    return MPI_Allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm);
+#else
+    std::memcpy(recvbuf, sendbuf, sendtype * sendcount);
+    return 0;
+#endif
+}

--- a/src/sst/core/sst_mpi.h
+++ b/src/sst/core/sst_mpi.h
@@ -32,4 +32,105 @@ REENABLE_WARNING
 
 #endif
 
+/*************************************************************************
+   Make it so that we can do simple MPI functions without having to
+   guard using SST_CONFIG_HAVE_MPI.  This will include SST_MPI_*
+   versions of the supported operations, as well as definitions for
+   some of the MPI types
+ *************************************************************************/
+
+struct mpi_short_int_t
+{
+    short val;
+    int   rank;
+};
+
+struct mpi_long_int_t
+{
+    long val;
+    int  rank;
+};
+
+struct mpi_float_int_t
+{
+    double val;
+    int    rank;
+};
+
+struct mpi_double_int_t
+{
+    double val;
+    int    rank;
+};
+
+#ifndef SST_CONFIG_HAVE_MPI
+
+// Define some MPI types and some of the values for those types
+#define MPI_Datatype int
+#define MPI_Op       int
+#define MPI_Comm     int
+
+#define MPI_COMM_WORLD 0
+
+// MPI_datatype values. These will just be set to the sizeof() the represented type
+
+#define MPI_SIGNED_CHAR    (sizeof(signed char))
+#define MPI_UNSIGNED_CHAR  (sizeof(unsigned char))
+#define MPI_SHORT          (sizeof(short))
+#define MPI_UNSIGNED_SHORT (sizeof(unsigned short))
+#define MPI_INT            (sizeof(int))
+#define MPI_UNSIGNED       (sizeof(unsigned))
+#define MPI_LONG           (sizeof(long))
+#define MPI_UNSIGNED_LONG  (sizeof(unsigned long))
+// MPI_LONG_LONG_INT (a.k.a MPI_LONG_LONG) / MPI_UNSIGNED_LONG_LONG
+#define MPI_CHAR           (sizeof(char))
+#define MPI_WCHAR          (sizeof(wchar))
+#define MPI_FLOAT          (sizeof(float))
+#define MPI_DOUBLE         (sizeof(double))
+// MPI_LONG_DOUBLE
+#define MPI_INT8_T         (sizeof(int8_t))
+#define MPI_UINT8_T        (sizeof(uint8_t))
+#define MPI_INT16_T        (sizeof(int16_t))
+#define MPI_UINT16_T       (sizeof(uint16_t))
+#define MPI_INT32_T        (sizeof(int32_t))
+#define MPI_UINT32_T       (sizeof(uint32_t))
+#define MPI_INT64_T        (sizeof(int64_t))
+#define MPI_UINT64_T       (sizeof(uint64_t))
+#define MPI_C_BOOL
+// MPI_C_COMPLEX
+// MPI_C_FLOAT_COMPLEX
+// MPI_C_DOUBLE_COMPLEX
+// MPI_C_LONG_DOUBLE_COMPLEX
+// MPI_AINT
+// MPI_COUNT
+// MPI_OFFSET
+// MPI_BYTE
+// MPI_PACKED
+
+// List of datatypes for reduction functions MPI_MINLOC and MPI_MAXLOC:
+#define MPI_SHORT_INT  (sizeof(mpi_short_int_t))
+#define MPI_LONG_INT   (sizeof(mpi_long_int_t))
+#define MPI_FLOAT_INT  (sizeof(mpi_float_int_t))
+#define MPI_DOUBLE_INT (sizeof(mpi_double_int_t))
+// MPI_LONG_DOUBLE_INT
+// MPI_2INT
+
+// Allreduce operations. Numbers are unused because they are all
+// no-ops in the case of MPI
+#define MPI_SUM    0
+#define MPI_MAX    0
+#define MPI_MIN    0
+#define MPI_MAXLOC 0
+#define MPI_MINLOC 0
+
+#endif
+
+// Verions of typical MPI functions that will hide the
+// SST_CONFIG_HAVE_MPI macros
+
+int SST_MPI_Allreduce(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int SST_MPI_Barrier(MPI_Comm comm);
+int SST_MPI_Allgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+    MPI_Datatype recvtype, MPI_Comm comm);
+
 #endif

--- a/src/sst/core/timingOutput.cc
+++ b/src/sst/core/timingOutput.cc
@@ -24,9 +24,9 @@ namespace json = ::nlohmann;
 namespace SST {
 namespace Core {
 
-TimingOutput::TimingOutput(const SST::Output& output, bool printEnable) :
+TimingOutput::TimingOutput(const SST::Output& output, int print_verbosity) :
     output_(output),
-    printEnable_(printEnable),
+    print_verbosity_(print_verbosity),
     jsonEnable_(false)
 {}
 
@@ -71,7 +71,7 @@ TimingOutput::~TimingOutput()
 void
 TimingOutput::generate()
 {
-    if ( printEnable_ ) renderText();
+    if ( print_verbosity_ ) renderText();
     if ( jsonEnable_ ) renderJSON();
 }
 
@@ -100,10 +100,8 @@ TimingOutput::renderText()
     output_.output("\n");
     output_.output("\n");
     output_.output("------------------------------------------------------------\n");
-    output_.output("Simulation Timing Information (Wall Clock Times):\n");
-    output_.output("  Build time:                      %f seconds\n", dmap_.at(MAX_BUILD_TIME));
-    output_.output("  Run loop time:                   %f seconds\n", dmap_.at(MAX_RUN_TIME));
-    output_.output("  Total time:                      %f seconds\n", dmap_.at(MAX_TOTAL_TIME));
+    output_.output("Simulation Resource Utilization for Code Regions:\n");
+    Simulation_impl::basicPerf.outputRegionData(output_, print_verbosity_);
     output_.output("\n");
     output_.output("Simulated time:                    %s\n", uamap_.at(SIMULATED_TIME_UA).toStringBestSI().c_str());
     output_.output("\n");

--- a/src/sst/core/timingOutput.h
+++ b/src/sst/core/timingOutput.h
@@ -72,7 +72,7 @@ public:
         { THREADS, "threads" },
     };
 
-    TimingOutput(const SST::Output& output, bool printEnable);
+    TimingOutput(const SST::Output& output, int print_verbosity);
     virtual ~TimingOutput();
     void setJSON(const std::string& path);
     void generate();
@@ -85,7 +85,7 @@ public:
 
 private:
     SST::Output output_;
-    bool        printEnable_;
+    int         print_verbosity_;
     bool        jsonEnable_;
 
     std::map<Key, uint64_t>    u64map_    = {};

--- a/src/sst/core/util/Makefile.inc
+++ b/src/sst/core/util/Makefile.inc
@@ -6,6 +6,8 @@
 
 
 sst_core_sources += \
+	util/basicPerf.cc \
+	util/basicPerf.h \
 	util/smartTextFormatter.cc \
 	util/filesystem.cc
 

--- a/src/sst/core/util/basicPerf.cc
+++ b/src/sst/core/util/basicPerf.cc
@@ -1,0 +1,396 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst_config.h"
+
+#include "sst/core/util/basicPerf.h"
+
+#include "sst/core/cputimer.h"
+#include "sst/core/memuse.h"
+#include "sst/core/simulation_impl.h"
+#include "sst/core/sst_mpi.h"
+
+namespace SST::Util {
+
+
+void
+BasicPerfTracker::initialize(int rank, int num_ranks)
+{
+    rank_      = rank;
+    num_ranks_ = num_ranks;
+}
+
+
+RegionPerfInfo&
+BasicPerfTracker::getRegion(const std::string& tag, const std::string& function_name, bool must_be_ended)
+{
+    for ( auto& x : regions_ ) {
+        if ( tag == x.tag ) {
+            if ( x.end_mem == 0 && must_be_ended ) {
+                // ERROR, region has not ended
+                fprintf(stderr, "Called BasicPerfTracker::%s() on region that has not ended: %s\n",
+                    function_name.c_str(), tag.c_str());
+                SST_Exit(1);
+            }
+            return x;
+        }
+    }
+
+    // ERROR, region not started
+    fprintf(stderr, "Called BasicPerfTracker::%s() on region that has not started: %s\n", function_name.c_str(),
+        tag.c_str());
+    SST_Exit(1);
+}
+
+
+RegionPerfInfo
+BasicPerfTracker::getRegionPerfInfo(const std::string& tag)
+{
+    return getRegion(tag, "getRegionPerfInfo");
+}
+
+void
+BasicPerfTracker::beginRegion(const std::string& tag)
+{
+    for ( auto& x : regions_ ) {
+        if ( tag == x.tag ) {
+            // ERROR, region already started
+            fprintf(stderr, "Called BasicPerfTracker::beginRegion() on region that has already been started: %s\n",
+                tag.c_str());
+            SST_Exit(1);
+        }
+    }
+
+    // Let my parent know that they have a child
+    if ( current_regions_.size() != 0 ) {
+        regions_[current_regions_.top()].has_child = true;
+    }
+
+    // Push the index that this region will be in the vector to the
+    // stack
+    current_regions_.push(regions_.size());
+
+    size_t level = current_regions_.size();
+
+    // Need to see if there are other regions in this level that need
+    // to have last_of_level set to false.  Easier to do this before
+    // we insert the current region
+    for ( auto iter = regions_.rbegin(); iter != regions_.rend(); ++iter ) {
+        // Find last item with current level.  If we ever hit a level
+        // less than ours, then we are the first child at the level
+        // and we can stop looking.
+        if ( iter->level < level ) break;
+        if ( iter->level == level ) {
+            iter->last_of_level = false;
+            break;
+        }
+    }
+
+    // Create the region in the vector. The level will be the
+    // current size of the current_regions_ stack.
+    regions_.emplace_back(tag, current_regions_.size());
+    RegionPerfInfo& region = regions_.back();
+
+    region.begin_mem  = Core::localMemSize();
+    region.begin_time = sst_get_cpu_time();
+}
+
+void
+BasicPerfTracker::endRegion(const std::string& tag)
+{
+    // Current region must be ended before any enclosing regions can be ended
+    RegionPerfInfo& region = regions_[current_regions_.top()];
+    if ( tag != region.tag ) {
+        fprintf(stderr,
+            "Called BasicPerfTracker::endRegion() on region that is not the current region: %s (current = %s)\n",
+            tag.c_str(), region.tag.c_str());
+        SST_Exit(1);
+    }
+
+    region.end_time = sst_get_cpu_time();
+    region.end_mem  = Core::localMemSize();
+
+    current_regions_.pop();
+
+    // Barrier until all ranks are ready to collect total and max
+    // utilizations
+    SST_MPI_Barrier(MPI_COMM_WORLD);
+
+    ////// Execution time //////
+    mpi_double_int_t in, out;
+    in.val  = region.end_time - region.begin_time;
+    in.rank = rank_;
+
+    SST_MPI_Allreduce(&in, &out, 1, MPI_DOUBLE_INT, MPI_MAXLOC, MPI_COMM_WORLD);
+    region.rollup_duration.push_back(out.val);
+    region.rollup_max_duration_rank = out.rank;
+
+    ///// Memory Usage //////
+
+    /// Begin memory ///
+    uint64_t global_mem = 0;
+    SST_MPI_Allreduce(&region.begin_mem, &global_mem, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
+    region.rollup_begin_mem.push_back(global_mem);
+
+    uint64_t max_mem = 0;
+    SST_MPI_Allreduce(&region.begin_mem, &max_mem, 1, MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
+    region.rollup_begin_mem.push_back(max_mem);
+
+    // Because MPI doesn't have a guaranteed 64-bit data type for the
+    // MAX_LOC operation, we can't use it without defining a custom
+    // data type.  To get the location, just have each rank see if
+    // they are the max, and if they are, set the location to their
+    // rank and do another allreduce.
+    int my_location = (region.begin_mem == max_mem) ? rank_ : 0;
+    int location    = my_location;
+    SST_MPI_Allreduce(&my_location, &location, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+    region.rollup_begin_mem_max_rank = location;
+
+    /// End memory ///
+    global_mem = 0;
+    SST_MPI_Allreduce(&region.end_mem, &global_mem, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
+    region.rollup_end_mem.push_back(global_mem);
+
+    max_mem = 0;
+    SST_MPI_Allreduce(&region.end_mem, &max_mem, 1, MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
+    region.rollup_end_mem.push_back(max_mem);
+
+    // Because MPI doesn't have a guaranteed 64-bit data type for the
+    // MAX_LOC operation, we can't use it without defining a custom
+    // data type.  To get the location, just have each rank see if
+    // they are the max, and if they are, set the location to their
+    // rank and do another allreduce.
+    my_location = (region.end_mem == max_mem) ? rank_ : 0;
+    location    = my_location;
+    SST_MPI_Allreduce(&my_location, &location, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+    region.rollup_end_mem_max_rank = location;
+}
+
+
+double
+BasicPerfTracker::getRegionBeginTime(const std::string& tag)
+{
+    RegionPerfInfo& region = getRegion(tag, "getRegionBeginTime", false);
+    return region.begin_time;
+}
+
+double
+BasicPerfTracker::getRegionEndTime(const std::string& tag)
+{
+    RegionPerfInfo& region = getRegion(tag, "getRegionEndTime");
+    return region.end_time;
+}
+
+double
+BasicPerfTracker::getRegionDuration(const std::string& tag)
+{
+    RegionPerfInfo& region = getRegion(tag, "getRegionDuration");
+
+    return region.end_time - region.begin_time;
+}
+
+double
+BasicPerfTracker::getRegionGlobalDuration(const std::string& tag)
+{
+    RegionPerfInfo& region = getRegion(tag, "getRegionGlobalDuration");
+
+    return region.rollup_duration[0];
+}
+
+
+uint64_t
+BasicPerfTracker::getLocalRegionBeginMemSize(const std::string& tag)
+{
+    RegionPerfInfo& region = getRegion(tag, "getLocalRegionBeginMemSize");
+    return region.begin_mem;
+}
+
+uint64_t
+BasicPerfTracker::getGlobalTotalRegionBeginMemSize(const std::string& tag)
+{
+    RegionPerfInfo& region = getRegion(tag, "getGlobalTotalRegionBeginMemSize");
+    return region.rollup_begin_mem[0];
+}
+
+std::pair<uint64_t, int>
+BasicPerfTracker::getGlobalMaxRegionBeginMemSize(const std::string& tag)
+{
+    RegionPerfInfo& region = getRegion(tag, "getGlobalMaxRegionBeginMemSize");
+    return std::make_pair(region.rollup_begin_mem[1], region.rollup_begin_mem_max_rank);
+}
+
+
+uint64_t
+BasicPerfTracker::getLocalRegionEndMemSize(const std::string& tag)
+{
+    RegionPerfInfo& region = getRegion(tag, "getLocalRegionEndMemSize");
+    return region.end_mem;
+}
+
+uint64_t
+BasicPerfTracker::getGlobalTotalRegionEndMemSize(const std::string& tag)
+{
+    RegionPerfInfo& region = getRegion(tag, "getGlobalTotalRegionEndMemSize");
+    return region.rollup_end_mem[0];
+}
+
+std::pair<uint64_t, int>
+BasicPerfTracker::getGlobalMaxRegionEndMemSize(const std::string& tag)
+{
+    RegionPerfInfo& region = getRegion(tag, "getGlobalMaxRegionEndMemSize");
+    return std::make_pair(region.rollup_end_mem[1], region.rollup_end_mem_max_rank);
+}
+
+
+void
+BasicPerfTracker::addMetric(const std::string& name, uint64_t value)
+{
+    scalars_unsigned[name] = value;
+}
+
+void
+BasicPerfTracker::addMetric(const std::string& name, int64_t value)
+{
+    scalars_signed[name] = value;
+}
+
+void
+BasicPerfTracker::addMetric(const std::string& name, double value)
+{
+    scalars_float[name] = value;
+}
+
+
+uint64_t
+BasicPerfTracker::getMetricUnsigned(const std::string& name)
+{
+    return scalars_unsigned[name];
+}
+
+int64_t
+BasicPerfTracker::getMetricSigned(const std::string& name)
+{
+    return scalars_signed[name];
+}
+
+double
+BasicPerfTracker::getMetricFloat(const std::string& name)
+{
+    return scalars_float[name];
+}
+
+// Need to use wstring for the unicode box drawing characters
+std::wstring horizontal   = L"─"; // ─
+std::wstring vertical     = L"│"; // │
+std::wstring topLeft      = L"┌"; // ┌
+std::wstring topRight     = L"┐"; // ┐
+std::wstring bottomLeft   = L"└"; // └
+std::wstring bottomRight  = L"┘"; // ┘
+std::wstring vertAndRight = L"├"; // ├
+std::wstring fullBox      = L"■"; // ■
+
+
+void
+BasicPerfTracker::outputRegionData(Output& out, size_t verbose)
+{
+    bool print = (rank_ == 0);
+
+    // Use vector as stack to keep track of hierarchy
+    std::vector<std::pair<RegionPerfInfo*, bool>> region_stack;
+
+    std::wstring prefix_stats;
+    std::wstring prefix_region;
+
+    for ( auto& x : regions_ ) {
+
+        if ( x.level > verbose ) continue;
+
+        // First, need to see if we need to remove the last region
+        // and/or adjust the bool that controls the printing of the
+        // vertical bars
+
+        // If the level has descreased, need to pop all regions
+        // that are greater than current level
+
+        if ( region_stack.size() > 1 ) {
+            while ( region_stack.back().first->level > x.level ) {
+                region_stack.pop_back();
+            }
+
+            // If last region is same level as this region, remove it
+            if ( region_stack.back().first->level == x.level ) {
+                region_stack.pop_back();
+            }
+        }
+
+
+        std::wstring region_indicator;
+        if ( x.level == 1 ) {
+            region_indicator += L"■ ";
+        }
+        else if ( !x.last_of_level ) {
+            region_indicator += L"├ ■ ";
+        }
+        else {
+            region_indicator += L"└ ■ ";
+        }
+
+        // If I'm the last child at this level, need to turn | off for my parent
+        if ( x.level != 1 && x.last_of_level ) region_stack.back().second = false;
+
+        // Create prefix string
+        std::wstring prefix;
+        for ( size_t i = 0; i < region_stack.size(); ++i ) {
+            if ( region_stack[i].second )
+                prefix += L"│ ";
+            else
+                prefix += L"  ";
+        }
+
+        // If this is the last level to print because of verbosity,
+        // act like the region has no children
+        bool has_child = x.has_child && x.level != verbose;
+        region_stack.push_back(std::make_pair(&x, has_child));
+
+        // The prefix for the region string needs to remove the indent
+        // caused by the current level
+        std::wstring region_prefix = prefix.substr(0, prefix.length() - 2);
+
+        if ( print ) out.output("%ls%ls%s\n", region_prefix.c_str(), region_indicator.c_str(), x.tag.c_str());
+
+        // Print the perf values
+        std::wstring stat_prefix = prefix + (has_child ? L"│ " : L"  ") + L"├──";
+        if ( print ) out.output("%ls Duration: %.3lf seconds\n", stat_prefix.c_str(), x.end_time - x.begin_time);
+
+        uint64_t    mem_size_global = getGlobalTotalRegionEndMemSize(x.tag);
+        UnitAlgebra mem_size_global_us("1kB");
+        mem_size_global_us *= mem_size_global;
+
+        stat_prefix = prefix + (has_child ? L"│ " : L"  ") + L"└──";
+        if ( num_ranks_ > 1 ) {
+            auto        mem_size_max = getGlobalMaxRegionEndMemSize(x.tag);
+            UnitAlgebra mem_size_max_us("1kB");
+            mem_size_max_us *= mem_size_max.first;
+
+            if ( print )
+                out.output("%ls Memory: Total - %s, Max - %s (rank %d)\n", stat_prefix.c_str(),
+                    mem_size_global_us.toStringBestSI(4).c_str(), mem_size_max_us.toStringBestSI(4).c_str(),
+                    mem_size_max.second);
+        }
+        else {
+            if ( print )
+                out.output(
+                    "%ls Memory: Total - %s\n", stat_prefix.c_str(), mem_size_global_us.toStringBestSI(4).c_str());
+        }
+    }
+}
+
+} // namespace SST::Util

--- a/src/sst/core/util/basicPerf.h
+++ b/src/sst/core/util/basicPerf.h
@@ -1,0 +1,230 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_UTIL_BASIC_PERF_H
+#define SST_CORE_UTIL_BASIC_PERF_H
+
+#include <map>
+#include <stack>
+#include <string>
+#include <vector>
+
+namespace SST {
+class Output;
+
+namespace Util {
+
+struct RegionPerfInfo
+{
+    double      begin_time    = 0.0;
+    double      end_time      = 0.0;
+    uint64_t    begin_mem     = 0;
+    uint64_t    end_mem       = 0;
+    size_t      level         = 0;
+    bool        last_of_level = true;
+    bool        has_child     = false;
+    std::string tag;
+
+    // Roll-up data
+
+    // First entry will be the max duration.  If detailed is turned on
+    // (i.e. report all rank data), then all the rank data will come
+    // after, with index 1 being rank 0, etc.
+    std::vector<double> rollup_duration;
+
+    // Rank with the max duration
+    int rollup_max_duration_rank = -1;
+
+    // This tracks the begin memory.  Index 0 will be the total
+    // global memory, index 1 will be the max memory on any one
+    // rank. If detailed is turned on (i.e. report all rank data),
+    // then all the rank data will come after, with index 2 being rank
+    // 0, etc.
+    std::vector<uint64_t> rollup_begin_mem;
+
+    // Rank with the max memory
+    int rollup_begin_mem_max_rank = -1;
+
+    // This tracks the end memory.  Index 0 will be the total
+    // global memory, index 1 will be the max memory on any one
+    // rank. If detailed is turned on (i.e. report all rank data),
+    // then all the rank data will come after, with index 2 being rank
+    // 0, etc.
+    std::vector<uint64_t> rollup_end_mem;
+
+    // Rank with the max memory
+    int rollup_end_mem_max_rank = -1;
+
+    RegionPerfInfo(const std::string& tag, size_t level) :
+        level(level),
+        tag(tag)
+    {}
+};
+
+/**
+   Class used to track various performance data during simulation
+   execution.
+
+   Regions:
+
+   Regions are tracked hierarchically and you can output various
+   levels of data based on the verbose value supplied to the output
+   functions.  Each region is denoted using beginRegion() and
+   endRegion().  Each regions can be contained with another region,
+   but it must be wholly contained within that region. For output, the
+   verbose value can be used to indicate how much detail to output.
+   The verbose value indicates how deep to print in the region
+   hierarchy.  A verbose value of 0 indicates no output, 1 will output
+   only the top level regions, etc.  The default verbose level is 2.
+
+   Scalars:
+
+   Scalars are tracked using the addMetric<>() function and are
+   retrieved by using the getMetric<>() function.  These can only
+   track signed and unsigned ints and floating point numbers.  All
+   types are stored as their 64-bit versions.
+ */
+class BasicPerfTracker
+{
+public:
+
+    void initialize(int rank, int num_ranks);
+
+    RegionPerfInfo getRegionPerfInfo(const std::string& name);
+
+    /**
+       Begin a new code region
+     */
+    void beginRegion(const std::string& tag);
+
+    /**
+       End the named region.  This will cause a series of collectives
+       to gather the total and max resource utilizations for the
+       region.  This data will be kept on all ranks.
+     */
+    void endRegion(const std::string& tag);
+
+    ///// Functions to get the local and global information about the execution /////
+
+    /**
+       Get the local begin time for the specified region
+     */
+    double getRegionBeginTime(const std::string& tag);
+
+    /**
+       Get the local ending time for the specified region
+     */
+    double getRegionEndTime(const std::string& tag);
+
+    /**
+       Get the local duration for the specified region
+     */
+    double getRegionDuration(const std::string& tag);
+
+    /**
+       Get the global duration for the specified region
+     */
+    double getRegionGlobalDuration(const std::string& tag);
+
+    ///// Functions to get the local and global information about the memory usage /////
+
+    /**
+       Get the local memory size at begin for the specified region
+
+       @return local memory usage in bytes
+    */
+    uint64_t getLocalRegionBeginMemSize(const std::string& tag);
+
+    /**
+       Get the global total memory size at begin for the specified region
+
+       @return global total memory usage in bytes
+    */
+    uint64_t getGlobalTotalRegionBeginMemSize(const std::string& tag);
+
+    /**
+       Get the global max memory size at begin for the specified region
+
+       @return pair of max memory usage in bytes and the rank that
+       usage was from
+    */
+    std::pair<uint64_t, int> getGlobalMaxRegionBeginMemSize(const std::string& tag);
+
+
+    /**
+       Get the local memory size at end for the specified region
+
+       @return local memory usage in bytes
+    */
+    uint64_t getLocalRegionEndMemSize(const std::string& tag);
+
+    /**
+       Get the global total memory size at end for the specified region
+
+       @return global total memory usage in bytes
+    */
+    uint64_t getGlobalTotalRegionEndMemSize(const std::string& tag);
+
+    /**
+       Get the global max memory size at end for the specified region
+
+       @return pair of max memory usage in bytes and the rank that
+       usage was from
+    */
+    std::pair<uint64_t, int> getGlobalMaxRegionEndMemSize(const std::string& tag);
+
+
+    void addMetric(const std::string& name, uint64_t value);
+    void addMetric(const std::string& name, int64_t value);
+    void addMetric(const std::string& name, double value);
+
+    uint64_t getMetricUnsigned(const std::string& name);
+    int64_t  getMetricSigned(const std::string& name);
+    double   getMetricFloat(const std::string& name);
+
+    void outputRegionData(Output& out, size_t verbose);
+
+private:
+
+    /**
+       Stores the regions in the order they are created
+     */
+    std::vector<RegionPerfInfo> regions_;
+
+    /**
+       Stack of currently active regions
+     */
+    std::stack<size_t> current_regions_;
+
+    /**
+       Gets the specified region from the regions_ vector.  If it's
+       not there, prints an error message that references the passed
+       in function name and calls SST_Exit().
+     */
+    RegionPerfInfo& getRegion(const std::string& tag, const std::string& function_name, bool must_be_ended = true);
+
+
+    // Scalar storage
+    std::map<std::string, uint64_t> scalars_unsigned;
+    std::map<std::string, int64_t>  scalars_signed;
+    std::map<std::string, double>   scalars_float;
+
+    int        rank_;
+    int        num_ranks_;
+    // TEMP
+    static int level;
+};
+
+
+} // namespace Util
+} // namespace SST
+
+#endif // SST_CORE_UTIL_BASIC_PERF_H


### PR DESCRIPTION
- Better aligned regions for regular and restart runs
- Added comments to regions to better describe what each does
- Added resource tracking at region level
- Changed --print-timing-info to take a verbosity level
- Added some SST version of MPI calls that hide the SST_CONFIF_HAVE_MPI checks
