### PR TITLE
Add cast to remove errors on some platforms

### DIFF
--- a/src/sst/core/serialization/impl/serialize_shared_ptr.h
+++ b/src/sst/core/serialization/impl/serialize_shared_ptr.h
@@ -349,7 +349,8 @@ public:
 
                 // Set the std::shared_ptr or std::weak_ptr to either nullptr, or to an offset within the owner.
                 // What is very important, is that "ptr" must have the same control block as "owner".
-                ptr = std::shared_ptr<PTR_TYPE>(owner, addr);
+                ptr = std::shared_ptr<PTR_TYPE>(
+                    owner, reinterpret_cast<typename std::shared_ptr<PTR_TYPE>::element_type*>(addr));
             }
             break;
         }


### PR DESCRIPTION
@feldergast @gvoskuilen 

This PR is experimental. Please try it and see if it removes errors building on some platforms.

It uses a cast which normally should not be necessary.
