### PR TITLE
Add ObjectMap support for std::unique_ptr

### DIFF
--- a/src/sst/core/serialization/impl/serialize_unique_ptr.h
+++ b/src/sst/core/serialization/impl/serialize_unique_ptr.h
@@ -79,7 +79,11 @@ class serialize_impl<pvt::unique_ptr_wrapper<PTR_TYPE, DELETER, SIZE_T>>
         const auto mode = ser.mode();
 
         if ( mode == serializer::MAP ) {
-            // TODO: Mapping std::unique_ptr
+            auto* ptr_value = ptr.ptr.get();
+            if constexpr ( is_unbounded_array_v<PTR_TYPE> )
+                SST_SER_NAME(SST::Core::Serialization::array(ptr_value, ptr.size), ser.getMapName());
+            else
+                SST_SER_NAME(ptr_value, ser.getMapName());
             return;
         }
 


### PR DESCRIPTION
This adds `ObjectMap` support for `std::unique_ptr`. It has been tested for scalars, unbounded arrays, and bounded arrays.
