### PR TITLE
Interactive Console Updates

### DIFF
--- a/src/sst/core/checkpointAction.cc
+++ b/src/sst/core/checkpointAction.cc
@@ -331,6 +331,14 @@ initializeCheckpointInfrastructure(Config* cfg, bool rt_can_ckpt, int myRank)
     std::string checkpoint_dir_name = "";
 
     if ( myRank == 0 ) {
+        // Verify prefix format (no '/')
+        const std::string prefix   = cfg->checkpoint_prefix();
+        size_t            foundPos = prefix.find('/');
+        if ( foundPos != std::string::npos ) {
+            throw std::invalid_argument("Invalid checkpoint prefix: " + prefix);
+        }
+
+        // Create checkpoint directory path
         SST::Util::Filesystem& fs = Simulation_impl::getSimulation()->filesystem;
         checkpoint_dir_name       = fs.createUniqueDirectory(cfg->checkpoint_prefix());
     }

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -40,11 +40,16 @@ SimpleDebugger::SimpleDebugger(Params& params) :
     if ( sstReplayFilePath.size() > 0 ) injectedCommand << "replay " << sstReplayFilePath << std::endl;
 
     // Populate the command registry
-    cmdRegistry = {
+    // cmdRegistry = std::vector<ConsoleCommand>({
+    cmdRegistry = CommandRegistry({
         { "help", "?", "<[CMD]>: show this help or detailed command help", ConsoleCommandGroup::GENERAL,
             [this](std::vector<std::string>& tokens) { cmd_help(tokens); } },
         { "verbose", "v", "[mask]: set verbosity mask or print if no mask specified", ConsoleCommandGroup::GENERAL,
             [this](std::vector<std::string>& tokens) { cmd_verbose(tokens); } },
+        { "info", "info", "\"current\"|\"all\" print summary for current thread or all threads",
+            ConsoleCommandGroup::GENERAL, [this](std::vector<std::string>& tokens) { cmd_info(tokens); } },
+        { "thread", "thd", "[threadID]: switch to specified thread ID", ConsoleCommandGroup::GENERAL,
+            [this](std::vector<std::string>& tokens) { cmd_thread(tokens); } },
         { "confirm", "cfm", "<true/false>: set confirmation requests on (default) or off", ConsoleCommandGroup::GENERAL,
             [this](std::vector<std::string>& tokens) { cmd_setConfirm(tokens); } },
         { "pwd", "pwd", "print the current working directory in the object map", ConsoleCommandGroup::NAVIGATION,
@@ -59,6 +64,10 @@ SimpleDebugger::SimpleDebugger(Params& params) :
             [this](std::vector<std::string>& tokens) { cmd_print(tokens); } },
         { "set", "s", "var value: set value for a variable at the current level", ConsoleCommandGroup::STATE,
             [this](std::vector<std::string>& tokens) { cmd_set(tokens); } },
+#ifdef __CT_RECURSE__
+        { "examine", "e", "<obj> prints object in the current scope. See SimpleDebugger::cmd_examine",
+            ConsoleCommandGroup::STATE, [this](std::vector<std::string>& tokens) { cmd_examine(tokens); } },
+#endif
         { "watch", "w", "<trig>: adds watchpoint to the watchlist", ConsoleCommandGroup::WATCH,
             [this](std::vector<std::string>& tokens) { cmd_watch(tokens); } },
         { "trace", "t", "<trig> : <bufSize> <postDelay> : <v1> ... <vN> : <action>", ConsoleCommandGroup::WATCH,
@@ -99,10 +108,14 @@ SimpleDebugger::SimpleDebugger(Params& params) :
             [this](std::vector<std::string>& tokens) { cmd_clear(tokens); } },
         { "spinThread", "spin", "enter spin loop. See SimpleDebugger::cmd_spinThread", ConsoleCommandGroup::MISC,
             [this](std::vector<std::string>& tokens) { cmd_spinThread(tokens); } },
-    };
+        { "define", "def", "define a user command sequence", ConsoleCommandGroup::MISC,
+            [this](std::vector<std::string>& tokens) { cmd_define(tokens); } },
+        { "document", "doc", "document help for a user defined command", ConsoleCommandGroup::MISC,
+            [this](std::vector<std::string>& tokens) { cmd_document(tokens); } },
+    });
 
     // Detailed help from some commands. Can also add general things like 'help navigation'
