### PR TITLE
Fix missing #includes in interactive debugger

### DIFF
--- a/src/sst/core/impl/interactive/cmdLineEditor.cc
+++ b/src/sst/core/impl/interactive/cmdLineEditor.cc
@@ -11,12 +11,11 @@
 
 #include "sst/core/impl/interactive/cmdLineEditor.h"
 
-#include <cctype>
+#include <algorithm>
 #include <cerrno>
 #include <cstring>
 #include <iterator>
 #include <sstream>
-#include <unistd.h>
 
 // #define _KEYB_DEBUG_
 

--- a/src/sst/core/impl/interactive/cmdLineEditor.h
+++ b/src/sst/core/impl/interactive/cmdLineEditor.h
@@ -12,6 +12,7 @@
 #ifndef SST_CORE_IMPL_INTERACTIVE_CMDLINEEDITOR_H
 #define SST_CORE_IMPL_INTERACTIVE_CMDLINEEDITOR_H
 
+#include <cctype>
 #include <fstream>
 #include <functional>
 #include <list>


### PR DESCRIPTION
* Add missing `#include <algorithm>` in `cmdLineEditor.cc`
* Move  `#include <cctype>` from `cmdLineEditor.cc` to `cmdLineEditor.h` since it is needed there too
* Remove redundant `#include <unistd.h>` in `cmdLineEditor.cc` since it already exists in `cmdLineEditor.h`

@jleidel @kpgriesser 