### PR TITLE
Test framework: deprecate passing bytes to `os_awk_print`

### DIFF
--- a/src/sst/core/testingframework/sst_unittest_support.py
+++ b/src/sst/core/testingframework/sst_unittest_support.py
@@ -2044,6 +2044,11 @@ def os_awk_print(in_str: str, fields_index_list: List[int]) -> str:
             (str) Space separated string of extracted fields.
     """
     if isinstance(in_str, bytes):
+        warn(
+            "Passing bytes and not a string to os_awk_print() is deprecated and will be disallowed in future version of SST.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         check_param_type("in_str", in_str, bytes)
     else:
         check_param_type("in_str", in_str, str)


### PR DESCRIPTION
While it is possible for the function to operate on bytestrings in addition to (Unicode) strings, it is unlikely that bytestrings will be used as the captured stdout from subprocess calls should always converted to strings for use in other functions anyway.

This deprecation will put the future param type check in line with the function type annotation.