### PR TITLE
Support ObjectMap for std::shared_ptr and std::weak_ptr

### DIFF
--- a/src/sst/core/serialization/impl/serialize_array.h
+++ b/src/sst/core/serialization/impl/serialize_array.h
@@ -81,7 +81,7 @@ struct serialize_impl_fixed_array
         const auto& aPtr     = get_ptr(ary); // reference to ary if it's a pointer; &ary otherwise
         switch ( ser.mode() ) {
         case serializer::MAP:
-            serialize_array_map(ser, &(*aPtr)[0], elem_opt, SIZE, new ObjectMapArray<ELEM_T>(&(*aPtr)[0], SIZE),
+            serialize_array_map(ser, &(*aPtr)[0], elem_opt, SIZE, new ObjectMapBoundedArray<ELEM_T, SIZE>(&(*aPtr)[0]),
                 serialize_array_map_element<ELEM_T>);
             break;
 

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -1411,7 +1411,18 @@ public:
         ObjectMapContainer<T>(addr),
         size(size)
     {}
+    std::string getType() const override { return this->demangle_name(typeid(T[]).name()); }
     ~ObjectMapArray() override = default;
+};
+
+template <class T, size_t SIZE>
+struct ObjectMapBoundedArray : public ObjectMapContainer<T>
+{
+    ObjectMapBoundedArray(T* addr) :
+        ObjectMapContainer<T>(addr)
+    {}
+    std::string getType() const override { return this->demangle_name(typeid(T[SIZE]).name()); }
+    ~ObjectMapBoundedArray() override = default;
 };
 
 // ObjectMap for reference proxy types such as std::bitset<N>::reference, std::vector<bool>::reference,


### PR DESCRIPTION
- Support `ObjectMap` for `std::shared_ptr` and `std::weak_ptr`;
- Add type print override for `ObjectMapArray` (prints `T[]`)
- Add `ObjectMapBoundedArray` (prints `T[N]`)
