### PR TITLE
Use =default for trivial constructors and destructors

### DIFF
--- a/src/sst/core/clock.cc
+++ b/src/sst/core/clock.cc
@@ -30,11 +30,6 @@ Clock::Clock(TimeConverter* period, int priority) :
     setPriority(priority);
 }
 
-Clock::~Clock()
-{
-    // Handlers are owned by BaseComponent and are deleted there
-}
-
 bool
 Clock::registerHandler(Clock::HandlerBase* handler)
 {

--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -35,7 +35,7 @@ class Clock : public Action
 public:
     /** Create a new clock with a specified period */
     Clock(TimeConverter* period, int priority = CLOCKPRIORITY);
-    ~Clock();
+    ~Clock() = default; // Handlers are owned by BaseComponent and are deleted there
 
     /**
        Base handler for clock functions.

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -137,8 +137,6 @@ ElemLoader::ElemLoader(const std::string& searchPaths) :
     }
 }
 
-ElemLoader::~ElemLoader() {}
-
 void
 ElemLoader::updateSearchPaths(const std::string& paths)
 {

--- a/src/sst/core/elemLoader.h
+++ b/src/sst/core/elemLoader.h
@@ -25,7 +25,7 @@ class ElemLoader
 public:
     /** Create a new ElementLoader with a given searchpath of directories */
     explicit ElemLoader(const std::string& searchPaths);
-    ~ElemLoader();
+    ~ElemLoader() = default;
 
     /**
        Update the search paths

--- a/src/sst/core/env/envconfig.cc
+++ b/src/sst/core/env/envconfig.cc
@@ -95,8 +95,6 @@ SST::Core::Environment::EnvironmentConfigGroup::writeTo(FILE* outFile)
     }
 }
 
-SST::Core::Environment::EnvironmentConfiguration::EnvironmentConfiguration() {}
-
 SST::Core::Environment::EnvironmentConfiguration::~EnvironmentConfiguration()
 {
     // Delete all the groups we have created

--- a/src/sst/core/env/envconfig.h
+++ b/src/sst/core/env/envconfig.h
@@ -107,7 +107,7 @@ class EnvironmentConfiguration
 {
 
 public:
-    EnvironmentConfiguration();
+    EnvironmentConfiguration() = default;
     ~EnvironmentConfiguration();
 
     EnvironmentConfigGroup* createGroup(const std::string& groupName);

--- a/src/sst/core/impl/timevortex/timeVortexBinnedMap.cc
+++ b/src/sst/core/impl/timevortex/timeVortexBinnedMap.cc
@@ -52,13 +52,6 @@ TimeVortexBinnedMapBase<TS>::TimeVortexBinnedMapBase(Params& UNUSED(params)) :
 }
 
 template <bool TS>
-TimeVortexBinnedMapBase<TS>::~TimeVortexBinnedMapBase()
-{
-    // Activities in TimeVortex all need to be deleted, but that
-    // happens when the TimeUnit pool goes out of scope.
-}
-
-template <bool TS>
 bool
 TimeVortexBinnedMapBase<TS>::empty()
 {

--- a/src/sst/core/impl/timevortex/timeVortexBinnedMap.h
+++ b/src/sst/core/impl/timevortex/timeVortexBinnedMap.h
@@ -136,7 +136,10 @@ private:
 
 public:
     explicit TimeVortexBinnedMapBase(Params& params);
-    ~TimeVortexBinnedMapBase();
+
+    // Activities in TimeVortex all need to be deleted, but that
+    // happens when the TimeUnit pool goes out of scope.
+    ~TimeVortexBinnedMapBase() = default;
 
     bool      empty() override;
     int       size() override;

--- a/src/sst/core/impl/timevortex/timeVortexPQ.cc
+++ b/src/sst/core/impl/timevortex/timeVortexPQ.cc
@@ -129,8 +129,8 @@ public:
     explicit TimeVortexPQ(Params& params) :
         TimeVortexPQBase<false>(params)
     {}
-    TimeVortexPQ() = delete;
-    ~TimeVortexPQ() {}
+    TimeVortexPQ()  = delete;
+    ~TimeVortexPQ() = default;
 
     SST_ELI_EXPORT(TimeVortexPQ)
 };
@@ -151,8 +151,8 @@ public:
     explicit TimeVortexPQ_ts(Params& params) :
         TimeVortexPQBase<true>(params)
     {}
-    TimeVortexPQ_ts() = delete;
-    ~TimeVortexPQ_ts() {}
+    TimeVortexPQ_ts()  = delete;
+    ~TimeVortexPQ_ts() = default;
 
     SST_ELI_EXPORT(TimeVortexPQ_ts)
 };

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -463,10 +463,8 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
 class NullEvent : public Event
 {
 public:
-    NullEvent() :
-        Event()
-    {}
-    ~NullEvent() {}
+    NullEvent()  = default;
+    ~NullEvent() = default;
 
     void execute() override
     {

--- a/src/sst/core/model/restart/sstcptmodel.cc
+++ b/src/sst/core/model/restart/sstcptmodel.cc
@@ -33,9 +33,6 @@ SSTCPTModelDefinition::SSTCPTModelDefinition(
     config_(config)
 {}
 
-SSTCPTModelDefinition::~SSTCPTModelDefinition() {}
-
-
 ConfigGraph*
 SSTCPTModelDefinition::createConfigGraph()
 {

--- a/src/sst/core/model/restart/sstcptmodel.h
+++ b/src/sst/core/model/restart/sstcptmodel.h
@@ -44,7 +44,7 @@ public:
     SST_ELI_DOCUMENT_MODEL_SUPPORTED_EXTENSIONS(".sstcpt")
 
     SSTCPTModelDefinition(const std::string& script_file, int verbosity, Config* config, double start_time);
-    ~SSTCPTModelDefinition();
+    ~SSTCPTModelDefinition() = default;
 
     ConfigGraph* createConfigGraph() override;
 

--- a/src/sst/core/profile/clockHandlerProfileTool.cc
+++ b/src/sst/core/profile/clockHandlerProfileTool.cc
@@ -136,7 +136,7 @@ public:
         ClockHandlerProfileToolTime<std::chrono::high_resolution_clock>(name, params)
     {}
 
-    ~ClockHandlerProfileToolTimeHighResolution() {}
+    ~ClockHandlerProfileToolTimeHighResolution() = default;
 
     SST_ELI_EXPORT(ClockHandlerProfileToolTimeHighResolution)
 };
@@ -157,7 +157,7 @@ public:
         ClockHandlerProfileToolTime<std::chrono::steady_clock>(name, params)
     {}
 
-    ~ClockHandlerProfileToolTimeSteady() {}
+    ~ClockHandlerProfileToolTimeSteady() = default;
 
     SST_ELI_EXPORT(ClockHandlerProfileToolTimeSteady)
 };

--- a/src/sst/core/profile/componentProfileTool.cc
+++ b/src/sst/core/profile/componentProfileTool.cc
@@ -148,7 +148,7 @@ public:
         ComponentCodeSegmentProfileToolTime<std::chrono::high_resolution_clock>(name, params)
     {}
 
-    ~ComponentCodeSegmentProfileToolTimeHighResolution() {}
+    ~ComponentCodeSegmentProfileToolTimeHighResolution() = default;
 
     SST_ELI_EXPORT(ComponentCodeSegmentProfileToolTimeHighResolution)
 };
@@ -169,7 +169,7 @@ public:
         ComponentCodeSegmentProfileToolTime<std::chrono::steady_clock>(name, params)
     {}
 
-    ~ComponentCodeSegmentProfileToolTimeSteady() {}
+    ~ComponentCodeSegmentProfileToolTimeSteady() = default;
 
     SST_ELI_EXPORT(ComponentCodeSegmentProfileToolTimeSteady)
 };

--- a/src/sst/core/profile/eventHandlerProfileTool.cc
+++ b/src/sst/core/profile/eventHandlerProfileTool.cc
@@ -176,7 +176,7 @@ public:
         EventHandlerProfileToolTime<std::chrono::high_resolution_clock>(name, params)
     {}
 
-    ~EventHandlerProfileToolTimeHighResolution() {}
+    ~EventHandlerProfileToolTimeHighResolution() = default;
 
     SST_ELI_EXPORT(EventHandlerProfileToolTimeHighResolution)
 };
@@ -197,7 +197,7 @@ public:
         EventHandlerProfileToolTime<std::chrono::steady_clock>(name, params)
     {}
 
-    ~EventHandlerProfileToolTimeSteady() {}
+    ~EventHandlerProfileToolTimeSteady() = default;
 
     SST_ELI_EXPORT(EventHandlerProfileToolTimeSteady)
 };

--- a/src/sst/core/profile/syncProfileTool.cc
+++ b/src/sst/core/profile/syncProfileTool.cc
@@ -82,7 +82,7 @@ public:
         SyncProfileToolTime<std::chrono::high_resolution_clock>(name, params)
     {}
 
-    ~SyncProfileToolTimeHighResolution() {}
+    ~SyncProfileToolTimeHighResolution() = default;
 
     SST_ELI_EXPORT(SyncProfileToolTimeHighResolution)
 };
@@ -103,7 +103,7 @@ public:
         SyncProfileToolTime<std::chrono::steady_clock>(name, params)
     {}
 
-    ~SyncProfileToolTimeSteady() {}
+    ~SyncProfileToolTimeSteady() = default;
 
     SST_ELI_EXPORT(SyncProfileToolTimeSteady)
 };

--- a/src/sst/core/rng/xorshift.cc
+++ b/src/sst/core/rng/xorshift.cc
@@ -139,8 +139,6 @@ XORShiftRNG::seed(uint64_t seed)
     z = 0;
 }
 
-XORShiftRNG::~XORShiftRNG() {}
-
 void
 XORShiftRNG::serialize_order(SST::Core::Serialization::serializer& ser)
 {

--- a/src/sst/core/rng/xorshift.h
+++ b/src/sst/core/rng/xorshift.h
@@ -82,7 +82,7 @@ public:
     /**
         Destructor for Xorshift
     */
-    ~XORShiftRNG();
+    ~XORShiftRNG() = default;
 
     /**
      * Serialization function for checkpoint

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -81,8 +81,8 @@ public:
     {
         nextSyncTime = MAX_SIMTIME_T;
     }
-    EmptyRankSync() {} // For serialization
-    ~EmptyRankSync() {}
+    EmptyRankSync()  = default; // For serialization
+    ~EmptyRankSync() = default;
 
     /** Register a Link which this Sync Object is responsible for */
     ActivityQueue* registerLink(const RankInfo& UNUSED(to_rank), const RankInfo& UNUSED(from_rank),
@@ -146,8 +146,8 @@ public:
     {
         nextSyncTime = MAX_SIMTIME_T;
     }
-    EmptyThreadSync() {} // For serialization
-    ~EmptyThreadSync() {}
+    EmptyThreadSync()  = default; // For serialization
+    ~EmptyThreadSync() = default;
 
     void before() override {}
     void after() override {}
@@ -245,7 +245,7 @@ RankSync::exchangeLinkInfo(uint32_t UNUSED_WO_MPI(my_rank))
 class SyncProfileToolList
 {
 public:
-    SyncProfileToolList() {}
+    SyncProfileToolList() = default;
 
     void syncManagerStart()
     {

--- a/src/sst/core/testElements/coreTest_ComponentExtension.cc
+++ b/src/sst/core/testElements/coreTest_ComponentExtension.cc
@@ -232,7 +232,7 @@ coreTestComponentExtMain::coreTestComponentExtMain(ComponentId_t id, Params& par
     primaryComponentDoNotEndSim();
 }
 
-coreTestComponentExtMain::~coreTestComponentExtMain() {}
+coreTestComponentExtMain::~coreTestComponentExtMain() = default;
 
 void
 coreTestComponentExtMain::serialize_order(SST::Core::Serialization::serializer& ser)

--- a/src/sst/core/testElements/coreTest_Serialization.cc
+++ b/src/sst/core/testElements/coreTest_Serialization.cc
@@ -560,7 +560,7 @@ public:
     explicit pointed_to_class(int val) :
         value(val)
     {}
-    pointed_to_class() {}
+    pointed_to_class() = default;
 
     int  getValue() { return value; }
     void setValue(int val) { value = val; }
@@ -580,7 +580,7 @@ public:
         value(val),
         pointed_to(ptc)
     {}
-    shell() {}
+    shell() = default;
 
     int  getValue() { return value; }
     void setValue(int val) { value = val; }
@@ -658,7 +658,7 @@ struct HandlerTest : public SST::Core::Serialization::serializable
     explicit HandlerTest(int in) :
         value(in)
     {}
-    HandlerTest() {}
+    HandlerTest() = default;
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override { SST_SER(value); }
     ImplementSerializable(HandlerTest)
@@ -681,7 +681,7 @@ struct RecursiveSerializationTest : public SST::Core::Serialization::serializabl
     Handler<RecursiveSerializationTest, &RecursiveSerializationTest::call, float>* handler;
     int                                                                            value;
 
-    RecursiveSerializationTest() {}
+    RecursiveSerializationTest() = default;
     explicit RecursiveSerializationTest(int in) :
         value(in)
     {

--- a/src/sst/core/unitAlgebra.cc
+++ b/src/sst/core/unitAlgebra.cc
@@ -216,14 +216,6 @@ Units::Units(const std::string& units, sst_big_num& multiplier)
 }
 
 Units&
-Units::operator=(const Units& v)
-{
-    numerator   = v.numerator;
-    denominator = v.denominator;
-    return *this;
-}
-
-Units&
 Units::operator*=(const Units& v)
 {
 

--- a/src/sst/core/unitAlgebra.h
+++ b/src/sst/core/unitAlgebra.h
@@ -74,14 +74,14 @@ public:
      * @param multiplier Value by which to multiply to get to this unit
      */
     Units(const std::string& units, sst_big_num& multiplier);
-    Units() {}
-    virtual ~Units() {}
+    Units()          = default;
+    virtual ~Units() = default;
 
     /** Copy constructor */
     Units(const Units&) = default;
 
     /** Assignment operator */
-    Units& operator=(const Units& v);
+    Units& operator=(const Units& v) = default;
     /** Self-multiplication operator */
     Units& operator*=(const Units& v);
     /** Self-division operator */

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -99,8 +99,6 @@ WatchPoint::WatchPoint(size_t index, const std::string& name, Core::Serializatio
     addComparison(obj);
 }
 
-WatchPoint::~WatchPoint() {}
-
 void
 WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Event* UNUSED(ev))
 {

--- a/src/sst/core/watchPoint.h
+++ b/src/sst/core/watchPoint.h
@@ -125,7 +125,7 @@ public:
 
     // Construction
     WatchPoint(size_t index, const std::string& name, Core::Serialization::ObjectMapComparison* obj);
-    ~WatchPoint();
+    ~WatchPoint() = default;
 
     // Inherited from both Event and Clock handler AttachPoints.
     // WatchPoint doesn't use the key, so just return 0


### PR DESCRIPTION
**This is less important than** https://github.com/sstsimulator/sst-core/pull/1518, and should only be merged after it.

This was generated with `scripts/clang-tidy.sh  --checks modernize-use-equals-default,performance-trivially-destructible --fix`, with some massaging of the code.

