### PR TITLE
remove warning about versions, since it isn't really that useful and causes a strange Perl warning

### DIFF
--- a/scripts/test-includes.pl
+++ b/scripts/test-includes.pl
@@ -41,8 +41,6 @@ sub find_gcc {
                 if (/$regex/ && $+{header} eq "<vector>") {
                     $gcc = $gcc_val;
                     print STDERR `$gcc --version` if !$quiet;
-                    print STDERR "Warning: GCC versions prior to 10 may not find all missing #includes\n"
-                        if int(`$gcc -dumpversion`) < 10;
                     return;
                 }
             }


### PR DESCRIPTION
The warning about GCC versions below 10 not finding missing `#include`s is not very precise or useful. It also causes a strange Perl warning.

@berquist 