### PR TITLE
Pass std::string and RankInfo by value and use std::move() to move it, reducing allocations and copies

### DIFF
--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -20,13 +20,14 @@
 
 #include <cinttypes>
 #include <cstdio>
+#include <utility>
 
 namespace SST {
 
-ComponentInfo::ComponentInfo(ComponentId_t id, const std::string& name) :
+ComponentInfo::ComponentInfo(ComponentId_t id, std::string name) :
     id_(id),
     parent_info(nullptr),
-    name(name),
+    name(std::move(name)),
     type(""),
     link_map(nullptr),
     component(nullptr),
@@ -81,12 +82,12 @@ ComponentInfo::ComponentInfo() :
 // }
 
 // Constructor used for Anonymous SubComponents
-ComponentInfo::ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const std::string& type,
-    const std::string& slot_name, int slot_num, uint64_t share_flags /*, const Params& params_in*/) :
+ComponentInfo::ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, std::string type, std::string slot_name,
+    int slot_num, uint64_t share_flags /*, const Params& params_in*/) :
     id_(id),
     parent_info(parent_info),
     name(""),
-    type(type),
+    type(std::move(type)),
     link_map(nullptr),
     component(nullptr),
     params(/*new Params()*/ nullptr),
@@ -97,7 +98,7 @@ ComponentInfo::ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const
     statLoadLevel(0),
     coordinates(parent_info->coordinates),
     subIDIndex(1),
-    slot_name(slot_name),
+    slot_name(std::move(slot_name)),
     slot_num(slot_num),
     share_flags(share_flags)
 {
@@ -387,11 +388,10 @@ ComponentInfo::hasLinks() const
 
 ////  Functions for testing serialization
 
-ComponentInfo::ComponentInfo(
-    ComponentId_t id, const std::string& name, const std::string& slot_name, TimeConverter tv) :
+ComponentInfo::ComponentInfo(ComponentId_t id, std::string name, std::string slot_name, TimeConverter tv) :
     id_(id),
     parent_info(nullptr),
-    name(name),
+    name(std::move(name)),
     type(""),
     link_map(nullptr),
     component(nullptr),
@@ -403,7 +403,7 @@ ComponentInfo::ComponentInfo(
     all_stat_config_(nullptr),
     coordinates(3, 0.0),
     subIDIndex(1),
-    slot_name(slot_name),
+    slot_name(std::move(slot_name)),
     slot_num(-1),
     share_flags(0)
 {}

--- a/src/sst/core/componentInfo.h
+++ b/src/sst/core/componentInfo.h
@@ -158,7 +158,7 @@ private:
     // inline void setParent(BaseComponent* comp) { parent = comp; }
 
     /* Lookup Key style constructor */
-    ComponentInfo(ComponentId_t id, const std::string& name);
+    ComponentInfo(ComponentId_t id, std::string name);
     void finalizeLinkConfiguration() const;
     void prepareForComplete() const;
 
@@ -181,8 +181,8 @@ public:
     ComponentInfo(const std::string& type, const Params* params, const ComponentInfo* parent_info);
 
     /* Anonymous SubComponent */
-    ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, const std::string& type, const std::string& slot_name,
-        int slot_num, uint64_t share_flags /*, const Params& params_in*/);
+    ComponentInfo(ComponentId_t id, ComponentInfo* parent_info, std::string type, std::string slot_name, int slot_num,
+        uint64_t share_flags /*, const Params& params_in*/);
 
     /* New ELI Style */
     ComponentInfo(ConfigComponent* ccomp, const std::string& name, ComponentInfo* parent_info, LinkMap* link_map);
@@ -272,8 +272,7 @@ public:
     /**
        (DO NOT USE) Constructor used only for serialization testing
      */
-    ComponentInfo(
-        ComponentId_t id, const std::string& name, const std::string& slot_name, TimeConverter tv = TimeConverter());
+    ComponentInfo(ComponentId_t id, std::string name, std::string slot_name, TimeConverter tv = TimeConverter());
 
     ComponentInfo* test_addSubComponentInfo(
         const std::string& name, const std::string& slot_name, TimeConverter tv = TimeConverter());

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <dirent.h>
 #include <ostream>
+#include <utility>
 #include <vector>
 
 #ifdef HAVE_DLFCN_H
@@ -120,8 +121,8 @@ splitPath(const std::string& searchPaths)
     return paths;
 }
 
