### PR TITLE
Test framework: read generic `/etc/os-release`

### DIFF
--- a/src/sst/core/testingframework/sst_unittest_support.py
+++ b/src/sst/core/testingframework/sst_unittest_support.py
@@ -31,6 +31,7 @@ import threading
 import time
 import traceback
 import unittest
+from pathlib import Path
 from shutil import which
 from typing import (Any, Callable, List, Mapping, Optional, Sequence, Tuple,
                     Type, TypeVar, Union)
@@ -48,6 +49,7 @@ if not sys.warnoptions:
 ################################################################################
 
 OS_DIST_OSX = "OSX"
+OS_DIST_ARCH = "ARCH"
 OS_DIST_CENTOS = "CENTOS"
 OS_DIST_RHEL = "RHEL"
 OS_DIST_TOSS = "TOSS"
@@ -241,6 +243,8 @@ def host_os_get_distribution_type() -> str:
     if k_type == 'Linux':
         lin_dist = _get_linux_distribution()
         dist_name = lin_dist[0].lower()
+        if "arch" in dist_name:
+            return OS_DIST_ARCH
         if "centos" in dist_name:
             return OS_DIST_CENTOS
         if "red hat" in dist_name:
@@ -2214,13 +2218,11 @@ def _get_linux_distribution() -> Tuple[str, str]:
     elif os.path.isfile("/etc/redhat-release"):
         distname = "red hat"
         distver = _get_linux_version("/etc/redhat-release", " ")
-    elif os.path.isfile("/etc/lsb-release"):
-        # Until we have other OS's, this is Ubuntu.
-        distname = "ubuntu"
-        distver = _get_linux_version("/etc/lsb-release", " ")
     elif os.path.isfile("/etc/rocky-release"):
         distname = "rocky"
         distver = _get_linux_version("/etc/rocky-release", " ")
+    elif os.path.isfile("/etc/os-release"):
+        distname, distver = _read_os_release("/etc/os-release")
     rtn_data = (distname, distver)
     return rtn_data
 
@@ -2238,6 +2240,17 @@ def _get_linux_version(filepath: str, sep: str) -> str:
                     found_ver = m_data.string[m_data.start():m_data.end()]
                     return found_ver
     return "undefined"
+
+
+def _read_os_release(filepath: str) -> Tuple[str, str]:
+    """Read key-value pairs from a file that looks like /etc/os-release."""
+    lines = Path(filepath).read_text(encoding="utf-8").splitlines()
+    entries = dict()
+    for line in lines:
+        if line.strip() and not line.startswith("#"):
+            key, value = line.strip().split("=", 1)
+            entries[key] = value
+    return entries["ID"], entries.get("VERSION_ID", "")
 
 
 ################################################################################


### PR DESCRIPTION
Done as part of https://github.com/sstsimulator/sst-core/issues/1067.

The current implementation of `_get_linux_distribution` looks at only the distro-specific `/etc/*-release` files.  This adds the fallback to the ["standard" `/etc/os-release` file](https://www.freedesktop.org/software/systemd/man/latest/os-release.html).

Although we will eventually use the [`platform`](https://docs.python.org/3/library/platform.html) standard library module as part of saving performance data, we skip using [`freedesktop_os_release`](https://﻿﻿https://docs.python.org/3/library/platform.html#platform.freedesktop_os_release) for now since
1. It requires 3.10, and we would need to conditionally look for that as 3.9 will be the new minimum required.
2. The implementation of reading `/etc/os-release` is trivial.