### PR TITLE
Add #include <typeinfo> to places which use typeid()

### DIFF
--- a/src/sst/core/from_string.h
+++ b/src/sst/core/from_string.h
@@ -18,6 +18,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <typeinfo>
 
 namespace SST::Core {
 

--- a/src/sst/core/timeLord.cc
+++ b/src/sst/core/timeLord.cc
@@ -24,6 +24,7 @@
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>
+#include <typeinfo>
 
 namespace SST {
 

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -26,6 +26,7 @@
 #include <mutex>
 #include <ostream>
 #include <string>
+#include <typeinfo>
 #include <vector>
 
 namespace SST {


### PR DESCRIPTION
Strictly speaking, `#include <typeinfo>` must appear in files which use the `typeid()` operator. My script did not detect them as missing, because GCC does not warn about it being missing.