### PR TITLE
Suppress spurious unused variable warnings which are conditionally used in `if constexpr`

### DIFF
--- a/src/sst/core/serialization/impl/serialize_insertable.h
+++ b/src/sst/core/serialization/impl/serialize_insertable.h
@@ -140,7 +140,8 @@ class serialize_impl<OBJ, std::enable_if_t<is_insertable_v<OBJ>>>
     void operator()(OBJ& obj, serializer& ser, ser_opt_t options)
     {
         // Options to use per-element
-        const ser_opt_t opts = SerOption::is_set(options, SerOption::as_ptr_elem) ? SerOption::as_ptr : SerOption::none;
+        const ser_opt_t UNUSED(opts) =
+            SerOption::is_set(options, SerOption::as_ptr_elem) ? SerOption::as_ptr : SerOption::none;
 
         switch ( const auto mode = ser.mode() ) {
         case serializer::SIZER:

--- a/src/sst/core/serialization/impl/serialize_trivial.h
+++ b/src/sst/core/serialization/impl/serialize_trivial.h
@@ -52,7 +52,7 @@ class serialize_impl<T,
     std::enable_if_t<std::conjunction_v<std::negation<is_trivially_serializable_excluded<std::remove_pointer_t<T>>>,
         is_trivially_serializable<std::remove_pointer_t<T>>>>>
 {
-    void operator()(T& t, serializer& ser, ser_opt_t options)
+    void operator()(T& t, serializer& ser, ser_opt_t UNUSED(options))
     {
         switch ( const auto mode = ser.mode() ) {
         case serializer::MAP:


### PR DESCRIPTION
On some older compilers, spurious "unused variable" warnings occur even though the variable is used in some branches of `if constexpr`.

It is related to [this bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81676).
