### PR TITLE
Use const and final methods where possible

### DIFF
--- a/src/sst/core/serialization/impl/serialize_string.h
+++ b/src/sst/core/serialization/impl/serialize_string.h
@@ -36,15 +36,15 @@ public:
 
        @return address of represented object
      */
-    void* getAddr() override { return addr_; }
+    void* getAddr() const final { return addr_; }
 
-    std::string get() override { return *addr_; }
+    std::string get() const final { return *addr_; }
 
-    void set_impl(const std::string& value) override { *addr_ = value; }
+    void set_impl(const std::string& value) final { *addr_ = value; }
 
-    virtual bool isFundamental() override { return true; }
+    virtual bool isFundamental() const final { return true; }
 
-    std::string getType() override
+    std::string getType() const final
     {
         // The demangled name for std::string is ridiculously long, so
         // just return "std::string"

--- a/src/sst/core/serialization/objectMap.cc
+++ b/src/sst/core/serialization/objectMap.cc
@@ -23,13 +23,7 @@ namespace SST::Core::Serialization {
 const std::multimap<std::string, ObjectMap*> ObjectMap::emptyVars;
 
 std::string
-ObjectMap::getName()
-{
-    return mdata_ ? mdata_->name : "";
-}
-
-std::string
-ObjectMap::getFullName()
+ObjectMap::getFullName() const
 {
     if ( !mdata_ ) return "";
 

--- a/src/sst/core/serialization/objectMapDeferred.h
+++ b/src/sst/core/serialization/objectMapDeferred.h
@@ -34,7 +34,7 @@ public:
 
        @return empty type of object
      */
-    std::string getType() override { return type_; }
+    std::string getType() const final { return type_; }
 
     /**
        Returns nullptr since there is no underlying object being
@@ -42,7 +42,7 @@ public:
 
        @return nullptr
      */
-    void* getAddr() override { return static_cast<void*>(addr_); }
+    void* getAddr() const final { return addr_; }
 
 
     /**
@@ -52,7 +52,7 @@ public:
        ObjectMap's child variables. pair.first is the name of the
        variable in the context of this object.
      */
-    const std::multimap<std::string, ObjectMap*>& getVariables() override { return obj_->getVariables(); }
+    const std::multimap<std::string, ObjectMap*>& getVariables() const final { return obj_->getVariables(); }
 
     /**
        For the Deferred Build, the only variable that gets added will
@@ -61,7 +61,7 @@ public:
        @param name Name of the object
        @param obj ObjectMap to add as a variable
      */
-    void addVariable(const std::string& name, ObjectMap* obj) override
+    void addVariable(const std::string& name, ObjectMap* obj) final
     {
         // This should be the real ObjectMap for the class we are
         // representing. We will check it by making sure the name
@@ -84,10 +84,10 @@ public:
     ~ObjectMapDeferred() override { delete obj_; }
 
 protected:
-    void activate_callback() override
+    void activate_callback() final
     {
         // On activate, we need to create the ObjectMap data structure
-        if ( obj_ != nullptr ) return;
+        if ( obj_ ) return;
 
         SST::Core::Serialization::serializer ser;
         ser.enable_pointer_tracking();
@@ -96,7 +96,7 @@ protected:
         SST_SER_NAME(addr_, "!proxy!");
     }
 
-    void deactivate_callback() override
+    void deactivate_callback() final
     {
         // On deactivate, need to delete obj_;
         obj_->decRefCount();
@@ -117,7 +117,7 @@ private:
 
     /**
        Type of the variable as given by the demangled version of
-       typeif<T>.name() for the type.
+       typeid(T).name() for the type.
      */
     std::string type_ = "";
 };

--- a/src/sst/core/timeLord.cc
+++ b/src/sst/core/timeLord.cc
@@ -194,7 +194,7 @@ protected:
 
 public:
     // We'll treat this as a period when printing
-    std::string get() override
+    std::string get() const final
     {
         if ( nullptr == *addr_ ) return "nullptr";
         TimeLord*   timelord = Simulation_impl::getTimeLord();
@@ -206,14 +206,14 @@ public:
     void set_impl(const std::string& UNUSED(value)) override { return; }
 
     // We'll act like we're a fundamental type
-    bool isFundamental() override { return true; }
+    bool isFundamental() const final { return true; }
 
     /**
        Get the address of the variable represented by the ObjectMap
 
        @return Address of varaible
      */
-    void* getAddr() override { return addr_; }
+    void* getAddr() const final { return addr_; }
 
     explicit ObjectMapFundamental(TimeConverter** addr) :
         ObjectMap(),
@@ -222,7 +222,7 @@ public:
         setReadOnly(true);
     }
 
-    std::string getType() override { return demangle_name(typeid(TimeConverter).name()); }
+    std::string getType() const final { return demangle_name(typeid(TimeConverter).name()); }
 };
 
 template <>
@@ -236,7 +236,7 @@ protected:
 
 public:
     // We'll treat this as a period when printing
-    std::string get() override
+    std::string get() const final
     {
         TimeLord*   timelord = Simulation_impl::getTimeLord();
         UnitAlgebra base     = timelord->getTimeBase();
@@ -244,17 +244,17 @@ public:
         return base.toStringBestSI();
     }
 
-    void set_impl(const std::string& UNUSED(value)) override { return; }
+    void set_impl(const std::string& UNUSED(value)) final { return; }
 
     // We'll act like we're a fundamental type
-    bool isFundamental() override { return true; }
+    bool isFundamental() const final { return true; }
 
     /**
        Get the address of the variable represented by the ObjectMap
 
        @return Address of varaible
      */
-    void* getAddr() override { return addr_; }
+    void* getAddr() const final { return addr_; }
 
     explicit ObjectMapFundamental(TimeConverter* addr) :
         ObjectMap(),
@@ -263,7 +263,7 @@ public:
         setReadOnly(true);
     }
 
-    std::string getType() override { return demangle_name(typeid(TimeConverter).name()); }
+    std::string getType() const final { return demangle_name(typeid(TimeConverter).name()); }
 };
 
 void

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -415,25 +415,25 @@ protected:
     UnitAlgebra* addr_ = nullptr;
 
 public:
-    std::string get() override { return addr_->toStringBestSI(); }
+    std::string get() const final { return addr_->toStringBestSI(); }
     void        set_impl(const std::string& value) override { addr_->init(value); }
 
     // We'll act like we're a fundamental type
-    bool isFundamental() override { return true; }
+    bool isFundamental() const final { return true; }
 
     /**
        Get the address of the variable represented by the ObjectMap
 
        @return Address of varaible
      */
-    void* getAddr() override { return addr_; }
+    void* getAddr() const final { return addr_; }
 
     explicit ObjectMapFundamental(UnitAlgebra* addr) :
         ObjectMap(),
         addr_(addr)
     {}
 
-    std::string getType() override { return demangle_name(typeid(UnitAlgebra).name()); }
+    std::string getType() const final { return demangle_name(typeid(UnitAlgebra).name()); }
 };
 
 template <>


### PR DESCRIPTION
`const` and `final` have been added to all `ObjectMap`-related methods where appropriate
- `const` is used for Getters, and is good C++ programming practice
- `final` indicates that a method should not be overriden
  - Such as `ObjectMapFundamental::isFundamental()`, which should not be overriden when `ObjectMapFundamentalReference` derives from `ObjectMapFundamental`
- `final` allows the compiler to de-virtualize function calls if the method is `final` in the class in which it is invoked
