### PR TITLE
adding missing header file to appease test-includes script

### DIFF
--- a/src/sst/core/eli/checkpointableInfo.h
+++ b/src/sst/core/eli/checkpointableInfo.h
@@ -18,8 +18,8 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
-#include <vector>
 #include <type_traits>
+#include <vector>
 
 namespace SST::ELI {
 


### PR DESCRIPTION
Fixes a missing header in the `checkpointableInfo.h` header file.  passes all tests, include the test-headers.pl script.  