### PR TITLE
GitHub Actions: Pin Python versions for macOS runners

### DIFF
--- a/.github/workflows/free-macos-14.yml
+++ b/.github/workflows/free-macos-14.yml
@@ -45,6 +45,11 @@ jobs:
           echo "MAKEFLAGS=${MAKEFLAGS}" >> "${GITHUB_ENV}"
           echo "TERM=dumb" >> "${GITHUB_ENV}"
 
+      - name: Pin Python version
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        with:
+          python-version: '3.9'
+
       - name: Compile core
         run: |
           # TODO the argument does nothing as long as Spack is unavailable

--- a/.github/workflows/free-macos-15.yml
+++ b/.github/workflows/free-macos-15.yml
@@ -45,6 +45,11 @@ jobs:
           echo "MAKEFLAGS=${MAKEFLAGS}" >> "${GITHUB_ENV}"
           echo "TERM=dumb" >> "${GITHUB_ENV}"
 
+      - name: Pin Python version
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        with:
+          python-version: '3.13'
+
       - name: Compile core
         run: |
           # TODO the argument does nothing as long as Spack is unavailable


### PR DESCRIPTION
Closes #1453

This works by using the `setup-python` action.

- macOS 14 with Python 3.9: https://github.com/berquist/sst-core/actions/runs/18697069009/job/53317308615#step:8:301
- macOS 15 with Python 3.13: https://github.com/berquist/sst-core/actions/runs/18697069009/job/53317308649#step:8:301