-    cmdHelp = {
+    cmdRegistry.cmdHelp = {
         { "verbose", "[mask]: set verbosity mask or print if no mask specified\n"
                      "\tA mask is used to select which features to enable verbosity.\n"
                      "\tTo turn on all features set the mask to 0xffffffff\n"
@@ -112,6 +125,7 @@ SimpleDebugger::SimpleDebugger(Params& params) :
         { "set", "<obj> <value>: sets an object in the current scope to the provided value\n"
                  "\tobject must be a 'fundamental type' (arithmetic or string)\n"
                  "\t e.g. set mystring hello world" },
+        { "examine", "[e][<obj>]: prints object in the current scope\n" },
         { "watchpoints",
             "Manage watchpoints (with or without tracing)\n"
             "\tA <trigger> can be a <comparison> or a sequence of comparisons combined with a <logicOp>\n"
@@ -123,7 +137,9 @@ SimpleDebugger::SimpleDebugger(Params& params) :
             "\t'watch' creates a default watchpoint that breaks into an interactive console when triggered\n"
             "\t'trace' creates a watchpoint with a trace buffer to trace a set of variables and trigger an <action>\n"
             "\tAvailable actions include: \n"
-            "\t  interactive, printTrace, checkpoint, set <var> <val>, printStatus, or shutdown" },
+            "\t  interactive, printTrace, checkpoint, set <var> <val>, printStatus, or shutdown"
+            "\t  Note: checkpoint action must be enabled at startup via the '--checkpoint-enable' command line "
+            "option\n" },
         { "watch", "<trigger>: adds watchpoint to the watchlist; breaks into interactive console when triggered\n"
                    "\tExample: watch var1 > 90 && var2 < 100 || var3 changed" },
         { "trace",
@@ -167,16 +183,27 @@ SimpleDebugger::SimpleDebugger(Params& params) :
                      "\tctrl-d: delete character at cursor\n"
                      "\tctrl-e: move cursor to end of line\n"
                      "\tctrl-f: move cursor to the right\n" },
+        { "spinThread", ": (Deprecated) Put current thread in an infinite loop to allow\n"
+                        "an external debug to attach. The debugger can clear the spin\n"
+                        "condition and continue execution. On entry, the process id will\n"
+                        "be printed. Once in the the debugger, set the breakpoint in\n"
+                        "SimpleDebugger::cmd_spinThread (see code comments for more info)\n" },
+        { "define", "<cmd-name>: enter a command sequence for a user defined command.\n"
+                    "Terminate the sequence by typing \"end\"\n" },
+        { "document", "<cmd-name>: provide help documentation for a user defined command.\n"
+                      "The first line will be summarized in the short help text.\n"
+                      "Remaining lines will be provided in detailed help\n"
+                      "Terminate the sequence by typing \"end\"\n" },
     };
 
     // Command autofill strings
     std::list<std::string> cmdStrings;
-    for ( const ConsoleCommand& c : cmdRegistry ) {
+    for ( const ConsoleCommand& c : cmdRegistry.getRegistryVector() ) {
         cmdStrings.emplace_back(c.str_long());
         cmdStrings.emplace_back(c.str_short());
     }
     cmdStrings.sort();
-    cmdLineEditor.set_cmd_strings(cmdStrings); // could also realize as callback to generalize
+    cmdLineEditor.set_cmd_strings(cmdStrings);
 
     // Callback for directory listing strings
     cmdLineEditor.set_listing_callback([this](std::list<std::string>& vec) { get_listing_strings(vec); });
@@ -189,28 +216,84 @@ SimpleDebugger::~SimpleDebugger()
 }
 
 void
+SimpleDebugger::summary()
+{
+#if 0
+    RankInfo info = getRank();
+    RankInfo nRanks = getNumRanks();
+    std::count << "\n(Rank:" << info.rank << " / " << nRanks.rank
+        << " Thread:" << info.thread << "/" << nRanks.thread
+        << ")\n";
+    std::cout << " -- Trigger Status\n";
+#endif
+
+    std::cout << " -- Component Summary\n";
+#if 0
+    std::vector<std::string> tokens;
+    if (nullptr == obj_) {
+        obj_ = getComponentObjectMap();
+    }
+    cmd_ls(tokens);
+#else
+    SST::Core::Serialization::ObjectMap* baseObj = getComponentObjectMap();
+    auto&                                vars    = baseObj->getVariables();
+    for ( auto& x : vars ) {
+        if ( x.second->isFundamental() ) {
+            std::cout << x.first << " = " << x.second->get() << " (" << x.second->getType() << ")" << std::endl;
+        }
+        else {
+            std::cout << x.first.c_str() << "/ (" << x.second->getType() << ")\n";
+        }
+    }
+#endif
+}
+
+int
 SimpleDebugger::execute(const std::string& msg)
 {
-    printf("Entering interactive mode at time %" PRI_SIMTIME " \n", getCurrentSimCycle());
+    RankInfo info   = getRank();
+    RankInfo nRanks = getNumRanks();
+    printf("\n---- Rank%d:Thread%d: Entering interactive mode at time %" PRI_SIMTIME " \n", info.rank, info.thread,
+        getCurrentSimCycle());
     printf("%s\n", msg.c_str());
 
     if ( nullptr == obj_ ) {
         obj_ = getComponentObjectMap();
     }
-    done = false;
+    done     = false;
+    retState = DONE;
 
+
+    // Select the input source and next command line
     std::string line;
     while ( !done ) {
-
         try {
+            // User input prompt (except during user command)
+            if ( eStack.size() == 0 ) std::cout << "> " << std::flush;
+
+            // Logging disable has edge cases for stack push/pop
+            bool squashLogging = false;
+
             // User input prompt
-            std::cout << "> " << std::flush;
+            // std::cout << "R" << info.rank << ":T" << info.thread << "> " << std::flush;
 
             if ( !injectedCommand.str().empty() ) {
-                // Injected command stream (currently just one command)
+                // Injected commands allow sst command line options to cause actions (currently only replay)
                 line = injectedCommand.str();
                 injectedCommand.str("");
                 std::cout << line << std::endl;
+            }
+            else if ( eStack.size() > 0 ) {
+                // Do no log internals of user defined command
+                squashLogging = true;
+                // Execute next instruction in a user defined command
+                line          = eState.next();
+                if ( eState.ret() ) {
+                    eState = eStack.top();
+                    eStack.pop();
+                    // back to normal command entry
+                    if ( eStack.size() == 0 ) cmdHistoryBuf.enable(true);
+                }
             }
             else if ( replayFile.is_open() ) {
                 // Replay commands from file
@@ -235,10 +318,11 @@ SimpleDebugger::execute(const std::string& msg)
                     std::getline(std::cin, line);
             }
 
+            // We have a constructed command line. Ship it
             dispatch_cmd(line);
 
-            // Command Logging
-            if ( enLogging ) loggingFile << line.c_str() << std::endl;
+            // Log commands if enabled and not executing a user defined command
+            if ( enLogging && !squashLogging ) loggingFile << line.c_str() << std::endl;
             // This prevents logging the 'logging' command
             if ( loggingFile.is_open() ) enLogging = true;
         }
@@ -246,6 +330,7 @@ SimpleDebugger::execute(const std::string& msg)
             std::cout << "Parsing error. Ignoring " << line << std::endl;
         }
     }
+    return retState;
 }
 
 // Invoke the command.
@@ -290,18 +375,64 @@ SimpleDebugger::dispatch_cmd(std::string& cmd)
         }
     }
 
-    // Search for the requested command and execute it if found.
-    for ( auto consoleCommand : cmdRegistry ) {
-        if ( consoleCommand.match(tokens[0]) ) {
-            consoleCommand.exec(tokens); // TODO prefer having return code to know if succeeded
+    // Check for 'end' string to terminate special line entry modes
+    if ( (line_entry_mode != LINE_ENTRY_MODE::NORMAL) && (cmd == "end") ) {
+        if ( line_entry_mode == LINE_ENTRY_MODE::DEFINE )
+            cmdRegistry.commitUserCommand();
+        else if ( line_entry_mode == LINE_ENTRY_MODE::DOCUMENT )
+            cmdRegistry.commitDocCommand();
+        else {
+            std::cout << "Error: unknown line entry mode" << std::endl;
+            assert(false);
+        }
+
+        line_entry_mode = LINE_ENTRY_MODE::NORMAL;
+        std::cout << "[ returning to normal line entry mode ]" << std::endl;
+        return;
+    }
+
+    // Do the right thing based on the entry mode
+    switch ( line_entry_mode ) {
+    case LINE_ENTRY_MODE::NORMAL:
+    {
+        // normal execution
+        auto consoleCommand = cmdRegistry.seek(tokens[0], CommandRegistry::SEARCH_TYPE::BUILTIN);
+        if ( consoleCommand.second ) {
+            consoleCommand.first.exec(tokens);
             cmdHistoryBuf.append(cmd);
             return;
         }
-    }
+        // user defined entry
+        consoleCommand = cmdRegistry.seek(tokens[0], CommandRegistry::SEARCH_TYPE::USER);
+        if ( consoleCommand.second ) {
+            cmdHistoryBuf.append(cmd);
+            // Do nothing if user command is empty
+            if ( cmdRegistry.commandIsEmpty(tokens[0]) ) return;
+            // save current context
+            eStack.push(eState);
+            // new context for user call
+            eState = { consoleCommand.first, tokens, cmdRegistry.userCommandInsts(tokens[0]) };
+            // History capture disabled when stack size > 0
+            cmdHistoryBuf.enable(false);
+            return;
+        }
 
-    // No matching command found
-    std::cout << "Unknown command: " << tokens[0].c_str() << std::endl;
-    cmdHistoryBuf.append(cmd); // want garbled command so we can fix using command line editor
+        // No matching command found but keep in history so we can fix it
+        std::cout << "Unknown command: " << tokens[0].c_str() << std::endl;
+        cmdHistoryBuf.append(cmd);
+        return;
+    }
+    case LINE_ENTRY_MODE::DEFINE:
+        // entering a user defined command
+        cmdRegistry.appendUserCommand(tokens[0], cmd);
+        return;
+    case LINE_ENTRY_MODE::DOCUMENT:
+        cmdRegistry.appendDocCommand(cmd);
+        return;
+    default:
+        std::cout << "ERROR: unhandled line entry mode" << std::endl;
+        assert(false);
+    } // switch (line_entry_mode)
 }
 
 //
