### PR TITLE
Add missing #include <memory>

### DIFF
--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <ostream>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
Must've slipped past our tests as I split larger PRs into smaller ones. We need my script to be [integrated into the CI](https://github.com/sstsimulator/sst-core/issues/1439),