### PR TITLE
Print bool values as true or false instead of 1 or 0

### DIFF
--- a/src/sst/core/from_string.h
+++ b/src/sst/core/from_string.h
@@ -112,14 +112,16 @@ std::enable_if_t<!std::is_enum_v<T>, std::string>
 to_string(const T& input)
 {
     if constexpr ( std::is_floating_point_v<T> ) {
-        std::stringstream s;
-        T                 abs_val = input < 0 ? -input : input;
+        std::ostringstream s;
+        T                  abs_val = input < 0 ? -input : input;
         if ( abs_val > (T)10e6 || abs_val < (T)10e-6 )
             s << std::scientific << std::setprecision(std::numeric_limits<double>::max_digits10) << input;
         else
             s << std::fixed << std::setprecision(std::numeric_limits<double>::max_digits10) << input;
-        return s.str().c_str();
+        return s.str();
     }
+    else if constexpr ( std::is_same_v<T, bool> )
+        return input ? "true" : "false";
     else if constexpr ( std::is_arithmetic_v<T> )
         return std::to_string(input);
     else


### PR DESCRIPTION
Print `bool` values as `true` or `false` instead of `1` or `0`

This makes `to_string()` print `bool` values in the debugger as `true` or `false`, which are already acceptable as inputs to `from_string<bool>()`.

Some tests might need to be modified to expect `true` or `false` results instead of `1` or `0` results.

(Also, the floating-point `to_string()` code was cleaned up, by using the more specific `std::ostringstream` instead of the more general `std::stringstream`, and by not using `.c_str()` when returning a `std::string` value, since it avoids an extra conversion and allows the `std::ostringstream` string value to be moved instead of copied, without having to allocate a new `std::string` and then destroying the old one.)


