### PR TITLE
Use SST_SER() and SST_SER_NAME() macros instead of calling sst_ser_object()

### DIFF
--- a/src/sst/core/serialization/impl/serialize_array.h
+++ b/src/sst/core/serialization/impl/serialize_array.h
@@ -56,7 +56,7 @@ template <typename ELEM_T>
 void
 serialize_array_element(serializer& ser, void* data, ser_opt_t opt, size_t index)
 {
-    sst_ser_object(ser, static_cast<ELEM_T*>(data)[index], opt, nullptr);
+    SST_SER(static_cast<ELEM_T*>(data)[index], opt);
 }
 
 // Serialize an array map element
@@ -65,7 +65,7 @@ template <typename ELEM_T>
 void
 serialize_array_map_element(serializer& ser, void* data, ser_opt_t opt, size_t index, const char* name)
 {
-    sst_ser_object(ser, static_cast<ELEM_T*>(data)[index], opt, name);
+    SST_SER_NAME(static_cast<ELEM_T*>(data)[index], name, opt);
 }
 
 // Serialize fixed arrays

--- a/src/sst/core/serialization/impl/serialize_optional.h
+++ b/src/sst/core/serialization/impl/serialize_optional.h
@@ -58,7 +58,7 @@ class serialize_impl<std::optional<T>>
         }
 
         // Serialize the optional object if it is present
-        if ( has_value ) sst_ser_object(ser, *obj, options, nullptr);
+        if ( has_value ) SST_SER(*obj, options);
     }
 
     SST_FRIEND_SERIALIZE();

--- a/src/sst/core/serialization/impl/serialize_tuple.h
+++ b/src/sst/core/serialization/impl/serialize_tuple.h
@@ -33,7 +33,7 @@ class serialize_impl<T,
     {
         // Serialize each element of tuple or pair
         ser_opt_t opt = SerOption::is_set(options, SerOption::as_ptr_elem) ? SerOption::as_ptr : SerOption::none;
-        std::apply([&](auto&... e) { ((sst_ser_object(ser, e, opt)), ...); }, t);
+        std::apply([&](auto&... e) { ((SST_SER(e, opt)), ...); }, t);
     }
 
     SST_FRIEND_SERIALIZE();

--- a/src/sst/core/serialization/impl/serialize_valarray.h
+++ b/src/sst/core/serialization/impl/serialize_valarray.h
@@ -65,7 +65,7 @@ class serialize_impl<T, std::enable_if_t<is_valarray_v<std::remove_pointer_t<T>>
             ser.mapper().map_hierarchy_start(
                 ser.getMapName(), new ObjectMapContainer<std::remove_pointer_t<T>>(objPtr));
             for ( size_t i = 0; i < size; ++i )
-                sst_ser_object(ser, (*objPtr)[i], SerOption::none, std::to_string(i).c_str());
+                SST_SER_NAME((*objPtr)[i], std::to_string(i).c_str());
             ser.mapper().map_hierarchy_end();
             return;
         }

--- a/src/sst/core/serialization/objectMapDeferred.h
+++ b/src/sst/core/serialization/objectMapDeferred.h
@@ -93,7 +93,7 @@ protected:
         ser.enable_pointer_tracking();
         ser.start_mapping(this);
 
-        sst_ser_object(ser, addr_, SerOption::none, "!proxy!");
+        SST_SER_NAME(addr_, "!proxy!");
     }
 
     void deactivate_callback() override

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -86,8 +86,7 @@ struct SerOption
 namespace Core::Serialization {
 
 template <typename T>
-void sst_ser_object(serializer& ser, T&& obj, ser_opt_t options = SerOption::none, const char* name = nullptr);
-
+void sst_ser_object(serializer& ser, T&& obj, ser_opt_t options, const char* name);
 
 // get_ptr() returns reference to argument if it's a pointer, else address of argument
 template <typename T>
@@ -382,7 +381,7 @@ template <class T>
 void
 operator&(serializer& ser, T&& obj)
 {
-    SST::Core::Serialization::sst_ser_object(ser, obj, SerOption::no_map);
+    SST::Core::Serialization::sst_ser_object(ser, obj, SerOption::no_map, "");
 }
 
 template <class T>
@@ -392,7 +391,7 @@ template <class T>
 void
 operator|(serializer& ser, T&& obj)
 {
-    SST::Core::Serialization::sst_ser_object(ser, obj, SerOption::no_map | SerOption::as_ptr);
+    SST::Core::Serialization::sst_ser_object(ser, obj, SerOption::no_map | SerOption::as_ptr, "");
 }
 
 


### PR DESCRIPTION
**Sorry for this last-minute fix, but it's critical for debugging**.

Fix mapping serialization errors which affect debugging, causing `nullptr` to be passed for object map `name`:
- Use `SST_SER()` and `SST_SER_NAME()` macros instead of calling `sst_ser_object()`
  - We might want to make `sst_ser_object()` more private in later releases
- Remove default arguments for `sst_ser_object()` to reduce the chances of surprise errors, such as `std::tuple` serialization calling `sst_ser_object()` with a default `name = nullptr`, even in mapping mode
  - `sst_ser_object()` should only be called by `SST_SER()` and `SST_SER_NAME()`, and should never receive a `nullptr` `name`.

