### PR TITLE
Fix distribution so that elements can include configGraph.h

### DIFF
--- a/src/sst/core/model/Makefile.inc
+++ b/src/sst/core/model/Makefile.inc
@@ -8,12 +8,9 @@
 sst_core_sources += \
 	model/sstmodel.h \
 	model/sstmodel.cc \
-	model/configComponent.h \
 	model/configComponent.cc \
 	model/configGraph.cc \
-	model/configLink.h \
 	model/configLink.cc \
-	model/configStatistic.h \
 	model/configStatistic.cc \
 	model/element_python.h \
 	model/element_python.cc \
@@ -30,7 +27,10 @@ sst_core_sources += \
 
 
 nobase_dist_sst_HEADERS += \
+	model/configComponent.h \
 	model/configGraph.h \
+	model/configLink.h \
+	model/configStatistic.h \
 	model/element_python.h
 
 


### PR DESCRIPTION
This was identified due to sst-macro test failures because some headers needed by configGraph.h are not installed. Specifically the new files that were split out of configGraph.h: configComponent.h, configLink.h, and configStatistic.h.