### PR TITLE
Use faster string find methods

### DIFF
--- a/src/sst/core/checkpointAction.cc
+++ b/src/sst/core/checkpointAction.cc
@@ -96,7 +96,7 @@ CheckpointAction::CheckpointAction(Config* cfg, RankInfo this_rank, Simulation_i
     // to make sure there was no more than one directory separator (/)
     // and that no invalid % sequences were used.
     std::string format = cfg->checkpoint_name_format();
-    size_t      split  = format.find("/");
+    size_t      split  = format.find('/');
     if ( split == format.npos ) {
         dir_format_  = format;
         file_format_ = format;

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -656,7 +656,7 @@ Factory::findLibrary(const std::string& elemlib, std::ostream& err_os)
 std::pair<std::string, std::string>
 Factory::parseLoadName(const std::string& wholename)
 {
-    std::size_t found = wholename.find_first_of(".");
+    std::size_t found = wholename.find_first_of('.');
     if ( found == std::string::npos ) {
         if ( wholename.empty() ) {
             out.output(CALL_INFO, "Warning: got empty element library. "

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -239,7 +239,7 @@ do_link_preparation(ConfigGraph* graph, SST::Simulation_impl* sim, const RankInf
 static std::string
 addRankToFileName(std::string& file_name, int rank)
 {
-    auto        index = file_name.find_last_of(".");
+    auto        index = file_name.find_last_of('.');
     std::string base;
     std::string ext;
     // If there is an extension, add it before the extension
@@ -326,7 +326,7 @@ start_graph_creation(ConfigGraph*& graph, const RankInfo& world_size, const Rank
 
     if ( cfg.configFile() != "NONE" ) {
         // Get the file extension by finding the last .
-        std::string extension = cfg.configFile().substr(cfg.configFile().find_last_of("."));
+        std::string extension = cfg.configFile().substr(cfg.configFile().find_last_of('.'));
 
         std::string model_name;
         try {

--- a/src/sst/core/model/configComponent.cc
+++ b/src/sst/core/model/configComponent.cc
@@ -458,18 +458,18 @@ ConfigComponent::findSubComponent(ComponentId_t sid) const
 ConfigComponent*
 ConfigComponent::findSubComponentByName(const std::string& name)
 {
-    size_t      colon_index = name.find(":");
+    size_t      colon_index = name.find(':');
     std::string slot        = name.substr(0, colon_index);
 
     // Get the slot number
     int    slot_num      = 0;
-    size_t bracket_index = slot.find("[");
+    size_t bracket_index = slot.find('[');
     if ( bracket_index == std::string::npos ) {
         // No brackets, slot_num 0
         slot_num = 0;
     }
     else {
-        size_t close_index = slot.find("]");
+        size_t close_index = slot.find(']');
         size_t length      = close_index - bracket_index - 1;
         slot_num           = Core::from_string<int>(slot.substr(bracket_index + 1, length));
         slot               = slot.substr(0, bracket_index);

--- a/src/sst/core/model/configGraph.cc
+++ b/src/sst/core/model/configGraph.cc
@@ -435,7 +435,7 @@ ConfigComponent*
 ConfigGraph::findComponentByName(const std::string& name)
 {
     std::string origname(name);
-    auto        index    = origname.find(":");
+    auto        index    = origname.find(':');
     std::string compname = origname.substr(0, index);
     auto        itr      = comps_by_name_.find(compname);
 

--- a/src/sst/core/model/restart/sstcptmodel.cc
+++ b/src/sst/core/model/restart/sstcptmodel.cc
@@ -59,7 +59,7 @@ SSTCPTModelDefinition::createConfigGraph()
         SST_Exit(-1);
     }
 
-    std::string checkpoint_directory = cfg.configFile().substr(0, cfg.configFile().find_last_of("/"));
+    std::string checkpoint_directory = cfg.configFile().substr(0, cfg.configFile().find_last_of('/'));
 
     std::string line;
 

--- a/src/sst/core/output.cc
+++ b/src/sst/core/output.cc
@@ -345,7 +345,7 @@ Output::buildPrefixString(uint32_t line, const std::string& file, const std::str
     while ( std::string::npos != findindex ) {
 
         // Find the next '@' from the starting index
-        findindex = m_outputPrefix.find("@", startindex);
+        findindex = m_outputPrefix.find('@', startindex);
 
         // Check to see if we found anything
         if ( std::string::npos != findindex ) {

--- a/src/sst/core/profile/clockHandlerProfileTool.cc
+++ b/src/sst/core/profile/clockHandlerProfileTool.cc
@@ -56,7 +56,7 @@ ClockHandlerProfileTool::getKeyForHandler(const AttachPointMetaData& mdata)
         break;
     case Profile_Level::Component:
         // Get just the component name, no subcomponents
-        key = data.comp_name.substr(0, data.comp_name.find(":"));
+        key = data.comp_name.substr(0, data.comp_name.find(':'));
         break;
     case Profile_Level::Subcomponent:
         key = data.comp_name;

--- a/src/sst/core/profile/componentProfileTool.cc
+++ b/src/sst/core/profile/componentProfileTool.cc
@@ -56,7 +56,7 @@ ComponentProfileTool::getKeyForCodeSegment(
         break;
     case Profile_Level::Component:
         // Get just the component name, no subcomponents
-        key = name.substr(0, name.find(":"));
+        key = name.substr(0, name.find(':'));
         break;
     case Profile_Level::Subcomponent:
         key = name;

--- a/src/sst/core/profile/eventHandlerProfileTool.cc
+++ b/src/sst/core/profile/eventHandlerProfileTool.cc
@@ -61,7 +61,7 @@ EventHandlerProfileTool::getKeyForHandler(const AttachPointMetaData& mdata)
         break;
     case Profile_Level::Component:
         // Get just the component name, no subcomponents
-        key = data.comp_name.substr(0, data.comp_name.find(":"));
+        key = data.comp_name.substr(0, data.comp_name.find(':'));
         break;
     case Profile_Level::Subcomponent:
         key = data.comp_name;

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -503,7 +503,7 @@ Simulation_impl::parseSignalString(std::string& arg, std::string& name, Params& 
     }
 
     // Check for parameters and parse if needed
-    if ( handler.find("(") != std::string::npos ) { // Handler has parameters type(...)
+    if ( handler.find('(') != std::string::npos ) { // Handler has parameters type(...)
         if ( handler.substr(handler.size() - 1, 1) != ")" ) {
             sim_output.fatal(CALL_INFO, 1,
                 "ERROR: Invalid format for parsing signal handler option string. Found '(' in '%s' but string does not "
@@ -512,7 +512,7 @@ Simulation_impl::parseSignalString(std::string& arg, std::string& name, Params& 
         }
 
         // Split string and remove open/close parentheses
-        delim                = handler.find("(");
+        delim                = handler.find('(');
         std::string paramstr = handler.substr(delim + 1, handler.length() - delim - 2);
         handler              = handler.substr(0, delim);
 
@@ -1635,7 +1635,7 @@ Simulation_impl::initializeProfileTools(const std::string& config)
 
         // Need to get the profiler type and parameters
         start = 0;
-        end   = profiler_info.find("(", start);
+        end   = profiler_info.find('(', start);
         if ( end == std::string::npos ) {
             // No parameters
             type = profiler_info;
@@ -1645,7 +1645,7 @@ Simulation_impl::initializeProfileTools(const std::string& config)
             trim(type);
 
             start = end + 1;
-            end   = profiler_info.find(")", start);
+            end   = profiler_info.find(')', start);
             if ( end == std::string::npos ) {
                 // Format error, not end paran
             }
@@ -1687,7 +1687,7 @@ Simulation_impl::initializeProfileTools(const std::string& config)
             // Check to see if this is a valid profile point
             std::string p(tok);
             SST::trim(p);
-            auto index = p.find_last_of(".");
+            auto index = p.find_last_of('.');
 
             bool valid = false;
             if ( index == std::string::npos ) {
@@ -2001,7 +2001,7 @@ Simulation_impl::restart()
 {
     std::ifstream fs(config.configFile());
 
-    std::string checkpoint_directory = config.configFile().substr(0, config.configFile().find_last_of("/"));
+    std::string checkpoint_directory = config.configFile().substr(0, config.configFile().find_last_of('/'));
 
     std::string line;
 

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -808,7 +808,7 @@ SSTInfoConfig::addFilter(const std::string& name_str)
     std::string name(name_str);
     if ( name.size() > 3 && name.substr(0, 3) == "lib" ) name = name.substr(3);
 
-    size_t dotLoc = name.find(".");
+    size_t dotLoc = name.find('.');
     if ( dotLoc == std::string::npos ) {
         m_filters.insert(std::make_pair(name, ""));
     }

--- a/src/sst/core/sstregistertool.cc
+++ b/src/sst/core/sstregistertool.cc
@@ -236,7 +236,7 @@ listModels(int option)
                 // check if the model is valid by confirming it is located in the path registered in the sst config file
                 getline(infile, s); // grab the next line containing the model location
 
-                if ( s.find("/") != std::string::npos ) { // check to see if there is a path
+                if ( s.find('/') != std::string::npos ) { // check to see if there is a path
                     if ( validModel(s) ) {
                         std::cout << count << ". " << std::setw(25) << std::left << strNew << "VALID" << std::endl;
                     }
@@ -300,7 +300,7 @@ sstUnregisterMultiple(std::vector<std::string> elementsArray)
 bool
 validModel(const std::string& s)
 {
-    std::size_t locationStart = s.find("/");
+    std::size_t locationStart = s.find('/');
     std::string str1          = s.substr(locationStart); // grabs the rest of the line from / to the end
 
     struct stat statbuf;

--- a/src/sst/core/statapi/statoutputcsv.cc
+++ b/src/sst/core/statapi/statoutputcsv.cc
@@ -246,7 +246,7 @@ StatisticOutputCSV::openFile()
         std::string rankstr = "_" + std::to_string(rank);
 
         // Search for any extension
-        size_t index = m_FilePath.find_last_of(".");
+        size_t index = m_FilePath.find_last_of('.');
         if ( std::string::npos != index ) {
             // We found a . at the end of the file, insert the rank string
             filename.insert(index, rankstr);

--- a/src/sst/core/statapi/statoutputjson.cc
+++ b/src/sst/core/statapi/statoutputjson.cc
@@ -235,7 +235,7 @@ StatisticOutputJSON::openFile()
         std::string rankstr = "_" + std::to_string(rank);
 
         // Search for any extension
-        size_t index = m_FilePath.find_last_of(".");
+        size_t index = m_FilePath.find_last_of('.');
         if ( std::string::npos != index ) {
             // We found a . at the end of the file, insert the rank string
             filename.insert(index, rankstr);

--- a/src/sst/core/statapi/statoutputtxt.cc
+++ b/src/sst/core/statapi/statoutputtxt.cc
@@ -296,7 +296,7 @@ StatisticOutputTextBase::openFile()
         std::string rankstr = "_" + std::to_string(rank);
 
         // Search for any extension
-        size_t index = filename.find_last_of(".");
+        size_t index = filename.find_last_of('.');
         if ( std::string::npos != index ) {
             // We found a . at the end of the file, insert the rank string
             filename.insert(index, rankstr);


### PR DESCRIPTION
**This is less important than** https://github.com/sstsimulator/sst-core/pull/1518, and should only be merged after it.

Generated with `scripts/clang-tidy.sh --checks performance-faster-string-find --fix`