@@ -334,14 +465,24 @@ SimpleDebugger::cmd_help(std::vector<std::string>& tokens)
     // First check for specific command help
     if ( tokens.size() == 1 ) {
         for ( const auto& g : GroupText ) {
-            std::cout << "--- " << g.second << " ---" << std::endl;
-            for ( const auto& c : cmdRegistry ) {
-                if ( g.first == c.group() ) std::cout << c << std::endl;
+            if ( g.first != ConsoleCommandGroup::USER ) {
+                std::cout << "--- " << g.second << " ---" << std::endl;
+                for ( const auto& c : cmdRegistry.getRegistryVector() ) {
+                    if ( g.first == c.group() ) std::cout << c << std::endl;
+                }
+            }
+            else if ( cmdRegistry.getUserRegistryVector().size() > 0 ) {
+                std::cout << "--- " << g.second << " ---" << std::endl;
+                for ( const auto& c : cmdRegistry.getUserRegistryVector() ) {
+                    if ( g.first == c.group() ) {
+                        std::cout << c << std::endl;
+                    }
+                }
             }
         }
-        std::cout << "\nMore detailed help also available for:\n";
+        std::cout << "\nMore detailed help available for:\n";
         std::stringstream s;
-        for ( const auto& pair : cmdHelp ) {
+        for ( const auto& pair : cmdRegistry.cmdHelp ) {
             if ( (s.str().length() + pair.first.length() > 39) ) {
                 std::cout << "\t" << s.str() << std::endl;
                 s.str("");
@@ -356,11 +497,11 @@ SimpleDebugger::cmd_help(std::vector<std::string>& tokens)
 
     if ( tokens.size() > 1 ) {
         std::string c = tokens[1];
-        if ( cmdHelp.find(c) != cmdHelp.end() ) {
-            std::cout << c << " " << cmdHelp.at(c) << std::endl;
+        if ( cmdRegistry.cmdHelp.find(c) != cmdRegistry.cmdHelp.end() ) {
+            std::cout << c << " " << cmdRegistry.cmdHelp.at(c) << std::endl;
         }
         else {
-            for ( auto& creg : cmdRegistry ) {
+            for ( auto& creg : cmdRegistry.getRegistryVector() ) {
                 if ( creg.match(c) ) std::cout << creg << std::endl;
             }
         }
@@ -390,6 +531,80 @@ SimpleDebugger::cmd_verbose(std::vector<std::string>& tokens)
         if ( x.first ) x.first->setVerbosity(verbosity);
     }
 }
+
+void
+SimpleDebugger::cmd_info(std::vector<std::string>& UNUSED(tokens))
+{
+
+    if ( tokens.size() != 2 ) {
+        printf("Invalid format for info command (info \"current\"|\"all\")\n");
+        return;
+    }
+
+    RankInfo info   = getRank();
+    RankInfo nRanks = getNumRanks();
+    if ( tokens[1] == "current" ) {
+        std::cout << "Rank " << info.rank << "/" << nRanks.rank << ", Thread " << info.thread << "/" << nRanks.thread
+                  << " (Process " << getppid() << ")" << std::endl;
+    }
+    else if ( tokens[1] == "all" ) {
+        if ( nRanks.rank == 1 && nRanks.thread == 1 ) {
+            std::cout << "Rank " << info.rank << "/" << nRanks.rank << ", Thread " << info.thread << "/"
+                      << nRanks.thread << " (Process " << getppid() << ")" << std::endl;
+        }
+        else {
+            // Return to syncmanager to print summary for all threads
+            retState = SUMMARY; // summary info
+            done     = true;
+        }
+    }
+    else {
+        printf("Invalid argument for info command: %s (info \"current\"|\"all\")\n", tokens[1].c_str());
+        return;
+    }
+}
+
+// thread <threadID> : switches to new thread
+void
+SimpleDebugger::cmd_thread(std::vector<std::string>& tokens)
+{
+
+    if ( tokens.size() != 2 ) {
+        printf("Invalid format for thread command (thread <threadID>)\n");
+        return;
+    }
+
+    RankInfo info   = getRank();
+    RankInfo nRanks = getNumRanks();
+    int      threadID;
+
+    // Get threadID
+    try {
+        threadID = std::stoi(tokens[1]);
+    }
+    catch ( const std::invalid_argument& e ) {
+        std::cout << "Invalid argument for threadID: " << tokens[1] << std::endl;
+        return;
+    }
+    catch ( const std::out_of_range& e ) {
+        std::cout << "Out of range for threadID: " << tokens[1] << std::endl;
+        return;
+    }
+
+    // Check if valid threadID
+    if ( threadID < 0 || threadID >= static_cast<int>(nRanks.thread) ) {
+        printf("ThreadID %d out of range (0:%d)\n", threadID, nRanks.thread - 1);
+        return;
+    }
+
+    // If not current thread, set retState and done flag
+    if ( threadID != static_cast<int>(info.thread) ) {
+        retState = threadID;
+        done     = true;
+    }
+    return;
+}
+
 
 // pwd: print current working directory
 void
@@ -442,10 +657,18 @@ SimpleDebugger::get_listing_strings(std::list<std::string>& list)
 void
 SimpleDebugger::cmd_cd(std::vector<std::string>& tokens)
 {
+#if 1
     if ( tokens.size() != 2 ) {
         printf("Invalid format for cd command (cd <obj>)\n");
         return;
     }
+#else
+    // skk This works but doesn't delete/deactivate like objmap selectParent
+    if ( tokens.size() == 1 ) {
+        obj_ = getComponentObjectMap();
+        return;
+    }
+#endif
 
     // Allow for trailing '/'
     std::string selection = tokens[1];
@@ -512,29 +735,24 @@ SimpleDebugger::cmd_print(std::vector<std::string>& tokens)
     // See if have a -r or not
     int         recurse = 0;
     std::string tok     = tokens[1];
-    if ( tok.size() >= 2 && tok[0] == '-' && tok[1] == 'r' ) {
+    if ( (tok.size() >= 2) && (tok[0] == '-') && (tok[1] == 'r') ) {
         // Got a -r
-        std::string num = tok.substr(2);
-        if ( num.size() != 0 ) {
-            try {
-                recurse = SST::Core::from_string<int>(num);
-            }
-            catch ( const std::invalid_argument& e ) {
-                printf("Invalid number format specified with -r: %s\n", tok.c_str());
-                return;
-            }
+        if ( tok.size() == 2 ) {
+            recurse = 4;
         }
         else {
-            recurse = 4; // default -r depth
+            std::string num = tok.substr(2);
+            if ( num.size() != 0 ) {
+                try {
+                    recurse = SST::Core::from_string<int>(num);
+                }
+                catch ( std::invalid_argument& e ) {
+                    printf("Invalid number format specified with -r: %s\n", tok.c_str());
+                    return;
+                }
+            }
         }
-
         var_index = 2;
-    }
-
-    if ( tokens.size() == var_index ) {
-        // Print current object
-        obj_->list(recurse);
-        return;
     }
 
     if ( tokens.size() != (var_index + 1) ) {
@@ -544,15 +762,70 @@ SimpleDebugger::cmd_print(std::vector<std::string>& tokens)
 
     bool        found;
     std::string listing = obj_->listVariable(tokens[var_index], found, recurse);
-
     if ( !found ) {
-        printf("Unknown object in print command: %s\n", tokens[1].c_str());
+        printf("Unknown object in print command: %s\n", tokens[var_index].c_str());
         return;
     }
     else {
         printf("%s", listing.c_str());
     }
 }
+
+#ifdef __CT_RECURSE__
+static void
+recursive_examine(
+    SimpleDebugger& debugger, SST::Core::Serialization::ObjectMap& self, std::string const& name, int level)
+{
+    std::string ret;
+    std::string indent = std::string(level, ' ');
+    if ( self.isFundamental() ) {
+        printf("%s%s = %s (%s)\n", indent.c_str(), name.c_str(), self.get().c_str(), self.getType().c_str());
+        return;
+    }
+
+    printf("%s%s = (%s)\n", indent.c_str(), name.c_str(), self.get().c_str());
+    auto vars = self.getVariables();
+
+    for ( auto var : vars ) {
+        if ( nullptr == var.second->mdata_ ) {
+            var.second->activate(&self, var.first);
+            recursive_examine(debugger, *var.second, var.first, level + 1);
+            var.second->deactivate();
+        }
+    }
+}
+#endif
+
+/*
+ * feature to assist with debugging serialization - recursively prints the contents
+ * of the object map to make sure what is in the object map is consistent with expectations
+ * we've had issues previously with serialization not supporting specific types and this
+ * feature provides the foundation to simplify the object map's verification process. this
+ * feature avoids creating a situation where the team needs to create an exhaustive list
+ * of bash scripts to perform the verification of the object map.
+ *
+ * [examine,e] [<obj>] : prints object in the current scope
+ */
+
+#ifdef __CT_RECURSE__
+void
+SimpleDebugger::cmd_examine(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() < 2 ) {
+        printf("Invalid format for set command (examine <obj>)\n");
+        return;
+    }
+
+    if ( obj_ == nullptr ) {
+        printf("objectMap is null\n");
+        return;
+    }
+
+    recursive_examine(*this, *obj_, tokens[1], 0);
+
+    return;
+}
+#endif
 
 // set <obj> <value>: set object to value
 void
@@ -642,6 +915,21 @@ SimpleDebugger::cmd_run(std::vector<std::string>& tokens)
             printf("Unknown time in call to run: %s\n", tokens[1].c_str());
             return;
         }
+    }
+    else if ( tokens.size() == 3 ) {
+        std::string time = tokens[1] + tokens[2];
+        try {
+            TimeConverter* tc  = getTimeConverter(time);
+            std::string    msg = format_string("Running clock %" PRI_SIMTIME " sim cycles", tc->getFactor());
+            schedule_interactive(tc->getFactor(), msg);
+        }
+        catch ( std::exception& e ) {
+            printf("Unknown time in call to run: %s\n", time.c_str());
+            return;
+        }
+    }
+    else if ( tokens.size() != 1 ) {
+        printf("Too many arguments for 'run <time>'\n");
     }
 
     done = true;
@@ -979,6 +1267,28 @@ SimpleDebugger::cmd_clear(std::vector<std::string>& UNUSED(tokens))
 {
     // clear screen and move cursor to (0,0)
     std::cout << "\033[2J\033[1;1H";
+}
+
+void
+SimpleDebugger::cmd_define(std::vector<std::string>& UNUSED(tokens))
+{
+    if ( tokens.size() != 2 ) {
+        std::cout << "Invalid\nsyntax: define <cmd_name>" << std::endl;
+        return;
+    }
+
+    // Create a user command entry (or clear existing one)
+    if ( cmdRegistry.beginUserCommand(tokens[1]) ) line_entry_mode = LINE_ENTRY_MODE::DEFINE;
+}
+
+void
+SimpleDebugger::cmd_document(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() != 2 ) {
+        std::cout << "Invalid\nsyntax: document <cmd_name>" << std::endl;
+        return;
+    }
+    if ( cmdRegistry.beginDocCommand(tokens[1]) ) line_entry_mode = LINE_ENTRY_MODE::DOCUMENT;
 }
 
 // gdb helper. Recommended SST configuration
@@ -1597,6 +1907,7 @@ SimpleDebugger::cmd_shutdown(std::vector<std::string>& UNUSED(tokens))
 void
 CommandHistoryBuffer::append(std::string s)
 {
+    if ( !en_ ) return;
     buf_[nxt_] = std::make_pair(count_++, s);
     sz_        = sz_ < MAX_CMDS - 1 ? sz_ + 1 : MAX_CMDS;
     cur_       = nxt_;
@@ -1799,5 +2110,141 @@ SimpleDebugger::msg(VERBOSITY_MASK mask, std::string message)
     if ( (!static_cast<uint32_t>(mask)) & verbosity ) return;
     std::cout << message << std::endl;
 }
+
+std::pair<ConsoleCommand, bool> const
+CommandRegistry::seek(std::string token, SEARCH_TYPE search_type)
+{
+    last_seek_command.second = false;
+    if ( search_type == SEARCH_TYPE::ALL || search_type == SEARCH_TYPE::BUILTIN ) {
+        for ( auto consoleCommand : registry ) {
+            if ( consoleCommand.match(token) ) {
+                last_seek_command.first  = consoleCommand;
+                last_seek_command.second = true;
+                return last_seek_command;
+            }
+        }
+    }
+    if ( search_type == SEARCH_TYPE::ALL || search_type == SEARCH_TYPE::USER ) {
+        for ( auto consoleCommand : user_registry ) {
+            if ( consoleCommand.match(token) ) {
+                last_seek_command.first  = consoleCommand;
+                last_seek_command.second = true;
+                return last_seek_command;
+            }
+        }
+    }
+
+    return last_seek_command;
+}
+
+bool
+CommandRegistry::beginUserCommand(std::string name)
+{
+    // Make sure not a built-in command
+    auto res = seek(name, CommandRegistry::SEARCH_TYPE::BUILTIN);
+    if ( res.second ) {
+        std::cout << "Cannot overwrite built-in command \"" << name << "\"" << std::endl;
+        return false;
+    }
+    user_command_wip                        = name;
+    // Create or overwrite existing user defined command
+    user_defined_commands[user_command_wip] = {};
+    std::cout << "Enter commands for \"" << user_command_wip << "\" terminated by \"end\"" << std::endl;
+    return true;
+}
+
+void
+CommandRegistry::appendUserCommand(std::string token0, std::string line)
+{
+    // No recursion
+    if ( token0 == user_command_wip ) {
+        std::cout << token0 << " cannot call itself" << std::endl;
+        return;
+    }
+
+    // Commands not allowed: define, document, replay
+    std::pair<ConsoleCommand, bool> res = seek(token0, CommandRegistry::SEARCH_TYPE::BUILTIN);
+    if ( res.second ) {
+        // Disallow nested `define` or `document` since these change user_command_wip
+        if ( res.first.str_long() == "define" || res.first.str_long() == "document" ) {
+            std::cout << "Ignoring entry: " << res.first.str_long() << "/" << res.first.str_short() << std::endl;
+            return;
+        }
+        // Replay support requires changes to dispatch_cmd
+        if ( res.first.str_long() == "replay" ) {
+            std::cout << "Ignoring entry: " << res.first.str_long() << "/" << res.first.str_short() << std::endl;
+            return;
+        }
+    }
+    user_defined_commands[user_command_wip].emplace_back(line);
+}
+
+void
+CommandRegistry::commitUserCommand()
+{
+    std::cout << "Committing definition for " << user_command_wip << std::endl;
+    user_registry.emplace_back(ConsoleCommand(user_command_wip));
+    user_command_wip = "";
+}
+
+bool
+CommandRegistry::beginDocCommand(std::string name)
+{
+    // Make sure not a built-in command
+    auto res = seek(name, CommandRegistry::SEARCH_TYPE::BUILTIN);
+    if ( res.second ) {
+        std::cout << "Cannot overwrite built-in command \"" << name << "\"" << std::endl;
+        return false;
+    }
+    // Make sure user command is defined
+    res = seek(name, CommandRegistry::SEARCH_TYPE::USER);
+    if ( !res.second ) {
+        std::cout << "\"" << name << "\" must be defined before documenting" << std::endl;
+        return false;
+    }
+
+    user_command_wip = name;
+    user_doc_wip     = {};
+    std::cout << "Enter documentation for \"" << user_command_wip << "\" terminated by \"end\"" << std::endl;
+    return true;
+}
+
+void
+CommandRegistry::appendDocCommand(std::string line)
+{
+    user_doc_wip.emplace_back(line);
+}
+
+void
+CommandRegistry::commitDocCommand()
+{
+    bool found = false;
+    for ( ConsoleCommand& consoleCommand : user_registry ) {
+        if ( consoleCommand.match(user_command_wip) ) {
+            std::cout << "Committing documentation for " << user_command_wip << std::endl;
+            consoleCommand.setUserHelp(user_doc_wip[0]);
+            addHelp(user_command_wip, user_doc_wip);
+            found = true;
+        }
+    }
+
+    if ( !found )
+        std::cout << "Unable to commit documentation. Could not locate definition for " << user_command_wip
+                  << std::endl;
+
+    user_command_wip = "";
+    user_doc_wip     = {};
+}
+
+void
+CommandRegistry::addHelp(std::string key, std::vector<std::string>& vec)
+{
+    std::stringstream s;
+    for ( const auto& line : vec )
+        s << line << "\n";
+    cmdHelp[key] = s.str();
+    ;
+}
+
 
 } // namespace SST::IMPL::Interactive

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -32,7 +32,7 @@
 
 namespace SST::IMPL::Interactive {
 
-enum class ConsoleCommandGroup { GENERAL, NAVIGATION, STATE, WATCH, SIMULATION, LOGGING, MISC };
+enum class ConsoleCommandGroup { GENERAL, NAVIGATION, STATE, WATCH, SIMULATION, LOGGING, MISC, USER };
 
 const std::map<ConsoleCommandGroup, std::string> GroupText {
     { ConsoleCommandGroup::GENERAL, "General" },
@@ -42,16 +42,26 @@ const std::map<ConsoleCommandGroup, std::string> GroupText {
     { ConsoleCommandGroup::SIMULATION, "Simulation" },
     { ConsoleCommandGroup::LOGGING, "Logging" },
     { ConsoleCommandGroup::MISC, "Misc" },
+    { ConsoleCommandGroup::USER, "User Defined" },
 };
 
+// Each bit of mask enables verbosity for different debug features.
+// This is primarily for developers.
 enum class VERBOSITY_MASK : uint32_t {
     WATCHPOINTS = 0b0001'0000 // 0x10
+};
+
+enum class LINE_ENTRY_MODE : int {
+    NORMAL,   // line is executed as a command
+    DEFINE,   // line is captured in user defined command sequence
+    DOCUMENT, // documenting a user defined command
 };
 
 // Encapsulate a console command.
 class ConsoleCommand
 {
 public:
+    // Constructor for built-in commands has callback
     ConsoleCommand(std::string str_long, std::string str_short, std::string str_help, ConsoleCommandGroup group,
         std::function<void(std::vector<std::string>& tokens)> func) :
         str_long_(str_long),
@@ -60,17 +70,28 @@ public:
         group_(group),
         func_(func)
     {}
-    const std::string&         str_long() const { return str_long_; }
-    const std::string&         str_short() const { return str_short_; }
-    const std::string&         str_help() const { return str_help_; }
+    // Constructor for user-defined commands
+    ConsoleCommand(std::string str_long) :
+        str_long_(str_long),
+        str_short_(str_long),
+        str_help_("user defined command"),
+        group_(ConsoleCommandGroup::USER)
+    {}
+    ConsoleCommand() {}; // default constructor
+    const std::string& str_long() const { return str_long_; }
+    const std::string& str_short() const { return str_short_; }
+    const std::string& str_help() const { return str_help_; }
+    void               setUserHelp(std::string& help) { str_help_ = help; }
+
+    // Command Execution
+    void exec(std::vector<std::string>& tokens) { return func_(tokens); }
+
     const ConsoleCommandGroup& group() const { return group_; }
-    void                       exec(std::vector<std::string>& tokens) { return func_(tokens); }
     bool                       match(const std::string& token)
     {
         std::string lctoken = toLower(token);
         if ( lctoken.size() == str_long_.size() && lctoken == toLower(str_long_) ) return true;
         if ( lctoken.size() == str_short_.size() && lctoken == toLower(str_short_) ) return true;
-
         return false;
     }
     friend std::ostream& operator<<(std::ostream& os, const ConsoleCommand c)
@@ -84,13 +105,14 @@ private:
     std::string                                           str_short_;
     std::string                                           str_help_;
     ConsoleCommandGroup                                   group_;
-    std::function<void(std::vector<std::string>& tokens)> func_;
+    std::function<void(std::vector<std::string>& tokens)> func_ = {};
     std::string                                           toLower(std::string s)
     {
         std::transform(s.begin(), s.end(), s.begin(), ::tolower);
         return s;
     }
-};
+
+}; // class ConsoleCommand
 
 class CommandHistoryBuffer
 {
@@ -102,8 +124,10 @@ public:
     std::vector<std::string>& getBuffer();
     enum BANG_RC { INVALID, ECHO_ONLY, EXEC, NOP };
     BANG_RC bang(const std::string& token, std::string& newcmd);
+    void    enable(bool en) { en_ = en; }
 
 private:
+    bool                                             en_    = true;
     int                                              cur_   = 0;
     int                                              nxt_   = 0;
     int                                              sz_    = 0;
@@ -116,6 +140,94 @@ private:
     bool                     searchFirst(const std::string& s, std::string& newcmd);
     bool                     searchAny(const std::string& s, std::string& newcmd);
 };
+
+class CommandRegistry
+{
+
+public:
+    // Construction
+    CommandRegistry() {}
+    CommandRegistry(const std::vector<ConsoleCommand> in) :
+        registry(in)
+    {}
+    // Access
+    std::vector<ConsoleCommand>& getRegistryVector() { return registry; }
+    std::vector<ConsoleCommand>& getUserRegistryVector() { return user_registry; }
+    enum SEARCH_TYPE { ALL, BUILTIN, USER };
+    std::pair<ConsoleCommand, bool> const seek(std::string token, SEARCH_TYPE search_type);
+    // User defined command entry
+    bool                                  beginUserCommand(std::string name);
+    void                                  appendUserCommand(std::string token0, std::string line);
+    void                                  commitUserCommand();
+    std::vector<std::string>*             userCommandInsts(std::string key)
+    {
+        if ( user_defined_commands.find(key) == user_defined_commands.end() ) return nullptr;
+        return &user_defined_commands[key];
+    }
+    // User defined command help doc entry
+    bool beginDocCommand(std::string name);
+    void appendDocCommand(std::string line);
+    void commitDocCommand();
+    bool commandIsEmpty(const std::string key)
+    {
+        if ( user_defined_commands.find(key) == user_defined_commands.end() ) return true;
+        if ( user_defined_commands[key].size() == 0 ) return true;
+        return false;
+    };
+
+    // User defined command help from vector
+    void                               addHelp(std::string key, std::vector<std::string>& vec);
+    // Detailed Command Help (public for now)
+    std::map<std::string, std::string> cmdHelp;
+
+private:
+    // built-in commands
+    std::vector<ConsoleCommand>                     registry              = {};
+    // user defined commands
+    std::vector<ConsoleCommand>                     user_registry         = {};
+    std::map<std::string, std::vector<std::string>> user_defined_commands = {};
+    std::string                                     user_command_wip      = "";
+    std::vector<std::string>                        user_doc_wip          = {};
+
+    // Last searched command with valid indicator
+    std::pair<ConsoleCommand, bool> last_seek_command = {};
+}; // class CommandRegistry
+
+// Support for nesting user defined commands
+class ExecState
+{
+public:
+    // Constructor for entering a new user command
+    ExecState(ConsoleCommand cmd, std::vector<std::string> tokens, std::vector<std::string>* insts) :
+        cmd_(cmd),
+        tokens_(tokens),
+        insts_(insts),
+        index_(0),
+        user_(true)
+    {
+        assert(insts_->size() > 0);
+    };
+    ExecState() {};
+    bool        ret() { return ret_; }
+    // Advance state and return the next user instruction
+    std::string next()
+    {
+        assert(user_);
+        assert(!ret_);
+        assert(insts_);
+        assert(index_ < insts_->size());
+        ret_ = (index_ + 1) == insts_->size();
+        return insts_->at(index_++);
+    }
+
+private:
+    ConsoleCommand            cmd_    = {};      // user command in progress
+    std::vector<std::string>  tokens_ = {};      // command args
+    std::vector<std::string>* insts_  = nullptr; // command sequence
+    size_t                    index_  = 0;       // command pointer
+    bool                      user_   = false;   // in user command
+    bool                      ret_    = false;   // user command complete, return to caller
+}; // class ExecState
 
 class SimpleDebugger : public SST::InteractiveConsole
 {
@@ -138,7 +250,8 @@ public:
     explicit SimpleDebugger(Params& params);
     ~SimpleDebugger();
 
-    void execute(const std::string& msg) override;
+    int  execute(const std::string& msg) override;
+    void summary() override;
 
     // Callbacks from command line completions
     void get_listing_strings(std::list<std::string>&);
@@ -151,8 +264,9 @@ private:
     // directory as far as we can.
     std::vector<std::string> name_stack;
 
-    SST::Core::Serialization::ObjectMap* obj_ = nullptr;
-    bool                                 done = false;
+    SST::Core::Serialization::ObjectMap* obj_     = nullptr;
+    bool                                 done     = false;
+    int                                  retState = -1; // -1 DONE, -2 SUMAMRY, positive number is threadID
 
     bool autoCompleteEnable = true;
 
@@ -166,8 +280,12 @@ private:
     std::string   replayFilePath  = "sst-console.in";
     bool          enLogging       = false;
 
-    // command injection
-    std::stringstream injectedCommand; // TODO use ConsoleCommand object
+    // command injection (for sst --replay option)
+    std::stringstream injectedCommand;
+
+    // execution state management for nested user commands
+    ExecState             eState = {};
+    std::stack<ExecState> eStack = {};
 
     // Keep a pointer to the ObjectMap for the top level Component
     SST::Core::Serialization::ObjectMapDeferred<BaseComponent>* base_comp_ = nullptr;
@@ -182,6 +300,8 @@ private:
     // Navigation
     void cmd_help(std::vector<std::string>& UNUSED(tokens));
     void cmd_verbose(std::vector<std::string>&(tokens));
+    void cmd_info(std::vector<std::string>& UNUSED(tokens));
+    void cmd_thread(std::vector<std::string>& tokens);
     void cmd_pwd(std::vector<std::string>& UNUSED(tokens));
     void cmd_ls(std::vector<std::string>& UNUSED(tokens));
     void cmd_cd(std::vector<std::string>& tokens);
@@ -192,6 +312,9 @@ private:
     void cmd_time(std::vector<std::string>& tokens);
     void cmd_watch(std::vector<std::string>& tokens);
     void cmd_unwatch(std::vector<std::string>& tokens);
+#ifdef __CT_RECURSE__
+    void cmd_examine(std::vector<std::string>& tokens);
+#endif
 
     // Simulation Control
     void cmd_run(std::vector<std::string>& tokens);
@@ -219,22 +342,25 @@ private:
     // Reset terminal
     void cmd_clear(std::vector<std::string>& UNUSED(tokens));
 
+    // User defined commands
+    void cmd_define(std::vector<std::string>& tokens);
+    void cmd_document(std::vector<std::string>& tokens);
+
     // LLDB/GDB helper
     void cmd_spinThread(std::vector<std::string>& tokens);
 
+    // command entry point
     void dispatch_cmd(std::string& cmd);
 
     // Command Registry
-    std::vector<ConsoleCommand> cmdRegistry;
-
-    // Detailed Command Help
-    std::map<std::string, std::string> cmdHelp;
+    CommandRegistry cmdRegistry;
 
     // Command History
     CommandHistoryBuffer cmdHistoryBuf;
 
     // Command Line Editor
-    CmdLineEditor cmdLineEditor;
+    CmdLineEditor   cmdLineEditor;
+    LINE_ENTRY_MODE line_entry_mode = LINE_ENTRY_MODE::NORMAL;
 
     // Verbosity controlled console printing
     uint32_t verbosity = 0;

--- a/src/sst/core/interactiveAction.h
+++ b/src/sst/core/interactiveAction.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/action.h"
 // Can include this because this header is not installed
+#include "sst/core/interactiveConsole.h"
 #include "sst/core/simulation_impl.h"
 
 #include <string>
@@ -31,7 +32,6 @@ public:
        Create a new InteractiveAction object for the simulation core to initiate interactive mode
     */
     InteractiveAction(Simulation_impl* sim, const std::string& msg) :
-        Action(),
         sim_(sim),
         msg_(msg)
     {
@@ -39,6 +39,26 @@ public:
     }
 
     ~InteractiveAction() {}
+#if 1
+    /**
+       Indicates InteractiveAction should be inserted into the
+       TimeVortex. The insertion will only happen for serial runs, as
+       InteractiveAction is managed by the SyncManager in parallel
+       runs.
+     */
+    void insertIntoTimeVortex(SimTime_t time)
+    {
+        // If this is a serial job, insert this into
+        // the time TimeVortex.  If it is parallel, then the
+        // InteractiveAction is managed by the SyncManager.
+        // std::cout << "skk: insertIntoTimeVortex called\n";
+        RankInfo num_ranks = sim_->getNumRanks();
+        // if (num_ranks.rank == 1 && num_ranks.thread == 1) {
+        // std::cout << "  skk: insertIntoTimeVortex insertActivity\n";
+        sim_->insertActivity(time, this);
+        //}
+    }
+#endif
 
     /** Called by TimeVortex to trigger interactive mode. */
     void execute() override
@@ -47,6 +67,7 @@ public:
         sim_->interactive_msg_   = msg_;
         delete this;
     }
+
 
 private:
     Simulation_impl* sim_;

--- a/src/sst/core/interactiveConsole.cc
+++ b/src/sst/core/interactiveConsole.cc
@@ -114,7 +114,9 @@ InteractiveConsole::getComponentObjectMap()
 void
 InteractiveConsole::simulationShutdown()
 {
-    Simulation_impl::getSimulation()->endSimulation();
+    // Simulation_impl::getSimulation()->endSimulation();  // Only works for single thread
+    std::cout << "Simulation shutdown\n";
+    Simulation_impl::getSimulation()->signalShutdown(false);
 }
 
 

--- a/src/sst/core/interactiveConsole.h
+++ b/src/sst/core/interactiveConsole.h
@@ -57,8 +57,12 @@ public:
     InteractiveConsole()          = default;
     virtual ~InteractiveConsole() = default;
 
+    /** Interactive Console execute return codes: Positive number is thread ID to switch to, negative is other state */
+    enum ICretcode { DONE = -1, SUMMARY = -2 };
     /** Called by TimeVortex to trigger checkpoint on simulation clock interval - not used in parallel simulation */
-    virtual void execute(const std::string& msg) = 0;
+    virtual int  execute(const std::string& msg) = 0;
+    /** Called by SyncManager to get summary info for each thread */
+    virtual void summary()                       = 0;
 
 protected:
     // Functions that can be called by child class

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -468,6 +468,11 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
         Simulation_impl::createSimulation(info.myRank, info.world_size, restart, currentSimCycle, currentPriority);
     double start_run = 0.0;
 
+    // Setup the real time actions (all of these have to be defined on
+    // the command-line or SDL file, they will not be checkpointed and
+    // restored
+    sim->setupSimActions();
+
     // Thread zero needs to initialize the checkpoint data structures
     // if any checkpointing options were turned on.  This will return
     // an empty string if checkpointing was not enabled.
@@ -527,13 +532,6 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
         barrier.wait();
 
     } // if ( restart )
-
-
-    // Setup the real time actions (all of these have to be defined on
-    // the command-line or SDL file, they will not be checkpointed and
-    // restored
-    sim->setupSimActions();
-
 
     if ( !restart ) {
 

--- a/src/sst/core/realtime.h
+++ b/src/sst/core/realtime.h
@@ -127,7 +127,9 @@ public:
     InteractiveRealTimeAction();
     void execute() override;
     bool isValidSigalrmAction() override { return false; }
-    bool canInitiateCheckpoint() override { return true; }
+    // Separate --checkpoint-enable flag is currently used to control checkpointing for interactive console
+    // If we set canInitiateCheckpoint to true here, it will ALWAYS set up checkpointing and the flag is unnecessary
+    bool canInitiateCheckpoint() override { return false; }
 };
 
 /* Wrapper for RealTimeActions that occur on a time interval */

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -1136,7 +1136,7 @@ public:
             return;
         }
         if ( state_ != CLEAR ) {
-            std::cout << "TriggerRecord:@cycle" << triggerCycle << ": samples lost = " << samplesLost_ << ": ";
+            std::cout << "LastTriggerRecord:@cycle" << triggerCycle << ": SamplesLost=" << samplesLost_ << ": ";
             for ( size_t obj = 0; obj < numObjects; obj++ ) {
                 ObjectBuffer* varBuffer_ = objBuffers_[obj];
                 std::cout << SST::Core::to_string(varBuffer_->getName()) << "=" << varBuffer_->getTriggerVal() << " ";

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -938,6 +938,63 @@ Simulation_impl::prepare_for_run()
 }
 
 void
+Simulation_impl::setup_interactive_mode()
+{
+
+
+    // Start just with multithreading right now
+    if ( num_ranks.rank == 1 ) {
+        // std::cout << "skk: run: setup interactive\n";
+        if ( interactive_type_ != "" ) {
+            // --interactive-console used to override default
+            initialize_interactive_console(interactive_type_);
+        }
+        else if ( (interactive_start_ != "") || (config.sigusr1() == "sst.rt.interactive") ||
+                  (config.sigusr2() == "sst.rt.interactive") ) {
+            // use default interactive console
+            interactive_type_ = "sst.interactive.simpledebug";
+            initialize_interactive_console(interactive_type_);
+        }
+
+        if ( interactive_start_ != "" ) {
+            // std::cout << "skk: run: interactive start\n";
+            if ( nullptr == interactive_ ) { // Should never get here
+                sim_output.fatal(CALL_INFO, 1,
+                    "ERROR: Specified --interactive-start, but did not specify --interactive-mode to set the "
+                    "interactive action that should be used.\n");
+            }
+            SimTime_t offset;
+            try {
+                UnitAlgebra time(interactive_start_);
+                printf("%s\n", time.toStringBestSI().c_str());
+
+                if ( time.isValueZero() ) {
+                    offset = 0;
+                }
+                else {
+                    TimeConverter* tc = timeLord.getTimeConverter(time);
+                    offset            = tc->getFactor();
+                }
+            }
+            catch ( std::exception& e ) {
+                sim_output.fatal(CALL_INFO, 1, "Invalid format for time in interactive start: %s\n", e.what());
+            }
+
+            // Special case, invoke interactive console now rather than wait for sync
+            if ( num_ranks.thread > 1 && offset == 0 ) {
+                enter_interactive_ = true;
+                syncManager->handleInteractiveConsole();
+            }
+            else {
+                InteractiveAction* act =
+                    new InteractiveAction(this, format_string("Interactive start at %" PRI_SIMTIME, offset));
+                act->insertIntoTimeVortex(currentSimCycle + offset);
+            }
+        }
+    }
+}
+
+void
 Simulation_impl::run()
 {
 #if SST_PERFORMANCE_INSTRUMENTING
@@ -954,47 +1011,7 @@ Simulation_impl::run()
 #endif
 #endif
 
-    // Setup interactive mode (only in serial jobs for now)
-    if ( num_ranks.rank == 1 && num_ranks.thread == 1 ) {
-        if ( interactive_type_ != "" ) {
-            // --interactive-console used to override default
-            initialize_interactive_console(interactive_type_);
-        }
-        else if ( (interactive_start_ != "") || (config.sigusr1() == "sst.rt.interactive") ||
-                  (config.sigusr2() == "sst.rt.interactive") ) {
-            // use default interactive console
-            interactive_type_ = "sst.interactive.simpledebug";
-            initialize_interactive_console(interactive_type_);
-        }
-
-        if ( interactive_start_ != "" ) {
-            if ( nullptr == interactive_ ) { // Should never get here
-                sim_output.fatal(CALL_INFO, 1,
-                    "ERROR: Specified --interactive-start, but did not specify --interactive-mode to set the "
-                    "interactive action that should be used.\n");
-            }
-            try {
-                UnitAlgebra time(interactive_start_);
-                printf("%s\n", time.toStringBestSI().c_str());
-                SimTime_t offset;
-                if ( time.isValueZero() ) {
-                    offset = 0;
-                }
-                else {
-                    TimeConverter* tc = timeLord.getTimeConverter(time);
-                    offset            = tc->getFactor();
-                }
-
-                InteractiveAction* act =
-                    new InteractiveAction(this, format_string("Interactive start at %" PRI_SIMTIME, offset));
-                act->setDeliveryTime(currentSimCycle + offset);
-                timeVortex->insert(act);
-            }
-            catch ( const std::exception& e ) {
-                sim_output.fatal(CALL_INFO, 1, "Invalid format for time in interactive start: %s\n", e.what());
-            }
-        }
-    }
+    setup_interactive_mode();
 
     run_phase_start_time_ = sst_get_cpu_time();
 
@@ -1034,10 +1051,13 @@ Simulation_impl::run()
                 signal_arrived_ = 0;
                 real_time_->notifySignal();
             }
-            if ( enter_interactive_ ) {
-                enter_interactive_ = false;
-                if ( interactive_ != nullptr ) interactive_->execute(interactive_msg_);
-            }
+            // If serial execution (1 rank, 1 thread)
+            if ( (num_ranks.rank == 1) && (num_ranks.thread == 1) ) {
+                if ( enter_interactive_ ) {
+                    enter_interactive_ = false;
+                    if ( interactive_ != nullptr ) interactive_->execute(interactive_msg_);
+                }
+            } // Otherwise handled in sync manager
         }
 
 #if SST_PERIODIC_PRINT
@@ -1068,7 +1088,6 @@ Simulation_impl::run()
     }
 
     /* We shouldn't need to do this, but to be safe... */
-
     runBarrier.wait(); // TODO<- Is this needed?
 
     run_phase_total_time_ = sst_get_cpu_time() - run_phase_start_time_;
@@ -1123,6 +1142,21 @@ Simulation_impl::signalShutdown(bool abnormal)
     else {
         shutdown_mode_ = SHUTDOWN_CLEAN;
     }
+
+    if ( num_ranks.rank == 1 && num_ranks.thread == 1 ) {
+        // Set endsim right away if serial
+        endSim = true;
+    }
+    else {
+        // Otherwise handle shutdown in sync
+        enter_shutdown_ = true;
+    }
+}
+
+void
+Simulation_impl::setEndSim()
+{
+    // Called from sync
     endSim = true;
 }
 
@@ -2139,6 +2173,14 @@ Simulation_impl::initialize_interactive_console(const std::string& type)
     if ( replay_file_.size() > 0 ) p.insert("replayFile", replay_file_);
 
     interactive_ = factory->Create<InteractiveConsole>(actual_type, p);
+}
+
+void
+Simulation_impl::scheduleInteractiveConsole(const std::string& msg)
+{
+    // std::cout << "skk: scheduleIC\n";
+    enter_interactive_ = true;
+    interactive_msg_   = msg;
 }
 
 

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -242,6 +242,8 @@ public:
 
     void prepare_for_run();
 
