### PR TITLE
Add warnings for trivially serializable types which cannot automatically have an ObjectMap created for them

### DIFF
--- a/src/sst/core/serialization/impl/ser_shared_ptr_tracker.cc
+++ b/src/sst/core/serialization/impl/ser_shared_ptr_tracker.cc
@@ -54,7 +54,7 @@ ser_shared_ptr_unpacker::get_shared_ptr_owner(size_t tag)
     }
 
     Output::getDefaultObject().fatal(
-        __LINE__, __FILE__, __func__, 1, "Serialization Error: std::shared_ptr ownership tag is out of order");
+        CALL_INFO, 1, "Serialization Error: std::shared_ptr ownership tag is out of order");
 }
 
 } // namespace SST::Core::Serialization::pvt

--- a/src/sst/core/serialization/impl/serialize_shared_ptr.h
+++ b/src/sst/core/serialization/impl/serialize_shared_ptr.h
@@ -142,7 +142,7 @@ pack_shared_ptr_address(
         const void* parent_addr = parent.get();
 
         if ( !parent_addr )
-            Output::getDefaultObject().fatal(__LINE__, __FILE__, __func__, 1,
+            Output::getDefaultObject().fatal(CALL_INFO, 1,
                 "Serialization Error: Serialized std::%s has a non-null stored pointer, but the parent specified by %s "
                 "has a null stored pointer.\nThere is no way to know how this raw pointer should be serialized.\n",
                 ptr_string<PTR_TEMPLATE>, wrapper_string<PTR_TEMPLATE, PARENT_TYPE>);
@@ -159,7 +159,7 @@ pack_shared_ptr_address(
 
         // Make sure that the address offset is inside of the parent or one byte past the end
         if ( offset < 0 || static_cast<size_t>(offset) > parent_size )
-            Output::getDefaultObject().fatal(__LINE__, __FILE__, __func__, 1,
+            Output::getDefaultObject().fatal(CALL_INFO, 1,
                 "Serialization Error: Serialized std::%s has a stored pointer outside of the bounds of the parent "
                 "specified by %s.\nThere is no way to know how this raw pointer should be serialized.\n",
                 ptr_string<PTR_TEMPLATE>, wrapper_string<PTR_TEMPLATE, PARENT_TYPE>);
@@ -308,7 +308,7 @@ public:
 
             // If ptr is an expired std::weak_ptr, expect parent to be an empty pointer for the purposes of this test
             if ( ptr.use_count() ? owner_ne(parent, ptr) : owner_ne(parent, PTR_TEMPLATE<PTR_TYPE>()) )
-                Output::getDefaultObject().fatal(__LINE__, __FILE__, __func__, 1,
+                Output::getDefaultObject().fatal(CALL_INFO, 1,
                     "Serialization Error: Serialized std::%s does not have the same owning control block as the parent "
                     "specified by %s.\n",
                     ptr_string<PTR_TEMPLATE>, wrapper_string<PTR_TEMPLATE, PARENT_TYPE>);

--- a/src/sst/core/serialization/impl/serialize_trivial.h
+++ b/src/sst/core/serialization/impl/serialize_trivial.h
@@ -17,11 +17,14 @@
     "The header file sst/core/serialization/impl/serialize_trivial.h should not be directly included as it is not part of the stable public API.  The file is included in sst/core/serialization/serialize.h"
 #endif
 
+#include "sst/core/output.h"
 #include "sst/core/serialization/serializer.h"
 
 #include <array>
 #include <bitset>
+#include <string>
 #include <type_traits>
+#include <typeinfo>
 #include <utility>
 
 namespace SST::Core::Serialization {
@@ -54,24 +57,56 @@ class serialize_impl<T,
 {
     void operator()(T& t, serializer& ser, ser_opt_t options)
     {
+        using U          = std::remove_pointer_t<T>;
         const auto& tPtr = get_ptr(t);
-        switch ( const auto mode = ser.mode() ) {
+        switch ( ser.mode() ) {
         case serializer::MAP:
-            // Right now only arithmetic, enum and complex types are handled in mapping mode without custom serializer
-            if constexpr ( std::is_arithmetic_v<std::remove_pointer_t<T>> || std::is_enum_v<std::remove_pointer_t<T>> ||
-                           complex_properties<std::remove_pointer_t<T>>::is_complex ) {
-                ObjectMap* obj_map = new ObjectMapFundamental<std::remove_pointer_t<T>>(tPtr);
+            // Arithmetic, enum, complex types, and types constructible from std::string and convertible to std::string,
+            // are handled in mapping mode without a custom serializer
+            if constexpr ( std::is_arithmetic_v<U> || std::is_enum_v<U> || complex_properties<U>::is_complex ||
+                           (std::is_constructible_v<U, std::string> && std::is_convertible_v<U, std::string>)) {
+                ObjectMap* obj_map = new ObjectMapFundamental<U>(tPtr);
                 if ( SerOption::is_set(options, SerOption::map_read_only) ) obj_map->setReadOnly();
                 ser.mapper().map_primitive(ser.getMapName(), obj_map);
             }
             else {
-                // TODO: Handle mapping mode for trivially serializable types without from_string() methods which do not
-                // define their own serialization methods.
+                // Print warning at verbose levels >= 2, but only print it once for each type
+                // This reduces surprise when a variable is not added to the ObjectMap
+                static int UNUSED(once) = [] {
+                    Output& output = Output::getDefaultObject();
+                    if ( output.getVerboseLevel() >= 2 ) {
+                        std::string typestr = ObjectMap::demangle_name(typeid(U).name());
+                        const char* type    = typestr.c_str();
+                        if constexpr ( std::is_class_v<U> )
+                            output.verbose(CALL_INFO, 0, 0,
+                                "Warning: Trivially serializable class type %s does not automatically have an "
+                                "ObjectMap created for it.\nTo create an ObjectMap for %s, use one of these "
+                                "methods:\n1. Add a serialize_order() method to %s.\n2. Define a serialize_impl<%s> "
+                                "specialization.\n3. Add a constructor taking a std::string and an operator "
+                                "std::string() const to %s, to allow conversion from/to std::string.\n\n",
+                                type, type, type, type, type);
+                        else if constexpr ( std::is_union_v<U> )
+                            output.verbose(CALL_INFO, 0, 0,
+                                "Warning: Trivially serializable union type %s does not automatically have an "
+                                "ObjectMap created for it.\nTo create an ObjectMap for %s, use one of these "
+                                "methods:\n1. Define a serialize_impl<%s> specialization.\n2. Add a constructor "
+                                "taking a std::string and an operator std::string() const to %s, to allow "
+                                "conversion from/to std::string.\n\n",
+                                type, type, type, type);
+                        else
+                            output.verbose(CALL_INFO, 0, 0,
+                                "Warning: Trivially serializable type %s does not automatically have an ObjectMap "
+                                "created for it.\nTo create an ObjectMap for %s, define a serialize_impl<%s> "
+                                "specialization.\n\n",
+                                type, type, type);
+                    }
+                    return 0;
+                }();
             }
             break;
 
         case serializer::UNPACK:
-            if constexpr ( std::is_pointer_v<T> ) t = new std::remove_pointer_t<T>();
+            if constexpr ( std::is_pointer_v<T> ) t = new U();
             [[fallthrough]];
 
         default:


### PR DESCRIPTION
Add warnings for trivially serializable types which cannot automatically have an `ObjectMap` created for them

This is motivated by: https://github.com/tactcomplabs/sst-ext-tests/issues/79

The problem:

For classes/unions/odd scalar types which are trivially serializable but do not define their own serialization methods, there is no compilation error, and the current code is faster for checkpointing, but no `ObjectMap` is created, so the debugger appears defective in not listing certain objects.

If trivial serialization was totally removed, then both checkpointing and mapping would require the user to define their own serialization method. Users who do not care about mapping would need to define serialization methods when they do not need to currently, and users who care about mapping would _still_ need to define serialization methods.

The solution:

If a type is trivially serializable but the user has not defined their own serialization method, and has not defined methods to convert their type to/from `std::string`, a warning message is displayed once for each such type when the verbose level >= 2.

In the debugger, it appears like this:

```
>  sst --verbose=2 --interactive-start=0 dbgsst15.py
Entering interactive mode at time 0
Interactive start at 0
> cd cp0
 SST Core: Warning: Trivially serializable union type SSTDEBUG::DbgSST15::ag_union_t does not automatically have an ObjectMap created for it.
To create an ObjectMap for SSTDEBUG::DbgSST15::ag_union_t, use one of these methods:
1. Define a serialize_impl<SSTDEBUG::DbgSST15::ag_union_t> specialization.
2. Add a constructor taking a std::string and a conversion operator to std::string to SSTDEBUG::DbgSST15::ag_union_t.

 SST Core: Warning: Trivially serializable union type SSTDEBUG::DbgSST15::ag_union_struct_t does not automatically have an ObjectMap created for it.
To create an ObjectMap for SSTDEBUG::DbgSST15::ag_union_struct_t, use one of these methods:
1. Define a serialize_impl<SSTDEBUG::DbgSST15::ag_union_struct_t> specialization.
2. Add a constructor taking a std::string and a conversion operator to std::string to SSTDEBUG::DbgSST15::ag_union_struct_t.
```
A compile-time warning could be generated instead of a runtime warning at `verboseLevel >= 2`, but it would need to use non-standard compiler extensions or clever tricks to produce specific warning messages, since C++17 has no standard way to print compile-time warnings except for [`#warning`](https://en.cppreference.com/w/cpp/preprocessor/error) at the preprocessor level, which cannot handle this problem.

Also, this runtime warning is more helpful than a compile-time warning, since it occurs every time the simulation is run, at exactly the time that the unsupported `ObjectMap` needs to be created but isn't. Also, compile-time warnings are often ignored, since they are often false-positives.

Even though the warnings are printed at runtime, the code to print them is conditionally enabled by `if constexpr`, and there is no performance impact if the warnings are not generated.

Previously: `ObjectMap` was silently not created for types which are trivially serializable but which do not define their own serialization methods, and do not have known ways of converting them to `ObjectMapFundamental`. Variables of these types would simply not appear in the debugger.

After this change: A warning message showing the type and how to fix it to get it added to `ObjectMap`, is printed once for each type when `verboseLevel >= 2`, at the point where `ObjectMap` needs to be created.

If it is not too intrusive, I can lower the `verboseLevel` threshold to `1`. I already only print the warning once for each type, and only when that type is considered for `ObjectMap` creation.

@kpgriesser @skuntz @jleidel 