### PR TITLE
adding checkpoint compatibility checks; Issue sstsimulator#1486

### DIFF
--- a/src/sst/core/model/restart/sstcptmodel.cc
+++ b/src/sst/core/model/restart/sstcptmodel.cc
@@ -112,7 +112,6 @@ SSTCPTModelDefinition::createConfigGraph()
     SST_SER(graph->cpt_currentSimCycle);
     SST_SER(graph->cpt_currentPriority);
 
-
     // Deserialization continues below
 
     ////// Check to make sure we have the right parallelism in the restart
@@ -143,6 +142,97 @@ SSTCPTModelDefinition::createConfigGraph()
     // Get set of loaded libraries
     SST_SER(*(graph->cpt_libnames.get()));
 
+    // Get the checkpoint system info
+    SST_SER(version_);
+    SST_SER(arch_);
+    SST_SER(os_);
+
+    ////// Check to make sure we have the right SSTCore version, architecture and operating system
+    if ( version_ != PACKAGE_STRING ) {
+        Output::getDefaultObject().fatal(CALL_INFO, 1,
+            "Version mismatch in SST checkpoint file.  SSTCore version is %s. "
+            "Checkpoint version is %s\n",
+            PACKAGE_VERSION, version_.c_str());
+    }
+
+    std::string tmp_arch = "";
+#if defined(__x86_64__) || defined(_M_X64)
+    tmp_arch = "x86_64";
+#elif defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+    tmp_arch = "x86_32";
+#elif defined(__ARM_ARCH_2__)
+    tmp_arch = "ARM2";
+#elif defined(__ARM_ARCH_3__) || defined(__ARM_ARCH_3M__)
+    tmp_arch = "ARM3";
+#elif defined(__ARM_ARCH_4T__) || defined(__TARGET_ARM_4T)
+    tmp_arch = "ARM4T";
+#elif defined(__ARM_ARCH_5_) || defined(__ARM_ARCH_5E_)
+    tmp_arch = "ARM5"
+#elif defined(__ARM_ARCH_6T2_) || defined(__ARM_ARCH_6T2_)
+    tmp_arch = "ARM6T2";
+#elif defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) || \
+    defined(__ARM_ARCH_6ZK__)
+    tmp_arch = "ARM6";
+#elif defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) || \
+    defined(__ARM_ARCH_7S__)
+    tmp_arch = "ARM7";
+#elif defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7S__)
+    tmp_arch = "ARM7A";
+#elif defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7S__)
+    tmp_arch = "ARM7R";
+#elif defined(__ARM_ARCH_7M__)
+    tmp_arch = "ARM7M";
+#elif defined(__ARM_ARCH_7S__)
+    tmp_arch = "ARM7S";
+#elif defined(__aarch64__) || defined(_M_ARM64)
+    tmp_arch = "ARM64";
+#elif defined(mips) || defined(__mips__) || defined(__mips)
+    tmp_arch = "MIPS";
+#elif defined(__sh__)
+    tmp_arch = "SUPERH";
+#elif defined(__powerpc) || defined(__powerpc__) || defined(__powerpc64__) || defined(__POWERPC__) || \
+    defined(__ppc__) || defined(__PPC__) || defined(_ARCH_PPC)
+    tmp_arch = "POWERPC";
+#elif defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
+    tmp_arch = "POWERPC64";
+#elif defined(__sparc__) || defined(__sparc)
+    tmp_arch = "SPARC";
+#elif defined(__m68k__)
+    tmp_arch = "M68K";
+#elif defined(__riscv__) || defined(_riscv) || defined(__riscv)
+    tmp_arch = "RISCV";
+#else
+    tmp_arch = "UNKNOWN";
+#endif
+
+    if ( arch_ != tmp_arch ) {
+        Output::getDefaultObject().fatal(CALL_INFO, 1,
+            "Architecture mismatch in SST checkpoint file.  Current architecture is %s. "
+            "Checkpointed architecture is %s\n",
+            tmp_arch.c_str(), arch_.c_str());
+    }
+
+    std::string tmp_os = "";
+#if defined(_WIN32) || defined(_WIN64)
+    tmp_os = "OS_WINDOWS";
+#elif defined(__APPLE__) && defined(__MACH__)
+    tmp_os = "OS_MACOS";
+#elif defined(__linux__)
+    tmp_os = "OS_LINUX";
+#elif defined(__unix__) || defined(__unix)
+    tmp_os = "OS_UNIX";
+#elif defined(__FreeBSD__)
+    tmp_os = "OS_FREEBSD";
+#else
+    tmp_os = "OS_UNKNOWN";
+#endif
+
+    if ( os_ != tmp_os ) {
+        Output::getDefaultObject().fatal(CALL_INFO, 1,
+            "Operating system mismatch in SST checkpoint file.  Current OS is %s. "
+            "Checkpointed OS is %s\n",
+            tmp_os.c_str(), os_.c_str());
+    }
 
     // factory->loadUnloadedLibraries(libnames);
 

--- a/src/sst/core/model/restart/sstcptmodel.h
+++ b/src/sst/core/model/restart/sstcptmodel.h
@@ -54,6 +54,10 @@ protected:
     Config*      config_     = nullptr;
     ConfigGraph* graph_      = nullptr;
     double       start_time_ = 0.0;
