### PR TITLE
Support ObjectMap for std::bitset<N>, std::vector<bool>, and std::atomic<T>

### DIFF
--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -86,9 +86,26 @@ struct SerOption
 namespace Core::Serialization {
 
 namespace pvt {
+
 template <typename T>
 void sst_ser_object(serializer& ser, T&& obj, ser_opt_t options, const char* name);
-}
+
+// Proxy struct which represents a bit reference wrapper similar to std::reference_wrapper.
+// This proxy is needed in order for us to partially specialize serialize_impl for the
+// std::bitset<N>::reference and std::vector<bool>::reference types in mapping mode.
+template <typename T>
+struct bit_reference_wrapper
+{
+    typename T::reference ref;
+    explicit bit_reference_wrapper(typename T::reference ref) :
+        ref(ref)
+    {}
+    bit_reference_wrapper(const bit_reference_wrapper&)            = default;
+    bit_reference_wrapper& operator=(const bit_reference_wrapper&) = delete;
+    ~bit_reference_wrapper()                                       = default;
+};
+
+} // namespace pvt
 
 // get_ptr() returns reference to argument if it's a pointer, else address of argument
 template <typename T>
@@ -100,7 +117,6 @@ get_ptr(T& t)
     else
         return &t;
 }
-
 
 /**
    Base serialize class.

--- a/src/sst/core/serialization/serializer.h
+++ b/src/sst/core/serialization/serializer.h
@@ -95,6 +95,8 @@ public:
     template <typename T>
     void primitive(T& t)
     {
+        static_assert(std::is_trivially_copyable_v<T> && std::is_standard_layout_v<T>,
+            "Error: ser.primitive() can only be called on trivially copyable, standard layout types.");
         switch ( mode() ) {
         case SIZER:
             sizer().size(t);


### PR DESCRIPTION
Support debugging of `std::bitset<N>` and `std::vector<bool>` by:
1. Create a new `ObjectMapBitReference` type which is derived from `ObjectMapFundamental` but passes a second optional template argument `REF` to `ObjectMapFundamental` indicating the reference proxy class for the object, like `std::bitset<N>::reference` or `std::vector<bool>::reference`.
2. Create a `SST::Core::Serialization::pvt::reference_wrapper` class which allows serialization of reference wrappers.
3. Specialize `serialize_impl` for the `pvt::reference_wrapper<std::bitset<N>>` and `pvt::reference_wrapper<std::vector<bool, ALLOC>>`.
   - **Note:** The `SST::Core::Serialization::pvt::reference_wrapper` class is needed in order for template argument deduction to work, because we cannot partially specialize `serialize_impl<std::bitset<N>::reference>` or `serialize_impl<std::vector<bool, ALLOC>::reference>` and deduce `N` or `ALLOC`.
4. Change the serialization of `std::bitset<N>` and `std::vector<bool>` to create `ObjectMapBitReference` and then serialize individual bits with `pvt::reference_wrapper` objects in mapping mode, but serialization remains unchanged for non-mapping mode.

# Phase 2

`ObjectBitMapReference` has been renamed to `ObjectMapFundamentalReference`, and now supports `std::atomic<T>` in addition to `std::bitset<N>` and `std::vector<bool>`.

#### `ObjectMapFundamentalReference<T, REF, PTYPE = T>`

- `ObjectMap` for reference proxy types such as `std::bitset<N>::reference`, `std::vector<bool>::reference`, `atomic_reference`, whose referenced types can either not be copied, or not be pointed to with C++ pointers, but whose underlying values are ordinary **fundamental** types.

A third parameter `PTYPE` has been added to `ObjectMapFundamentalReference` as the type to print, which defaults to `T`.
- `T` is the underlying fundamental type, such as `bool`, which is the type in which values are read and written
- `REF` is the type of the proxy reference class which is copyable, convertible to `T`, and assignable from `T`
- `PTYPE` is the type to print, which defaults to `T`, but might be a decorated class name like `std::atomic<T>`

Examples of `ObjectMapFundamentalReference` template arguments:

| Object | ObjectMapFundamentalReference Arguments | Comments |
|---|---|---|
| `std::bitset<N>` elements | `ObjectMapFundamentalReference<bool, std::bitset<N>::reference>` | `PTYPE` defaults to `bool` so elements are printed as `bool` |
| `std::vector<bool>` elements | `ObjectMapFundamentalReference<bool, std::vector<bool>::reference>` | `PTYPE` defaults to `bool` |
| `std::atomic<T>` | `ObjectMapFundamentalReference<T, atomic_reference, std::atomic<T>>` | `std::atomic<T>` is fundamental and has no children <br><br> `atomic_reference` is our own proxy class which is copyable, convertible to `T`, and assignable from `T`, while reading/writing the atomic variable <br><br> `PTYPE` =`std::atomic<T>`, so the type of the fundamental is printed out as `std::atomic<T>` |


