### PR TITLE
Throw exceptions for unsupported mapping mode serializations

### DIFF
--- a/src/sst/core/objectSerialization.h
+++ b/src/sst/core/objectSerialization.h
@@ -29,8 +29,7 @@ serialize(dataType& data)
 
     size_t size = ser.size();
 
-    std::vector<char> buffer;
-    buffer.resize(size);
+    std::vector<char> buffer(size);
 
     ser.start_packing(buffer.data(), size);
     SST_SER(data);

--- a/src/sst/core/timeVortex.cc
+++ b/src/sst/core/timeVortex.cc
@@ -24,7 +24,7 @@ namespace TV::pvt {
 void
 pack_timevortex(TimeVortex*& s, SST::Core::Serialization::serializer& ser)
 {
-    std::string type = Simulation_impl::getSimulation()->timeVortexType;
+    std::string& type = Simulation_impl::getSimulation()->timeVortexType;
     SST_SER(type);
     s->serialize_order(ser);
 }


### PR DESCRIPTION
~~Throw exceptions for unsupported mapping mode serializations~~

Use a reference in timeVortex to avoid a copy

Simplify a `std::vector` declaration