+    void setup_interactive_mode();
+
     void run();
 
     void finish();
@@ -403,6 +405,7 @@ public:
 
     std::string initializeCheckpointInfrastructure(const std::string& prefix);
     void        scheduleCheckpoint();
+    void        scheduleInteractiveConsole(const std::string& msg);
 
     /**
        Write the partition specific checkpoint data
@@ -477,6 +480,11 @@ public:
      */
     void signalShutdown(bool abnormal);
 
+    /** Set EndSim
+     * Called by SyncMgr when interactive console ready to shutdown
+     */
+    void setEndSim();
+
     /** Normal Shutdown
      */
     void endSimulation();
@@ -511,6 +519,7 @@ public:
     unsigned int            untimed_phase;
     volatile sig_atomic_t   signal_arrived_; // true if a signal has arrived
     ShutdownMode_t          shutdown_mode_;
+    bool                    enter_shutdown_ = false;
     bool                    wireUpFinished_;
     RealTimeManager*        real_time_;
     std::string             interactive_type_  = "";

--- a/src/sst/core/sync/syncManager.h
+++ b/src/sst/core/sync/syncManager.h
@@ -146,6 +146,8 @@ public:
     ActivityQueue* registerLink(
         const RankInfo& to_rank, const RankInfo& from_rank, const std::string& name, Link* link);
     void exchangeLinkInfo();