+
+    std::string version_ = "";
+    std::string arch_    = "";
+    std::string os_      = "";
 };
 
 } // namespace SST::Core

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -347,6 +347,72 @@ Simulation_impl::Simulation_impl(
     interactive_type_  = config.interactive_console();
     interactive_start_ = config.interactive_start_time();
     replay_file_       = config.replay_file();
+
+    // Version info for checkpointing
+    version_ = PACKAGE_STRING;
+
+#if defined(__x86_64__) || defined(_M_X64)
+    arch_ = "x86_64";
+#elif defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+    arch_ = "x86_32";
+#elif defined(__ARM_ARCH_2__)
+    arch_ = "ARM2";
+#elif defined(__ARM_ARCH_3__) || defined(__ARM_ARCH_3M__)
+    arch_ = "ARM3";
+#elif defined(__ARM_ARCH_4T__) || defined(__TARGET_ARM_4T)
+    arch_ = "ARM4T";
+#elif defined(__ARM_ARCH_5_) || defined(__ARM_ARCH_5E_)
+    arch_ = "ARM5"
+#elif defined(__ARM_ARCH_6T2_) || defined(__ARM_ARCH_6T2_)
+    arch_ = "ARM6T2";
+#elif defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) || \
+    defined(__ARM_ARCH_6ZK__)
+    arch_ = "ARM6";
+#elif defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) || \
+    defined(__ARM_ARCH_7S__)
+    arch_ = "ARM7";
+#elif defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7S__)
+    arch_ = "ARM7A";
+#elif defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7S__)
+    arch_ = "ARM7R";
+#elif defined(__ARM_ARCH_7M__)
+    arch_ = "ARM7M";
+#elif defined(__ARM_ARCH_7S__)
+    arch_ = "ARM7S";
+#elif defined(__aarch64__) || defined(_M_ARM64)
+    arch_ = "ARM64";
+#elif defined(mips) || defined(__mips__) || defined(__mips)
+    arch_ = "MIPS";
+#elif defined(__sh__)
+    arch_ = "SUPERH";
+#elif defined(__powerpc) || defined(__powerpc__) || defined(__powerpc64__) || defined(__POWERPC__) || \
+    defined(__ppc__) || defined(__PPC__) || defined(_ARCH_PPC)
+    arch_ = "POWERPC";
+#elif defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
+    arch_ = "POWERPC64";
+#elif defined(__sparc__) || defined(__sparc)
+    arch_ = "SPARC";
+#elif defined(__m68k__)
+    arch_ = "M68K";
+#elif defined(__riscv__) || defined(_riscv) || defined(__riscv)
+    arch_ = "RISCV";
+#else
+    arch_ = "UNKNOWN";
+#endif
+
+#if defined(_WIN32) || defined(_WIN64)
+    os_ = "OS_WINDOWS";
+#elif defined(__APPLE__) && defined(__MACH__)
+    os_ = "OS_MACOS";
+#elif defined(__linux__)
+    os_ = "OS_LINUX";
+#elif defined(__unix__) || defined(__unix)
+    os_ = "OS_UNIX";
+#elif defined(__FreeBSD__)
+    os_ = "OS_FREEBSD";
+#else
+        os_ = "OS_UNKNOWN";
+#endif
 }
 
 void
@@ -1689,7 +1755,6 @@ Simulation_impl::scheduleCheckpoint()
     }
 }
 
-
 void
 Simulation_impl::checkpoint_write_globals(int checkpoint_id, const std::string& checkpoint_directory,
     const std::string& registry_filename, const std::string& globals_filename)
@@ -1738,6 +1803,10 @@ Simulation_impl::checkpoint_write_globals(int checkpoint_id, const std::string& 
     factory->getLoadedLibraryNames(libnames);
     SST_SER(libnames);
 
+    SST_SER(version_);
+    SST_SER(arch_);
+    SST_SER(os_);
+
     size = ser.size();
     buffer.resize(size);
 
@@ -1752,6 +1821,10 @@ Simulation_impl::checkpoint_write_globals(int checkpoint_id, const std::string& 
 
     // Add list of loaded libraries
     SST_SER(libnames);
+
+    SST_SER(version_);
+    SST_SER(arch_);
+    SST_SER(os_);
 
     fs.write(reinterpret_cast<const char*>(&size), sizeof(size));
     fs.write(buffer.data(), size);

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -666,6 +666,9 @@ public:
     uint32_t                                   checkpoint_id_       = 0;
     std::string                                checkpoint_prefix_   = "";
     std::string                                globalOutputFileName = "";
+    std::string                                version_             = "";
+    std::string                                arch_                = "";
+    std::string                                os_                  = "";
     bool                                       serial_restart_      = false;
 
     // Config object used by the simulation


### PR DESCRIPTION
Fix for (enhancement) Issue #1486.  Adds compatibility checks when using checkpoint + restart actions.  The checkpoint now saves the SSTCore version, architecture (as defined by the compiler) and the operating system (also defined by the compiler) in the checkpoint globals file as three serialized `std::string` variables.  The restart mechanism de-serializes these three strings, interrogates the system for the respective values, compares them to what is currently in the globals file and prints a fatal message if any differences occur.  Fatal messages will indicate the version or platform info stored in the global versus what was discovered on the system.  All variables associated with serialization are stored in the respective class private or protected blocks in order to avoid variable lifetime issues in the future. 