### PR TITLE
Make test-includes.pl script run 10x faster and find more cases of missing #includes, plus print helpful instructions

### DIFF
--- a/src/sst/core/activity.h
+++ b/src/sst/core/activity.h
@@ -19,9 +19,11 @@
 #include "sst/core/warnmacros.h"
 
 #include <cinttypes>
+#include <cstdint>
 #include <cstring>
 #include <errno.h>
 #include <sstream>
+#include <string>
 
 // Default Priority Settings
 #define INTERACTIVEPRIOIRTY    0

--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -32,6 +32,9 @@
 #include "sst/core/warnmacros.h"
 #include "sst/core/watchPoint.h"
 
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
 #include <string>
 
 namespace SST {

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -31,6 +31,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 using namespace SST::Statistics;

--- a/src/sst/core/bootshared.cc
+++ b/src/sst/core/bootshared.cc
@@ -16,7 +16,10 @@
 #include "sst/core/env/envquery.h"
 #include "sst/core/warnmacros.h"
 
+#include <cerrno>
 #include <climits>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <map>
 #include <string>

--- a/src/sst/core/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/jsonConfigOutput.cc
@@ -23,6 +23,7 @@
 
 #include "nlohmann/json.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <fstream>
 #include <iomanip>

--- a/src/sst/core/cfgoutput/pythonConfigOutput.cc
+++ b/src/sst/core/cfgoutput/pythonConfigOutput.cc
@@ -21,6 +21,8 @@
 
 #include <cinttypes>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <vector>
 

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -19,6 +19,7 @@
 #include "sst/core/serialization/serializer.h"
 
 #include <cinttypes>
+#include <cstdio>
 
 namespace SST {
 

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -17,11 +17,13 @@
 #include "sst/core/sst_types.h"
 #include "sst/core/timeConverter.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <map>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 namespace SST {
 

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -18,13 +18,17 @@
 #include "sst/core/unitAlgebra.h"
 #include "sst/core/warnmacros.h"
 
+#include <cerrno>
+#include <cstdint>
 #include <cstdlib>
+#include <functional>
 #include <getopt.h>
 #include <iostream>
 #include <string>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <vector>
 
 namespace SST {
 

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -17,6 +17,8 @@
 #include "sst/core/sst_types.h"
 
 // Pull in the patchlevel for Python so we can check Python version
+#include <cstddef>
+#include <cstdio>
 #include <patchlevel.h>
 #include <string>
 

--- a/src/sst/core/configBase.cc
+++ b/src/sst/core/configBase.cc
@@ -18,6 +18,7 @@
 #include "sst/core/util/smartTextFormatter.h"
 #include "sst/core/warnmacros.h"
 
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
 #include <getopt.h>

--- a/src/sst/core/configBase.h
+++ b/src/sst/core/configBase.h
@@ -17,7 +17,10 @@
 #include "sst/core/sst_types.h"
 #include "sst/core/warnmacros.h"
 
+#include <cstddef>
 #include <cstdint>
+#include <cstdio>
+#include <exception>
 #include <functional>
 #include <getopt.h>
 #include <iostream>

--- a/src/sst/core/configGraph.cc
+++ b/src/sst/core/configGraph.cc
@@ -23,6 +23,7 @@
 #include "sst/core/warnmacros.h"
 
 #include <algorithm>
+#include <cstdio>
 #include <fstream>
 #include <string>
 #include <utility>

--- a/src/sst/core/configGraph.h
+++ b/src/sst/core/configGraph.h
@@ -32,6 +32,7 @@
 #include <ostream>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace SST::Statistics;

--- a/src/sst/core/configShared.h
+++ b/src/sst/core/configShared.h
@@ -16,7 +16,10 @@
 #include "sst/core/sst_types.h"
 #include "sst/core/warnmacros.h"
 
+#include <cstdio>
 #include <iostream>
+#include <stdexcept>
+#include <string>
 
 
 namespace SST {

--- a/src/sst/core/decimal_fixedpoint.h
+++ b/src/sst/core/decimal_fixedpoint.h
@@ -16,10 +16,13 @@
 
 #include "sst/core/from_string.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <iomanip>
 #include <limits>
+#include <ostream>
 #include <sstream>
+#include <string>
 #include <type_traits>
 
 namespace SST {

--- a/src/sst/core/eli/attributeInfo.h
+++ b/src/sst/core/eli/attributeInfo.h
@@ -16,6 +16,7 @@
 #include "sst/core/warnmacros.h"
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace SST::ELI {

--- a/src/sst/core/eli/elibase.cc
+++ b/src/sst/core/eli/elibase.cc
@@ -13,6 +13,8 @@
 
 #include "sst/core/eli/elibase.h"
 
+#include <utility>
+
 namespace SST::ELI {
 
 /**************************************************************************

--- a/src/sst/core/eli/elibase.h
+++ b/src/sst/core/eli/elibase.h
@@ -15,6 +15,7 @@
 #include "sst/core/sst_types.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <deque>
 #include <map>

--- a/src/sst/core/eli/paramsInfo.h
+++ b/src/sst/core/eli/paramsInfo.h
@@ -15,6 +15,7 @@
 #include "sst/core/eli/elibase.h"
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace SST::ELI {

--- a/src/sst/core/eli/portsInfo.h
+++ b/src/sst/core/eli/portsInfo.h
@@ -15,6 +15,7 @@
 #include "sst/core/eli/elibase.h"
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace SST::ELI {

--- a/src/sst/core/eli/profilePointInfo.h
+++ b/src/sst/core/eli/profilePointInfo.h
@@ -15,6 +15,7 @@
 #include "sst/core/eli/elibase.h"
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace SST::ELI {

--- a/src/sst/core/eli/statsInfo.h
+++ b/src/sst/core/eli/statsInfo.h
@@ -15,6 +15,7 @@
 #include "sst/core/eli/elibase.h"
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace SST::ELI {

--- a/src/sst/core/eli/subcompSlotInfo.h
+++ b/src/sst/core/eli/subcompSlotInfo.h
@@ -15,6 +15,7 @@
 #include "sst/core/eli/elibase.h"
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace SST::ELI {

--- a/src/sst/core/env/envconfig.cc
+++ b/src/sst/core/env/envconfig.cc
@@ -20,6 +20,7 @@
 #include <set>
 #include <string>
 #include <sys/file.h>
+#include <utility>
 #include <vector>
 
 // SST::Core::Environment::EnvironmentConfigGroup(std::string gName) {

--- a/src/sst/core/env/envquery.cc
+++ b/src/sst/core/env/envquery.cc
@@ -21,6 +21,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <ostream>
 #include <string>
 #include <sys/file.h>
 

--- a/src/sst/core/event.h
+++ b/src/sst/core/event.h
@@ -18,7 +18,9 @@
 
 #include <atomic>
 #include <cinttypes>
+#include <cstdint>
 #include <string>
+#include <utility>
 
 namespace SST {
 

--- a/src/sst/core/exit.cc
+++ b/src/sst/core/exit.cc
@@ -18,6 +18,7 @@
 #include "sst/core/sst_mpi.h"
 #include "sst/core/stopAction.h"
 
+#include <cstdint>
 #include <mutex>
 
 using SST::Core::ThreadSafe::Spinlock;

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -25,6 +25,7 @@
 #include "sst/core/warnmacros.h"
 
 #include <fstream>
+#include <ostream>
 #include <set>
 #include <stdio.h>
 #include <tuple>

--- a/src/sst/core/factory.h
+++ b/src/sst/core/factory.h
@@ -18,10 +18,15 @@
 #include "sst/core/sst_types.h"
 #include "sst/core/sstpart.h"
 
+#include <cstdint>
 #include <iostream>
 #include <mutex>
 #include <set>
+#include <sstream>
 #include <stdio.h>
+#include <string>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 /* Forward declare for Friendship */

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -17,6 +17,7 @@
 #include "sst/core/stringize.h"
 #include "sst/core/timeConverter.h"
 
+#include <cstdio>
 #include <iostream>
 #include <stdexcept>
 

--- a/src/sst/core/impl/oneshotManager.h
+++ b/src/sst/core/impl/oneshotManager.h
@@ -19,6 +19,7 @@
 #include <cinttypes>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace SST {

--- a/src/sst/core/impl/timevortex/timeVortexBinnedMap.h
+++ b/src/sst/core/impl/timevortex/timeVortexBinnedMap.h
@@ -15,6 +15,8 @@
 #include "sst/core/threadsafe.h"
 
 #include <atomic>
+#include <cstdint>
+#include <map>
 #include <queue>
 #include <sst/core/timeVortex.h>
 #include <vector>

--- a/src/sst/core/interfaces/simpleNetwork.h
+++ b/src/sst/core/interfaces/simpleNetwork.h
@@ -21,6 +21,7 @@
 #include "sst/core/subcomponent.h"
 #include "sst/core/warnmacros.h"
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 

--- a/src/sst/core/interfaces/stdMem.h
+++ b/src/sst/core/interfaces/stdMem.h
@@ -24,6 +24,7 @@
 
 #include <atomic>
 #include <climits>
+#include <cstdint>
 #include <iomanip>
 #include <ios>
 #include <map>

--- a/src/sst/core/interprocess/ipctunnel.h
+++ b/src/sst/core/interprocess/ipctunnel.h
@@ -14,6 +14,8 @@
 
 #include "sst/core/interprocess/circularBuffer.h"
 
+#include <cerrno>
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -23,6 +25,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 namespace SST::Core::Interprocess {

--- a/src/sst/core/interprocess/mmapparent.h
+++ b/src/sst/core/interprocess/mmapparent.h
@@ -12,6 +12,7 @@
 #ifndef SST_CORE_INTERPROCESS_TUNNEL_MMAP_PARENT_H
 #define SST_CORE_INTERPROCESS_TUNNEL_MMAP_PARENT_H
 
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/src/sst/core/interprocess/shmchild.h
+++ b/src/sst/core/interprocess/shmchild.h
@@ -14,6 +14,8 @@
 
 #include "sst/core/interprocess/tunneldef.h"
 
+#include <cerrno>
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>

--- a/src/sst/core/interprocess/shmparent.h
+++ b/src/sst/core/interprocess/shmparent.h
@@ -12,6 +12,7 @@
 #ifndef SST_CORE_INTERPROCESS_TUNNEL_SHM_PARENT_H
 #define SST_CORE_INTERPROCESS_TUNNEL_SHM_PARENT_H
 
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/src/sst/core/interprocess/tunneldef.h
+++ b/src/sst/core/interprocess/tunneldef.h
@@ -22,8 +22,11 @@
 
 #include "sst/core/interprocess/circularBuffer.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <inttypes.h>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 namespace SST::Core::Interprocess {

--- a/src/sst/core/iouse.cc
+++ b/src/sst/core/iouse.cc
@@ -15,6 +15,7 @@
 
 #include "sst/core/sst_mpi.h"
 
+#include <cstdint>
 #include <sys/resource.h>
 
 using namespace SST::Core;

--- a/src/sst/core/linkMap.h
+++ b/src/sst/core/linkMap.h
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace SST {

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -20,6 +20,13 @@ DISABLE_WARN_DEPRECATED_REGISTER
 #undef _XOPEN_SOURCE
 #endif
 #include <Python.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 REENABLE_WARNING
 
 #include "sst/core/activity.h"

--- a/src/sst/core/mempool.cc
+++ b/src/sst/core/mempool.cc
@@ -17,6 +17,7 @@
 #include "sst/core/output.h"
 #include "sst/core/threadsafe.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <list>
 #include <sstream>

--- a/src/sst/core/memuse.cc
+++ b/src/sst/core/memuse.cc
@@ -15,6 +15,7 @@
 
 #include "sst/core/sst_mpi.h"
 
+#include <cstdint>
 #include <sys/resource.h>
 
 using namespace SST::Core;

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -34,6 +34,9 @@
 
 DISABLE_WARN_DEPRECATED_REGISTER
 #include <Python.h>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 REENABLE_WARNING
 
 #include "sst/core/sst_mpi.h"

--- a/src/sst/core/model/python/pymodel.h
+++ b/src/sst/core/model/python/pymodel.h
@@ -27,6 +27,7 @@
 
 DISABLE_WARN_DEPRECATED_REGISTER
 #include <Python.h>
+#include <cstddef>
 REENABLE_WARNING
 
 #include <map>

--- a/src/sst/core/model/python/pymodel_comp.h
+++ b/src/sst/core/model/python/pymodel_comp.h
@@ -19,6 +19,7 @@
 
 DISABLE_WARN_DEPRECATED_REGISTER
 #include <Python.h>
+#include <cstdint>
 REENABLE_WARNING
 
 #include <string>

--- a/src/sst/core/output.cc
+++ b/src/sst/core/output.cc
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <cerrno>
 #include <cinttypes>
+#include <cstddef>
 #include <cstdlib>
 #include <cstring>
 #include <stdexcept>

--- a/src/sst/core/output.h
+++ b/src/sst/core/output.h
@@ -15,7 +15,10 @@
 #include "sst/core/serialization/serializer_fwd.h"
 #include "sst/core/warnmacros.h"
 
+#include <cstdarg>
+#include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 // UNCOMMENT OUT THIS LINE TO ENABLE THE DEBUG METHOD -OR_

--- a/src/sst/core/params.cc
+++ b/src/sst/core/params.cc
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <mutex>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/src/sst/core/params.h
+++ b/src/sst/core/params.h
@@ -18,6 +18,8 @@
 #include "sst/core/threadsafe.h"
 
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <inttypes.h>
 #include <iostream>
 #include <map>
@@ -27,6 +29,8 @@
 #include <stack>
 #include <stdexcept>
 #include <stdlib.h>
+#include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/src/sst/core/profile/clockHandlerProfileTool.cc
+++ b/src/sst/core/profile/clockHandlerProfileTool.cc
@@ -19,6 +19,7 @@
 
 #include <chrono>
 #include <cinttypes>
+#include <cstdio>
 
 namespace SST::Profile {
 

--- a/src/sst/core/profile/clockHandlerProfileTool.h
+++ b/src/sst/core/profile/clockHandlerProfileTool.h
@@ -20,6 +20,7 @@
 #include "sst/core/warnmacros.h"
 
 #include <chrono>
+#include <cstdint>
 #include <map>
 #include <string>
 

--- a/src/sst/core/profile/componentProfileTool.cc
+++ b/src/sst/core/profile/componentProfileTool.cc
@@ -19,6 +19,7 @@
 
 #include <chrono>
 #include <cinttypes>
+#include <cstdio>
 
 namespace SST::Profile {
 

--- a/src/sst/core/profile/componentProfileTool.h
+++ b/src/sst/core/profile/componentProfileTool.h
@@ -18,8 +18,10 @@
 #include "sst/core/warnmacros.h"
 
 #include <chrono>
+#include <cstdint>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace SST {

--- a/src/sst/core/profile/eventHandlerProfileTool.cc
+++ b/src/sst/core/profile/eventHandlerProfileTool.cc
@@ -19,6 +19,7 @@
 
 #include <chrono>
 #include <cinttypes>
+#include <cstdio>
 
 namespace SST::Profile {
 

--- a/src/sst/core/profile/eventHandlerProfileTool.h
+++ b/src/sst/core/profile/eventHandlerProfileTool.h
@@ -21,6 +21,7 @@
 #include "sst/core/warnmacros.h"
 
 #include <chrono>
+#include <cstdint>
 #include <map>
 #include <string>
 

--- a/src/sst/core/profile/syncProfileTool.cc
+++ b/src/sst/core/profile/syncProfileTool.cc
@@ -18,6 +18,7 @@
 
 #include <chrono>
 #include <cinttypes>
+#include <cstdio>
 
 namespace SST::Profile {
 

--- a/src/sst/core/profile/syncProfileTool.h
+++ b/src/sst/core/profile/syncProfileTool.h
@@ -19,6 +19,7 @@
 #include "sst/core/warnmacros.h"
 
 #include <chrono>
+#include <cstdint>
 #include <map>
 #include <string>
 

--- a/src/sst/core/realtime.cc
+++ b/src/sst/core/realtime.cc
@@ -24,6 +24,7 @@
 #include "sst/core/unitAlgebra.h"
 
 #include <cinttypes>
+#include <cstddef>
 #include <string>
 #include <unistd.h>
 

--- a/src/sst/core/realtime.h
+++ b/src/sst/core/realtime.h
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <ctime>
 #include <map>
 #include <set>
 #include <signal.h>

--- a/src/sst/core/rng/marsaglia.h
+++ b/src/sst/core/rng/marsaglia.h
@@ -16,6 +16,7 @@
 
 #include "rng.h"
 
+#include <cstdint>
 #include <stdint.h>
 #include <sys/time.h>
 

--- a/src/sst/core/rng/mersenne.h
+++ b/src/sst/core/rng/mersenne.h
@@ -14,6 +14,7 @@
 
 #include "rng.h"
 
+#include <cstdint>
 #include <stdint.h>
 #include <sys/time.h>
 

--- a/src/sst/core/rng/rng.h
+++ b/src/sst/core/rng/rng.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/serialization/serializable.h"
 
+#include <cstdint>
 #include <stdint.h>
 
 namespace SST::RNG {

--- a/src/sst/core/rng/xorshift.h
+++ b/src/sst/core/rng/xorshift.h
@@ -14,6 +14,7 @@
 
 #include "rng.h"
 
+#include <cstdint>
 #include <stdint.h>
 #include <sys/time.h>
 

--- a/src/sst/core/serialization/impl/serialize_insertable.h
+++ b/src/sst/core/serialization/impl/serialize_insertable.h
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <deque>
 #include <forward_list>
+#include <iterator>
 #include <list>
 #include <map>
 #include <set>

--- a/src/sst/core/serialization/impl/serialize_string.h
+++ b/src/sst/core/serialization/impl/serialize_string.h
@@ -20,6 +20,7 @@
 #include "sst/core/serialization/serializer.h"
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace SST::Core::Serialization {

--- a/src/sst/core/serialization/impl/serialize_trivial.cc
+++ b/src/sst/core/serialization/impl/serialize_trivial.cc
@@ -18,6 +18,7 @@
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -15,6 +15,7 @@
 #include "sst/core/from_string.h"
 #include "sst/core/warnmacros.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <string>

--- a/src/sst/core/serialization/serializable_base.h
+++ b/src/sst/core/serialization/serializable_base.h
@@ -15,6 +15,7 @@
 #include "sst/core/serialization/serializer.h"
 #include "sst/core/warnmacros.h"
 
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <stdint.h>

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -22,6 +22,7 @@
 #undef SST_INCLUDING_SERIALIZE_H
 
 #include <atomic>
+#include <cstdint>
 #include <iostream>
 #include <type_traits>
 #include <typeinfo>

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -24,6 +24,7 @@
 
 #include "sst/core/warnmacros.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <string>

--- a/src/sst/core/shared/sharedMap.h
+++ b/src/sst/core/shared/sharedMap.h
@@ -19,6 +19,7 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <utility>
 
 namespace SST::Shared {
 

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -46,11 +46,16 @@
 #include <algorithm>
 #include <atomic>
 #include <cinttypes>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <ctime>
 #include <exception>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <mutex>
+#include <ostream>
 #include <set>
 #include <string>
 #include <thread>

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -28,14 +28,17 @@
 #include "sst/core/util/filesystem.h"
 
 #include <atomic>
+#include <cstdint>
 #include <cstdio>
 #include <iostream>
 #include <map>
 #include <mutex>
 #include <set>
 #include <signal.h>
+#include <string>
 #include <thread>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 /* Forward declare for Friendship */

--- a/src/sst/core/sparseVectorMap.h
+++ b/src/sst/core/sparseVectorMap.h
@@ -18,6 +18,7 @@
 #include "sst/core/sst_types.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/src/sst/core/sst_types.h
+++ b/src/sst/core/sst_types.h
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <iosfwd>
 #include <limits>
+#include <ostream>
 
 namespace SST {
 

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
@@ -37,8 +38,10 @@
 #include <iostream>
 #include <list>
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <sys/stat.h>
+#include <utility>
 
 using namespace SST;
 using namespace SST::Core;

--- a/src/sst/core/sstregistertool.cc
+++ b/src/sst/core/sstregistertool.cc
@@ -14,6 +14,7 @@
 #include "sst/core/env/envconfig.h"
 #include "sst/core/env/envquery.h"
 
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -21,6 +22,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <string>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 namespace SST {

--- a/src/sst/core/statapi/statengine.cc
+++ b/src/sst/core/statapi/statengine.cc
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <string>
+#include <utility>
 
 namespace SST::Statistics {
 

--- a/src/sst/core/statapi/statgroup.h
+++ b/src/sst/core/statapi/statgroup.h
@@ -16,6 +16,7 @@
 #include "sst/core/sst_types.h"
 #include "sst/core/unitAlgebra.h"
 
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/src/sst/core/statapi/statoutput.cc
+++ b/src/sst/core/statapi/statoutput.cc
@@ -19,6 +19,8 @@
 #include "sst/core/stringize.h"
 #include "sst/core/util/filesystem.h"
 
+#include <cstdint>
+
 
 namespace SST::Statistics {
 

--- a/src/sst/core/statapi/statoutputcsv.cc
+++ b/src/sst/core/statapi/statoutputcsv.cc
@@ -15,7 +15,10 @@
 
 #include "sst/core/stringize.h"
 
+#include <cerrno>
 #include <cinttypes>
+#include <cstdarg>
+#include <cstddef>
 #include <cstdint>
 
 namespace SST::Statistics {

--- a/src/sst/core/statapi/statoutputjson.cc
+++ b/src/sst/core/statapi/statoutputjson.cc
@@ -16,6 +16,8 @@
 #include "sst/core/statapi/statoutputcsv.h"
 #include "sst/core/stringize.h"
 
+#include <cerrno>
+#include <cstddef>
 #include <cstdint>
 
 namespace SST::Statistics {

--- a/src/sst/core/statapi/statoutputtxt.cc
+++ b/src/sst/core/statapi/statoutputtxt.cc
@@ -15,6 +15,9 @@
 
 #include "sst/core/stringize.h"
 
+#include <cerrno>
+#include <cstdarg>
+#include <cstddef>
 #include <cstdint>
 
 namespace SST::Statistics {

--- a/src/sst/core/stopAction.h
+++ b/src/sst/core/stopAction.h
@@ -17,6 +17,7 @@
 
 #include <cinttypes>
 #include <iostream>
+#include <string>
 
 namespace SST {
 

--- a/src/sst/core/sync/rankSyncParallelSkip.cc
+++ b/src/sst/core/sync/rankSyncParallelSkip.cc
@@ -23,6 +23,8 @@
 #include "sst/core/sync/syncQueue.h"
 #include "sst/core/timeConverter.h"
 
+#include <cstddef>
+
 #if SST_EVENT_PROFILING
 #define SST_EVENT_PROFILE_START auto event_profile_start = std::chrono::high_resolution_clock::now();
 

--- a/src/sst/core/sync/threadSyncSimpleSkip.cc
+++ b/src/sst/core/sync/threadSyncSimpleSkip.cc
@@ -19,6 +19,7 @@
 #include "sst/core/simulation_impl.h"
 #include "sst/core/timeConverter.h"
 
+#include <cstddef>
 #include <mutex>
 
 namespace SST {

--- a/src/sst/core/testElements/coreTest_MemPoolTest.cc
+++ b/src/sst/core/testElements/coreTest_MemPoolTest.cc
@@ -17,6 +17,7 @@
 #include "sst/core/mempoolAccessor.h"
 #include "sst/core/output.h"
 
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/src/sst/core/testElements/coreTest_PerfComponent.h
+++ b/src/sst/core/testElements/coreTest_PerfComponent.h
@@ -12,6 +12,8 @@
 #ifndef SST_CORE_CORETEST_PERF_COMPONENT_H
 #define SST_CORE_CORETEST_PERF_COMPONENT_H
 
+#include <cstddef>
+#include <cstdio>
 #include <sst/core/component.h>
 #include <sst/core/link.h>
 #include <sst/core/rng/marsaglia.h>

--- a/src/sst/core/testElements/message_mesh/enclosingComponent.h
+++ b/src/sst/core/testElements/message_mesh/enclosingComponent.h
@@ -21,6 +21,7 @@
 #include "sst/core/ssthandler.h"
 #include "sst/core/subcomponent.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 

--- a/src/sst/core/threadsafe.h
+++ b/src/sst/core/threadsafe.h
@@ -25,6 +25,8 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstddef>
+#include <cstdint>
 #include <mutex>
 #include <thread>
 #include <vector>

--- a/src/sst/core/timingOutput.cc
+++ b/src/sst/core/timingOutput.cc
@@ -20,6 +20,7 @@
 #include <cinttypes>
 #include <iomanip>
 #include <ostream>
+#include <sstream>
 #include <sys/ioctl.h>
 
 namespace json = ::nlohmann;

--- a/src/sst/core/uninitializedQueue.cc
+++ b/src/sst/core/uninitializedQueue.cc
@@ -15,6 +15,7 @@
 
 #include "sst/core/warnmacros.h"
 
+#include <cstdlib>
 #include <iostream>
 #include <ostream>
 

--- a/src/sst/core/unitAlgebra.cc
+++ b/src/sst/core/unitAlgebra.cc
@@ -16,8 +16,11 @@
 #include "sst/core/output.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <iostream>
+#include <stdexcept>
 #include <string>
+#include <utility>
 
 using namespace SST;
 

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -21,8 +21,10 @@
 #include "sst/core/sst_types.h"
 #include "sst/core/warnmacros.h"
 
+#include <cstdint>
 #include <map>
 #include <mutex>
+#include <ostream>
 #include <string>
 #include <vector>
 

--- a/src/sst/core/util/basicPerf.cc
+++ b/src/sst/core/util/basicPerf.cc
@@ -19,6 +19,7 @@
 #include "sst/core/sst_mpi.h"
 
 #include <clocale>
+#include <cstdio>
 
 namespace SST::Util {
 

--- a/src/sst/core/util/basicPerf.h
+++ b/src/sst/core/util/basicPerf.h
@@ -12,10 +12,12 @@
 #ifndef SST_CORE_UTIL_BASIC_PERF_H
 #define SST_CORE_UTIL_BASIC_PERF_H
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <stack>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace SST {

--- a/src/sst/core/util/filesystem.cc
+++ b/src/sst/core/util/filesystem.cc
@@ -17,6 +17,7 @@
 #include <dirent.h>
 #include <filesystem>
 #include <fstream>
+#include <ostream>
 #include <random>
 #include <string>
 #include <sys/stat.h>

--- a/src/sst/core/util/filesystem.h
+++ b/src/sst/core/util/filesystem.h
@@ -13,9 +13,11 @@
 #define SST_CORE_FILESYSTEM_H
 
 #include <cstdio>
+#include <fstream>
 #include <iostream>
 #include <mutex>
 #include <stdexcept>
+#include <string>
 
 // REMOVE ME
 #include <filesystem>

--- a/src/sst/core/util/smartTextFormatter.cc
+++ b/src/sst/core/util/smartTextFormatter.cc
@@ -13,6 +13,7 @@
 
 #include "smartTextFormatter.h"
 
+#include <cstddef>
 #include <string>
 #include <sys/ioctl.h>
 #include <unistd.h>


### PR DESCRIPTION
Improve script to run faster, and to detect missing `#include`s by removing existing `#include`s, determine which new ones need to be added, and then only add the newly needed ones.

Part of #1439 