### PR TITLE
Use 'std::scoped_lock' instead of 'std::lock_guard'

### DIFF
--- a/src/sst/core/exit.cc
+++ b/src/sst/core/exit.cc
@@ -45,7 +45,7 @@ Exit::~Exit()
 void
 Exit::refInc(uint32_t thread)
 {
-    std::lock_guard<Spinlock> lock(slock_);
+    std::scoped_lock lock(slock_);
     ++ref_count_;
     ++thread_counts_[thread];
 }
@@ -53,7 +53,7 @@ Exit::refInc(uint32_t thread)
 void
 Exit::refDec(uint32_t thread)
 {
-    std::lock_guard<Spinlock> lock(slock_);
+    std::scoped_lock lock(slock_);
     if ( ref_count_ == 0 ) {
         Simulation_impl::getSimulation()->getSimulationOutput().fatal(CALL_INFO, 1, "ref_count is already 0\n");
     }

--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -222,7 +222,7 @@ Factory::CreateComponent(ComponentId_t id, const std::string& type, Params& para
     std::stringstream sstr;
     requireLibrary(elemlib, sstr);
 
-    std::lock_guard<std::recursive_mutex> lock(factoryMutex);
+    std::scoped_lock lock(factoryMutex);
     // Check to see if library is loaded into new
     // ElementLibraryDatabase
 
@@ -261,7 +261,7 @@ Factory::DoesSubComponentSlotExist(const std::string& type, const std::string& s
     std::stringstream error_os;
     requireLibrary(elemlib, error_os);
 
-    std::lock_guard<std::recursive_mutex> lock(factoryMutex);
+    std::scoped_lock lock(factoryMutex);
 
     // Check to see if library is loaded into new ElementLibraryDatabase
     auto* compLib = ELI::InfoDatabase::getLibrary<Component>(elemlib);
@@ -305,7 +305,7 @@ Factory::GetStatisticValidityAndEnableLevel(const std::string& comp_type, const 
     std::stringstream error_os;
     requireLibrary(elemlib, error_os);
 
-    std::lock_guard<std::recursive_mutex> lock(factoryMutex);
+    std::scoped_lock lock(factoryMutex);
 
     // Check if elemlib is a component and if so, get ELI
     auto* comp_lib = ELI::InfoDatabase::getLibrary<Component>(elemlib);
@@ -371,7 +371,7 @@ Factory::DoesComponentInfoStatisticNameExist(const std::string& comp_type, const
     std::stringstream error_os;
     requireLibrary(elemlib, error_os);
 
-    std::lock_guard<std::recursive_mutex> lock(factoryMutex);
+    std::scoped_lock lock(factoryMutex);
 
     // Check to see if library is loaded into new
     // ElementLibraryDatabase
@@ -510,10 +510,10 @@ Factory::doesSubComponentExist(const std::string& type)
     // ensure library is already loaded...
     requireLibrary(elemlib);
 
-    std::lock_guard<std::recursive_mutex> lock(factoryMutex);
+    std::scoped_lock lock(factoryMutex);
     // Check to see if library is loaded into new
     // ElementLibraryDatabase
-    auto*                                 lib = ELI::InfoDatabase::getLibrary<SubComponent>(elemlib);
+    auto*            lib = ELI::InfoDatabase::getLibrary<SubComponent>(elemlib);
     if ( lib ) {
         auto* info = lib->getInfo(elem);
         if ( info ) return true;
@@ -647,7 +647,7 @@ bool
 Factory::findLibrary(const std::string& elemlib, std::ostream& err_os)
 {
 
-    std::lock_guard<std::recursive_mutex> lock(factoryMutex);
+    std::scoped_lock lock(factoryMutex);
     if ( loaded_libraries.count(elemlib) == 1 ) return true;
 
     return loadLibrary(elemlib, err_os);

--- a/src/sst/core/mempool.cc
+++ b/src/sst/core/mempool.cc
@@ -63,8 +63,8 @@ class OverflowFreeList
 public:
     void insert(size_t size, std::vector<void*>& list)
     {
-        std::lock_guard<ThreadSafe::Spinlock> slock(lock);
-        bool                                  found = false;
+        std::scoped_lock slock(lock);
+        bool             found = false;
         for ( auto& x : store ) {
             if ( x.size == size ) {
                 found = true;
@@ -79,8 +79,8 @@ public:
 
     bool remove(size_t size, std::vector<void*>& list)
     {
-        std::lock_guard<ThreadSafe::Spinlock> slock(lock);
-        bool                                  found = false;
+        std::scoped_lock slock(lock);
+        bool             found = false;
         for ( auto& x : store ) {
             if ( x.size == size ) {
                 if ( !x.lists.empty() ) {

--- a/src/sst/core/params.cc
+++ b/src/sst/core/params.cc
@@ -104,8 +104,8 @@ Params::count(const key_type& k) const
 void
 Params::print_all_params(std::ostream& os, const std::string& prefix) const
 {
-    std::lock_guard<std::recursive_mutex> lock(keyLock);
-    int                                   level = 0;
+    std::scoped_lock lock(keyLock);
+    int              level = 0;
     for ( auto map : data ) {
         if ( level == 0 ) {
             if ( !map->empty() ) os << "Local params:" << std::endl;
@@ -125,8 +125,8 @@ Params::print_all_params(std::ostream& os, const std::string& prefix) const
 void
 Params::print_all_params(Output& out, const std::string& prefix) const
 {
-    std::lock_guard<std::recursive_mutex> lock(keyLock);
-    int                                   level = 0;
+    std::scoped_lock lock(keyLock);
+    int              level = 0;
     for ( auto map : data ) {
         if ( level == 0 ) {
             if ( !map->empty() ) out.output("%sLocal params:\n", prefix.c_str());
@@ -146,9 +146,9 @@ Params::print_all_params(Output& out, const std::string& prefix) const
 std::string
 Params::toString(const std::string& prefix) const
 {
-    std::lock_guard<std::recursive_mutex> lock(keyLock);
-    std::stringstream                     str;
-    int                                   level = 0;
+    std::scoped_lock  lock(keyLock);
+    std::stringstream str;
+    int               level = 0;
     for ( auto map : data ) {
         if ( level == 0 ) {
             if ( !map->empty() ) str << "Local params:" << std::endl;
@@ -170,7 +170,7 @@ Params::toString(const std::string& prefix) const
 void
 Params::insert(const std::string& key, const std::string& value, bool overwrite)
 {
-    std::lock_guard<std::recursive_mutex> lock(keyLock);
+    std::scoped_lock lock(keyLock);
     if ( overwrite ) {
         my_data[getKey(key)] = value;
     }
@@ -183,7 +183,7 @@ Params::insert(const std::string& key, const std::string& value, bool overwrite)
 void
 Params::insert(const Params& params)
 {
-    std::lock_guard<std::recursive_mutex> lock(keyLock);
+    std::scoped_lock lock(keyLock);
     my_data.insert(params.my_data.begin(), params.my_data.end());
     for ( size_t i = 1; i < params.data.size(); ++i ) {
         bool already_there = false;
@@ -197,8 +197,8 @@ Params::insert(const Params& params)
 std::set<std::string>
 Params::getKeys() const
 {
-    std::lock_guard<std::recursive_mutex> lock(keyLock);
-    std::set<std::string>                 ret;
+    std::scoped_lock      lock(keyLock);
+    std::set<std::string> ret;
     for ( auto map : data ) {
         for ( auto value : *map ) {
             ret.insert(keyMapReverse[value.first]);
@@ -210,8 +210,8 @@ Params::getKeys() const
 Params
 Params::get_scoped_params(const std::string& scope) const
 {
-    std::lock_guard<std::recursive_mutex> lock(keyLock);
-    Params                                ret;
+    std::scoped_lock lock(keyLock);
+    Params           ret;
     ret.enableVerify(false);
 
     std::string prefix = scope + ".";
@@ -282,7 +282,7 @@ Params::verifyParam(const key_type& k) const
 const std::string&
 Params::getParamName(uint32_t id)
 {
-    std::lock_guard<std::recursive_mutex> lock(keyLock);
+    std::scoped_lock lock(keyLock);
     return keyMapReverse[id];
 }
 
@@ -356,8 +356,8 @@ Params::serialize_order(SST::Core::Serialization::serializer& ser)
 uint32_t
 Params::getKey(const std::string& str)
 {
-    std::lock_guard<std::recursive_mutex> lock(keyLock);
-    auto                                  i = keyMap.find(str);
+    std::scoped_lock lock(keyLock);
+    auto             i = keyMap.find(str);
     if ( i == keyMap.end() ) {
         uint32_t id = nextKeyID++;
         keyMap.insert(std::make_pair(str, id));
@@ -372,7 +372,7 @@ Params::getKey(const std::string& str)
 void
 Params::addSharedParamSet(const std::string& set)
 {
-    std::lock_guard<SST::Core::ThreadSafe::Spinlock> lock(sharedLock);
+    std::scoped_lock lock(sharedLock);
     if ( shared_params.count(set) == 0 ) {
         shared_params[set][0] = set;
     }
@@ -383,7 +383,7 @@ Params::addSharedParamSet(const std::string& set)
 void
 Params::insert_shared(const std::string& shared_key, const std::string& key, const std::string& value, bool overwrite)
 {
-    std::lock_guard<SST::Core::ThreadSafe::Spinlock> lock(sharedLock);
+    std::scoped_lock lock(sharedLock);
     if ( shared_params.count(shared_key) == 0 ) {
         shared_params[shared_key][0] = shared_key;
     }

--- a/src/sst/core/shared/sharedObject.cc
+++ b/src/sst/core/shared/sharedObject.cc
@@ -45,7 +45,7 @@ getNumRanks()
 void
 SharedObjectDataManager::updateState(bool finalize)
 {
-    std::lock_guard<std::mutex> lock(update_mtx);
+    std::scoped_lock lock(update_mtx);
 
 #ifdef SST_CONFIG_HAVE_MPI
     // Exchange data between ranks

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -251,7 +251,7 @@ Simulation_impl::createSimulation(
     std::thread::id  tid      = std::this_thread::get_id();
     Simulation_impl* instance = new Simulation_impl(my_rank, num_ranks, restart, currentSimCycle, currentPriority);
 
-    std::lock_guard<std::mutex> lock(simulationMutex);
+    std::scoped_lock lock(simulationMutex);
     instanceMap[tid] = instance;
     instanceVec_.resize(num_ranks.thread);
     instanceVec_[my_rank.thread] = instance;
@@ -754,7 +754,7 @@ Simulation_impl::prepareLinks(ConfigGraph& graph, const RankInfo& myRank, SimTim
 
             // Need to mutex to access cross_thread_links
             {
-                std::lock_guard<SST::Core::ThreadSafe::Spinlock> lock(cross_thread_lock);
+                std::scoped_lock lock(cross_thread_lock);
                 if ( cross_thread_links.find(clink->id) != cross_thread_links.end() ) {
                     // The other side already initialized.  Hook them
                     // together as a pair.
@@ -1167,7 +1167,7 @@ Simulation_impl::run()
 void
 Simulation_impl::emergencyShutdown()
 {
-    std::lock_guard<std::mutex> lock(simulationMutex);
+    std::scoped_lock lock(simulationMutex);
 
     for ( auto&& instance : instanceVec_ ) {
         instance->shutdown_mode_ = SHUTDOWN_EMERGENCY;

--- a/src/sst/core/sync/rankSyncParallelSkip.cc
+++ b/src/sst/core/sync/rankSyncParallelSkip.cc
@@ -87,7 +87,7 @@ ActivityQueue*
 RankSyncParallelSkip::registerLink(
     const RankInfo& to_rank, const RankInfo& from_rank, const std::string& name, Link* link)
 {
-    std::lock_guard<Core::ThreadSafe::Spinlock> slock(lock);
+    std::scoped_lock slock(lock);
 
     // For sends, we track the remote rank and thread ID
     RankSyncQueue* queue;

--- a/src/sst/core/sync/rankSyncSerialSkip.cc
+++ b/src/sst/core/sync/rankSyncSerialSkip.cc
@@ -67,7 +67,7 @@ ActivityQueue*
 RankSyncSerialSkip::registerLink(
     const RankInfo& to_rank, const RankInfo& UNUSED(from_rank), const std::string& name, Link* link)
 {
-    std::lock_guard<Core::ThreadSafe::Spinlock> slock(lock);
+    std::scoped_lock slock(lock);
 
     RankSyncQueue* queue;
     if ( comm_map.count(to_rank.rank) == 0 ) {

--- a/src/sst/core/sync/syncQueue.cc
+++ b/src/sst/core/sync/syncQueue.cc
@@ -43,21 +43,21 @@ RankSyncQueue::RankSyncQueue(RankInfo to_rank) :
 bool
 RankSyncQueue::empty()
 {
-    std::lock_guard<Spinlock> lock(slock);
+    std::scoped_lock lock(slock);
     return activities.empty();
 }
 
 int
 RankSyncQueue::size()
 {
-    std::lock_guard<Spinlock> lock(slock);
+    std::scoped_lock lock(slock);
     return activities.size();
 }
 
 void
 RankSyncQueue::insert(Activity* activity)
 {
-    std::lock_guard<Spinlock> lock(slock);
+    std::scoped_lock lock(slock);
     activities.push_back(activity);
 }
 
@@ -83,14 +83,14 @@ RankSyncQueue::front()
 void
 RankSyncQueue::clear()
 {
-    std::lock_guard<Spinlock> lock(slock);
+    std::scoped_lock lock(slock);
     activities.clear();
 }
 
 char*
 RankSyncQueue::getData()
 {
-    std::lock_guard<Spinlock> lock(slock);
+    std::scoped_lock lock(slock);
 
     serializer ser;
 

--- a/src/sst/core/sync/threadSyncSimpleSkip.cc
+++ b/src/sst/core/sync/threadSyncSimpleSkip.cc
@@ -68,8 +68,8 @@ ThreadSyncSimpleSkip::~ThreadSyncSimpleSkip()
 void
 ThreadSyncSimpleSkip::registerLink(const std::string& name, Link* link)
 {
-    std::lock_guard<Core::ThreadSafe::Spinlock> slock(lock);
-    auto                                        iter = link_map.find(name);
+    std::scoped_lock slock(lock);
+    auto             iter = link_map.find(name);
     if ( iter == link_map.end() ) {
         // I have initialized first, so just put the name and link in
         // the map
@@ -86,8 +86,8 @@ ThreadSyncSimpleSkip::registerLink(const std::string& name, Link* link)
 ActivityQueue*
 ThreadSyncSimpleSkip::registerRemoteLink(int tid, const std::string& name, Link* link)
 {
-    std::lock_guard<Core::ThreadSafe::Spinlock> slock(lock);
-    auto                                        iter = link_map.find(name);
+    std::scoped_lock slock(lock);
+    auto             iter = link_map.find(name);
     if ( iter == link_map.end() ) {
         // I have initialized first, so just put the name and link in
         // the map

--- a/src/sst/core/timeLord.cc
+++ b/src/sst/core/timeLord.cc
@@ -34,7 +34,7 @@ TimeConverter*
 TimeLord::getTimeConverter(const std::string& ts)
 {
     // See if this is in the cache
-    std::lock_guard<std::recursive_mutex> lock(slock_);
+    std::scoped_lock lock(slock_);
     if ( parse_cache_.find(ts) == parse_cache_.end() ) {
         TimeConverter* tc = getTimeConverter(UnitAlgebra(ts));
         parse_cache_[ts]  = tc;
@@ -47,7 +47,7 @@ TimeConverter*
 TimeLord::getTimeConverter(SimTime_t sim_cycles)
 {
     // Check to see if we already have a TimeConverter with this value
-    std::lock_guard<std::recursive_mutex> lock(slock_);
+    std::scoped_lock lock(slock_);
     if ( tc_map_.find(sim_cycles) == tc_map_.end() ) {
         TimeConverter* tc   = new TimeConverter(sim_cycles);
         tc_map_[sim_cycles] = tc;
@@ -120,7 +120,7 @@ SimTime_t
 TimeLord::getSimCycles(const std::string& ts, const std::string& UNUSED(where))
 {
     // See if this is in the cache
-    std::lock_guard<std::recursive_mutex> lock(slock_);
+    std::scoped_lock lock(slock_);
     if ( parse_cache_.find(ts) == parse_cache_.end() ) {
         TimeConverter* tc = getTimeConverter(UnitAlgebra(ts));
         parse_cache_[ts]  = tc;

--- a/src/sst/core/unitAlgebra.cc
+++ b/src/sst/core/unitAlgebra.cc
@@ -91,11 +91,11 @@ Units::reduce()
 void
 Units::addUnit(const std::string& units, sst_big_num& multiplier, bool invert)
 {
-    std::lock_guard<std::recursive_mutex> lock(unit_lock);
+    std::scoped_lock lock(unit_lock);
     // Check to see if the unit matches one of the registered unit
     // names.  If not, check for SI units and strip them, then check
     // again.
-    int                                   si_length = 0;
+    int              si_length = 0;
     if ( valid_base_units.find(units) == valid_base_units.end() &&
          valid_compound_units.find(units) == valid_compound_units.end() ) {
         // Now get the si prefix
@@ -165,7 +165,7 @@ Units::addUnit(const std::string& units, sst_big_num& multiplier, bool invert)
 void
 Units::registerBaseUnit(const std::string& u)
 {
-    std::lock_guard<std::recursive_mutex> lock(unit_lock);
+    std::scoped_lock lock(unit_lock);
     if ( valid_base_units.find(u) != valid_base_units.end() ) return;
     valid_base_units[u] = count;
     unit_strings[count] = u;
@@ -176,7 +176,7 @@ Units::registerBaseUnit(const std::string& u)
 void
 Units::registerCompoundUnit(const std::string& u, const std::string& v)
 {
-    std::lock_guard<std::recursive_mutex> lock(unit_lock);
+    std::scoped_lock lock(unit_lock);
     if ( valid_compound_units.find(u) != valid_compound_units.end() ) return;
     sst_big_num multiplier = 1;
     Units       unit(v, multiplier);
@@ -269,7 +269,7 @@ Units::invert()
 std::string
 Units::toString() const
 {
-    std::lock_guard<std::recursive_mutex> lock(unit_lock);
+    std::scoped_lock lock(unit_lock);
     if ( numerator.size() == 0 && denominator.size() == 0 ) return "";
 
     // Special case Hz

--- a/src/sst/core/util/filesystem.cc
+++ b/src/sst/core/util/filesystem.cc
@@ -145,7 +145,7 @@ bool
 Filesystem::ensureDirectoryExists(std::filesystem::path p, bool strip_filename)
 {
     // Can only be in one function that may create a directory at a time
-    std::lock_guard<std::mutex> guard(create_mutex_);
+    std::scoped_lock guard(create_mutex_);
 
     // If strip_filename is true, then this is a filename and we need
     // to strip it off to get the path


### PR DESCRIPTION
**This is less important than** https://github.com/sstsimulator/sst-core/pull/1518, and should only be merged after it.

This was generated with `scripts/clang-tidy.sh --checks modernize-use-scoped-lock --fix`.