### PR TITLE
Use std::common_type_t to compare variables using common type

### DIFF
--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <ostream>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
 Use `std::common_type_t` to simplify the comparison of different variable types. If a common type exists for which both operands can be explicitly converted to, then you convert them to this common type and perform the comparison on this common type.
   - **Note:** `std::common_type_t<std::bitset<N>::reference, bool>` = `bool` and `std::common_type_t<std::vector<bool>::reference, bool>` = `bool`.
   - `std::common_type<T1, T2>` is the only `<type_traits>` class which can have user-defined specializations, as long as at least `T1` or `T2` is a user-defined type, but I did not need to define a specialization.

Use the same `cmp()` function which uses `std::common_type_t` for both variable change-detection as well as regular comparisons.