### PR TITLE
lib-and-graph-fix

### DIFF
--- a/src/sst/core/configShared.cc
+++ b/src/sst/core/configShared.cc
@@ -71,7 +71,7 @@ ConfigShared::addVerboseOptions(bool sdl_avail)
 
  */
 std::string
-ConfigShared::getLibPath() const
+ConfigShared::getLibPath(bool exclude_ext_paths) const
 {
     std::string fullLibPath;
 
@@ -114,6 +114,8 @@ ConfigShared::getLibPath() const
 
                 if ( key.size() >= 6 ) {
                     if ( "LIBDIR" == key.substr(key.size() - 6) ) {
+                        // See if this is an _EXT_ key and if we need to skip it
+                        if ( exclude_ext_paths && (key.find("_EXT_") != std::string::npos) ) continue;
                         // See if there is a value, if not, skip it
                         if ( value.size() > 0 ) {
                             // If this is the first one, we don't need

--- a/src/sst/core/configShared.h
+++ b/src/sst/core/configShared.h
@@ -96,7 +96,7 @@ private:
 
 public:
 
-    std::string getLibPath() const;
+    std::string getLibPath(bool exclude_ext_paths = false) const;
 };
 
 } // namespace SST

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -503,7 +503,6 @@ Simulation_impl::processGraphInfo(ConfigGraph& graph, const RankInfo& UNUSED(myR
     if ( my_rank.thread == 0 ) {
         minPartTC = minPartToTC(min_part);
     }
-
     // Get the minimum latencies for links between the various threads
     interThreadLatencies.resize(num_ranks.thread);
     for ( size_t i = 0; i < interThreadLatencies.size(); i++ ) {
@@ -519,7 +518,11 @@ Simulation_impl::processGraphInfo(ConfigGraph& graph, const RankInfo& UNUSED(myR
         // Find the minimum latency across a partition
         for ( auto iter = links.begin(); iter != links.end(); ++iter ) {
             ConfigLink* clink = *iter;
-            RankInfo    rank[2];
+            // If link is nonlocal, then doesn't affect interthread latencies
+            if ( clink->nonlocal ) continue;
+
+            // If link is not nonlocal, see if it crosses a thread boundary
+            RankInfo rank[2];
             rank[0] = comps[COMPONENT_ID_MASK(clink->component[0])]->rank;
             rank[1] = comps[COMPONENT_ID_MASK(clink->component[1])]->rank;
             // We only care about links that are on my rank, but

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -152,7 +152,7 @@ main(int argc, char* argv[])
     }
 
     // Process all specified libraries
-    g_searchPath = g_configuration.getLibPath();
+    g_searchPath = g_configuration.getLibPath(true);
     processSSTElementFiles();
 
     // Run interactive mode
@@ -175,7 +175,7 @@ main(int argc, char* argv[])
     }
 
     // Process all specified libraries
-    g_searchPath = g_configuration.getLibPath();
+    g_searchPath = g_configuration.getLibPath(true);
     processSSTElementFiles();
 
     // Run interactive mode


### PR DESCRIPTION
Fixed bug where mpi+threads segfaulted in processGraphInfo().  

Also added ability to exclude path keys that have \_EXT\_ in them from the path returned from ConfigShared::getLibPath().  This gives elements a place to put libraries that sst-info will not see.
