### PR TITLE
Modernize loops to use C++11 range-based-for

### DIFF
--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -928,7 +928,6 @@ BaseComponent::getComponentProfileTools(const std::string& point)
     return sim_->getProfileTool<Profile::ComponentProfileTool>(point);
 }
 
-
 /**** Primary Component API ****/
 
 void

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -197,8 +197,8 @@ ComponentInfo::serialize_comp(SST::Core::Serialization::serializer& ser)
 {
     SST_SER(component);
     SST_SER(link_map);
-    for ( auto it = subComponents.begin(); it != subComponents.end(); ++it ) {
-        it->second.serialize_comp(ser);
+    for ( auto& subComponent : subComponents ) {
+        subComponent.second.serialize_comp(ser);
     }
 }
 

--- a/src/sst/core/configBase.cc
+++ b/src/sst/core/configBase.cc
@@ -160,16 +160,15 @@ ConfigBase::parseWallTimeToSeconds(const std::string& arg, bool& success, const 
     }
 
     static const char* templates[] = { "%H:%M:%S", "%M:%S", "%S", "%Hh", "%Mm", "%Ss" };
-    const size_t       n_templ     = sizeof(templates) / sizeof(templates[0]);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
     struct tm res = {}; /* This warns on GCC 4.8 due to a bug in GCC */
 #pragma GCC diagnostic pop
     char* p;
 
-    for ( size_t i = 0; i < n_templ; i++ ) {
+    for ( auto& i : templates ) {
         memset(&res, '\0', sizeof(res));
-        p = strptime(arg.c_str(), templates[i], &res);
+        p = strptime(arg.c_str(), i, &res);
         if ( p != nullptr && *p == '\0' ) {
             seconds = res.tm_sec;
             seconds += res.tm_min * 60;
@@ -181,8 +180,8 @@ ConfigBase::parseWallTimeToSeconds(const std::string& arg, bool& success, const 
     fprintf(stderr,
         "ERROR: for option \"%s\", wall time argument could not be parsed. Argument = [%s]\nValid formats are:\n",
         option.c_str(), arg.c_str());
-    for ( size_t i = 0; i < n_templ; i++ ) {
-        fprintf(stderr, "\t%s\n", templates[i]);
+    for ( auto& i : templates ) {
+        fprintf(stderr, "\t%s\n", i);
     }
     success = false;
     // Let caller handle error
@@ -302,8 +301,8 @@ ConfigBase::printUsage()
     if ( has_extended_help_ ) {
         fprintf(stderr, "\nOptions annotated with 'H' have extended help available\n");
     }
-    for ( size_t i = 0; i < annotations_.size(); ++i ) {
-        fprintf(stderr, "%s\n", annotations_[i].help.c_str());
+    for ( auto& annotation : annotations_ ) {
+        fprintf(stderr, "%s\n", annotation.help.c_str());
     }
 
     // Print info about annotations

--- a/src/sst/core/configShared.cc
+++ b/src/sst/core/configShared.cc
@@ -102,14 +102,13 @@ ConfigShared::getLibPath(bool exclude_ext_paths) const
         std::set<std::string> configGroups = envConfig->getGroupNames();
 
         // iterate over groups of settings
-        for ( auto groupItr = configGroups.begin(); groupItr != configGroups.end(); groupItr++ ) {
-            SST::Core::Environment::EnvironmentConfigGroup* currentGroup = envConfig->getGroupByName(*groupItr);
+        for ( const auto& configGroup : configGroups ) {
+            SST::Core::Environment::EnvironmentConfigGroup* currentGroup = envConfig->getGroupByName(configGroup);
             std::set<std::string>                           groupKeys    = currentGroup->getKeys();
 
             // find which keys have a LIBDIR at the END of the key we
             // recognize these may house elements
-            for ( auto keyItr = groupKeys.begin(); keyItr != groupKeys.end(); keyItr++ ) {
-                const std::string& key   = *keyItr;
+            for ( const auto& key : groupKeys ) {
                 const std::string& value = currentGroup->getValue(key);
 
                 if ( key.size() >= 6 ) {

--- a/src/sst/core/env/envconfig.cc
+++ b/src/sst/core/env/envconfig.cc
@@ -38,8 +38,8 @@ SST::Core::Environment::EnvironmentConfigGroup::getKeys() const
 {
     std::set<std::string> retKeys;
 
-    for ( auto mapItr = params.begin(); mapItr != params.end(); mapItr++ ) {
-        retKeys.insert(mapItr->first);
+    for ( const auto& param : params ) {
+        retKeys.insert(param.first);
     }
 
     return retKeys;
@@ -80,8 +80,8 @@ SST::Core::Environment::EnvironmentConfigGroup::print()
 
     printf("\n");
 
-    for ( auto paramsItr = params.begin(); paramsItr != params.end(); paramsItr++ ) {
-        printf("%s=%s\n", paramsItr->first.c_str(), paramsItr->second.c_str());
+    for ( auto& param : params ) {
+        printf("%s=%s\n", param.first.c_str(), param.second.c_str());
     }
 }
 
@@ -90,8 +90,8 @@ SST::Core::Environment::EnvironmentConfigGroup::writeTo(FILE* outFile)
 {
     fprintf(outFile, "\n[%s]\n", groupName.c_str());
 
-    for ( auto paramsItr = params.begin(); paramsItr != params.end(); paramsItr++ ) {
-        fprintf(outFile, "%s=%s\n", paramsItr->first.c_str(), paramsItr->second.c_str());
+    for ( auto& param : params ) {
+        fprintf(outFile, "%s=%s\n", param.first.c_str(), param.second.c_str());
     }
 }
 
@@ -100,8 +100,8 @@ SST::Core::Environment::EnvironmentConfiguration::EnvironmentConfiguration() {}
 SST::Core::Environment::EnvironmentConfiguration::~EnvironmentConfiguration()
 {
     // Delete all the groups we have created
-    for ( auto groupItr = groups.begin(); groupItr != groups.end(); groupItr++ ) {
-        delete groupItr->second;
+    for ( auto& group : groups ) {
+        delete group.second;
     }
 }
 
@@ -136,8 +136,8 @@ SST::Core::Environment::EnvironmentConfiguration::getGroupNames()
 {
     std::set<std::string> groupNames;
 
-    for ( auto groupItr = groups.begin(); groupItr != groups.end(); groupItr++ ) {
-        groupNames.insert(groupItr->first);
+    for ( auto& group : groups ) {
+        groupNames.insert(group.first);
     }
 
     return groupNames;
@@ -152,8 +152,8 @@ SST::Core::Environment::EnvironmentConfiguration::getGroupByName(const std::stri
 void
 SST::Core::Environment::EnvironmentConfiguration::print()
 {
-    for ( auto groupItr = groups.begin(); groupItr != groups.end(); groupItr++ ) {
-        groupItr->second->print();
+    for ( auto& group : groups ) {
+        group.second->print();
     }
 }
 
@@ -173,8 +173,8 @@ SST::Core::Environment::EnvironmentConfiguration::writeTo(const std::string& fil
     // exclusive since no one else should muck with it)
     flock(outputFD, LOCK_EX);
 
-    for ( auto groupItr = groups.begin(); groupItr != groups.end(); groupItr++ ) {
-        groupItr->second->writeTo(output);
+    for ( auto& group : groups ) {
+        group.second->writeTo(output);
     }
 
     flock(outputFD, LOCK_UN);
@@ -184,7 +184,7 @@ SST::Core::Environment::EnvironmentConfiguration::writeTo(const std::string& fil
 void
 SST::Core::Environment::EnvironmentConfiguration::writeTo(FILE* output)
 {
-    for ( auto groupItr = groups.begin(); groupItr != groups.end(); groupItr++ ) {
-        groupItr->second->writeTo(output);
+    for ( auto& group : groups ) {
+        group.second->writeTo(output);
     }
 }

--- a/src/sst/core/env/envquery.cc
+++ b/src/sst/core/env/envquery.cc
@@ -197,7 +197,7 @@ SST::Core::Environment::getSSTEnvironmentConfiguration(const std::vector<std::st
     }
 
     // NEXT - override paths
-    for ( std::string nextPath : overridePaths ) {
+    for ( const std::string& nextPath : overridePaths ) {
         populateEnvironmentConfig(nextPath, envConfig, true);
     }
 

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -632,8 +632,8 @@ Factory::getLoadedLibraryNames(std::set<std::string>& lib_names)
 void
 Factory::loadUnloadedLibraries(const std::set<std::string>& lib_names)
 {
-    for ( std::set<std::string>::const_iterator i = lib_names.begin(); i != lib_names.end(); ++i ) {
-        findLibrary(*i);
+    for ( const auto& lib_name : lib_names ) {
+        findLibrary(lib_name);
     }
 }
 

--- a/src/sst/core/impl/partitioners/rrobin.cc
+++ b/src/sst/core/impl/partitioners/rrobin.cc
@@ -29,9 +29,9 @@ SSTRoundRobinPartition::performPartition(PartitionGraph* graph)
     PartitionComponentMap_t& compMap = graph->getComponentMap();
     RankInfo                 rank(0, 0);
 
-    for ( PartitionComponentMap_t::iterator compItr = compMap.begin(); compItr != compMap.end(); compItr++ ) {
+    for ( auto& compItr : compMap ) {
 
-        (*compItr)->rank = rank;
+        compItr->rank = rank;
 
         rank.rank++;
         if ( rank.rank == world_size.rank ) {

--- a/src/sst/core/impl/partitioners/simplepart.cc
+++ b/src/sst/core/impl/partitioners/simplepart.cc
@@ -74,9 +74,9 @@ cost_external_links(ComponentId_t* setA, const int lengthA, ComponentId_t* setB,
 
     for ( int i = 0; i < lengthA; i++ ) {
         auto* compMap = timeTable[setA[i]];
-        for ( auto compMapItr = compMap->cbegin(); compMapItr != compMap->cend(); compMapItr++ ) {
-            if ( findIndex(setB, lengthB, compMapItr->first) > -1 ) {
-                cost += compMapItr->second;
+        for ( auto compMapItr : *compMap ) {
+            if ( findIndex(setB, lengthB, compMapItr.first) > -1 ) {
+                cost += compMapItr.second;
             }
         }
     }
@@ -186,10 +186,9 @@ SimplePartitioner::performPartition(PartitionGraph* graph)
     PartitionComponentMap_t& component_map = graph->getComponentMap();
 
     if ( total_parts == 1 ) {
-        for ( PartitionComponentMap_t::iterator compItr = component_map.begin(); compItr != component_map.end();
-            ++compItr ) {
+        for ( auto& compItr : component_map ) {
 
-            (*compItr)->rank = RankInfo(0, 0);
+            compItr->rank = RankInfo(0, 0);
         }
     }
     else {
@@ -211,10 +210,9 @@ SimplePartitioner::performPartition(PartitionGraph* graph)
 
         // size_t nComp = component_map.size();
         // for(size_t theComponent = 0 ; theComponent < nComp ; theComponent++ ) {
-        for ( PartitionComponentMap_t::iterator compItr = component_map.begin(); compItr != component_map.end();
-            ++compItr ) {
+        for ( auto& compItr : component_map ) {
 
-            ComponentId_t theComponent = (*compItr)->id;
+            ComponentId_t theComponent = compItr->id;
 
             auto compConnectMap = timeTable[theComponent] = new std::map<ComponentId_t, SimTime_t>();
 
@@ -225,15 +223,14 @@ SimplePartitioner::performPartition(PartitionGraph* graph)
                 setB[indexB++] = theComponent;
             }
 
-            LinkIdMap_t component_links = (*compItr)->links;
+            LinkIdMap_t component_links = compItr->links;
 
             PartitionLinkMap_t& linkMap = graph->getLinkMap();
 
-            for ( LinkIdMap_t::const_iterator linkItr = component_links.begin(); linkItr != component_links.end();
-                linkItr++ ) {
+            for ( unsigned int component_link : component_links ) {
 
                 // ConfigLink* theLink = (*linkItr);
-                PartitionLink& theLink = linkMap[*linkItr];
+                PartitionLink& theLink = linkMap[component_link];
                 compConnectMap->insert(
                     std::pair<ComponentId_t, SimTime_t>(theLink.component[1], theLink.getMinLatency()));
             }

--- a/src/sst/core/impl/timevortex/timeVortexPQ.cc
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.cc
@@ -102,8 +102,8 @@ TimeVortexPQBase<TS>::dbg_print(Output& out) const
 
     //  STL's priority_queue does not support iteration.
     const std::vector<Activity*>& act = getContainer();
-    for ( auto it = act.begin(); it != act.end(); it++ ) {
-        (*it)->print("  ", out);
+    for ( auto it : act ) {
+        it->print("  ", out);
     }
 }
 

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -164,8 +164,7 @@ dump_partition(ConfigGraph* graph, const RankInfo& size)
                 graph_file << "Rank: " << i << "." << t << " Component List:" << std::endl;
 
                 RankInfo r(i, t);
-                for ( ConfigComponentMap_t::const_iterator j = component_map.begin(); j != component_map.end(); ++j ) {
-                    auto c = *j;
+                for ( auto c : component_map ) {
                     if ( c->rank == r ) {
                         graph_file << "   " << c->name << " (ID=" << c->id << ")" << std::endl;
                         graph_file << "      -> type      " << c->type << std::endl;
@@ -311,10 +310,10 @@ start_graph_creation(ConfigGraph*& graph, const RankInfo& world_size, const Rank
 
     // Create a map of extensions to the model that supports them
     std::map<std::string, std::string> extension_map;
-    for ( auto x : models ) {
+    for ( const auto& x : models ) {
         // auto extensions = factory->getSimpleInfo<SSTModelDescription, 1, std::vector<std::string>>(x);
         auto extensions = SSTModelDescription::getElementSupportedExtensions(x);
-        for ( auto y : extensions ) {
+        for ( const auto& y : extensions ) {
             extension_map[y] = x;
         }
     }

--- a/src/sst/core/mempool.cc
+++ b/src/sst/core/mempool.cc
@@ -140,8 +140,8 @@ public:
 
     ~MemPoolNoMutex()
     {
-        for ( std::list<uint8_t*>::iterator i = arenas.begin(); i != arenas.end(); ++i ) {
-            ::free(*i);
+        for ( auto& arena : arenas ) {
+            ::free(arena);
         }
     }
 
@@ -381,9 +381,9 @@ MemPoolAccessor::printUndeletedMemPoolItems(const std::string& header, Output& o
             size_t                     arenaSize = entry.pool->getArenaSize();
             size_t                     allocSize = entry.pool->getAllocSize();
             size_t                     nelem     = arenaSize / allocSize;
-            for ( auto iter = arenas.begin(); iter != arenas.end(); ++iter ) {
+            for ( auto arena : arenas ) {
                 for ( size_t j = 0; j < nelem; j++ ) {
-                    uint64_t* ptr = (uint64_t*)((*iter) + (allocSize * j));
+                    uint64_t* ptr = (uint64_t*)(arena + (allocSize * j));
                     if ( *ptr != 0 ) {
                         MemPoolItem* act = (MemPoolItem*)(ptr + 1);
                         act->print(header, out);

--- a/src/sst/core/model/cfgoutput/pythonConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/pythonConfigOutput.cc
@@ -471,8 +471,8 @@ PythonConfigGraphOutput::isMultiLine(const std::string& check) const
 {
     bool isMultiLine = false;
 
-    for ( size_t i = 0; i < check.size(); i++ ) {
-        if ( check.at(i) == '\n' || check.at(i) == '\r' || check.at(i) == '\f' ) {
+    for ( char i : check ) {
+        if ( i == '\n' || i == '\r' || i == '\f' ) {
             isMultiLine = true;
             break;
         }

--- a/src/sst/core/model/cfgoutput/xmlConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/xmlConfigOutput.cc
@@ -38,12 +38,12 @@ XMLConfigGraphOutput::generate(const Config* UNUSED(cfg), ConfigGraph* graph)
     const auto compMap = graph->getComponentMap();
     const auto linkMap = graph->getLinkMap();
 
-    for ( auto compItr = compMap.begin(); compItr != compMap.end(); compItr++ ) {
-        generateXML("      ", (*compItr), linkMap);
+    for ( auto compItr : compMap ) {
+        generateXML("      ", compItr, linkMap);
     }
 
-    for ( auto linkItr = linkMap.begin(); linkItr != linkMap.end(); linkItr++ ) {
-        generateXML("      ", (*linkItr), compMap);
+    for ( auto linkItr : linkMap ) {
+        generateXML("      ", linkItr, compMap);
     }
 
     fprintf(outputFile, "   </component>\n");
@@ -60,9 +60,9 @@ XMLConfigGraphOutput::generateXML(
 
     // for(auto paramsItr = comp->params.begin(); paramsItr != comp->params.end(); paramsItr++) {
     auto keys = comp->params.getKeys();
-    for ( auto paramsItr = keys.begin(); paramsItr != keys.end(); paramsItr++ ) {
-        std::string paramName  = *paramsItr;
-        std::string paramValue = comp->params.find<std::string>(*paramsItr);
+    for ( const auto& key : keys ) {
+        std::string paramName  = key;
+        std::string paramValue = comp->params.find<std::string>(key);
 
         fprintf(outputFile, "%s%s<param name=\"%s\" value=\"%s\"/>\n", indent.c_str(), "   ", paramName.c_str(),
             paramValue.c_str());

--- a/src/sst/core/model/configComponent.cc
+++ b/src/sst/core/model/configComponent.cc
@@ -149,8 +149,8 @@ ConfigComponent::print(std::ostream& os) const
     os << "  rank = " << rank.rank << std::endl;
     os << "  thread = " << rank.thread << std::endl;
     os << "  Links:" << std::endl;
-    for ( size_t i = 0; i != links.size(); ++i ) {
-        os << "    " << links[i];
+    for ( unsigned int link : links ) {
+        os << "    " << link;
     }
     os << std::endl;
     os << "  Params:" << std::endl;
@@ -575,8 +575,8 @@ ConfigComponent::checkPorts() const
     auto& graph_links = graph->getLinkMap();
 
     // Loop over all the links
-    for ( unsigned int i = 0; i < links.size(); i++ ) {
-        const ConfigLink* link = graph_links[links[i]];
+    for ( unsigned int i : links ) {
+        const ConfigLink* link = graph_links[i];
         for ( int j = 0; j < 2; j++ ) {
             // If this is a nonlocal link, then there is no port to check for index 1
             if ( link->nonlocal && j == 1 ) continue;

--- a/src/sst/core/pollingLinkQueue.cc
+++ b/src/sst/core/pollingLinkQueue.cc
@@ -18,8 +18,8 @@ namespace SST {
 PollingLinkQueue::~PollingLinkQueue()
 {
     // Need to delete any events left in the queue
-    for ( auto it = data.begin(); it != data.end(); ++it ) {
-        delete *it;
+    for ( auto it : data ) {
+        delete it;
     }
     data.clear();
 }

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -578,8 +578,8 @@ Simulation_impl::processGraphInfo(ConfigGraph& graph, const RankInfo& UNUSED(myR
     }
     // Get the minimum latencies for links between the various threads
     interThreadLatencies.resize(num_ranks.thread);
-    for ( size_t i = 0; i < interThreadLatencies.size(); i++ ) {
-        interThreadLatencies[i] = MAX_SIMTIME_T;
+    for ( unsigned long& interThreadLatencie : interThreadLatencies ) {
+        interThreadLatencie = MAX_SIMTIME_T;
     }
 
     interThreadMinLatency      = MAX_SIMTIME_T;
@@ -589,8 +589,7 @@ Simulation_impl::processGraphInfo(ConfigGraph& graph, const RankInfo& UNUSED(myR
         ConfigComponentMap_t comps = graph.getComponentMap();
         ConfigLinkMap_t      links = graph.getLinkMap();
         // Find the minimum latency across a partition
-        for ( auto iter = links.begin(); iter != links.end(); ++iter ) {
-            ConfigLink* clink = *iter;
+        for ( auto clink : links ) {
             // If link is nonlocal, then doesn't affect interthread latencies
             if ( clink->nonlocal ) continue;
 
@@ -670,8 +669,7 @@ Simulation_impl::prepareLinks(ConfigGraph& graph, const RankInfo& myRank, SimTim
     // First, go through all the components that are in this rank and
     // create the ComponentInfo object for it, then populate the
     // LinkMaps
-    for ( ConfigComponentMap_t::const_iterator iter = graph.comps_.begin(); iter != graph.comps_.end(); ++iter ) {
-        ConfigComponent* ccomp = *iter;
+    for ( auto ccomp : graph.comps_ ) {
         if ( ccomp->rank == myRank ) {
             compInfoMap.insert(new ComponentInfo(ccomp, ccomp->name, nullptr, new LinkMap()));
         }
@@ -828,9 +826,7 @@ Simulation_impl::performWireUp(ConfigGraph& graph, const RankInfo& myRank, SimTi
 
 
     // Now, build all the components
-    for ( auto iter = graph.comps_.begin(); iter != graph.comps_.end(); ++iter ) {
-        ConfigComponent* ccomp = *iter;
-
+    for ( auto ccomp : graph.comps_ ) {
         if ( ccomp->rank == myRank ) {
             Component* tmp;
 
@@ -879,8 +875,8 @@ Simulation_impl::initialize()
         if ( my_rank.thread == 0 ) untimed_msg_count = 0;
         initBarrier.wait();
 
-        for ( auto iter = compInfoMap.begin(); iter != compInfoMap.end(); ++iter ) {
-            (*iter)->getComponent()->init(untimed_phase);
+        for ( auto iter : compInfoMap ) {
+            iter->getComponent()->init(untimed_phase);
         }
 
         initBarrier.wait();
@@ -932,8 +928,8 @@ Simulation_impl::complete()
         if ( my_rank.thread == 0 ) untimed_msg_count = 0;
         completeBarrier.wait();
 
-        for ( auto iter = compInfoMap.begin(); iter != compInfoMap.end(); ++iter ) {
-            (*iter)->getComponent()->complete(untimed_phase);
+        for ( auto iter : compInfoMap ) {
+            iter->getComponent()->complete(untimed_phase);
         }
 
         completeBarrier.wait();
@@ -960,8 +956,8 @@ Simulation_impl::setup()
 
     setupBarrier.wait();
 
-    for ( auto iter = compInfoMap.begin(); iter != compInfoMap.end(); ++iter ) {
-        (*iter)->getComponent()->setup();
+    for ( auto iter : compInfoMap ) {
+        iter->getComponent()->setup();
     }
 
     setupBarrier.wait();
@@ -1230,8 +1226,8 @@ void
 Simulation_impl::finish()
 {
 
-    for ( auto iter = compInfoMap.begin(); iter != compInfoMap.end(); ++iter ) {
-        (*iter)->getComponent()->finish();
+    for ( auto iter : compInfoMap ) {
+        iter->getComponent()->finish();
     }
 
     finishBarrier.wait();
@@ -1275,8 +1271,8 @@ Simulation_impl::printStatus(bool fullStatus)
     if ( fullStatus ) {
         timeVortex->print(out);
         out.output("---- Components: ----\n");
-        for ( auto iter = compInfoMap.begin(); iter != compInfoMap.end(); ++iter ) {
-            (*iter)->getComponent()->printStatus(out);
+        for ( auto iter : compInfoMap ) {
+            iter->getComponent()->printStatus(out);
         }
     }
 }
@@ -1733,8 +1729,7 @@ Simulation_impl::getComponentObjectMap()
     SST::Core::Serialization::ObjectMapClass* obj_map = new SST::Core::Serialization::ObjectMapClass();
     // ser.enable_pointer_tracking();
     // ser.start_mapping(obj_map);
-    for ( auto comp = compInfoMap.begin(); comp != compInfoMap.end(); comp++ ) {
-        ComponentInfo* compinfo = *comp;
+    for ( auto compinfo : compInfoMap ) {
         // // SST_SER(compinfo->component);
         // sst_map_object(ser, compinfo->component, compinfo->getName().c_str());
         obj_map->addVariable(compinfo->getName(), new SST::Core::Serialization::ObjectMapDeferred<BaseComponent>(
@@ -1976,9 +1971,8 @@ Simulation_impl::checkpoint(const std::string& checkpoint_filename)
     component_blob_offsets_.clear();
 
     // Serialize component blobs individually
-    for ( auto comp = compInfoMap.begin(); comp != compInfoMap.end(); comp++ ) {
+    for ( auto compinfo : compInfoMap ) {
         ser.start_sizing();
-        ComponentInfo* compinfo = *comp;
         SST_SER(compinfo);
         size = ser.size();
         buffer.resize(size);
@@ -2255,9 +2249,9 @@ Simulation_impl::printSimulationState()
     // instanceMap
 
     sim_output.output("\n\nPrinting ComponentInfoMap:\n");
-    for ( auto comp = compInfoMap.begin(); comp != compInfoMap.end(); comp++ ) {
-        (*comp)->test_printComponentInfoHierarchy();
-        (*comp)->getComponent()->printStatus(sim_output);
+    for ( auto comp : compInfoMap ) {
+        comp->test_printComponentInfoHierarchy();
+        comp->getComponent()->printStatus(sim_output);
     }
 
     /*

--- a/src/sst/core/sstconfigtool.cc
+++ b/src/sst/core/sstconfigtool.cc
@@ -126,8 +126,8 @@ main(int argc, char* argv[])
 
         std::set<std::string> groupKeys = group->getKeys();
 
-        for ( auto keyItr = groupKeys.begin(); keyItr != groupKeys.end(); keyItr++ ) {
-            if ( key == (*keyItr) ) {
+        for ( const auto& groupKey : groupKeys ) {
+            if ( key == groupKey ) {
                 printf("%s\n", group->getValue(key).c_str());
                 keyFound = true;
                 break;

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -632,8 +632,8 @@ processSSTElementFiles()
 
     // Store info strings for interactive mode
     if ( g_configuration.interactiveEnabled() ) {
-        for ( size_t x = 0; x < g_libInfoArray.size(); x++ ) {
-            g_libInfoArray[x].setAllLibraryInfo();
+        for ( auto& x : g_libInfoArray ) {
+            x.setAllLibraryInfo();
         }
     }
     else {
@@ -789,8 +789,7 @@ SSTInfoConfig::outputUsage()
 {
     using std::cout;
     using std::endl;
-    cout << "Usage: " << m_AppName << " [<element[.component|subcomponent]>] "
-         << " [options]" << endl;
+    cout << "Usage: " << m_AppName << " [<element[.component|subcomponent]>] " << " [options]" << endl;
     cout << "  -h, --help               Print Help Message\n";
     cout << "  -v, --version            Print SST Package Release Version\n";
     cout << "  -d, --debug              Enabled debugging messages\n";
@@ -1080,8 +1079,7 @@ SSTLibraryInfo::outputHumanReadable(std::ostream& os, int LibIndex)
     bool enableFullElementOutput = !doesLibHaveFilters(getLibraryName());
 
     os << "================================================================================\n";
-    os << "ELEMENT LIBRARY " << LibIndex << " = " << getLibraryName() << " (" << getLibraryDescription() << ")"
-       << "\n";
+    os << "ELEMENT LIBRARY " << LibIndex << " = " << getLibraryName() << " (" << getLibraryDescription() << ")" << "\n";
 
     outputHumanReadable<Component>(os, enableFullElementOutput);
     outputHumanReadable<SubComponent>(os, enableFullElementOutput);

--- a/src/sst/core/sstregistertool.cc
+++ b/src/sst/core/sstregistertool.cc
@@ -286,8 +286,8 @@ sstUnregisterMultiple(std::vector<std::string> elementsArray)
             elementsToRemove.push_back(temp);
         }
         // go through the vector of items to be removed and unregister them
-        for ( unsigned i = 0; i < elementsToRemove.size(); i++ )
-            sstUnregister(elementsArray[elementsToRemove[i] - 1]); //-1 because our displayed list starts at 1 and not 0
+        for ( int i : elementsToRemove )
+            sstUnregister(elementsArray[i - 1]); //-1 because our displayed list starts at 1 and not 0
     }
     else
         std::cout << "Nothing to unregister.\n\n";
@@ -320,8 +320,8 @@ autoUnregister()
 {
     std::vector<std::string> elementsArray =
         listModels(2); // passes 2 to listModels to tell the function to only store INVALID models
-    for ( unsigned i = 0; i < elementsArray.size(); i++ ) {
-        sstUnregister(elementsArray[i]);
+    for ( const auto& i : elementsArray ) {
+        sstUnregister(i);
     }
 }
 

--- a/src/sst/core/statapi/statengine.cc
+++ b/src/sst/core/statapi/statengine.cc
@@ -92,8 +92,8 @@ StatisticProcessingEngine::restart()
     for ( auto group : stat_default_groups_ ) {
         group.second.output = stat_outputs_[0];
     }
-    for ( std::vector<StatisticGroup>::iterator it = stat_groups_.begin(); it != stat_groups_.end(); it++ ) {
-        it->restartGroup(this);
+    for ( auto& stat_group : stat_groups_ ) {
+        stat_group.restartGroup(this);
     }
 }
 

--- a/src/sst/core/sync/rankSyncParallelSkip.cc
+++ b/src/sst/core/sync/rankSyncParallelSkip.cc
@@ -65,13 +65,13 @@ RankSyncParallelSkip::RankSyncParallelSkip(RankInfo num_ranks) :
 
 RankSyncParallelSkip::~RankSyncParallelSkip()
 {
-    for ( auto i = comm_send_map.begin(); i != comm_send_map.end(); ++i ) {
-        delete i->second.squeue;
+    for ( auto& i : comm_send_map ) {
+        delete i.second.squeue;
     }
     comm_send_map.clear();
 
-    for ( auto i = comm_recv_map.begin(); i != comm_recv_map.end(); ++i ) {
-        delete[] i->second.rbuf;
+    for ( auto& i : comm_recv_map ) {
+        delete[] i.second.rbuf;
     }
     comm_recv_map.clear();
 
@@ -163,12 +163,12 @@ uint64_t
 RankSyncParallelSkip::getDataSize() const
 {
     size_t count = 0;
-    for ( auto it = comm_send_map.begin(); it != comm_send_map.end(); ++it ) {
-        count += it->second.squeue->getDataSize();
+    for ( const auto& it : comm_send_map ) {
+        count += it.second.squeue->getDataSize();
     }
 
-    for ( auto it = comm_recv_map.begin(); it != comm_recv_map.end(); ++it ) {
-        count += it->second.local_size;
+    for ( const auto& it : comm_recv_map ) {
+        count += it.second.local_size;
     }
     return count;
 }
@@ -228,8 +228,8 @@ RankSyncParallelSkip::exchange_slave(int thread)
             // comm_recv_pair* recv = link_send_queue[thread].remove();
             my_recv_count--;
 
-            for ( size_t i = 0; i < recv->activity_vec.size(); i++ ) {
-                Event*    ev    = static_cast<Event*>(recv->activity_vec[i]);
+            for ( auto& i : recv->activity_vec ) {
+                Event*    ev    = static_cast<Event*>(i);
                 SimTime_t delay = ev->getDeliveryTime() - current_cycle;
                 getDeliveryLink(ev)->send(delay, ev);
             }

--- a/src/sst/core/sync/rankSyncSerialSkip.cc
+++ b/src/sst/core/sync/rankSyncSerialSkip.cc
@@ -53,8 +53,8 @@ RankSyncSerialSkip::RankSyncSerialSkip(RankInfo num_ranks) :
 
 RankSyncSerialSkip::~RankSyncSerialSkip()
 {
-    for ( comm_map_t::iterator i = comm_map.begin(); i != comm_map.end(); ++i ) {
-        delete i->second.squeue;
+    for ( auto& i : comm_map ) {
+        delete i.second.squeue;
     }
     comm_map.clear();
 
@@ -124,8 +124,8 @@ uint64_t
 RankSyncSerialSkip::getDataSize() const
 {
     size_t count = 0;
-    for ( comm_map_t::const_iterator it = comm_map.begin(); it != comm_map.end(); ++it ) {
-        count += (it->second.squeue->getDataSize() + it->second.local_size);
+    for ( const auto& it : comm_map ) {
+        count += (it.second.squeue->getDataSize() + it.second.local_size);
     }
     return count;
 }

--- a/src/sst/core/sync/syncQueue.cc
+++ b/src/sst/core/sync/syncQueue.cc
@@ -116,8 +116,8 @@ RankSyncQueue::getData()
     SST_SER(activities);
 
     // Delete all the events
-    for ( unsigned int i = 0; i < activities.size(); i++ ) {
-        delete activities[i];
+    for ( auto& activitie : activities ) {
+        delete activitie;
     }
     activities.clear();
 

--- a/src/sst/core/sync/threadSyncSimpleSkip.cc
+++ b/src/sst/core/sync/threadSyncSimpleSkip.cc
@@ -107,11 +107,10 @@ ThreadSyncSimpleSkip::before()
 {
     SimTime_t current_cycle = sim->getCurrentSimCycle();
     // Empty all the queues and send events on the links
-    for ( size_t i = 0; i < queues.size(); i++ ) {
-        ThreadSyncQueue*        queue = queues[i];
-        std::vector<Activity*>& vec   = queue->getVector();
-        for ( size_t j = 0; j < vec.size(); j++ ) {
-            Event*    ev    = static_cast<Event*>(vec[j]);
+    for ( auto queue : queues ) {
+        std::vector<Activity*>& vec = queue->getVector();
+        for ( auto& j : vec ) {
+            Event*    ev    = static_cast<Event*>(j);
             SimTime_t delay = ev->getDeliveryTime() - current_cycle;
             getDeliveryLink(ev)->send(delay, ev);
         }
@@ -150,8 +149,8 @@ ThreadSyncSimpleSkip::processLinkUntimedData()
     for ( int i = 0; i < num_threads; i++ ) {
         ThreadSyncQueue*        queue = queues[i];
         std::vector<Activity*>& vec   = queue->getVector();
-        for ( size_t j = 0; j < vec.size(); j++ ) {
-            Event* ev = static_cast<Event*>(vec[j]);
+        for ( auto& j : vec ) {
+            Event* ev = static_cast<Event*>(j);
             sendUntimedData_sync(getDeliveryLink(ev), ev);
         }
         queue->clear();
@@ -161,16 +160,16 @@ ThreadSyncSimpleSkip::processLinkUntimedData()
 void
 ThreadSyncSimpleSkip::finalizeLinkConfigurations()
 {
-    for ( auto i = link_map.begin(); i != link_map.end(); ++i ) {
-        finalizeConfiguration(i->second);
+    for ( auto& i : link_map ) {
+        finalizeConfiguration(i.second);
     }
 }
 
 void
 ThreadSyncSimpleSkip::prepareForComplete()
 {
-    for ( auto i = link_map.begin(); i != link_map.end(); ++i ) {
-        prepareForCompleteInt(i->second);
+    for ( auto& i : link_map ) {
+        prepareForCompleteInt(i.second);
     }
 }
 

--- a/src/sst/core/testElements/coreTest_Serialization.cc
+++ b/src/sst/core/testElements/coreTest_Serialization.cc
@@ -1038,8 +1038,8 @@ coreTestSerialization::coreTestSerialization(ComponentId_t id, Params& params) :
     else if ( test == "array" ) {
         {
             int32_t array_in[10];
-            for ( size_t i = 0; i < 10; ++i )
-                array_in[i] = rng->generateNextInt32();
+            for ( int& i : array_in )
+                i = rng->generateNextInt32();
             passed = checkFixedArraySerializeDeserialize(array_in);
             if ( !passed ) out.output("ERROR: int32_t[10] did not serialize/deserialize properly\n");
         }

--- a/src/sst/core/timeLord.cc
+++ b/src/sst/core/timeLord.cc
@@ -106,10 +106,8 @@ TimeLord::init(const std::string& timebase_string)
 TimeLord::~TimeLord()
 {
     // Delete all the TimeConverter objects
-    std::map<ComponentId_t, LinkMap*>::iterator it;
-    for ( TimeConverterMap_t::iterator it = tc_map_.begin(); it != tc_map_.end(); ++it ) {
-        delete it->second;
-    }
+    for ( auto& [time, conv] : tc_map_ )
+        delete conv;
     tc_map_.clear();
 
     // Clear the contents of the cache

--- a/src/sst/core/timeVortex.cc
+++ b/src/sst/core/timeVortex.cc
@@ -61,8 +61,8 @@ TimeVortex::print(Output& out) const
 
     std::sort(contents.begin(), contents.end(), Activity::less<true, true, true>());
 
-    for ( auto it = contents.begin(); it != contents.end(); it++ ) {
-        (*it)->print("  ", out);
+    for ( auto& content : contents ) {
+        content->print("  ", out);
     }
 }
 

--- a/src/sst/core/unitAlgebra.cc
+++ b/src/sst/core/unitAlgebra.cc
@@ -202,15 +202,15 @@ Units::Units(const std::string& units, sst_big_num& multiplier)
     split(s_numerator, "-", tokens);
 
     // Add all the numerators
-    for ( unsigned int i = 0; i < tokens.size(); i++ ) {
-        addUnit(tokens[i], multiplier, false);
+    for ( const auto& token : tokens ) {
+        addUnit(token, multiplier, false);
     }
     tokens.clear();
     split(s_denominator, "-", tokens);
 
     // Add all the denominators
-    for ( unsigned int i = 0; i < tokens.size(); i++ ) {
-        addUnit(tokens[i], multiplier, true);
+    for ( const auto& token : tokens ) {
+        addUnit(token, multiplier, true);
     }
     reduce();
 }

--- a/src/sst/core/util/basicPerf.cc
+++ b/src/sst/core/util/basicPerf.cc
@@ -356,8 +356,8 @@ BasicPerfTracker::outputRegionData(Output& out, size_t verbose)
 
         // Create prefix string
         std::wstring prefix;
-        for ( size_t i = 0; i < region_stack.size(); ++i ) {
-            if ( region_stack[i].second )
+        for ( auto& i : region_stack ) {
+            if ( i.second )
                 prefix += L"│ ";
             else
                 prefix += L"  ";


### PR DESCRIPTION
**This is less important than** https://github.com/sstsimulator/sst-core/pull/1518, and should only be merged after it.

This was generated with `scripts/clang-tidy.sh --fix --checks modernize-loop-convert`