+    void handleShutdown();
+    void handleInteractiveConsole();
     void execute() override;
 
     /** Cause an exchange of Initialization Data to occur */
@@ -186,8 +188,15 @@ private:
     sync_type_t next_sync_type_;
     SimTime_t   min_part_;
 
-    RealTimeManager*  real_time_;
-    CheckpointAction* checkpoint_;
+    RealTimeManager*                 real_time_;
+    CheckpointAction*                checkpoint_;
+    static std::atomic<unsigned>     enter_interactive_mask_;
+    static std::atomic<int>          current_ic_thread_;
+    static std::atomic<int>          current_ic_state_;
+    static std::atomic<unsigned>     enter_shutdown_;
+    static std::atomic<unsigned>     endSim_;
+    static std::atomic<unsigned>     shutdown_mode_;
+    static Core::ThreadSafe::Barrier ic_barrier_;
 
     SyncProfileToolList* profile_tools_ = nullptr;
 

--- a/src/sst/core/watchPoint.h
+++ b/src/sst/core/watchPoint.h
@@ -168,6 +168,7 @@ public:
     void        setHandler(unsigned handlerType);
     std::string handlerToString(HANDLER h);
     void        printHandler();
+    void        genericHandler(HANDLER h);
     void        printWatchpoint();
     void        resetTraceBuffer();
     inline bool checkReset() { return reset_; }
