### PR TITLE
Add ObjectMap support for std::optional and std::variant

### DIFF
--- a/src/sst/core/serialization/impl/mapper.h
+++ b/src/sst/core/serialization/impl/mapper.h
@@ -36,6 +36,8 @@ public:
         obj_ { object }
     {}
 
+    ObjectMap* get_top() const { return obj_.back(); }
+
     void map_primitive(const std::string& name, ObjectMap* map) { obj_.back()->addVariable(name, map); }
 
     void map_container(const std::string& name, ObjectMap* map) { obj_.back()->addVariable(name, map); }

--- a/src/sst/core/serialization/objectMap.cc
+++ b/src/sst/core/serialization/objectMap.cc
@@ -224,4 +224,19 @@ ObjectMap::listRecursive(const std::string& name, int level, int recurse)
     return ret;
 }
 
+std::ostream&
+dumpObjectMap(std::ostream& os, const ObjectMap& obj, size_t indent)
+{
+    for ( const auto& [name, value] : obj.getVariables() ) {
+        os << std::string(indent * 4, ' ');
+        if ( value->isFundamental() )
+            os << name << " = " << value->get() << " (" << value->getType() << ")\n";
+        else {
+            os << name << "/ (" << value->getType() << ")\n";
+            dumpObjectMap(os, *value, indent + 1);
+        }
+    }
+    return os;
+}
+
 } // namespace SST::Core::Serialization

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -391,7 +391,7 @@ public:
 
     /**
        Adds a variable to this ObjectMap.  NOTE: calls to this
-       function will be ignore if isFundamental() returns true.
+       function will be ignored if isFundamental() returns true.
 
        @param name Name of the object in the context of the parent class
 
@@ -399,6 +399,15 @@ public:
 
      */
     virtual void addVariable(const std::string& UNUSED(name), ObjectMap* UNUSED(obj)) {}
+
+    /**
+       Removes a variable from this ObjectMap.  NOTE: calls to this
+       function will be ignored if isFundamental() returns true.
+
+       @param name Name of the object in the context of the parent class
+    */
+
+    virtual void removeVariable(const std::string& UNUSED(name)) {}
 
     /************ Functions for getting/setting Object's Value *************/
 
@@ -448,7 +457,7 @@ public:
        classes for fundamentals will know how to convert the string to
        a value of the approproprite type.  NOTE: this function is only
        valid for ObjectMaps that represent non-fundamental types or
-       classes not treated as fundamentatl types (i.e. they must have
+       classes not treated as fundamental types (i.e. they must have
        children).
 
        @param var Name of variable
@@ -587,6 +596,17 @@ private:
 }; // class ObjectMap
 
 /**
+   Dump an ObjectMap structure in a formatted way to a stream
+**/
+std::ostream& dumpObjectMap(std::ostream& os, const ObjectMap& obj, size_t indent = 0);
+
+inline std::ostream&
+operator<<(std::ostream& os, const ObjectMap& obj)
+{
+    return dumpObjectMap(os, obj);
+}
+
+/**
    ObjectMap object for non-fundamental, non-container types.  This
    class allows for child variables.
  */
@@ -634,6 +654,13 @@ public:
        @param obj ObjectMap to add as a variable
      */
     void addVariable(const std::string& name, ObjectMap* obj) final override { variables_.emplace(name, obj); }
+
+    /**
+       Removes a variable from this ObjectMap
+
+       @param name Name of the object in the context of this ObjectMap
+     */
+    void removeVariable(const std::string& name) final override { variables_.erase(name); }
 
     /**
        Get the list of child variables contained in this ObjectMap

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -428,6 +428,22 @@ sst_ser_or_helper(Args... args)
 }
 
 } // namespace pvt
+
+// Serialize an object and return an ObjectMap which represents it
+template <typename T>
+ObjectMap*
+ObjectMapSerialization(T& obj, const char* name, ser_opt_t options = SerOption::none)
+{
+    ObjectMapClass root;
+    serializer     ser;
+    ser.enable_pointer_tracking();
+    ser.start_mapping(&root);
+    SST_SER_NAME(obj, name, options);
+    ObjectMap* ret = root.findVariable(name);
+    if ( ret ) ret->incRefCount();
+    return ret;
+}
+
 } // namespace Core::Serialization
 } // namespace SST
 


### PR DESCRIPTION
Add `ObjectMap` support for `std::optional` and `std::variant`

Add `removeVariable()` method for `ObjectMap`, analogous to `addVariable()`

Add `ObjectMapSerialization()` function to perform on-the-fly creation of `ObjectMap` from any data type

Add `operator<<` for `ObjectMap`, to provide debug dumps, e.g. `std::cout << objMap`