-ElemLoader::ElemLoader(const std::string& searchPaths) :
-    searchPaths(searchPaths),
+ElemLoader::ElemLoader(std::string searchPaths) :
+    searchPaths(std::move(searchPaths)),
     verbose(false),
     bindPolicy(RTLD_LAZY | RTLD_GLOBAL)
 {

--- a/src/sst/core/elemLoader.h
+++ b/src/sst/core/elemLoader.h
@@ -24,7 +24,7 @@ class ElemLoader
 {
 public:
     /** Create a new ElementLoader with a given searchpath of directories */
-    explicit ElemLoader(const std::string& searchPaths);
+    explicit ElemLoader(std::string searchPaths);
     ~ElemLoader() = default;
 
     /**

--- a/src/sst/core/impl/partitioners/rrobin.cc
+++ b/src/sst/core/impl/partitioners/rrobin.cc
@@ -16,11 +16,13 @@
 #include "sst/core/model/configGraph.h"
 #include "sst/core/warnmacros.h"
 
+#include <utility>
+
 namespace SST::IMPL::Partition {
 
 SSTRoundRobinPartition::SSTRoundRobinPartition(RankInfo world_size, RankInfo UNUSED(my_rank), int UNUSED(verbosity)) :
     SSTPartitioner(),
-    world_size(world_size)
+    world_size(std::move(world_size))
 {}
 
 void

--- a/src/sst/core/impl/partitioners/simplepart.cc
+++ b/src/sst/core/impl/partitioners/simplepart.cc
@@ -25,7 +25,7 @@ namespace SST::IMPL::Partition {
 
 SimplePartitioner::SimplePartitioner(RankInfo total_ranks, RankInfo UNUSED(my_rank), int UNUSED(verbosity)) :
     SSTPartitioner(),
-    world_size(total_ranks),
+    world_size(std::move(total_ranks)),
     total_parts(world_size.rank * world_size.thread)
 {}
 

--- a/src/sst/core/model/restart/sstcptmodel.cc
+++ b/src/sst/core/model/restart/sstcptmodel.cc
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <fstream>
 #include <string>
+#include <utility>
 
 // #include "nlohmann/json.hpp"
 // using json = nlohmann::json;
@@ -27,9 +28,9 @@
 namespace SST::Core {
 
 SSTCPTModelDefinition::SSTCPTModelDefinition(
-    const std::string& script_file, int UNUSED(verbosity), Config* config, double UNUSED(start_time)) :
+    std::string script_file, int UNUSED(verbosity), Config* config, double UNUSED(start_time)) :
     SSTModelDescription(config),
-    manifest_(script_file),
+    manifest_(std::move(script_file)),
     config_(config)
 {}
 

--- a/src/sst/core/model/restart/sstcptmodel.h
+++ b/src/sst/core/model/restart/sstcptmodel.h
@@ -43,7 +43,7 @@ public:
 
     SST_ELI_DOCUMENT_MODEL_SUPPORTED_EXTENSIONS(".sstcpt")
 
-    SSTCPTModelDefinition(const std::string& script_file, int verbosity, Config* config, double start_time);
+    SSTCPTModelDefinition(std::string script_file, int verbosity, Config* config, double start_time);
     ~SSTCPTModelDefinition() = default;
 
     ConfigGraph* createConfigGraph() override;

--- a/src/sst/core/profile/profiletool.cc
+++ b/src/sst/core/profile/profiletool.cc
@@ -16,14 +16,15 @@
 #include "sst/core/sst_types.h"
 
 #include <atomic>
+#include <utility>
 
 namespace SST::Profile {
 
 SST_ELI_DEFINE_INFO_EXTERN(ProfileTool)
 SST_ELI_DEFINE_CTOR_EXTERN(ProfileTool)
 
-ProfileTool::ProfileTool(const std::string& name) :
-    name(name)
+ProfileTool::ProfileTool(std::string name) :
+    name(std::move(name))
 {}
 
 } // namespace SST::Profile

--- a/src/sst/core/profile/profiletool.h
+++ b/src/sst/core/profile/profiletool.h
@@ -39,7 +39,7 @@ public:
         ELI::ProvidesInterface,
         ELI::ProvidesParams)
 
-    explicit ProfileTool(const std::string& name);
+    explicit ProfileTool(std::string name);
 
     virtual ~ProfileTool() {}
 

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -30,6 +30,7 @@
 #include <atomic>
 #include <cinttypes>
 #include <sys/time.h>
+#include <utility>
 
 namespace SST {
 
@@ -309,11 +310,11 @@ SyncManager::setupSyncObjects()
     }
 }
 
-SyncManager::SyncManager(const RankInfo& rank, const RankInfo& num_ranks, SimTime_t min_part,
+SyncManager::SyncManager(RankInfo rank, RankInfo num_ranks, SimTime_t min_part,
     const std::vector<SimTime_t>& UNUSED(interThreadLatencies), RealTimeManager* real_time) :
     Action(),
-    rank_(rank),
-    num_ranks_(num_ranks),
+    rank_(std::move(rank)),
+    num_ranks_(std::move(num_ranks)),
     threadSync_(nullptr),
     min_part_(min_part),
     real_time_(real_time)

--- a/src/sst/core/sync/syncManager.h
+++ b/src/sst/core/sync/syncManager.h
@@ -137,7 +137,7 @@ protected:
 class SyncManager : public Action
 {
 public:
-    SyncManager(const RankInfo& rank, const RankInfo& num_ranks, SimTime_t min_part,
+    SyncManager(RankInfo rank, RankInfo num_ranks, SimTime_t min_part,
         const std::vector<SimTime_t>& interThreadLatencies, RealTimeManager* real_time);
     SyncManager(); // For serialization only
     virtual ~SyncManager() = default;

--- a/src/sst/core/uninitializedQueue.cc
+++ b/src/sst/core/uninitializedQueue.cc
@@ -18,12 +18,13 @@
 #include <cstdlib>
 #include <iostream>
 #include <ostream>
+#include <utility>
 
 namespace SST {
 
-UninitializedQueue::UninitializedQueue(const std::string& message) :
+UninitializedQueue::UninitializedQueue(std::string message) :
     ActivityQueue(),
-    message(message)
+    message(std::move(message))
 {}
 
 DISABLE_WARN_MISSING_NORETURN

--- a/src/sst/core/uninitializedQueue.h
+++ b/src/sst/core/uninitializedQueue.h
@@ -28,7 +28,7 @@ public:
     /** Create a new Queue
      * @param message - Message to print when something attempts to use this Queue
      */
-    explicit UninitializedQueue(const std::string& message);
+    explicit UninitializedQueue(std::string message);
     UninitializedQueue()           = default; // Only used for serialization
     ~UninitializedQueue() override = default;
 

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -26,6 +26,7 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <utility>
 //clang-format on
 
 namespace SST {
@@ -90,10 +91,10 @@ WatchPoint::ShutdownWPAction::invokeAction(WatchPoint* wp)
     return;
 }
 
-WatchPoint::WatchPoint(size_t index, const std::string& name, Core::Serialization::ObjectMapComparison* obj) :
+WatchPoint::WatchPoint(size_t index, std::string name, Core::Serialization::ObjectMapComparison* obj) :
     Clock::HandlerBase::AttachPoint(),
     Event::HandlerBase::AttachPoint(),
-    name_(name),
+    name_(std::move(name)),
     wpIndex(index)
 {
     addComparison(obj);

--- a/src/sst/core/watchPoint.h
+++ b/src/sst/core/watchPoint.h
@@ -124,7 +124,7 @@ public:
     }; // class ShutdownWPAction
 
     // Construction
-    WatchPoint(size_t index, const std::string& name, Core::Serialization::ObjectMapComparison* obj);
+    WatchPoint(size_t index, std::string name, Core::Serialization::ObjectMapComparison* obj);
     ~WatchPoint() = default;
 
     // Inherited from both Event and Clock handler AttachPoints.


### PR DESCRIPTION
**This is less important than** https://github.com/sstsimulator/sst-core/pull/1518, and should only be merged after it.

This was obtained by running `scripts/clang-tidy.sh --checks modernize-pass-by-value --fix`. 