@@ -204,8 +205,10 @@ private:
     HANDLER                                                handler        = ALL;
     bool                                                   trigger        = false;
     HANDLER                                                triggerHandler = HANDLER::NONE;
+    size_t                                                 triggerCount   = 0;
     bool                                                   reset_         = false;
     WPAction*                                              wpAction;
+
 
     void     setBufferReset();
     void     check();

--- a/tests/testsuite_default_RealTime.py
+++ b/tests/testsuite_default_RealTime.py
@@ -170,7 +170,7 @@ class testcase_Signals(SSTTestCase):
         # Run test
         sdlfile = "{0}/test_RealTime.py".format(testsuitedir)
         outfile = "{0}/test_RealTime_heartbeat.out".format(outdir)
-        self.run_sst(sdlfile, outfile, other_args="--exit-after=6s --heartbeat-wall-period=1")
+        self.run_sst(sdlfile, outfile, other_args="--exit-after=6s --heartbeat-wall-period=2")
 
         # Cannot diff test output because times may differ
         # Check for at least 5 heartbeat messages
@@ -190,10 +190,10 @@ class testcase_Signals(SSTTestCase):
         ranks = testing_check_get_num_ranks()
         threads = testing_check_get_num_threads()
         num_para = threads * ranks
-        num_lines = 126 + 2*num_para # basic heartbeat (>25) + exit messages (1 + 2*para) + Component Finished messages (100)
+        num_lines = 116 + 2*num_para # basic heartbeat (>25) + exit messages (1 + 2*para) + Component Finished messages (100)
         if ranks > 1:
             num_lines += 10 # Extra heartbeat output for MPI
-        self.assertTrue(hb_count >= 5, "Heartbeat count incorrect, should be at least 5, found {0} in {1}".format(hb_count,outfile))
+        self.assertTrue(hb_count >= 2, "Heartbeat count incorrect, should be at least 2, found {0} in {1}".format(hb_count,outfile))
         self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(num_para,exit_count,outfile))
         self.assertTrue(line_count >= num_lines, "Line count incorrect, should be {0}, found {1} in {2}".format(num_lines,line_count,outfile))
 


### PR DESCRIPTION
This PR provides a set of updates to the interactive debug console, object mapping support, and bug fixes.

- Ensure signal command line flags are processed before the checkpoint directory is created and have it fail immediately if the --checkpoint-prefix PREFIX is not valid. 
- Add support for user defined commands in the interactive console, consisting of a named sequence of commands and supporting nested definitions 
- Single-rank, multithreaded interactive debug console support. In multithreaded simulations, interactive console is invoked from the syncManager, starting in thread 0. The user can navigate the object map, set watchpoints, etc. within a thread. The “info” command provides the rank, thread ID, and process ID for threads and the “thread” command switches control between threads. 



----
