### PR TITLE
Usually do not use std::endl since it is slower than \n

### DIFF
--- a/src/sst/core/clock.cc
+++ b/src/sst/core/clock.cc
@@ -138,7 +138,7 @@ Clock::schedule()
     }
 
     // std::cout << "Scheduling clock " << period->getFactor() << " at cycle " << next << " current cycle is " <<
-    // sim->getCurrentSimCycle() << std::endl;
+    // sim->getCurrentSimCycle() << '\n';
     sim->insertActivity(next, this);
     scheduled = true;
 }

--- a/src/sst/core/configShared.cc
+++ b/src/sst/core/configShared.cc
@@ -145,7 +145,7 @@ ConfigShared::getLibPath(bool exclude_ext_paths) const
     }
 
     // if ( verbose_ ) {
-    //     std::cout << "SST-Core: Configuration Library Path will read from: " << fullLibPath << std::endl;
+    //     std::cout << "SST-Core: Configuration Library Path will read from: " << fullLibPath << '\n';
     // }
 
     return fullLibPath;

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -264,7 +264,7 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
         err_os << "Error: unable to find \"" << elemlib << "\" element library\n";
         if ( !verbose ) {
             for ( auto& x : error_msgs ) {
-                err_os << x << std::endl;
+                err_os << x << '\n';
             }
         }
     }
@@ -276,7 +276,7 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
                    << " was successfully loaded, but there was a failed attempt at loading a different version of the "
                       "library before the successful load.  Error message follows:\n";
             for ( auto& x : error_msgs ) {
-                err_os << x << std::endl;
+                err_os << x << '\n';
             }
         }
     }

--- a/src/sst/core/eli/elementinfo.cc
+++ b/src/sst/core/eli/elementinfo.cc
@@ -103,10 +103,10 @@ ProvidesStats::toString(std::ostream& os) const
 void
 ProvidesDefaultInfo::toString(std::ostream& os) const
 {
-    if ( !getAlias().empty() ) os << "      " << getName() << " is aliased as: " << getAlias() << std::endl;
-    os << "      Description: " << getDescription() << std::endl;
-    os << "      ELI version: " << getELIVersionString() << std::endl;
-    os << "      Compiled using file: " << getCompileFile() << std::endl;
+    if ( !getAlias().empty() ) os << "      " << getName() << " is aliased as: " << getAlias() << '\n';
+    os << "      Description: " << getDescription() << '\n';
+    os << "      ELI version: " << getELIVersionString() << '\n';
+    os << "      Compiled using file: " << getCompileFile() << '\n';
 }
 
 void

