### PR TITLE
core: increase timeout for os_command

### DIFF
--- a/tests/testsuite_default_sstinfo.py
+++ b/tests/testsuite_default_sstinfo.py
@@ -51,7 +51,7 @@ class testcase_sstinfo(SSTTestCase):
         self.assertTrue(os.path.isdir(sst_app_path), err_str)
 
         cmd = '{0}/sst-info coreTestElement {1}'.format(sst_app_path, flags)
-        rtn = os_command(cmd, output_file_path = outfile, error_file_path = errfile).run(timeout_sec = 1)
+        rtn = os_command(cmd, output_file_path = outfile, error_file_path = errfile).run(timeout_sec = 5)
 
         if testtype == "coreTestElement":
             if rtn.result() != 0:


### PR DESCRIPTION
One second may not be enough on busy CI machines.  Increase it to 5 seconds.

