### PR TITLE
Make complex numbers first-class ObjectMapFundamental objects

### DIFF
--- a/src/sst/core/Makefile.am
+++ b/src/sst/core/Makefile.am
@@ -62,6 +62,7 @@ nobase_dist_sst_HEADERS = \
 	realtime.h \
 	realtimeAction.h \
 	sparseVectorMap.h \
+	sst_complex.h \
 	sst_types.h \
 	sstpart.h \
 	ssthandler.h \

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -787,6 +787,13 @@ constexpr bool have_common_type_v = false;
 template <class T1, class T2>
 constexpr bool have_common_type_v<T1, T2, std::void_t<std::common_type_t<T1, T2>>> = true;
 
+// Whether a type is ordered
+template <class T, class = void>
+constexpr bool is_ordered_v = false;
+
+template <class T>
+constexpr bool is_ordered_v<T, std::void_t<decltype(T {} < T {})>> = true;
+
 // Comparison of two variables if they are convertible to a common type
 // See https://en.cppreference.com/w/cpp/language/usual_arithmetic_conversions.html
 template <typename T1, typename T2>
@@ -796,13 +803,25 @@ cmp(T1 t1, ObjectMapComparison::Op op, T2 t2)
     using T = std::common_type_t<T1, T2>;
     switch ( op ) {
     case ObjectMapComparison::Op::LT:
-        return static_cast<T>(t1) < static_cast<T>(t2);
+        if constexpr ( is_ordered_v<T> )
+            return static_cast<T>(t1) < static_cast<T>(t2);
+        else
+            return false;
     case ObjectMapComparison::Op::LTE:
-        return static_cast<T>(t1) <= static_cast<T>(t2);
+        if constexpr ( is_ordered_v<T> )
+            return static_cast<T>(t1) <= static_cast<T>(t2);
+        else
+            return false;
     case ObjectMapComparison::Op::GT:
-        return static_cast<T>(t1) > static_cast<T>(t2);
+        if constexpr ( is_ordered_v<T> )
+            return static_cast<T>(t1) > static_cast<T>(t2);
+        else
+            return false;
     case ObjectMapComparison::Op::GTE:
-        return static_cast<T>(t1) >= static_cast<T>(t2);
+        if constexpr ( is_ordered_v<T> )
+            return static_cast<T>(t1) >= static_cast<T>(t2);
+        else
+            return false;
     case ObjectMapComparison::Op::EQ:
         return static_cast<T>(t1) == static_cast<T>(t2);
     case ObjectMapComparison::Op::NEQ:

--- a/src/sst/core/sst_complex.h
+++ b/src/sst/core/sst_complex.h
@@ -1,0 +1,63 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_COMPLEX_H
+#define SST_CORE_COMPLEX_H
+
+#include <cfloat>
+#include <complex>
+
+namespace SST::Core {
+
+// Traits for getting information about complex types
+template <class T>
+struct complex_properties
+{
+    static constexpr bool is_complex = false;
+    using real_t                     = void;
+};
+
+template <class T>
+struct complex_properties<std::complex<T>>
+{
+    static constexpr bool is_complex = true;
+    using real_t                     = T;
+};
+
+#ifndef __STDC_NO_COMPLEX__
+
+template <>
+struct complex_properties<float _Complex>
+{
+    static constexpr bool is_complex = true;
+    using real_t                     = float;
+};
+
+template <>
+struct complex_properties<double _Complex>
+{
+    static constexpr bool is_complex = true;
+    using real_t                     = double;
+};
+
+template <>
+struct complex_properties<long double _Complex>
+{
+
+    static constexpr bool is_complex = true;
+    using real_t                     = long double;
+};
+
+#endif // __STDC_NO_COMPLEX__
+
+} // namespace SST::Core
+
+#endif // SST_CORE_COMPLEX_H


### PR DESCRIPTION
This makes complex numbers (both C++ `std::complex` and C99 `_Complex`) first-class `ObjectMapFundamental` types
- A new `sst_complex.h` is used as the central header file for all macros/classes related to complex numbers
- A `complex_properties` trait is used in the serialization code to detect whether a type is considered a complex number, and what its corresponding real type is
- The code in `serialize_utility.h` was simplified to use `complex_properties`
- The `serialize_trivial.h` mapping code has been changed to create `ObjectMapFundamental` for arithmetic, enumeration, and complex types
- `to_string` and `from_string` have been enhanced to print and parse complex numbers. They are printed as `(real, imag)` but the parentheses are optional on input, and if the `, imag` is left out on input, it will be considered `0`
- In `ObjectMapFundamental`, if an ordered comparison is performed on complex numbers, it will always return `false` (instead of giving a compile-time error that `<`, `<=`, `>`, `>=` are undefined for complex values)