### PR TITLE
Remove warnings when MPI is disabled

### DIFF
--- a/src/sst/core/interprocess/mmapparent.cc
+++ b/src/sst/core/interprocess/mmapparent.cc
@@ -24,8 +24,9 @@ template class SST::Core::Interprocess::MMAPParent<testtunnel>;
 namespace SST::Core::Interprocess {
 
 int
-SST_MPI_Comm_spawn_multiple(int count, char* array_of_commands[], char** array_of_argv[], const int array_of_maxprocs[],
-    const char* array_of_env[])
+SST_MPI_Comm_spawn_multiple(int UNUSED_WO_MPI(count), char* UNUSED_WO_MPI(array_of_commands)[],
+    char** UNUSED_WO_MPI(array_of_argv)[], const int UNUSED_WO_MPI(array_of_maxprocs)[],
+    const char* UNUSED_WO_MPI(array_of_env)[])
 {
 
 #ifdef SST_CONFIG_HAVE_MPI


### PR DESCRIPTION
This removes some warnings about unused parameters when MPI is disabled. Although the macro is named `UNUSED()`, it turns into `[[maybe_unused]]` which prevents warnings about unused parameters but does not _require_ that they be unused.

```
  CXX      sstinfo.o
../../../../src/sst/core/interprocess/mmapparent.cc: In function ‘int SST::Core::Interprocess::SST_MPI_Comm_spawn_multiple(int, char**, char***, const int*, const char**)’:
../../../../src/sst/core/interprocess/mmapparent.cc:27:33: warning: unused parameter ‘count’ [-Wunused-parameter]
   27 | SST_MPI_Comm_spawn_multiple(int count, char* array_of_commands[], char** array_of_argv[], const int array_of_maxprocs[],
      |                             ~~~~^~~~~
../../../../src/sst/core/interprocess/mmapparent.cc:27:46: warning: unused parameter ‘array_of_commands’ [-Wunused-parameter]
   27 | SST_MPI_Comm_spawn_multiple(int count, char* array_of_commands[], char** array_of_argv[], const int array_of_maxprocs[],
      |                                        ~~~~~~^~~~~~~~~~~~~~~~~~~
../../../../src/sst/core/interprocess/mmapparent.cc:27:74: warning: unused parameter ‘array_of_argv’ [-Wunused-parameter]
   27 | SST_MPI_Comm_spawn_multiple(int count, char* array_of_commands[], char** array_of_argv[], const int array_of_maxprocs[],
      |                                                                   ~~~~~~~^~~~~~~~~~~~~~~
../../../../src/sst/core/interprocess/mmapparent.cc:27:101: warning: unused parameter ‘array_of_maxprocs’ [-Wunused-parameter]
   27 | SST_MPI_Comm_spawn_multiple(int count, char* array_of_commands[], char** array_of_argv[], const int array_of_maxprocs[],
      |                                                                                           ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
../../../../src/sst/core/interprocess/mmapparent.cc:28:17: warning: unused parameter ‘array_of_env’ [-Wunused-parameter]
   28 |     const char* array_of_env[])
      |     ~~~~~~~~~~~~^~~~~~~~~~~~~~
```