--- a/src/sst/core/env/envquery.cc
+++ b/src/sst/core/env/envquery.cc
@@ -87,7 +87,7 @@ SST::Core::Environment::populateEnvironmentConfig(
         else if ( '[' == lineBuffer[0] ) {
             if ( lineBuffer[strlen(lineBuffer) - 1] != ']' ) {
                 std::cerr << "SST: Error reading configuration file at line number: " << currentLine
-                          << ", no matching ]" << std::endl;
+                          << ", no matching ]\n";
                 exit(-1);
             }
 
@@ -129,7 +129,7 @@ SST::Core::Environment::populateEnvironmentConfig(
 
     if ( nullptr == configFile ) {
         if ( errorOnNotOpen ) {
-            std::cerr << "SST: Unable to open configuration file \'" << path << "\'" << std::endl;
+            std::cerr << "SST: Unable to open configuration file \'" << path << "\'\n";
             exit(-1);
         }
         else {

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -159,7 +159,7 @@ Factory::isPortNameValid(const std::string& type, const std::string& port_name)
         for ( auto& pair : lib->getMap() ) {
             err << pair.first << "\n";
         }
-        std::cerr << err.str() << std::endl;
+        std::cerr << err.str() << '\n';
         out.fatal(CALL_INFO, 1, "can't find requested component or subcomponent '%s'\n ", tmp.c_str());
         return false;
     }

--- a/src/sst/core/impl/interactive/cmdLineEditor.cc
+++ b/src/sst/core/impl/interactive/cmdLineEditor.cc
@@ -17,6 +17,8 @@
 #include <iterator>
 #include <sstream>
 
+// NOLINTBEGIN(performance-avoid-endl)
+
 // #define _KEYB_DEBUG_
 
 // only use termios read/write functions for console!
@@ -374,3 +376,5 @@ CmdLineEditor::getline(const std::vector<std::string>& cmdHistory, std::string& 
     newcmd = history[index];
     writeStr("\n");
 }
+
+// NOLINTEND(performance-avoid-endl)

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -30,6 +30,8 @@
 
 namespace SST::IMPL::Interactive {
 
+// NOLINTBEGIN(performance-avoid-endl)
+
 SimpleDebugger::SimpleDebugger(Params& params) :
     InteractiveConsole()
 {
@@ -1799,5 +1801,7 @@ SimpleDebugger::msg(VERBOSITY_MASK mask, std::string message)
     if ( (!static_cast<uint32_t>(mask)) & verbosity ) return;
     std::cout << message << std::endl;
 }
+
+// NOLINTEND(performance-avoid-endl)
 
 } // namespace SST::IMPL::Interactive

--- a/src/sst/core/linkMap.h
+++ b/src/sst/core/linkMap.h
@@ -174,7 +174,7 @@ public:
 
         //         if ( !checkPort(name) ) {
         // #ifdef USE_PARAM_WARNINGS
-        //             std::cerr << "Warning:  Using undocumented port '" << name << "'." << std::endl;
+        //             std::cerr << "Warning:  Using undocumented port '" << name << "'.\n";
         // #endif
         //         }
         std::map<std::string, Link*>::iterator it = linkMap.find(name);

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -161,18 +161,18 @@ dump_partition(ConfigGraph* graph, const RankInfo& size)
 
         for ( uint32_t i = 0; i < size.rank; i++ ) {
             for ( uint32_t t = 0; t < size.thread; t++ ) {
-                graph_file << "Rank: " << i << "." << t << " Component List:" << std::endl;
+                graph_file << "Rank: " << i << "." << t << " Component List:\n";
 
                 RankInfo r(i, t);
                 for ( ConfigComponentMap_t::const_iterator j = component_map.begin(); j != component_map.end(); ++j ) {
                     auto c = *j;
                     if ( c->rank == r ) {
-                        graph_file << "   " << c->name << " (ID=" << c->id << ")" << std::endl;
-                        graph_file << "      -> type      " << c->type << std::endl;
-                        graph_file << "      -> weight    " << c->weight << std::endl;
-                        graph_file << "      -> linkcount " << c->links.size() << std::endl;
-                        graph_file << "      -> rank      " << c->rank.rank << std::endl;
-                        graph_file << "      -> thread    " << c->rank.thread << std::endl;
+                        graph_file << "   " << c->name << " (ID=" << c->id << ")" << '\n';
+                        graph_file << "      -> type      " << c->type << '\n';
+                        graph_file << "      -> weight    " << c->weight << '\n';
+                        graph_file << "      -> linkcount " << c->links.size() << '\n';
+                        graph_file << "      -> rank      " << c->rank.rank << '\n';
+                        graph_file << "      -> thread    " << c->rank.thread << '\n';
                     }
                 }
             }
@@ -333,14 +333,13 @@ start_graph_creation(ConfigGraph*& graph, const RankInfo& world_size, const Rank
             model_name = extension_map.at(extension);
         }
         catch ( const std::exception& e ) {
-            std::cerr << "Unsupported SDL file type: \"" << extension << "\"" << std::endl;
+            std::cerr << "Unsupported SDL file type: \"" << extension << "\"\n";
             SST_Exit(EXIT_FAILURE);
         }
 
         // If doing parallel load, make sure this model is parallel capable
         if ( cfg.parallel_load() && !SSTModelDescription::isElementParallelCapable(model_name) ) {
-            std::cerr << "Model type for extension: \"" << extension << "\" does not support parallel loading."
-                      << std::endl;
+            std::cerr << "Model type for extension: \"" << extension << "\" does not support parallel loading.\n";
             SST_Exit(EXIT_FAILURE);
         }
 
@@ -1113,7 +1112,7 @@ main(int argc, char* argv[])
         // we need to put in a sync interval to look for the exit
         // conditions being met.
         // if ( min_part == MAX_SIMTIME_T ) {
-        //     // std::cout << "No links cross rank boundary" << std::endl;
+        //     // std::cout << "No links cross rank boundary\n";
         //     min_part = Simulation_impl::getTimeLord()->getSimCycles("1us","");
         // }
 

--- a/src/sst/core/model/configComponent.cc
+++ b/src/sst/core/model/configComponent.cc
@@ -142,27 +142,27 @@ ConfigPortModule::enableStatistic(const std::string& statistic_name, const SST::
 void
 ConfigComponent::print(std::ostream& os) const
 {
-    os << "Component " << name << " (id = " << std::hex << id << std::dec << ")" << std::endl;
-    os << "  slot_num = " << slot_num << std::endl;
-    os << "  type = " << type << std::endl;
-    os << "  weight = " << weight << std::endl;
-    os << "  rank = " << rank.rank << std::endl;
-    os << "  thread = " << rank.thread << std::endl;
-    os << "  Links:" << std::endl;
+    os << "Component " << name << " (id = " << std::hex << id << std::dec << ")\n";
+    os << "  slot_num = " << slot_num << '\n';
+    os << "  type = " << type << '\n';
+    os << "  weight = " << weight << '\n';
+    os << "  rank = " << rank.rank << '\n';
+    os << "  thread = " << rank.thread << '\n';
+    os << "  Links:\n";
     for ( size_t i = 0; i != links.size(); ++i ) {
         os << "    " << links[i];
     }
-    os << std::endl;
-    os << "  Params:" << std::endl;
+    os << '\n';
+    os << "  Params:" << '\n';
     params.print_all_params(os, "    ");
-    os << "  statLoadLevel = " << (uint32_t)statLoadLevel << std::endl;
-    os << "  enabledAllStats = " << enabledAllStats << std::endl;
-    os << "    Params:" << std::endl;
+    os << "  statLoadLevel = " << (uint32_t)statLoadLevel << '\n';
+    os << "  enabledAllStats = " << enabledAllStats << '\n';
+    os << "    Params:\n";
     allStatConfig.params.print_all_params(os, "      ");
-    os << "  Statistics:" << std::endl;
+    os << "  Statistics:\n";
     for ( auto& pair : enabledStatNames ) {
-        os << "    " << pair.first << std::endl;
-        os << "      Params:" << std::endl;
+        os << "    " << pair.first << '\n';
+        os << "      Params:\n";
         auto iter = statistics_.find(pair.second);
         iter->second.params.print_all_params(os, "      ");
     }

--- a/src/sst/core/model/configGraph.cc
+++ b/src/sst/core/model/configGraph.cc
@@ -888,11 +888,11 @@ PartitionComponent::print(std::ostream& os, const PartitionGraph* graph) const
     for ( ComponentIdMap_t::const_iterator git = group.begin(); git != group.end(); ++git ) {
         os << *git << " ";
     }
-    os << ")" << std::endl;
-    os << "  weight = " << weight << std::endl;
-    os << "  rank = " << rank.rank << std::endl;
-    os << "  thread = " << rank.thread << std::endl;
-    os << "  Links:" << std::endl;
+    os << ")\n";
+    os << "  weight = " << weight << '\n';
+    os << "  rank = " << rank.rank << '\n';
+    os << "  thread = " << rank.thread << '\n';
+    os << "  Links:\n";
     for ( LinkIdMap_t::const_iterator it = links.begin(); it != links.end(); ++it ) {
         graph->getLink(*it).print(os);
     }

--- a/src/sst/core/model/configGraph.h
+++ b/src/sst/core/model/configGraph.h
@@ -78,12 +78,12 @@ public:
     /** Print the configuration graph */
     void print(std::ostream& os) const
     {
-        os << "Printing graph" << std::endl;
-        os << "Components:" << std::endl;
+        os << "Printing graph\n";
+        os << "Components:\n";
         for ( ConfigComponentMap_t::const_iterator i = comps_.begin(); i != comps_.end(); ++i ) {
             (*i)->print(os);
         }
-        os << "Links:" << std::endl;
+        os << "Links:\n";
         for ( auto i = links_.begin(); i != links_.end(); ++i ) {
             (*i)->print(os);
         }
@@ -305,7 +305,7 @@ public:
     /** Print the configuration graph */
     void print(std::ostream& os) const
     {
-        os << "Printing graph" << std::endl;
+        os << "Printing graph\n";
         for ( PartitionComponentMap_t::const_iterator i = comps_.begin(); i != comps_.end(); ++i ) {
             (*i)->print(os, this);
         }

--- a/src/sst/core/model/configLink.h
+++ b/src/sst/core/model/configLink.h
@@ -185,14 +185,14 @@ public:
     */
     void print(std::ostream& os) const
     {
-        os << "Link " << name << " (id = " << id << ")" << std::endl;
-        os << "  nonlocal = " << nonlocal << std::endl;
-        os << "  component[0] = " << component[0] << std::endl;
-        os << "  port[0] = " << port[0] << std::endl;
-        os << "  latency[0] = " << latency[0] << std::endl;
-        os << "  component[1] = " << component[1] << std::endl;
-        os << "  port[1] = " << port[1] << std::endl;
-        os << "  latency[1] = " << latency[1] << std::endl;
+        os << "Link " << name << " (id = " << id << ")\n";
+        os << "  nonlocal = " << nonlocal << '\n';
+        os << "  component[0] = " << component[0] << '\n';
+        os << "  port[0] = " << port[0] << '\n';
+        os << "  latency[0] = " << latency[0] << '\n';
+        os << "  component[1] = " << component[1] << '\n';
+        os << "  port[1] = " << port[1] << '\n';
+        os << "  latency[1] = " << latency[1] << '\n';
     }
 
     /* Do not use.  For serialization only */
@@ -277,11 +277,11 @@ public:
     /** Print the Link information */
     void print(std::ostream& os) const
     {
-        os << "    Link " << id << std::endl;
-        os << "      component[0] = " << component[0] << std::endl;
-        os << "      latency[0] = " << latency[0] << std::endl;
-        os << "      component[1] = " << component[1] << std::endl;
-        os << "      latency[1] = " << latency[1] << std::endl;
+        os << "    Link " << id << '\n';
+        os << "      component[0] = " << component[0] << '\n';
+        os << "      latency[0] = " << latency[0] << '\n';
+        os << "      component[1] = " << component[1] << '\n';
+        os << "      latency[1] = " << latency[1] << '\n';
     }
 };
 

--- a/src/sst/core/objectComms.h
+++ b/src/sst/core/objectComms.h
@@ -60,7 +60,7 @@ send(int dest, int tag, dataType& data)
     std::vector<char> buffer = Comms::serialize<dataType>(data);
 
     // Now send the data.  Send size first, then payload
-    // std::cout<< sizeof(buffer.size()) << std::endl;
+    // std::cout<< sizeof(buffer.size()) << '\n';
     int64_t size = buffer.size();
     MPI_Send(&size, 1, MPI_INT64_T, dest, tag, MPI_COMM_WORLD);
 

--- a/src/sst/core/params.cc
+++ b/src/sst/core/params.cc
@@ -108,16 +108,16 @@ Params::print_all_params(std::ostream& os, const std::string& prefix) const
     int                                   level = 0;
     for ( auto map : data ) {
         if ( level == 0 ) {
-            if ( !map->empty() ) os << "Local params:" << std::endl;
+            if ( !map->empty() ) os << "Local params:\n";
             level++;
         }
         else if ( level == 1 ) {
-            os << "Shared params:" << std::endl;
+            os << "Shared params:\n";
             level++;
         }
 
         for ( auto value : *map ) {
-            os << "  " << prefix << "key=" << keyMapReverse[value.first] << ", value=" << value.second << std::endl;
+            os << "  " << prefix << "key=" << keyMapReverse[value.first] << ", value=" << value.second << '\n';
         }
     }
 }
@@ -151,16 +151,16 @@ Params::toString(const std::string& prefix) const
     int                                   level = 0;
     for ( auto map : data ) {
         if ( level == 0 ) {
-            if ( !map->empty() ) str << "Local params:" << std::endl;
+            if ( !map->empty() ) str << "Local params:\n";
             level++;
         }
         else if ( level == 1 ) {
-            str << "Shared params:" << std::endl;
+            str << "Shared params:\n";
             level++;
         }
 
         for ( auto value : *map ) {
-            str << "  " << prefix << "key=" << keyMapReverse[value.first] << ", value=" << value.second << std::endl;
+            str << "  " << prefix << "key=" << keyMapReverse[value.first] << ", value=" << value.second << '\n';
         }
     }
     return str.str();

--- a/src/sst/core/serialization/objectMap.cc
+++ b/src/sst/core/serialization/objectMap.cc
@@ -76,8 +76,8 @@ ObjectMap::selectVariable(std::string name, bool& loop_detected)
 // #define _DEBUG_NULL_META_
 #ifdef _DEBUG_NULL_META_
             std::cout << "current: &" << current->getName() << " = " << &current << "parent &" << parent->getName()
-                      << " = " << &parent << std::endl;
-            std::cout << "setting current=parent" << std::endl;
+                      << " = " << &parent << '\n';
+            std::cout << "setting current=parent\n";
 #endif
             // TODO: check for parent == nullptr, which
             // would be the case where we didn't detect
@@ -94,7 +94,7 @@ ObjectMap::selectVariable(std::string name, bool& loop_detected)
             // > set d 0.1
             if ( !current->mdata_ ) {
 #if _DEBUG_NULL_META_
-                std::cout << "mdata is null. Returning " << var->getName() << std::endl;
+                std::cout << "mdata is null. Returning " << var->getName() << '\n';
 #endif
                 return var;
             }

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -1061,7 +1061,7 @@ public:
 #ifdef _OBJMAP_DEBUG_
         std::cout << "    Sample:" << handler << ": numRecs:" << numRecs_ << " first:" << first_ << " cur:" << cur_
                   << " state:" << state2char.at(state_) << " isOverrun:" << isOverrun_
-                  << " samplesLost:" << samplesLost_ << std::endl;
+                  << " samplesLost:" << samplesLost_ << '\n';
 #endif
         cycleBuffer_[cur_]   = cycle;
         handlerBuffer_[cur_] = handler;
@@ -1128,7 +1128,7 @@ public:
         else {
             end = cur_ - 1;
         }
-        // std::cout << "start=" << start << " end=" << end << std::endl;
+        // std::cout << "start=" << start << " end=" << end << '\n';
 
         for ( int j = start;; j++ ) {
             size_t i = j % bufSize_;
@@ -1140,7 +1140,7 @@ public:
                 ObjectBuffer* varBuffer_ = objBuffers_[obj];
                 std::cout << SST::Core::to_string(varBuffer_->getName()) << "=" << varBuffer_->get(i) << " ";
             }
-            std::cout << std::endl;
+            std::cout << '\n';
 
             if ( i == end ) {
                 break;
@@ -1151,7 +1151,7 @@ public:
     void dumpTriggerRecord()
     {
         if ( numRecs_ == 0 ) {
-            std::cout << "No trace samples in current buffer" << std::endl;
+            std::cout << "No trace samples in current buffer\n";
             return;
         }
         if ( state_ != CLEAR ) {
@@ -1160,7 +1160,7 @@ public:
                 ObjectBuffer* varBuffer_ = objBuffers_[obj];
                 std::cout << SST::Core::to_string(varBuffer_->getName()) << "=" << varBuffer_->getTriggerVal() << " ";
             }
-            std::cout << std::endl;
+            std::cout << '\n';
         }
     }
 
@@ -1235,7 +1235,7 @@ public:
             *addr_ = SST::Core::from_string<T>(value);
         }
         catch ( const std::exception& e ) {
-            std::cerr << e.what() << ": " << value << std::endl;
+            std::cerr << e.what() << ": " << value << '\n';
         }
     }
 
@@ -1246,7 +1246,7 @@ public:
             return true;
         }
         catch ( const std::exception& e ) {
-            std::cerr << e.what() << ": " << value << std::endl;
+            std::cerr << e.what() << ": " << value << '\n';
             return false;
         }
     }
@@ -1314,11 +1314,11 @@ public:
 
         std::string type = var2->getType();
 #if 0
-        std::cout << "In ObjectMapComparison_var: " << name << " " << name2 << std::endl;
-        // std::cout << "typeid(T): " << demangle_name(typeid(T).name()) << std::endl;
+        std::cout << "In ObjectMapComparison_var: " << name << " " << name2 << '\n';
+        // std::cout << "typeid(T): " << demangle_name(typeid(T).name()) << '\n';
         std::string type1 = getType();
-        std::cout << "getType(v1): " << type1 << std::endl;
-        std::cout << "getType(v2): " << type << std::endl;
+        std::cout << "getType(v1): " << type1 << '\n';
+        std::cout << "getType(v2): " << type << '\n';
 #endif
 
         // Create ObjectMapComparison_var which compares two variables

--- a/src/sst/core/serialization/serializable_base.cc
+++ b/src/sst/core/serialization/serializable_base.cc
@@ -57,9 +57,9 @@ serializable_factory::add_builder(serializable_builder* builder, const char* nam
     if ( current != nullptr ) {
         // std::cerr << sprockit::printf(
         //   "amazingly %s and %s both hash to same serializable id %u",
-        //   current->name(), builder->name(), hash) << std::endl;
+        //   current->name(), builder->name(), hash) << '\n';
         std::cerr << "amazingly " << current->name() << " and " << builder->name()
-                  << " both hash to same serializable id " << hash << std::endl;
+                  << " both hash to same serializable id " << hash << '\n';
         abort();
     }
     current = builder;
@@ -78,7 +78,7 @@ serializable_factory::get_serializable(uint32_t cls_id)
 {
     builder_map::const_iterator it = builders_->find(cls_id);
     if ( it == builders_->end() ) {
-        std::cerr << "class id " << cls_id << " is not a valid serializable id" << std::endl;
+        std::cerr << "class id " << cls_id << " is not a valid serializable id\n";
         // spkt_throw_printf(value_error,
         //                  "class id %ld is not a valid serializable id",
         //                  cls_id);

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -784,7 +784,7 @@ Simulation_impl::performWireUp(ConfigGraph& graph, const RankInfo& myRank, SimTi
     graph.comps_.clear();
     */
     wireUpFinished_ = true;
-    // std::cout << "Done with performWireUp" << std::endl;
+    // std::cout << "Done with performWireUp\n";
 
     // Need to finalize stats engine configuration
     stat_engine.finalizeInitialization();
@@ -918,7 +918,7 @@ Simulation_impl::prepare_for_run()
     // just end
     if ( independent ) {
         if ( compInfoMap.empty() ) {
-            // std::cout << "Thread " << my_rank.thread << " is exiting with nothing to do" << std::endl;
+            // std::cout << "Thread " << my_rank.thread << " is exiting with nothing to do\n";
             StopAction* sa = new StopAction();
             sa->setDeliveryTime(0);
             timeVortex->insert(sa);
@@ -1811,14 +1811,12 @@ Simulation_impl::checkpoint_write_globals(int checkpoint_id, const std::string& 
 
     /* Section 1: Checkpoint info */
     fs_reg << "## Checkpoint #" << checkpoint_id << " at time " << currentSimCycle << " ("
-           << getElapsedSimTime().toStringBestSI() << ")\n"
-           << std::endl;
+           << getElapsedSimTime().toStringBestSI() << ")\n\n";
 
     /* Section 2: Config options */
-    fs_reg << "## Configuration Options" << std::endl;
-    fs_reg << "## Note: Values in this section are for information only, editing values will not affect restart"
-           << std::endl;
-#define WR(var) fs_reg << #var << " = " << var << std::endl;
+    fs_reg << "## Configuration Options\n";
+    fs_reg << "## Note: Values in this section are for information only, editing values will not affect restart\n";
+#define WR(var) fs_reg << #var << " = " << var << '\n';
     WR(num_ranks.rank);
     WR(num_ranks.thread);
     WR(timeLord.timeBaseString);
@@ -1830,10 +1828,10 @@ Simulation_impl::checkpoint_write_globals(int checkpoint_id, const std::string& 
     WR(globalOutputFileName);
     std::string checkpoint_prefix = checkpoint_prefix_;
     WR(checkpoint_prefix);
-    fs_reg << std::endl;
+    fs_reg << '\n';
 #undef WR
 
-    fs_reg << "** (globals): " << globals_filename << std::endl;
+    fs_reg << "** (globals): " << globals_filename << '\n';
 
     fs_reg.close();
 }
@@ -1852,10 +1850,10 @@ Simulation_impl::checkpoint_append_registry(const std::string& registry_name, co
     std::ofstream fs = filesystem.ofstream(registry_name, std::ios::out | std::ios::app);
 
     // Write out the component offsets
-    fs << "\n** (" << my_rank.rank << ":" << my_rank.thread << "): " << blob_name << std::endl;
+    fs << "\n** (" << my_rank.rank << ":" << my_rank.thread << "): " << blob_name << '\n';
     for ( auto x : component_blob_offsets_ ) {
         std::string name = getComponent(x.first)->getName();
-        fs << x.first << " : " << x.second << " (" << name << ")" << std::endl;
+        fs << x.first << " : " << x.second << " (" << name << ")\n";
     }
     fs.close();
 }

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -157,7 +157,7 @@ main(int argc, char* argv[])
 
     // Run interactive mode
     if ( g_configuration.interactiveEnabled() ) {
-        std::cout << "Curses library not found. Run SST-Info without the -i flag." << std::endl;
+        std::cout << "Curses library not found. Run SST-Info without the -i flag.\n";
     }
 
     return 0;
@@ -601,13 +601,13 @@ addELI(ElemLoader& loader, const std::string& lib, bool optional)
         fprintf(stderr, "**** CHECK: Do not include the prefix or file extension when using the lib option.\n");
         fprintf(stderr, "**** EXAMPLE: 'sst-info -l PaintShop' to display model information from libPaintShop.so\n");
         if ( g_configuration.debugEnabled() ) {
-            std::cerr << err_sstr.str() << std::endl;
+            std::cerr << err_sstr.str() << '\n';
         }
     }
     else {
         fprintf(stderr, "**** %s not Found!\n", lib.c_str());
         // regardless of debug - force error printing
-        std::cerr << err_sstr.str() << std::endl;
+        std::cerr << err_sstr.str() << '\n';
     }
 }
 
@@ -788,9 +788,7 @@ void
 SSTInfoConfig::outputUsage()
 {
     using std::cout;
-    using std::endl;
-    cout << "Usage: " << m_AppName << " [<element[.component|subcomponent]>] "
-         << " [options]" << endl;
+    cout << "Usage: " << m_AppName << " [<element[.component|subcomponent]>] [options]\n";
     cout << "  -h, --help               Print Help Message\n";
     cout << "  -v, --version            Print SST Package Release Version\n";
     cout << "  -d, --debug              Enabled debugging messages\n";
@@ -798,8 +796,7 @@ SSTInfoConfig::outputUsage()
     cout << "  -x, --xml                Generate XML data - default is off\n";
     cout << "  -o, --outputxml=FILE     File path to XML file. Default is SSTInfo.xml\n";
     cout << "  -l, --libs=LIBS          {all, <elementname>} - Element Library(s) to process\n";
-    cout << "  -q, --quiet              Quiet/print summary only\n";
-    cout << endl;
+    cout << "  -q, --quiet              Quiet/print summary only\n\n";
 }
 
 void
@@ -878,10 +875,9 @@ SSTLibraryInfo::setLibraryInfo(std::string baseName, std::string componentName, 
 void
 SSTLibraryInfo::outputText(std::stringstream& outputStream)
 {
-    using std::endl;
     if ( this->m_libraryFilter ) {
         outputStream << "\n================================================================================\n";
-        outputStream << "ELEMENT LIBRARY: " << this->m_name << endl;
+        outputStream << "ELEMENT LIBRARY: " << this->m_name << '\n';
 
         // Loop over component types
         for ( auto& pair : this->m_components ) {
@@ -896,20 +892,20 @@ SSTLibraryInfo::outputText(std::stringstream& outputStream)
                 bool filtered = std::find(m_componentFilters.begin(), m_componentFilters.end(),
                                     component.componentName) != m_componentFilters.end();
                 if ( (m_componentFilters.size() == 0) || filtered ) {
-                    outputStream << "  " << componentType << " " << idx << ": " << component.componentName << endl;
+                    outputStream << "  " << componentType << " " << idx << ": " << component.componentName << '\n';
 
                     // Iterate through infoMap using the string indexer
                     for ( auto key : component.stringIndexer ) {
                         std::string val = component.infoMap[key];
 
                         if ( val == "" ) {
-                            outputStream << key << endl;
+                            outputStream << key << '\n';
                         }
                         else {
-                            outputStream << key << ": " << val << endl;
+                            outputStream << key << ": " << val << '\n';
                         }
                     }
-                    outputStream << endl;
+                    outputStream << '\n';
                 }
             }
         }
@@ -1065,7 +1061,7 @@ SSTLibraryInfo::outputHumanReadable(std::ostream& os, bool printAll)
                     if ( g_configuration.doVerbose() ) pair.second->toString(os);
                 }
                 if ( print ) ++idx;
-                if ( print ) os << std::endl;
+                if ( print ) os << '\n';
             }
         }
     }

--- a/src/sst/core/sstregistertool.cc
+++ b/src/sst/core/sstregistertool.cc
@@ -236,10 +236,10 @@ listModels(int option)
 
                 if ( s.find("/") != std::string::npos ) { // check to see if there is a path
                     if ( validModel(s) ) {
-                        std::cout << count << ". " << std::setw(25) << std::left << strNew << "VALID" << std::endl;
+                        std::cout << count << ". " << std::setw(25) << std::left << strNew << "VALID\n";
                     }
                     else {
-                        std::cout << count << ". " << std::setw(25) << std::left << strNew << "INVALID" << std::endl;
+                        std::cout << count << ". " << std::setw(25) << std::left << strNew << "INVALID\n";
                         if ( option == 2 ) // if option = 2, then we only push the invalid models into the vector
                             elements.push_back(strNew);
                     }

--- a/src/sst/core/testElements/coreTest_ClockerComponent.cc
+++ b/src/sst/core/testElements/coreTest_ClockerComponent.cc
@@ -27,7 +27,7 @@ coreTestClockerComponent::coreTestClockerComponent(ComponentId_t id, Params& par
     clock_frequency_str = params.find<std::string>("clock", "1GHz");
     clock_count         = params.find<int64_t>("clockcount", 1000);
 
-    std::cout << "Clock is configured for: " << clock_frequency_str << std::endl;
+    std::cout << "Clock is configured for: " << clock_frequency_str << '\n';
 
     // tell the simulator not to end without us
     registerAsPrimaryComponent();
@@ -39,12 +39,12 @@ coreTestClockerComponent::coreTestClockerComponent(ComponentId_t id, Params& par
 
     // Set some other clocks
     // Second Clock (5ns)
-    std::cout << "REGISTER CLOCK #2 at 5 ns" << std::endl;
+    std::cout << "REGISTER CLOCK #2 at 5 ns\n";
     registerClock("5 ns",
         new Clock::Handler2<coreTestClockerComponent, &coreTestClockerComponent::Clock2Tick, uint32_t>(this, 222));
 
     // Third Clock (15ns)
-    std::cout << "REGISTER CLOCK #3 at 15 ns" << std::endl;
+    std::cout << "REGISTER CLOCK #3 at 15 ns\n";
     Clock3Handler =
         new Clock::Handler2<coreTestClockerComponent, &coreTestClockerComponent::Clock3Tick, uint32_t>(this, 333);
     tc = registerClock("15 ns", Clock3Handler);
@@ -75,7 +75,7 @@ bool
 coreTestClockerComponent::Clock2Tick(SST::Cycle_t CycleNum, uint32_t Param)
 {
     // NOTE: THIS IS THE 5NS CLOCK
-    std::cout << "  CLOCK #2 - TICK Num " << CycleNum << "; Param = " << Param << std::endl;
+    std::cout << "  CLOCK #2 - TICK Num " << CycleNum << "; Param = " << Param << '\n';
 
     // return false so we keep going or true to stop
     if ( CycleNum == 15 ) {
@@ -90,10 +90,10 @@ bool
 coreTestClockerComponent::Clock3Tick(SST::Cycle_t CycleNum, uint32_t Param)
 {
     // NOTE: THIS IS THE 15NS CLOCK
-    std::cout << "  CLOCK #3 - TICK Num " << CycleNum << "; Param = " << Param << std::endl;
+    std::cout << "  CLOCK #3 - TICK Num " << CycleNum << "; Param = " << Param << '\n';
 
     //    if ((CycleNum == 1) || (CycleNum == 4))  {
-    //        std::cout << "*** REGISTERING ONESHOTS " << std::endl ;
+    //        std::cout << "*** REGISTERING ONESHOTS\n";
     //        registerOneShot("10ns", callback1Handler);
     //        registerOneShot("18ns", callback2Handler);
     //    }
@@ -110,13 +110,13 @@ coreTestClockerComponent::Clock3Tick(SST::Cycle_t CycleNum, uint32_t Param)
 void
 coreTestClockerComponent::Oneshot1Callback(uint32_t Param)
 {
-    std::cout << "-------- ONESHOT #1 CALLBACK; Param = " << Param << std::endl;
+    std::cout << "-------- ONESHOT #1 CALLBACK; Param = " << Param << '\n';
 }
 
 void
 coreTestClockerComponent::Oneshot2Callback()
 {
-    std::cout << "-------- ONESHOT #2 CALLBACK" << std::endl;
+    std::cout << "-------- ONESHOT #2 CALLBACK\n";
 }
 
 // Serialization

--- a/src/sst/core/testElements/coreTest_DistribComponent.cc
+++ b/src/sst/core/testElements/coreTest_DistribComponent.cc
@@ -34,9 +34,9 @@ coreTestDistribComponent::finish()
     if ( bin_results ) {
         std::map<int64_t, uint64_t>::iterator map_itr;
 
-        std::cout << "Bin:" << std::endl;
+        std::cout << "Bin:\n";
         for ( map_itr = bins->begin(); map_itr != bins->end(); map_itr++ ) {
-            std::cout << map_itr->first << " " << map_itr->second << std::endl;
+            std::cout << map_itr->first << " " << map_itr->second << '\n';
         }
     }
 }
@@ -106,7 +106,7 @@ coreTestDistribComponent::coreTestDistribComponent(ComponentId_t id, Params& par
         comp_distrib = new SSTDiscreteDistribution(probs, prob_count, new MersenneRNG(10111));
     }
     else {
-        std::cerr << "Unknown distribution type." << std::endl;
+        std::cerr << "Unknown distribution type.\n";
         exit(-1);
     }
 

--- a/src/sst/core/testElements/coreTest_MessageGeneratorComponent.cc
+++ b/src/sst/core/testElements/coreTest_MessageGeneratorComponent.cc
@@ -22,7 +22,7 @@ coreTestMessageGeneratorComponent::coreTestMessageGeneratorComponent(ComponentId
     Component(id)
 {
     clock_frequency_str = params.find<std::string>("clock", "1GHz");
-    std::cout << "Clock is configured for: " << clock_frequency_str << std::endl;
+    std::cout << "Clock is configured for: " << clock_frequency_str << '\n';
 
     total_message_send_count = params.find<int64_t>("sendcount", 1000);
     output_message_info      = params.find<int64_t>("outputinfo", 1);
@@ -56,8 +56,7 @@ coreTestMessageGeneratorComponent::handleEvent(Event* event)
     message_counter_recv++;
 
     if ( output_message_info ) {
-        std::cout << "Received message: " << message_counter_recv << " (time=" << getCurrentSimTimeMicro() << "us)"
-                  << std::endl;
+        std::cout << "Received message: " << message_counter_recv << " (time=" << getCurrentSimTimeMicro() << "us)\n";
     }
 
     delete event;
@@ -77,8 +76,7 @@ coreTestMessageGeneratorComponent::tick(Cycle_t)
     remote_component->send(msg);
 
     if ( output_message_info ) {
-        std::cout << "Sent message: " << message_counter_sent << " (time=" << getCurrentSimTimeMicro() << "us)"
-                  << std::endl;
+        std::cout << "Sent message: " << message_counter_sent << " (time=" << getCurrentSimTimeMicro() << "us)\n";
     }
 
     message_counter_sent++;

--- a/src/sst/core/testElements/coreTest_Serialization.cc
+++ b/src/sst/core/testElements/coreTest_Serialization.cc
@@ -604,52 +604,52 @@ struct HandlerTest : public SST::Core::Serialization::serializable
     // Need 8 combinations to cover void and non-void for return type,
     // arg type and metadata type
 
-    void call_000() { std::cout << "internal value: " << value << std::endl; }
+    void call_000() { std::cout << "internal value: " << value << '\n'; }
 
     void call_001(float f)
     {
-        std::cout << "internal value: " << value << std::endl;
-        std::cout << "metadata value: " << f << std::endl;
+        std::cout << "internal value: " << value << '\n';
+        std::cout << "metadata value: " << f << '\n';
     }
 
     void call_010(int in)
     {
-        std::cout << "internal value: " << value << std::endl;
-        std::cout << "parameter value: " << in << std::endl;
+        std::cout << "internal value: " << value << '\n';
+        std::cout << "parameter value: " << in << '\n';
     }
 
     void call_011(int in, float f)
     {
-        std::cout << "internal value: " << value << std::endl;
-        std::cout << "parameter value: " << in << std::endl;
-        std::cout << "metadata value: " << f << std::endl;
+        std::cout << "internal value: " << value << '\n';
+        std::cout << "parameter value: " << in << '\n';
+        std::cout << "metadata value: " << f << '\n';
     }
 
     int call_100()
     {
-        std::cout << "internal value: " << value << std::endl;
+        std::cout << "internal value: " << value << '\n';
         return 4;
     }
 
     int call_101(float f)
     {
-        std::cout << "internal value: " << value << std::endl;
-        std::cout << "metadata value: " << f << std::endl;
+        std::cout << "internal value: " << value << '\n';
+        std::cout << "metadata value: " << f << '\n';
         return 5;
     }
 
     int call_110(int in)
     {
-        std::cout << "internal value: " << value << std::endl;
-        std::cout << "parameter value: " << in << std::endl;
+        std::cout << "internal value: " << value << '\n';
+        std::cout << "parameter value: " << in << '\n';
         return 6;
     }
 
     int call_111(int in, float f)
     {
-        std::cout << "internal value: " << value << std::endl;
-        std::cout << "parameter value: " << in << std::endl;
-        std::cout << "metadata value: " << f << std::endl;
+        std::cout << "internal value: " << value << '\n';
+        std::cout << "parameter value: " << in << '\n';
+        std::cout << "metadata value: " << f << '\n';
         return 7;
     }
 
@@ -672,9 +672,9 @@ struct RecursiveSerializationTest : public SST::Core::Serialization::serializabl
 
     int call(int input, float f)
     {
-        std::cout << "internal value: " << value << std::endl;
-        std::cout << "parameter value: " << input << std::endl;
-        std::cout << "metadata value: " << f << std::endl;
+        std::cout << "internal value: " << value << '\n';
+        std::cout << "parameter value: " << input << '\n';
+        std::cout << "metadata value: " << f << '\n';
         return 101;
     }
 
@@ -1552,46 +1552,42 @@ coreTestSerialization::coreTestSerialization(ComponentId_t id, Params& params) :
         // args -                 returnT, argT,       dataT
         auto* h000 = new SSTHandler2<void, void, HandlerTest, void, &HandlerTest::call_000>(t1);
         (*h000)();
-        std::cout << std::endl;
+        std::cout << '\n';
 
         // args -                 returnT, argT,       dataT
         auto* h001 = new SSTHandler2<void, void, HandlerTest, float, &HandlerTest::call_001>(t1, 1.2);
         (*h001)();
-        std::cout << std::endl;
+        std::cout << '\n';
 
         // args -                 returnT, argT,       dataT
         auto* h010 = new SSTHandler2<void, int, HandlerTest, void, &HandlerTest::call_010>(t1);
         (*h010)(52);
-        std::cout << std::endl;
+        std::cout << '\n';
 
         // args -                 returnT, argT,       dataT
         auto* h011 = new SSTHandler2<void, int, HandlerTest, float, &HandlerTest::call_011>(t1, 3.4);
         (*h011)(53);
-        std::cout << std::endl;
+        std::cout << '\n';
 
         // args -                returnT, argT,       dataT
         auto* h100 = new SSTHandler2<int, void, HandlerTest, void, &HandlerTest::call_100>(t2);
         int   ret  = (*h100)();
-        std::cout << "Return value: " << ret << std::endl;
-        std::cout << std::endl;
+        std::cout << "Return value: " << ret << "\n\n";
 
         // args -                returnT, argT,       dataT
         auto* h101 = new SSTHandler2<int, void, HandlerTest, float, &HandlerTest::call_101>(t2, 5.6);
         ret        = (*h101)();
-        std::cout << "Return value: " << ret << std::endl;
-        std::cout << std::endl;
+        std::cout << "Return value: " << ret << "\n\n";
 
         // args -                returnT, argT,       dataT
         auto* h110 = new SSTHandler2<int, int, HandlerTest, void, &HandlerTest::call_110>(t2);
         ret        = (*h110)(62);
-        std::cout << "Return value: " << ret << std::endl;
-        std::cout << std::endl;
+        std::cout << "Return value: " << ret << "\n\n";
 
         // args -                returnT, argT,       dataT
         auto* h111 = new SSTHandler2<int, int, HandlerTest, float, &HandlerTest::call_111>(t2, 7.8);
         ret        = (*h111)(63);
-        std::cout << "Return value: " << ret << std::endl;
-        std::cout << std::endl;
+        std::cout << "Return value: " << ret << "\n\n";
 
         // // Serialize and deserialize
         SST::Core::Serialization::serializer ser;
@@ -1666,37 +1662,32 @@ coreTestSerialization::coreTestSerialization(ComponentId_t id, Params& params) :
         SST_SER(h110_out);
         SST_SER(h111_out);
 
-        std::cout << "Internal value for t1: " << t1_out->value << std::endl;
-        std::cout << std::endl;
+        std::cout << "Internal value for t1: " << t1_out->value << "\n\n";
         t1_out->value = 100;
 
         (*h000_out)();
-        std::cout << std::endl;
+        std::cout << '\n';
 
         (*h001_out)();
-        std::cout << std::endl;
+        std::cout << '\n';
 
         (*h010_out)(52);
-        std::cout << std::endl;
+        std::cout << '\n';
 
         (*h011_out)(53);
-        std::cout << std::endl;
+        std::cout << '\n';
 
         ret = (*h100_out)();
-        std::cout << "Return value: " << ret << std::endl;
-        std::cout << std::endl;
+        std::cout << "Return value: " << ret << "\n\n";
 
         ret = (*h101_out)();
-        std::cout << "Return value: " << ret << std::endl;
-        std::cout << std::endl;
+        std::cout << "Return value: " << ret << "\n\n";
 
         ret = (*h110_out)(62);
-        std::cout << "Return value: " << ret << std::endl;
-        std::cout << std::endl;
+        std::cout << "Return value: " << ret << "\n\n";
 
         ret = (*h111_out)(63);
-        std::cout << "Return value: " << ret << std::endl;
-        std::cout << std::endl;
+        std::cout << "Return value: " << ret << "\n\n";
 
 
         // Test recursive serialization using handlers (i.e. the handler

--- a/src/sst/core/testElements/coreTest_StatisticsComponent.cc
+++ b/src/sst/core/testElements/coreTest_StatisticsComponent.cc
@@ -105,7 +105,7 @@ bool
 StatisticsComponentInt::Clock1Tick(Cycle_t UNUSED(CycleNum))
 {
     // NOTE: THIS IS THE 1NS CLOCK
-    //    std::cout << "@ " << CycleNum << std::endl;
+    //    std::cout << "@ " << CycleNum << '\n';
 
     uint32_t U32 = rng->generateNextUInt32();
     uint64_t U64 = rng->generateNextUInt64();

--- a/src/sst/core/timingOutput.cc
+++ b/src/sst/core/timingOutput.cc
@@ -133,7 +133,7 @@ TimingOutput::renderJSON()
 {
     json::ordered_json json_o;
     for ( auto kv : u64map_ ) {
-        // std::cout << key2cstr.at(kv.first) << " = " << std::dec << kv.second << std::endl;
+        // std::cout << key2cstr.at(kv.first) << " = " << std::dec << kv.second << '\n';
         json_o["timing-info"][key2cstr.at(kv.first)] = kv.second;
     }
     for ( auto kv : dmap_ ) {
@@ -144,7 +144,7 @@ TimingOutput::renderJSON()
     }
 
     std::stringstream ss;
-    ss << std::setw(2) << json_o << std::endl;
+    ss << std::setw(2) << json_o << '\n';
 
     // Avoid potential lifetime issues
     std::string outputString = ss.str();

--- a/src/sst/core/uninitializedQueue.cc
+++ b/src/sst/core/uninitializedQueue.cc
@@ -30,35 +30,35 @@ DISABLE_WARN_MISSING_NORETURN
 bool
 UninitializedQueue::empty()
 {
-    std::cout << message << std::endl;
+    std::cout << message << '\n';
     abort();
 }
 
 int
 UninitializedQueue::size()
 {
-    std::cout << message << std::endl;
+    std::cout << message << '\n';
     abort();
 }
 
 void
 UninitializedQueue::insert(Activity* UNUSED(activity))
 {
-    std::cout << message << std::endl;
+    std::cout << message << '\n';
     abort();
 }
 
 Activity*
 UninitializedQueue::pop()
 {
-    std::cout << message << std::endl;
+    std::cout << message << '\n';
     abort();
 }
 
 Activity*
 UninitializedQueue::front()
 {
-    std::cout << message << std::endl;
+    std::cout << message << '\n';
     abort();
 }
 REENABLE_WARNING

--- a/src/sst/core/unitAlgebra.cc
+++ b/src/sst/core/unitAlgebra.cc
@@ -359,13 +359,13 @@ UnitAlgebra::UnitAlgebra(const std::string& val)
 void
 UnitAlgebra::print(std::ostream& stream, int32_t precision)
 {
-    stream << value.toString(precision) << " " << unit.toString() << std::endl;
+    stream << value.toString(precision) << " " << unit.toString() << '\n';
 }
 
 void
 UnitAlgebra::printWithBestSI(std::ostream& stream, int32_t precision)
 {
-    stream << toStringBestSI(precision) << std::endl;
+    stream << toStringBestSI(precision) << '\n';
 }
 
 std::string

--- a/src/sst/core/util/filesystem.cc
+++ b/src/sst/core/util/filesystem.cc
@@ -85,9 +85,9 @@ isDirectoryWritable(const std::string& path)
     // Attempt to create and write to the file
     std::ofstream test_file(test_file_path.string());
     if ( test_file ) {
-        test_file << "This is a test file." << std::endl; // Write something to the file
-        test_file.close();                                // Close the file
-        fs::remove(test_file_path);                       // Clean up by removing the file
+        test_file << "This is a test file.\n"; // Write something to the file
+        test_file.close();                     // Close the file
+        fs::remove(test_file_path);            // Clean up by removing the file
 
         return true; // Directory is writable
     }

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -340,7 +340,7 @@ WatchPoint::printWatchpoint()
         std::cout << " : ";
     }
     printAction();
-    std::cout << std::endl;
+    std::cout << '\n';
 }
 
 void
@@ -456,7 +456,7 @@ WatchPoint::check()
     s << "    WatchPoint " << name_.c_str() << " tests:\n";
     s << "      ";
     cmpObjects_[0]->print(s);
-    s << " -> " << result << std::endl;
+    s << " -> " << result << '\n';
 
     for ( size_t i = 1; i < numCmpObj_; i++ ) {
         bool result2 = false;
@@ -465,16 +465,16 @@ WatchPoint::check()
         }
         s << "      ";
         cmpObjects_[i]->print(s);
-        s << " -> " << result2 << std::endl;
+        s << " -> " << result2 << '\n';
         // printf("      comparison%ld = %d\n", i, result2);
 
         if ( logicOps_[i - 1] == LogicOp::AND ) {
             result = result && result2;
-            s << "        AND -> " << result << std::endl;
+            s << "        AND -> " << result << '\n';
         }
         else if ( logicOps_[i - 1] == LogicOp::OR ) {
             result = result || result2;
-            s << "        OR -> " << result << std::endl;
+            s << "        OR -> " << result << '\n';
         }
         else {
             s << "    ERROR: invalid LogicOp\n";

--- a/src/sst/core/watchPoint.h
+++ b/src/sst/core/watchPoint.h
@@ -56,7 +56,7 @@ public:
         uint32_t    verbosity = 0;
         inline void msg(const std::string& msg)
         {
-            if ( WatchPoint::VMASK & verbosity ) std::cout << msg << std::endl;
+            if ( WatchPoint::VMASK & verbosity ) std::cout << msg << '\n';
         }
     }; // class WPAction
 
@@ -163,7 +163,7 @@ public:
     }
     inline void msg(const std::string& msg)
     {
-        if ( VMASK & verbosity ) std::cout << msg << std::endl;
+        if ( VMASK & verbosity ) std::cout << msg << '\n';
     }
     void        setHandler(unsigned handlerType);
     std::string handlerToString(HANDLER h);


### PR DESCRIPTION
**This is less important than** https://github.com/sstsimulator/sst-core/pull/1518, and should only be merged after it.

This was generated by `scripts/clang-tidy.sh --checks performance-avoid-endl --fix` with some massaging.

The interactive console code is exempted from this, since it requires `std::endl` to flush output.