### PR TITLE
Remove whitespace from GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ NOTE: If you are reporting an issue for a specific element library, please submi
 
 2 - Describe how to reproduce the issue
 
-3 - What Operating system(s) and versions 
+3 - What Operating system(s) and versions
 
 4 - What versions of external libraries (MPI, etc.)
 

--- a/.github/ISSUE_TEMPLATE/help-wanted.md
+++ b/.github/ISSUE_TEMPLATE/help-wanted.md
@@ -14,7 +14,7 @@ NOTE: If you are requesting help for a specific element library, please submit r
 
 2 - Describe how to reproduce the issue
 
-3 - What Operating system(s) and versions 
+3 - What Operating system(s) and versions
 
 4 - What version of external libraries (MPI, etc)
 


### PR DESCRIPTION
Closes #1403

This is intentionally a merge into `master`, unless someone wants to go manually update the files.  I'm not sure how this plays with the Autotester but assume it's ok because these files aren't related to the code in any way.