### PR TITLE
Expose MPI_Comm_spawn_multiple to elements

### DIFF
--- a/src/sst/core/interprocess/mmapparent.cc
+++ b/src/sst/core/interprocess/mmapparent.cc
@@ -23,23 +23,10 @@ template class SST::Core::Interprocess::MMAPParent<testtunnel>;
 
 namespace SST::Core::Interprocess {
 
-/** EXPERIMENTAL: Launch an MPI application. This is a wrapper around MPI_Comm_spawn_multiple
- * that hides all MPI information from the calling process. This is intended to be used
- * by elements that need to launch other processes, such as Ariel. Even if the launched
- * application does not use MPI, this function should be used as fork() should not be used
- * by MPI applications.
- *
- * @param count Number of commands
- * @param array_of_commands Commands to run
- * @param array_of_argv Argv for each command
- * @param array_of_maxprocs The maximum number of procs for each command
- * @param array_of_env A newline-delimited list of environment variables for each command
- * @param array_of_hosts Which host each command will run on
- */
 int
-SST_MPI_Comm_spawn_multiple2(int count, char *array_of_commands[],
+SST_MPI_Comm_spawn_multiple(int count, char *array_of_commands[],
                           char **array_of_argv[], const int array_of_maxprocs[],
-                          const char *array_of_env[], char *array_of_hosts[])
+                          const char *array_of_env[])
 {
 
     // Count the maximum number of ranks that may be launched
@@ -50,13 +37,17 @@ SST_MPI_Comm_spawn_multiple2(int count, char *array_of_commands[],
 
     int* array_of_errcodes = (int*)malloc(sizeof(int) * ranks);
 
+    char processor_name[MPI_MAX_PROCESSOR_NAME];
+    int  name_len;
+    MPI_Get_processor_name(processor_name, &name_len);
+
     // Passing environment variables to child processes is implementation-specific.
     // Documentation for MPI_Info options:
     // https://docs.open-mpi.org/en/main/man-openmpi/man3/MPI_Comm_spawn_multiple.3.html#info-arguments
     MPI_Info* array_of_info = (MPI_Info*)malloc(sizeof(MPI_Info) * count);
     for ( int i = 0; i < count; i++ ) {
         MPI_Info_create(&array_of_info[i]);
-        MPI_Info_set(array_of_info[i], "host", array_of_hosts[i]);
+        MPI_Info_set(array_of_info[i], "host", processor_name);
 
         // Do not set the child's environment if array_of_env[i] is empty, which seems to crash.
         if ( strcmp("", array_of_env[i]) ) {
@@ -90,258 +81,5 @@ SST_MPI_Comm_spawn_multiple2(int count, char *array_of_commands[],
     free(array_of_errcodes);
 
     return errors;
-}
-
-int
-SST_MPI_Comm_spawn_multiple_new(char** pin_command, const int ranks, const int tracerank, const char* env)
-{
-
-    // We have one command for ranks before the traced rank, one
-    // for the ranks after it, and one for the traced rank itself
-    int cmd_count = 1;
-    if ( tracerank > 0 ) {
-        cmd_count++;
-    }
-    if ( tracerank < (ranks - 1) ) {
-        cmd_count++;
-    }
-
-    // Ariel has already formed the entire string to launch PIN + the app.
-    // Find where the PIN arguments end and the app starts. The traced rank will
-    // launch with pin and the other ranks will launch normally.
-    int app_idx = -1;
-    for ( int i = 0; pin_command[i] != NULL; i++ ) {
-        if ( strcmp(pin_command[i], "--") == 0 ) {
-            app_idx = i + 1;
-            break;
-        }
-    }
-
-    if ( app_idx == -1 ) {
-        return 1;
-    }
-
-    char processor_name[MPI_MAX_PROCESSOR_NAME];
-    int  name_len;
-    MPI_Get_processor_name(processor_name, &name_len);
-
-    int*    array_of_maxprocs = (int*)malloc(sizeof(int) * cmd_count);
-    char**  array_of_commands = (char**)malloc(sizeof(char*) * cmd_count);
-    char*** array_of_argv     = (char***)malloc(sizeof(char**) * cmd_count);
-    const char**  array_of_env      = (const char**)malloc(sizeof(char*) * cmd_count);
-    char**  array_of_hosts    = (char**)malloc(sizeof(char*) * cmd_count);
-
-    if ( cmd_count == 1 ) {
-        array_of_maxprocs[0] = 1;
-        array_of_commands[0] = pin_command[0];
-        array_of_argv[0]     = pin_command + 1;
-    }
-    else if ( cmd_count == 2 ) {
-        if ( tracerank == 0 ) {
-            array_of_maxprocs[0] = 1;
-            array_of_maxprocs[1] = ranks - 1;
-
-            array_of_commands[0] = pin_command[0];
-            array_of_commands[1] = pin_command[app_idx];
-
-            array_of_argv[0] = pin_command + 1;
-            array_of_argv[1] = pin_command + app_idx + 1;
-        }
-        else {
-            array_of_maxprocs[0] = ranks - 1;
-            array_of_maxprocs[1] = 1;
-
-            array_of_commands[0] = pin_command[app_idx];
-            array_of_commands[1] = pin_command[0];
-
-            array_of_argv[0] = pin_command + app_idx + 1;
-            array_of_argv[1] = pin_command + 1;
-        }
-    }
-    else if ( cmd_count == 3 ) {
-        array_of_maxprocs[0] = tracerank;
-        array_of_maxprocs[1] = 1;
-        array_of_maxprocs[2] = ranks - tracerank - 1;
-
-        array_of_commands[0] = pin_command[app_idx];
-        array_of_commands[1] = pin_command[0];
-        array_of_commands[2] = pin_command[app_idx];
-
-        array_of_argv[0] = pin_command + app_idx + 1;
-        array_of_argv[1] = pin_command + 1;
-        array_of_argv[2] = pin_command + app_idx + 1;
-    }
-
-    for (int i = 0; i < cmd_count; i++) {
-        array_of_env[i] = env;
-        array_of_hosts[i] = processor_name;
-    }
-
-	int ret = SST_MPI_Comm_spawn_multiple2(cmd_count, array_of_commands,
-                          array_of_argv, array_of_maxprocs,
-                          array_of_env, array_of_hosts);
-
-    free(array_of_maxprocs);
-    free(array_of_commands);
-    free(array_of_argv);
-    free(array_of_env);
-    free(array_of_hosts);
-
-    return ret;
-}
-
-/** EXPERIMENTAL: Launch an MPI job with one rank traced by Pin.
- *
- * @param pin_command The full command to launch a process using the pintool
- * @param ranks The number of ranks to launch
- * @param tracerank The rank to be traced by Pin
- * @param env A newline-delimited list of environment variables to be set in the child
- */
-int
-SST_MPI_Comm_spawn_multiple(char** pin_command, const int ranks, const int tracerank, const char* env)
-{
-
-    // We have one command for ranks before the traced rank, one
-    // for the ranks after it, and one for the traced rank itself
-    int cmd_count = 1;
-    if ( tracerank > 0 ) {
-        cmd_count++;
-    }
-    if ( tracerank < (ranks - 1) ) {
-        cmd_count++;
-    }
-
-    // Ariel has already formed the entire string to launch PIN + the app.
-    // Find where the PIN arguments end and the app starts. The traced rank will
-    // launch with pin and the other ranks will launch normally.
-    int app_idx = -1;
-    for ( int i = 0; pin_command[i] != NULL; i++ ) {
-        if ( strcmp(pin_command[i], "--") == 0 ) {
-            app_idx = i + 1;
-            break;
-        }
-    }
-
-    if ( app_idx == -1 ) {
-        return 1;
-    }
-
-    // Users may specify environment variables in the Ariel parameters. We pass
-    // them to the child using MPI_Info. Also set the processor name so all ranks
-    // run on the same node as the parent SST process. We may relax this requirement in
-    // the future so that only the traced rank runs alongside SST.
-    // Documentation for MPI_Info options:
-    // https://docs.open-mpi.org/en/main/man-openmpi/man3/MPI_Comm_spawn_multiple.3.html#info-arguments
-    MPI_Info* array_of_info = (MPI_Info*)malloc(sizeof(MPI_Info) * cmd_count);
-
-    char processor_name[MPI_MAX_PROCESSOR_NAME];
-    int  name_len;
-    MPI_Get_processor_name(processor_name, &name_len);
-
-    for ( int i = 0; i < cmd_count; i++ ) {
-        MPI_Info_create(&array_of_info[i]);
-        MPI_Info_set(array_of_info[0], "host", processor_name);
-
-        // Do not set the child environment if env is empty, which seems to crash.
-        if ( strcmp("", env) ) {
-            MPI_Info_set(array_of_info[i], "env", env);
-        }
-    }
-
-    int*    array_of_maxprocs = (int*)malloc(sizeof(int) * cmd_count);
-    char**  array_of_commands = (char**)malloc(sizeof(char*) * cmd_count);
-    char*** array_of_argv     = (char***)malloc(sizeof(char**) * cmd_count);
-
-    if ( cmd_count == 1 ) {
-        array_of_maxprocs[0] = 1;
-        array_of_commands[0] = pin_command[0];
-        array_of_argv[0]     = pin_command + 1;
-    }
-    else if ( cmd_count == 2 ) {
-        if ( tracerank == 0 ) {
-            array_of_maxprocs[0] = 1;
-            array_of_maxprocs[1] = ranks - 1;
-
-            array_of_commands[0] = pin_command[0];
-            array_of_commands[1] = pin_command[app_idx];
-
-            array_of_argv[0] = pin_command + 1;
-            array_of_argv[1] = pin_command + app_idx + 1;
-        }
-        else {
-            array_of_maxprocs[0] = ranks - 1;
-            array_of_maxprocs[1] = 1;
-
-            array_of_commands[0] = pin_command[app_idx];
-            array_of_commands[1] = pin_command[0];
-
-            array_of_argv[0] = pin_command + app_idx + 1;
-            array_of_argv[1] = pin_command + 1;
-        }
-    }
-    else if ( cmd_count == 3 ) {
-        array_of_maxprocs[0] = tracerank;
-        array_of_maxprocs[1] = 1;
-        array_of_maxprocs[2] = ranks - tracerank - 1;
-
-        array_of_commands[0] = pin_command[app_idx];
-        array_of_commands[1] = pin_command[0];
-        array_of_commands[2] = pin_command[app_idx];
-
-        array_of_argv[0] = pin_command + app_idx + 1;
-        array_of_argv[1] = pin_command + 1;
-        array_of_argv[2] = pin_command + app_idx + 1;
-    }
-
-
-    /*
-    printf("[SST CORE] Count is %d\n", cmd_count);
-    for(int i = 0; i < cmd_count; i++) {
-       printf("[SST CORE] Command %d: \n", i);
-       printf("  maxprocs: %d\n", array_of_maxprocs[i]);
-       printf("  command: %s\n", array_of_commands[i]);
-       printf("  argv:\n");
-       for(int j = 0; array_of_argv[i][j]!=NULL; j++) {
-          printf("    %s ", array_of_argv[i][j]);
-       }
-       printf("\n");
-    }
-    */
-
-    MPI_Comm intercomm;
-    int*     array_of_errcodes = (int*)malloc(sizeof(int) * ranks);
-    int result = MPI_Comm_spawn_multiple(cmd_count, array_of_commands, array_of_argv, array_of_maxprocs, array_of_info,
-        0,             // root
-        MPI_COMM_SELF, // comm
-        &intercomm, array_of_errcodes);
-
-    int errors = 0;
-    if ( result != MPI_SUCCESS ) {
-        char error_string[MPI_MAX_ERROR_STRING];
-        int  length_of_error_string;
-        MPI_Error_string(result, error_string, &length_of_error_string);
-        fprintf(stderr, "Error in MPI_Comm_spawn_multiple: %s\n", error_string);
-        errors++;
-    }
-    else {
-        for ( int i = 0; i < ranks; i++ ) {
-            if ( array_of_errcodes[i] != MPI_SUCCESS ) {
-                fprintf(stderr, "Error in MPI_Comm_spawn_multiple: process %d failed to start\n", i);
-                errors++;
-            }
-        }
-    }
-
-    free(array_of_maxprocs);
-    free(array_of_commands);
-    free(array_of_argv);
-    free(array_of_info);
-    free(array_of_errcodes);
-
-    if ( errors > 0 ) {
-        return 1;
-    }
-
-    return 0;
 }
 } // namespace SST::Core::Interprocess

--- a/src/sst/core/interprocess/mmapparent.cc
+++ b/src/sst/core/interprocess/mmapparent.cc
@@ -56,7 +56,7 @@ namespace SST::Core::Interprocess {
       MPI_Info *array_of_info = (MPI_Info*)malloc(sizeof(MPI_Info) * count);
       for (int i = 0; i < count; i++) {
          MPI_Info_create(&array_of_info[i]);
-         //MPI_Info_set(array_of_info[i], "env", env); // TODO Why does this crash?
+         MPI_Info_set(array_of_info[i], "env", env); // TODO Why does this crash?
       }
 
       // Get the processor name so we can make the traced process

--- a/src/sst/core/interprocess/mmapparent.cc
+++ b/src/sst/core/interprocess/mmapparent.cc
@@ -74,7 +74,7 @@ namespace SST::Core::Interprocess {
          MPI_Info_set(array_of_info[0], "host", processor_name);
 
          // Do not set the child environment if env is empty, which seems to crash.
-         if (strcmp("", env) {
+         if (strcmp("", env)) {
             MPI_Info_set(array_of_info[i], "env", env);
          }
       }

--- a/src/sst/core/interprocess/mmapparent.cc
+++ b/src/sst/core/interprocess/mmapparent.cc
@@ -23,9 +23,179 @@ template class SST::Core::Interprocess::MMAPParent<testtunnel>;
 
 namespace SST::Core::Interprocess {
 
-/* [EXPERIMENTAL] Launch an MPI process
+/** EXPERIMENTAL: Launch an MPI application. This is a wrapper around MPI_Comm_spawn_multiple
+ * that hides all MPI information from the calling process. This is intended to be used
+ * by elements that need to launch other processes, such as Ariel. Even if the launched
+ * application does not use MPI, this function should be used as fork() should not be used
+ * by MPI applications.
  *
+ * @param count Number of commands
+ * @param array_of_commands Commands to run
+ * @param array_of_argv Argv for each command
+ * @param array_of_maxprocs The maximum number of procs for each command
+ * @param array_of_env A newline-delimited list of environment variables for each command
+ * @param array_of_hosts Which host each command will run on
+ */
+int
+SST_MPI_Comm_spawn_multiple2(int count, char *array_of_commands[],
+                          char **array_of_argv[], const int array_of_maxprocs[],
+                          const char *array_of_env[], char *array_of_hosts[])
+{
+
+    // Count the maximum number of ranks that may be launched
+    int ranks = 0;
+    for (int i = 0; i < count; i++) {
+        ranks += array_of_maxprocs[i];
+    }
+
+    int* array_of_errcodes = (int*)malloc(sizeof(int) * ranks);
+
+    // Passing environment variables to child processes is implementation-specific.
+    // Documentation for MPI_Info options:
+    // https://docs.open-mpi.org/en/main/man-openmpi/man3/MPI_Comm_spawn_multiple.3.html#info-arguments
+    MPI_Info* array_of_info = (MPI_Info*)malloc(sizeof(MPI_Info) * count);
+    for ( int i = 0; i < count; i++ ) {
+        MPI_Info_create(&array_of_info[i]);
+        MPI_Info_set(array_of_info[i], "host", array_of_hosts[i]);
+
+        // Do not set the child's environment if array_of_env[i] is empty, which seems to crash.
+        if ( strcmp("", array_of_env[i]) ) {
+            MPI_Info_set(array_of_info[i], "env", array_of_env[i]);
+        }
+    }
+
+    MPI_Comm intercomm;
+
+    int result = MPI_Comm_spawn_multiple(count, array_of_commands, array_of_argv, array_of_maxprocs, array_of_info, 0, MPI_COMM_SELF, &intercomm, array_of_errcodes);
+
+    // Handle errors here as doing so requires MPI macros and functions
+	int errors = 0;
+    if ( result != MPI_SUCCESS ) {
+        char error_string[MPI_MAX_ERROR_STRING];
+        int  length_of_error_string;
+        MPI_Error_string(result, error_string, &length_of_error_string);
+        fprintf(stderr, "Error in MPI_Comm_spawn_multiple: %s\n", error_string);
+        errors++;
+    }
+    else {
+        for ( int i = 0; i < ranks; i++ ) {
+            if ( array_of_errcodes[i] != MPI_SUCCESS ) {
+                fprintf(stderr, "Error in MPI_Comm_spawn_multiple: process %d failed to start\n", i);
+                errors++;
+            }
+        }
+    }
+
+    free(array_of_info);
+    free(array_of_errcodes);
+
+    return errors;
+}
+
+int
+SST_MPI_Comm_spawn_multiple_new(char** pin_command, const int ranks, const int tracerank, const char* env)
+{
+
+    // We have one command for ranks before the traced rank, one
+    // for the ranks after it, and one for the traced rank itself
+    int cmd_count = 1;
+    if ( tracerank > 0 ) {
+        cmd_count++;
+    }
+    if ( tracerank < (ranks - 1) ) {
+        cmd_count++;
+    }
+
+    // Ariel has already formed the entire string to launch PIN + the app.
+    // Find where the PIN arguments end and the app starts. The traced rank will
+    // launch with pin and the other ranks will launch normally.
+    int app_idx = -1;
+    for ( int i = 0; pin_command[i] != NULL; i++ ) {
+        if ( strcmp(pin_command[i], "--") == 0 ) {
+            app_idx = i + 1;
+            break;
+        }
+    }
+
+    if ( app_idx == -1 ) {
+        return 1;
+    }
+
+    char processor_name[MPI_MAX_PROCESSOR_NAME];
+    int  name_len;
+    MPI_Get_processor_name(processor_name, &name_len);
+
+    int*    array_of_maxprocs = (int*)malloc(sizeof(int) * cmd_count);
+    char**  array_of_commands = (char**)malloc(sizeof(char*) * cmd_count);
+    char*** array_of_argv     = (char***)malloc(sizeof(char**) * cmd_count);
+    const char**  array_of_env      = (const char**)malloc(sizeof(char*) * cmd_count);
+    char**  array_of_hosts    = (char**)malloc(sizeof(char*) * cmd_count);
+
+    if ( cmd_count == 1 ) {
+        array_of_maxprocs[0] = 1;
+        array_of_commands[0] = pin_command[0];
+        array_of_argv[0]     = pin_command + 1;
+    }
+    else if ( cmd_count == 2 ) {
+        if ( tracerank == 0 ) {
+            array_of_maxprocs[0] = 1;
+            array_of_maxprocs[1] = ranks - 1;
+
+            array_of_commands[0] = pin_command[0];
+            array_of_commands[1] = pin_command[app_idx];
+
+            array_of_argv[0] = pin_command + 1;
+            array_of_argv[1] = pin_command + app_idx + 1;
+        }
+        else {
+            array_of_maxprocs[0] = ranks - 1;
+            array_of_maxprocs[1] = 1;
+
+            array_of_commands[0] = pin_command[app_idx];
+            array_of_commands[1] = pin_command[0];
+
+            array_of_argv[0] = pin_command + app_idx + 1;
+            array_of_argv[1] = pin_command + 1;
+        }
+    }
+    else if ( cmd_count == 3 ) {
+        array_of_maxprocs[0] = tracerank;
+        array_of_maxprocs[1] = 1;
+        array_of_maxprocs[2] = ranks - tracerank - 1;
+
+        array_of_commands[0] = pin_command[app_idx];
+        array_of_commands[1] = pin_command[0];
+        array_of_commands[2] = pin_command[app_idx];
+
+        array_of_argv[0] = pin_command + app_idx + 1;
+        array_of_argv[1] = pin_command + 1;
+        array_of_argv[2] = pin_command + app_idx + 1;
+    }
+
+    for (int i = 0; i < cmd_count; i++) {
+        array_of_env[i] = env;
+        array_of_hosts[i] = processor_name;
+    }
+
+	int ret = SST_MPI_Comm_spawn_multiple2(cmd_count, array_of_commands,
+                          array_of_argv, array_of_maxprocs,
+                          array_of_env, array_of_hosts);
+
+    free(array_of_maxprocs);
+    free(array_of_commands);
+    free(array_of_argv);
+    free(array_of_env);
+    free(array_of_hosts);
+
+    return ret;
+}
+
+/** EXPERIMENTAL: Launch an MPI job with one rank traced by Pin.
  *
+ * @param pin_command The full command to launch a process using the pintool
+ * @param ranks The number of ranks to launch
+ * @param tracerank The rank to be traced by Pin
+ * @param env A newline-delimited list of environment variables to be set in the child
  */
 int
 SST_MPI_Comm_spawn_multiple(char** pin_command, const int ranks, const int tracerank, const char* env)

--- a/src/sst/core/interprocess/mmapparent.cc
+++ b/src/sst/core/interprocess/mmapparent.cc
@@ -12,169 +12,166 @@
 /* This exists only to test mmapparent during sst-core compilation */
 
 #include "sst_config.h"
-#include "sst/core/sst_mpi.h"
 
 #include "sst/core/interprocess/mmapparent.h"
 
 #include "sst/core/interprocess/tunneldef.h"
+#include "sst/core/sst_mpi.h"
 
 using testtunnel = SST::Core::Interprocess::TunnelDef<int, int>;
 template class SST::Core::Interprocess::MMAPParent<testtunnel>;
 
 namespace SST::Core::Interprocess {
 
-   /* [EXPERIMENTAL] Launch an MPI process
-    *
-    *
-    */
-   int SST_MPI_Comm_spawn_multiple (
-         char** pin_command,
-         const int ranks,
-         const int tracerank,
-         const char* env) {
+/* [EXPERIMENTAL] Launch an MPI process
+ *
+ *
+ */
+int
+SST_MPI_Comm_spawn_multiple(char** pin_command, const int ranks, const int tracerank, const char* env)
+{
 
-      // We have one command for ranks before the traced rank, one
-      // for the ranks after it, and one for the traced rank itself
-      int cmd_count = 1;
-      if (tracerank > 0) {
-         cmd_count++;
-      }
-      if (tracerank < (ranks-1)) {
-         cmd_count++;
-      }
+    // We have one command for ranks before the traced rank, one
+    // for the ranks after it, and one for the traced rank itself
+    int cmd_count = 1;
+    if ( tracerank > 0 ) {
+        cmd_count++;
+    }
+    if ( tracerank < (ranks - 1) ) {
+        cmd_count++;
+    }
 
-      // Ariel has already formed the entire string to launch PIN + the app.
-      // Find where the PIN arguments end and the app starts. The traced rank will
-      // launch with pin and the other ranks will launch normally.
-      int app_idx = -1;
-      for (int i = 0; pin_command[i] != NULL; i++) {
-        if (strcmp(pin_command[i], "--") == 0) {
-            app_idx = i+1;
+    // Ariel has already formed the entire string to launch PIN + the app.
+    // Find where the PIN arguments end and the app starts. The traced rank will
+    // launch with pin and the other ranks will launch normally.
+    int app_idx = -1;
+    for ( int i = 0; pin_command[i] != NULL; i++ ) {
+        if ( strcmp(pin_command[i], "--") == 0 ) {
+            app_idx = i + 1;
             break;
         }
-      }
+    }
 
-      if (app_idx == -1) {
-         return 1;
-      }
+    if ( app_idx == -1 ) {
+        return 1;
+    }
 
-      // Users may specify environment variables in the Ariel parameters. We pass
-      // them to the child using MPI_Info. Also set the processor name so all ranks
-      // run on the same node as the parent SST process. We may relax this requirement in
-      // the future so that only the traced rank runs alongside SST.
-      // Documentation for MPI_Info options: https://docs.open-mpi.org/en/main/man-openmpi/man3/MPI_Comm_spawn_multiple.3.html#info-arguments
-      MPI_Info *array_of_info = (MPI_Info*)malloc(sizeof(MPI_Info) * cmd_count);
+    // Users may specify environment variables in the Ariel parameters. We pass
+    // them to the child using MPI_Info. Also set the processor name so all ranks
+    // run on the same node as the parent SST process. We may relax this requirement in
+    // the future so that only the traced rank runs alongside SST.
+    // Documentation for MPI_Info options:
+    // https://docs.open-mpi.org/en/main/man-openmpi/man3/MPI_Comm_spawn_multiple.3.html#info-arguments
+    MPI_Info* array_of_info = (MPI_Info*)malloc(sizeof(MPI_Info) * cmd_count);
 
-      char processor_name[MPI_MAX_PROCESSOR_NAME];
-      int name_len;
-      MPI_Get_processor_name(processor_name, &name_len);
+    char processor_name[MPI_MAX_PROCESSOR_NAME];
+    int  name_len;
+    MPI_Get_processor_name(processor_name, &name_len);
 
-      for (int i = 0; i < cmd_count; i++) {
-         MPI_Info_create(&array_of_info[i]);
-         MPI_Info_set(array_of_info[0], "host", processor_name);
+    for ( int i = 0; i < cmd_count; i++ ) {
+        MPI_Info_create(&array_of_info[i]);
+        MPI_Info_set(array_of_info[0], "host", processor_name);
 
-         // Do not set the child environment if env is empty, which seems to crash.
-         if (strcmp("", env)) {
+        // Do not set the child environment if env is empty, which seems to crash.
+        if ( strcmp("", env) ) {
             MPI_Info_set(array_of_info[i], "env", env);
-         }
-      }
+        }
+    }
 
-      int    *array_of_maxprocs = (int*)   malloc(sizeof(int) * cmd_count);
-      char  **array_of_commands = (char**) malloc(sizeof(char*) * cmd_count);
-      char ***array_of_argv     = (char***)malloc(sizeof(char**) * cmd_count);
+    int*    array_of_maxprocs = (int*)malloc(sizeof(int) * cmd_count);
+    char**  array_of_commands = (char**)malloc(sizeof(char*) * cmd_count);
+    char*** array_of_argv     = (char***)malloc(sizeof(char**) * cmd_count);
 
-      if (cmd_count == 1) {
-         array_of_maxprocs[0] = 1;
-         array_of_commands[0] = pin_command[0];
-         array_of_argv[0] = pin_command+1;
-      } else if (cmd_count == 2) {
-         if (tracerank == 0) {
+    if ( cmd_count == 1 ) {
+        array_of_maxprocs[0] = 1;
+        array_of_commands[0] = pin_command[0];
+        array_of_argv[0]     = pin_command + 1;
+    }
+    else if ( cmd_count == 2 ) {
+        if ( tracerank == 0 ) {
             array_of_maxprocs[0] = 1;
-            array_of_maxprocs[1] = ranks-1;
+            array_of_maxprocs[1] = ranks - 1;
 
             array_of_commands[0] = pin_command[0];
             array_of_commands[1] = pin_command[app_idx];
 
-            array_of_argv[0] = pin_command+1;
-            array_of_argv[1] = pin_command+app_idx+1;
-         } else {
-            array_of_maxprocs[0] = ranks-1;
+            array_of_argv[0] = pin_command + 1;
+            array_of_argv[1] = pin_command + app_idx + 1;
+        }
+        else {
+            array_of_maxprocs[0] = ranks - 1;
             array_of_maxprocs[1] = 1;
 
             array_of_commands[0] = pin_command[app_idx];
             array_of_commands[1] = pin_command[0];
 
-            array_of_argv[0] = pin_command+app_idx+1;
-            array_of_argv[1] = pin_command+1;
-         }
-      } else if (cmd_count == 3) {
-         array_of_maxprocs[0] = tracerank;
-         array_of_maxprocs[1] = 1;
-         array_of_maxprocs[2] = ranks - tracerank - 1;
+            array_of_argv[0] = pin_command + app_idx + 1;
+            array_of_argv[1] = pin_command + 1;
+        }
+    }
+    else if ( cmd_count == 3 ) {
+        array_of_maxprocs[0] = tracerank;
+        array_of_maxprocs[1] = 1;
+        array_of_maxprocs[2] = ranks - tracerank - 1;
 
-         array_of_commands[0] = pin_command[app_idx];
-         array_of_commands[1] = pin_command[0];
-         array_of_commands[2] = pin_command[app_idx];
+        array_of_commands[0] = pin_command[app_idx];
+        array_of_commands[1] = pin_command[0];
+        array_of_commands[2] = pin_command[app_idx];
 
-         array_of_argv[0] = pin_command+app_idx+1;
-         array_of_argv[1] = pin_command+1;
-         array_of_argv[2] = pin_command+app_idx+1;
-      }
+        array_of_argv[0] = pin_command + app_idx + 1;
+        array_of_argv[1] = pin_command + 1;
+        array_of_argv[2] = pin_command + app_idx + 1;
+    }
 
 
-      /*
-      printf("[SST CORE] Count is %d\n", cmd_count);
-      for(int i = 0; i < cmd_count; i++) {
-         printf("[SST CORE] Command %d: \n", i);
-         printf("  maxprocs: %d\n", array_of_maxprocs[i]);
-         printf("  command: %s\n", array_of_commands[i]);
-         printf("  argv:\n");
-         for(int j = 0; array_of_argv[i][j]!=NULL; j++) {
-            printf("    %s ", array_of_argv[i][j]);
-         }
-         printf("\n");
-      }
-      */
+    /*
+    printf("[SST CORE] Count is %d\n", cmd_count);
+    for(int i = 0; i < cmd_count; i++) {
+       printf("[SST CORE] Command %d: \n", i);
+       printf("  maxprocs: %d\n", array_of_maxprocs[i]);
+       printf("  command: %s\n", array_of_commands[i]);
+       printf("  argv:\n");
+       for(int j = 0; array_of_argv[i][j]!=NULL; j++) {
+          printf("    %s ", array_of_argv[i][j]);
+       }
+       printf("\n");
+    }
+    */
 
-      MPI_Comm intercomm;
-      int *array_of_errcodes = (int*)malloc(sizeof(int) * ranks);
-      int result = MPI_Comm_spawn_multiple(cmd_count,
-             array_of_commands,
-             array_of_argv,
-             array_of_maxprocs,
-             array_of_info,
-             0,             //root
-             MPI_COMM_SELF, //comm
-             &intercomm,
-             array_of_errcodes);
+    MPI_Comm intercomm;
+    int*     array_of_errcodes = (int*)malloc(sizeof(int) * ranks);
+    int result = MPI_Comm_spawn_multiple(cmd_count, array_of_commands, array_of_argv, array_of_maxprocs, array_of_info,
+        0,             // root
+        MPI_COMM_SELF, // comm
+        &intercomm, array_of_errcodes);
 
-      int errors = 0;
-      if (result != MPI_SUCCESS) {
-         char error_string[MPI_MAX_ERROR_STRING];
-         int length_of_error_string;
-         MPI_Error_string(result, error_string, &length_of_error_string);
-         fprintf(stderr, "Error in MPI_Comm_spawn_multiple: %s\n", error_string);
-         errors++;
-      } else {
-         for (int i = 0; i < ranks; i++) {
-            if (array_of_errcodes[i] != MPI_SUCCESS) {
+    int errors = 0;
+    if ( result != MPI_SUCCESS ) {
+        char error_string[MPI_MAX_ERROR_STRING];
+        int  length_of_error_string;
+        MPI_Error_string(result, error_string, &length_of_error_string);
+        fprintf(stderr, "Error in MPI_Comm_spawn_multiple: %s\n", error_string);
+        errors++;
+    }
+    else {
+        for ( int i = 0; i < ranks; i++ ) {
+            if ( array_of_errcodes[i] != MPI_SUCCESS ) {
                 fprintf(stderr, "Error in MPI_Comm_spawn_multiple: process %d failed to start\n", i);
                 errors++;
             }
-         }
-      }
+        }
+    }
 
-      free(array_of_maxprocs);
-      free(array_of_commands);
-      free(array_of_argv);
-      free(array_of_info);
-      free(array_of_errcodes);
+    free(array_of_maxprocs);
+    free(array_of_commands);
+    free(array_of_argv);
+    free(array_of_info);
+    free(array_of_errcodes);
 
-      if (errors > 0) {
-         return 1;
-      }
+    if ( errors > 0 ) {
+        return 1;
+    }
 
-      return 0;
-   }
+    return 0;
 }
-
+} // namespace SST::Core::Interprocess

--- a/src/sst/core/interprocess/mmapparent.cc
+++ b/src/sst/core/interprocess/mmapparent.cc
@@ -12,6 +12,7 @@
 /* This exists only to test mmapparent during sst-core compilation */
 
 #include "sst_config.h"
+#include "sst/core/sst_mpi.h"
 
 #include "sst/core/interprocess/mmapparent.h"
 
@@ -19,3 +20,72 @@
 
 using testtunnel = SST::Core::Interprocess::TunnelDef<int, int>;
 template class SST::Core::Interprocess::MMAPParent<testtunnel>;
+
+namespace SST::Core::Interprocess {
+   int SST_MPI_Comm_spawn_multiple (int count,
+         char *array_of_commands[],
+         char **array_of_argv[],
+         const int array_of_maxprocs[]) {
+
+      MPI_Info *array_of_info = (MPI_Info*)malloc(sizeof(MPI_Info) * count);
+      for (int i = 0; i < count; i++) {
+         //TODO Check error
+         MPI_Info_create(&array_of_info[i]);
+      }
+
+      int root = 0;
+      MPI_Comm comm = MPI_COMM_SELF;
+      MPI_Comm intercomm; // TODO: Store somewhere
+
+      // Each command may spawn multiple ranks
+      // Each rank returns a separate error code
+      // We need to allocate space for each
+      int sum_max_procs = 0;
+      for (int i = 0; i < count; i++) {
+         sum_max_procs += array_of_maxprocs[i];
+      }
+      int *array_of_errcodes = (int*)malloc(sizeof(int) * sum_max_procs);
+
+      int result = MPI_Comm_spawn_multiple(count,
+             array_of_commands,
+             array_of_argv,
+             array_of_maxprocs,
+             array_of_info,
+             root,
+             comm,
+             &intercomm,
+             array_of_errcodes);
+
+      if (result != MPI_SUCCESS) {
+         char error_string[MPI_MAX_ERROR_STRING];
+         int length_of_error_string;
+         MPI_Error_string(result, error_string, &length_of_error_string);
+
+         // Print a meaningful error message
+         fprintf(stderr, "Error in MPI_Comm_spawn_multiple: %s\n", error_string);
+
+         // Optionally, you could handle the error further (e.g., abort the program)
+         //MPI_Abort(comm, result);
+         free(array_of_info);
+         free(array_of_errcodes);
+         return 1;
+      }
+
+      int errors = 0;
+      for (int i = 0; i < sum_max_procs; i++) {
+         if (array_of_errcodes[i] != MPI_SUCCESS) {
+             fprintf(stderr, "Error in MPI_Comm_spawn_multiple: process %d failed to start\n", i);
+             errors++;
+         }
+      }
+
+      free(array_of_info);
+      free(array_of_errcodes);
+
+      if (errors > 0) {
+         return 1;
+      }
+      return 0;
+   }
+}
+

--- a/src/sst/core/interprocess/mmapparent.cc
+++ b/src/sst/core/interprocess/mmapparent.cc
@@ -24,14 +24,13 @@ template class SST::Core::Interprocess::MMAPParent<testtunnel>;
 namespace SST::Core::Interprocess {
 
 int
-SST_MPI_Comm_spawn_multiple(int count, char *array_of_commands[],
-                          char **array_of_argv[], const int array_of_maxprocs[],
-                          const char *array_of_env[])
+SST_MPI_Comm_spawn_multiple(int count, char* array_of_commands[], char** array_of_argv[], const int array_of_maxprocs[],
+    const char* array_of_env[])
 {
 
     // Count the maximum number of ranks that may be launched
     int ranks = 0;
-    for (int i = 0; i < count; i++) {
+    for ( int i = 0; i < count; i++ ) {
         ranks += array_of_maxprocs[i];
     }
 
@@ -57,10 +56,11 @@ SST_MPI_Comm_spawn_multiple(int count, char *array_of_commands[],
 
     MPI_Comm intercomm;
 
-    int result = MPI_Comm_spawn_multiple(count, array_of_commands, array_of_argv, array_of_maxprocs, array_of_info, 0, MPI_COMM_SELF, &intercomm, array_of_errcodes);
+    int result = MPI_Comm_spawn_multiple(count, array_of_commands, array_of_argv, array_of_maxprocs, array_of_info, 0,
+        MPI_COMM_SELF, &intercomm, array_of_errcodes);
 
     // Handle errors here as doing so requires MPI macros and functions
-	int errors = 0;
+    int errors = 0;
     if ( result != MPI_SUCCESS ) {
         char error_string[MPI_MAX_ERROR_STRING];
         int  length_of_error_string;

--- a/src/sst/core/interprocess/mmapparent.h
+++ b/src/sst/core/interprocess/mmapparent.h
@@ -25,14 +25,19 @@
 
 namespace SST::Core::Interprocess {
 
-int SST_MPI_Comm_spawn_multiple(char** pin_command, const int ranks, const int tracerank, const char* env);
-int SST_MPI_Comm_spawn_multiple_new(char** pin_command, const int ranks, const int tracerank, const char* env);
-
-/*
-int SST_MPI_Comm_spawn(int count, char **array_of_commands,
- char ***array_of_argv, const int *array_of_maxprocs, int root,
- int *array_of_errcodes);
+/** EXPERIMENTAL: Launch an MPI application. This is a wrapper around MPI_Comm_spawn_multiple
+ * that hides all MPI information from the calling process. This is intended to be used
+ * by elements that need to launch other processes, such as Ariel. Even if the launched
+ * application does not use MPI, this function should be used as fork() should not be used
+ * by MPI applications.
+ *
+ * @param count Number of commands
+ * @param array_of_commands Commands to run
+ * @param array_of_argv Argv for each command
+ * @param array_of_maxprocs The maximum number of procs for each command
+ * @param array_of_env A newline-delimited list of environment variables for each command
  */
+int SST_MPI_Comm_spawn_multiple(int count, char *array_of_commands[], char **array_of_argv[], const int array_of_maxprocs[], const char *array_of_env[]);
 
 /** Class supports an IPC tunnel between two or more processes, via an mmap'd file.
  * This class creates the tunnel for the parent/master process

--- a/src/sst/core/interprocess/mmapparent.h
+++ b/src/sst/core/interprocess/mmapparent.h
@@ -26,6 +26,7 @@
 namespace SST::Core::Interprocess {
 
 int SST_MPI_Comm_spawn_multiple(char** pin_command, const int ranks, const int tracerank, const char* env);
+int SST_MPI_Comm_spawn_multiple_new(char** pin_command, const int ranks, const int tracerank, const char* env);
 
 /*
 int SST_MPI_Comm_spawn(int count, char **array_of_commands,

--- a/src/sst/core/interprocess/mmapparent.h
+++ b/src/sst/core/interprocess/mmapparent.h
@@ -28,7 +28,8 @@ namespace SST::Core::Interprocess {
     int SST_MPI_Comm_spawn_multiple (
         char **pin_command,
         const int ranks,
-        const int tracerank);
+        const int tracerank,
+        const char* env);
 
     /*
     int SST_MPI_Comm_spawn(int count, char **array_of_commands,

--- a/src/sst/core/interprocess/mmapparent.h
+++ b/src/sst/core/interprocess/mmapparent.h
@@ -37,7 +37,8 @@ namespace SST::Core::Interprocess {
  * @param array_of_maxprocs The maximum number of procs for each command
  * @param array_of_env A newline-delimited list of environment variables for each command
  */
-int SST_MPI_Comm_spawn_multiple(int count, char *array_of_commands[], char **array_of_argv[], const int array_of_maxprocs[], const char *array_of_env[]);
+int SST_MPI_Comm_spawn_multiple(int count, char* array_of_commands[], char** array_of_argv[],
+    const int array_of_maxprocs[], const char* array_of_env[]);
 
 /** Class supports an IPC tunnel between two or more processes, via an mmap'd file.
  * This class creates the tunnel for the parent/master process

--- a/src/sst/core/interprocess/mmapparent.h
+++ b/src/sst/core/interprocess/mmapparent.h
@@ -25,17 +25,13 @@
 
 namespace SST::Core::Interprocess {
 
-    int SST_MPI_Comm_spawn_multiple (
-        char **pin_command,
-        const int ranks,
-        const int tracerank,
-        const char* env);
+int SST_MPI_Comm_spawn_multiple(char** pin_command, const int ranks, const int tracerank, const char* env);
 
-    /*
-    int SST_MPI_Comm_spawn(int count, char **array_of_commands,
-     char ***array_of_argv, const int *array_of_maxprocs, int root,
-     int *array_of_errcodes);
-     */
+/*
+int SST_MPI_Comm_spawn(int count, char **array_of_commands,
+ char ***array_of_argv, const int *array_of_maxprocs, int root,
+ int *array_of_errcodes);
+ */
 
 /** Class supports an IPC tunnel between two or more processes, via an mmap'd file.
  * This class creates the tunnel for the parent/master process

--- a/src/sst/core/interprocess/mmapparent.h
+++ b/src/sst/core/interprocess/mmapparent.h
@@ -25,10 +25,10 @@
 
 namespace SST::Core::Interprocess {
 
-    int SST_MPI_Comm_spawn_multiple (int count,
-        char *array_of_commands[],
-        char **array_of_argv[],
-        const int array_of_maxprocs[]);
+    int SST_MPI_Comm_spawn_multiple (
+        char **pin_command,
+        const int ranks,
+        const int tracerank);
 
     /*
     int SST_MPI_Comm_spawn(int count, char **array_of_commands,

--- a/src/sst/core/interprocess/mmapparent.h
+++ b/src/sst/core/interprocess/mmapparent.h
@@ -25,6 +25,17 @@
 
 namespace SST::Core::Interprocess {
 
+    int SST_MPI_Comm_spawn_multiple (int count,
+        char *array_of_commands[],
+        char **array_of_argv[],
+        const int array_of_maxprocs[]);
+
+    /*
+    int SST_MPI_Comm_spawn(int count, char **array_of_commands,
+     char ***array_of_argv, const int *array_of_maxprocs, int root,
+     int *array_of_errcodes);
+     */
+
 /** Class supports an IPC tunnel between two or more processes, via an mmap'd file.
  * This class creates the tunnel for the parent/master process
  *


### PR DESCRIPTION
This PR allows element libraries to launch MPI processes. 

The Ariel frontends rely on launching child processes that they then capture memory references from. Traditionally, this has been done with a call to fork. However, [OpenMPI users are discouraged from calling fork](https://docs.open-mpi.org/en/main/tuning-apps/fork-system-popen.html). The proper way to launch a process from an MPI application is to use MPI_Comm_spawn and [MPI_Comm_spawn_multiple](https://docs.open-mpi.org/en/main/man-openmpi/man3/MPI_Comm_spawn_multiple.3.html#mpi-comm-spawn-multiple). Typically, SST-Core is compiled with an MPI compiler but SST-Elements is not. Thus, to call any MPI functions, elements must call into SST-Core. 

This PR adds a thin wrapper around SST_MPI_Comm_multiple that hides all MPI interfaces. It is general enough that we will not need another PR if we add support for tracing multiple ranks in Ariel, but changes will be needed if we want to allow the child job to run on hosts other than the one the parent runs on.

I added this wrapper to `mmapparent.cc` as this file is already included in Ariel, but I'm happy to move it to a more appropriate location.

