### PR TITLE
Avoid unnecessary copies by using references

### DIFF
--- a/src/sst/core/factory.cc
+++ b/src/sst/core/factory.cc
@@ -252,7 +252,7 @@ Factory::CreateComponent(ComponentId_t id, const std::string& type, Params& para
 bool
 Factory::DoesSubComponentSlotExist(const std::string& type, const std::string& slotName)
 {
-    std::string compTypeToLoad = type;
+    const std::string& compTypeToLoad = type;
 
     std::string elemlib, elem;
     std::tie(elemlib, elem) = parseLoadName(compTypeToLoad);

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -400,7 +400,7 @@ SimpleDebugger::cmd_help(std::vector<std::string>& tokens)
     }
 
     if ( tokens.size() > 1 ) {
-        std::string c = tokens[1];
+        const std::string& c = tokens[1];
         if ( cmdHelp.find(c) != cmdHelp.end() ) {
             std::cout << c << " " << cmdHelp.at(c) << std::endl;
         }
@@ -559,8 +559,8 @@ SimpleDebugger::cmd_print(std::vector<std::string>& tokens)
     }
 
     // See if have a -r or not
-    int         recurse = 0;
-    std::string tok     = tokens[1];
+    int                recurse = 0;
+    const std::string& tok     = tokens[1];
     if ( tok.size() >= 2 && tok[0] == '-' && tok[1] == 'r' ) {
         // Got a -r
         std::string num = tok.substr(2);
@@ -744,7 +744,7 @@ SimpleDebugger::cmd_setHandler(std::vector<std::string>& tokens)
     size_t   tindex  = 2;
     unsigned handler = 0;
     while ( tindex < tokens.size() ) {
-        std::string type = tokens[tindex++];
+        const std::string& type = tokens[tindex++];
         // printf("%s ", type.c_str());
 
         if ( type == "bc" )
@@ -802,7 +802,7 @@ SimpleDebugger::cmd_addTraceVar(std::vector<std::string>& tokens)
     // Get trace vars and add associated objectBuffers
     size_t tindex = 2;
     while ( tindex < tokens.size() ) {
-        std::string tvar = tokens[tindex++];
+        const std::string& tvar = tokens[tindex++];
         // printf("%s ", tvar.c_str());
 
         // Find and check trace variable
@@ -1070,12 +1070,12 @@ Core::Serialization::ObjectMapComparison*
 parseComparison(std::vector<std::string>& tokens, size_t& index, Core::Serialization::ObjectMap* obj, std::string& name)
 {
     // Get first comparison
-    std::string var = tokens[index++];
+    const std::string& var = tokens[index++];
     if ( index >= tokens.size() ) {
         printf("Invalid format for trigger test\n");
         return nullptr;
     }
-    std::string                                  opstr = tokens[index++];
+    const std::string&                           opstr = tokens[index++];
     Core::Serialization::ObjectMapComparison::Op op =
         Core::Serialization::ObjectMapComparison::getOperationFromString(opstr);
 
@@ -1165,7 +1165,7 @@ parseComparison(std::vector<std::string>& tokens, size_t& index, Core::Serializa
 WatchPoint::WPAction*
 parseAction(std::vector<std::string>& tokens, size_t& index, Core::Serialization::ObjectMap* obj)
 {
-    std::string action = tokens[index++];
+    const std::string& action = tokens[index++];
 
     if ( action == "interactive" ) {
         return new WatchPoint::InteractiveWPAction();
@@ -1188,14 +1188,14 @@ parseAction(std::vector<std::string>& tokens, size_t& index, Core::Serialization
             printf("Missing variable for set command\n");
             return nullptr;
         }
-        std::string tvar = tokens[index++];
+        const std::string& tvar = tokens[index++];
         // printf("%s ", tvar.c_str());
 
         if ( index >= tokens.size() ) {
             printf("Missing value for set command\n");
             return nullptr;
         }
-        std::string tval = tokens[index++];
+        const std::string& tval = tokens[index++];
 
         // Find and check variable
         Core::Serialization::ObjectMap* map = obj->findVariable(tvar);

--- a/src/sst/core/model/cfgoutput/xmlConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/xmlConfigOutput.cc
@@ -61,8 +61,8 @@ XMLConfigGraphOutput::generateXML(
     // for(auto paramsItr = comp->params.begin(); paramsItr != comp->params.end(); paramsItr++) {
     auto keys = comp->params.getKeys();
     for ( auto paramsItr = keys.begin(); paramsItr != keys.end(); paramsItr++ ) {
-        std::string paramName  = *paramsItr;
-        std::string paramValue = comp->params.find<std::string>(*paramsItr);
+        const std::string& paramName  = *paramsItr;
+        std::string        paramValue = comp->params.find<std::string>(*paramsItr);
 
         fprintf(outputFile, "%s%s<param name=\"%s\" value=\"%s\"/>\n", indent.c_str(), "   ", paramName.c_str(),
             paramValue.c_str());

--- a/src/sst/core/model/configGraph.cc
+++ b/src/sst/core/model/configGraph.cc
@@ -434,10 +434,10 @@ ConfigGraph::findComponent(ComponentId_t id) const
 ConfigComponent*
 ConfigGraph::findComponentByName(const std::string& name)
 {
-    std::string origname(name);
-    auto        index    = origname.find(':');
-    std::string compname = origname.substr(0, index);
-    auto        itr      = comps_by_name_.find(compname);
+    const std::string& origname(name);
+    auto               index    = origname.find(':');
+    std::string        compname = origname.substr(0, index);
+    auto               itr      = comps_by_name_.find(compname);
 
     // Check to see if component was found
     if ( itr == comps_by_name_.end() ) return nullptr;

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -2201,8 +2201,8 @@ Simulation_impl::initialize_interactive_console(const std::string& type)
 {
 
     // Need to parse the type string to see if there are any parameters
-    std::string actual_type = type;
-    SST::Params p {};
+    const std::string& actual_type = type;
+    SST::Params        p {};
     // For now, just ignore parameters
     // size_t index = type.find_first_of('(');
     // if ( index != std::string::npos ) {


### PR DESCRIPTION
**This is less important than** https://github.com/sstsimulator/sst-core/pull/1518, and should only be merged after it.

This runs `scripts/clang-tidy.sh --checks performance-unnecessary-copy-initialization --fix`, with a little massaging.
