### PR TITLE
Use more efficient string concatenation

### DIFF
--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -706,7 +706,6 @@ BaseComponent::performGlobalStatisticOutput()
     sim_->getStatisticsProcessingEngine()->performGlobalStatisticOutput(false);
 }
 
-
 void
 BaseComponent::fatal(uint32_t line, const char* file, const char* func, int exit_code, const char* format, ...) const
 {

--- a/src/sst/core/checkpointAction.cc
+++ b/src/sst/core/checkpointAction.cc
@@ -217,7 +217,10 @@ CheckpointAction::createCheckpoint(Simulation_impl* sim)
             for ( uint32_t t = 0; t < num_ranks.thread; ++t ) {
                 // If this is my thread go ahead
                 if ( t == rank_.thread ) {
-                    sim->checkpoint_append_registry(directory + "/" + registry_name, filename);
+                    std::string dir(directory);
+                    dir += '/';
+                    dir += registry_name;
+                    sim->checkpoint_append_registry(std::move(dir), filename);
                     barrier.wait();
                 }
                 else {

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -130,14 +130,14 @@ ComponentInfo::ComponentInfo(
 
     for ( auto sc : ccomp->subComponents ) {
         std::string sub_name(name);
-        sub_name += ":";
+        sub_name += ':';
         sub_name += sc->name;
         // If there is more than one subcomponent in this slot, need
         // to add [index] to the end.
         if ( counts[sc->name] > 1 ) {
-            sub_name += "[";
+            sub_name += '[';
             sub_name += std::to_string(sc->slot_num);
-            sub_name += "]";
+            sub_name += ']';
         }
         subComponents.emplace_hint(subComponents.end(), std::piecewise_construct, std::make_tuple(sc->id),
             std::forward_as_tuple(sc, sub_name, this, new LinkMap()));

--- a/src/sst/core/elemLoader.cc
+++ b/src/sst/core/elemLoader.cc
@@ -190,8 +190,9 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
                 if ( 0 == stat(full_path, &sb) ) {
                     // File found, record error
                     error_msgs.emplace_back("SST-DL: Loading failed for ");
-                    error_msgs.back() =
-                        error_msgs.back() + std::string(full_path) + ", error:\n" + std::string(dlerror());
+                    error_msgs.back() += full_path;
+                    error_msgs.back() += ", error:\n";
+                    error_msgs.back() += dlerror();
                 }
             }
         }
@@ -229,8 +230,9 @@ ElemLoader::loadLibrary(const std::string& elemlib, std::ostream& err_os)
                 if ( 0 == stat(full_path, &sb) ) {
                     // File found, record error
                     error_msgs.emplace_back("SST-DL: Loading failed for ");
-                    error_msgs.back() =
-                        error_msgs.back() + std::string(full_path) + ", error: " + std::string(dlerror());
+                    error_msgs.back() += full_path;
+                    error_msgs.back() += ", error: ";
+                    error_msgs.back() += dlerror();
                 }
             }
         }

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -661,7 +661,8 @@ SimpleDebugger::cmd_set(std::vector<std::string>& tokens)
     std::string value = tokens[2];
     if ( var->getType() == "std::string" ) {
         for ( size_t index = 3; index < tokens.size(); index++ ) {
-            value = value + " " + tokens[index];
+            value += ' ';
+            value += tokens[index];
         }
     }
     else {

--- a/src/sst/core/model/cfgoutput/pythonConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/pythonConfigOutput.cc
@@ -593,31 +593,21 @@ PythonConfigGraphOutput::strncmp(const char* a, const char* b, const size_t n) c
 char*
 PythonConfigGraphOutput::makeEscapeSafe(const std::string& input) const
 {
-
-    std::string escapedInput = "";
-    auto        inputLength  = input.size();
-
-    for ( size_t i = 0; i < inputLength; i++ ) {
-        const char nextChar = input.at(i);
-
+    std::string escapedInput;
+    for ( char nextChar : input ) {
         switch ( nextChar ) {
         case '\"':
-            escapedInput = escapedInput + "\\\"";
+            escapedInput += "\\\"";
             break;
         case '\'':
-            escapedInput = escapedInput + "\\\'";
+            escapedInput += "\\\'";
             break;
         case '\n':
-            escapedInput = escapedInput + "\\n";
+            escapedInput += "\\n";
             break;
         default:
-            escapedInput.push_back(nextChar);
+            escapedInput += nextChar;
         }
     }
-
-    size_t slen          = 1 + escapedInput.size();
-    char*  escapedBuffer = (char*)malloc(sizeof(char) * slen);
-    snprintf(escapedBuffer, slen, "%s", escapedInput.c_str());
-
-    return escapedBuffer;
+    return strdup(escapedInput.c_str());
 }

--- a/src/sst/core/model/json/jsonmodel.cc
+++ b/src/sst/core/model/json/jsonmodel.cc
@@ -52,7 +52,7 @@ SSTConfigSaxHandler::getCurrentPath() const
 {
     std::string path;
     for ( size_t i = 0; i < path_stack.size(); ++i ) {
-        if ( i > 0 ) path += ".";
+        if ( i > 0 ) path += '.';
         path += path_stack[i];
     }
     return path;

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -174,13 +174,16 @@ mlFindModule(PyObject* self, PyObject* args)
                 return self;
             }
             else {
-                loadErrors += std::string("Succeeded in loading library for ") + (const char*)modName +
-                              " but library does not contain a Python module\n";
+                loadErrors += "Succeeded in loading library for ";
+                loadErrors += modName;
+                loadErrors += " but library does not contain a Python module\n";
                 loadErrors += err_sstr.str();
             }
         }
         else {
-            loadErrors += std::string("No component or Python model registered for ") + (const char*)modName + "\n";
+            loadErrors += "No component or Python model registered for ";
+            loadErrors += modName;
+            loadErrors += '\n';
             loadErrors += err_sstr.str();
         }
     }
@@ -973,7 +976,9 @@ buildOverheadMeasureTest(PyObject* UNUSED(self), PyObject* args)
         gModel->getGraph()->findComponent(curr_comp_id)->addParameter("id", std::to_string(i), true);
 
         // Links
-        std::string link_base_name = std::string("l_") + std::to_string(i) + std::string("_");
+        std::string link_base_name("l_");
+        link_base_name += std::to_string(i);
+        link_base_name += '_';
         std::string link_name;
 
         std::string left("left_");
@@ -1241,7 +1246,7 @@ SSTPythonModelDefinition::SSTPythonModelDefinition(
     argv_vector.push_back("sstsim.x");
 
     const int   input_len = configObj->model_options().length();
-    std::string temp      = "";
+    std::string temp;
     bool        in_string = false;
 
     for ( int i = 0; i < input_len; ++i ) {
@@ -1262,7 +1267,7 @@ SSTPythonModelDefinition::SSTPythonModelDefinition(
         }
         else if ( configObj->model_options().substr(i, 1) == " " ) {
             if ( in_string ) {
-                temp += " ";
+                temp += ' ';
             }
             else {
                 if ( !(temp == "") ) {

--- a/src/sst/core/output.cc
+++ b/src/sst/core/output.cc
@@ -157,9 +157,9 @@ Output::fatal(uint32_t line, const char* file, const char* func, int exit_code, 
 {
     va_list     arg1;
     va_list     arg2;
-    std::string newFmt;
-
-    newFmt = std::string("FATAL: ") + buildPrefixString(line, file, func) + format;
+    std::string newFmt("FATAL: ");
+    newFmt += buildPrefixString(line, file, func);
+    newFmt += format;
 
     // Get the argument list
     va_start(arg1, format);
@@ -370,7 +370,7 @@ Output::buildPrefixString(uint32_t line, const std::string& file, const std::str
                 break;
             case 'r':
                 if ( 1 == getMPIWorldSize() ) {
-                    rtnstring += "";
+                    //                    rtnstring += "";
                 }
                 else {
                     snprintf(tempBuf, 256, "%d", getMPIWorldRank());
@@ -380,7 +380,7 @@ Output::buildPrefixString(uint32_t line, const std::string& file, const std::str
                 break;
             case 'R':
                 if ( 1 == getMPIWorldSize() ) {
-                    rtnstring += "0";
+                    rtnstring += '0';
                 }
                 else {
                     snprintf(tempBuf, 256, "%d", getMPIWorldRank());
@@ -390,7 +390,7 @@ Output::buildPrefixString(uint32_t line, const std::string& file, const std::str
                 break;
             case 'i':
                 if ( 1 == getNumThreads() ) {
-                    rtnstring += "";
+                    //                    rtnstring += "";
                 }
                 else {
                     snprintf(tempBuf, 256, "%u", getThreadRank());
@@ -423,7 +423,7 @@ Output::buildPrefixString(uint32_t line, const std::string& file, const std::str
 
             default:
                 // This character is not one of our tokens, so just copy it
-                rtnstring += "@";
+                rtnstring += '@';
                 startindex = findindex + 1;
                 break;
             }

--- a/src/sst/core/serialization/objectMap.cc
+++ b/src/sst/core/serialization/objectMap.cc
@@ -28,7 +28,7 @@ ObjectMap::getFullName() const
     std::string        slash("/");
     ObjectMapMetaData* curr = mdata_->parent->mdata_;
     while ( curr != nullptr ) {
-        fullname = curr->name + slash + fullname;
+        fullname = curr->name + slash + fullname; // NOLINT(performance-inefficient-string-concatenation)
         curr     = curr->parent->mdata_;
     }
     return fullname;

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -1008,7 +1008,8 @@ Simulation_impl::run()
 {
 #if SST_PERFORMANCE_INSTRUMENTING
     std::string filename = "rank_" + std::to_string(my_rank.rank);
-    filename += "_thread_" + std::to_string(my_rank.thread);
+    filename += "_thread_";
+    filename += std::to_string(my_rank.thread);
     fp = fopen(filename.c_str(), "w");
 #endif
 
@@ -2069,7 +2070,10 @@ Simulation_impl::restart()
         for ( uint32_t t = 0; t < num_ranks_cpt.thread; ++t ) {
             if ( !serial_restart_ && (my_rank.rank != r || my_rank.thread != t) ) continue;
             search_str = "** (";
-            search_str = search_str + std::to_string(r) + ":" + std::to_string(t) + "): ";
+            search_str += std::to_string(r);
+            search_str += ':';
+            search_str += std::to_string(t);
+            search_str += "): ";
             while ( std::getline(fs, line) ) {
                 size_t pos = line.find(search_str);
                 if ( pos == 0 ) {
@@ -2218,7 +2222,7 @@ Simulation_impl::initialize_interactive_console(const std::string& type)
 void
 Simulation_impl::printSimulationState()
 {
-    std::string tmp_str = "";
+    std::string tmp_str;
     sim_output.output("Printing simulation state\n");
 
     sim_output.output("num_ranks: %" PRIu32 ", %" PRIu32 "\n", num_ranks.rank, num_ranks.thread);
@@ -2228,9 +2232,10 @@ Simulation_impl::printSimulationState()
     sim_output.output("minPart: %" PRIu64 "\n", minPart);
     sim_output.output("minPartTC: %" PRIu64 "\n", minPartTC.getFactor());
     for ( auto i : interThreadLatencies ) {
-        tmp_str = tmp_str + " " + std::to_string(i);
+        tmp_str += ' ';
+        tmp_str += std::to_string(i);
     }
-    tmp_str += " ";
+    tmp_str += ' ';
     sim_output.output("interThreadLatencies: [%s]\n", tmp_str.c_str());
     sim_output.output("interThreadMinlatency: %" PRIu64 "\n", interThreadMinLatency);
     sim_output.output("endSim: %s\n", endSim ? "true" : "false");

--- a/src/sst/core/sstinfo.cc
+++ b/src/sst/core/sstinfo.cc
@@ -409,7 +409,8 @@ findLibraryInfo(std::list<std::string> args)
                 searchTerm += arg;
             }
             else {
-                searchTerm += arg + " ";
+                searchTerm += arg;
+                searchTerm += ' ';
             }
         }
 
@@ -530,28 +531,55 @@ getErrorText(std::string command, std::list<std::string> args)
 
                 if ( library != closest_lib ) {
                     if ( component != closest_comp ) {
-                        output += " - `" + library + "." + component + "` --- Did you mean '" + closest_lib + "." +
-                                  closest_comp + "'?\n";
+                        output += " - `";
+                        output += library;
+                        output += '.';
+                        output += component;
+                        output += "` --- Did you mean '";
+                        output += closest_lib;
+                        output += '.';
+                        output += closest_comp;
+                        output += "'?\n";
                     }
                     else {
-                        output += " - `" + library + "`." + component + "` --- Did you mean '" + closest_lib + "'?\n";
+                        output += " - `";
+                        output += library;
+                        output += "`.";
+                        output += component;
+                        output += "` --- Did you mean '";
+                        output += closest_lib;
+                        output += "'?\n";
                     }
                 }
                 else {
                     if ( component != closest_comp ) {
-                        output += " - " + library + ".`" + component + "` --- Did you mean '" + closest_comp + "'?\n";
+                        output += " - ";
+                        output += library;
+                        output += ".`";
+                        output += component;
+                        output += "` --- Did you mean '";
+                        output += closest_comp;
+                        output += "'?\n";
                     }
                     else {
-                        output += " - " + arg + "\n";
+                        output += " - ";
+                        output += arg;
+                        output += '\n';
                     }
                 }
             }
             else {
                 if ( library != closest_lib ) {
-                    output += " - `" + library + "` --- Did you mean '" + closest_lib + "'?\n";
+                    output += " - `";
+                    output += library;
+                    output += "` --- Did you mean '";
+                    output += closest_lib;
+                    output += "'?\n";
                 }
                 else {
-                    output += " - " + arg + "\n";
+                    output += " - ";
+                    output += arg;
+                    output += '\n';
                 }
             }
         }
@@ -789,8 +817,7 @@ SSTInfoConfig::outputUsage()
 {
     using std::cout;
     using std::endl;
-    cout << "Usage: " << m_AppName << " [<element[.component|subcomponent]>] "
-         << " [options]" << endl;
+    cout << "Usage: " << m_AppName << " [<element[.component|subcomponent]>] " << " [options]" << endl;
     cout << "  -h, --help               Print Help Message\n";
     cout << "  -v, --version            Print SST Package Release Version\n";
     cout << "  -d, --debug              Enabled debugging messages\n";
@@ -956,7 +983,10 @@ SSTLibraryInfo::filterSearch(std::stringstream& outputStream, std::string tag, s
                             component.infoMap[mapTag].insert(foundSecondIdx + searchTerm.size() + 1, "`");
                         }
 
-                        searchString += mapTag + ": " + component.infoMap[mapTag] + "\n";
+                        searchString += mapTag;
+                        searchString += ": ";
+                        searchString += component.infoMap[mapTag];
+                        searchString += '\n';
                     }
                     else {
                         if ( found ) {
@@ -1080,8 +1110,7 @@ SSTLibraryInfo::outputHumanReadable(std::ostream& os, int LibIndex)
     bool enableFullElementOutput = !doesLibHaveFilters(getLibraryName());
 
     os << "================================================================================\n";
-    os << "ELEMENT LIBRARY " << LibIndex << " = " << getLibraryName() << " (" << getLibraryDescription() << ")"
-       << "\n";
+    os << "ELEMENT LIBRARY " << LibIndex << " = " << getLibraryName() << " (" << getLibraryDescription() << ")\n";
 
     outputHumanReadable<Component>(os, enableFullElementOutput);
     outputHumanReadable<SubComponent>(os, enableFullElementOutput);

--- a/src/sst/core/statapi/statbase.cc
+++ b/src/sst/core/statapi/statbase.cc
@@ -119,12 +119,10 @@ std::string
 StatisticBase::buildStatisticFullName(
     const std::string& comp_name, const std::string& stat_name, const std::string& stat_sub_id)
 {
-    std::string stat_full_name_rtn;
-
-    stat_full_name_rtn = comp_name + ".";
+    std::string stat_full_name_rtn = comp_name + ".";
     stat_full_name_rtn += stat_name;
     if ( stat_sub_id != "" ) {
-        stat_full_name_rtn += ".";
+        stat_full_name_rtn += '.';
         stat_full_name_rtn += stat_sub_id;
     }
     return stat_full_name_rtn;

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -110,7 +110,10 @@ public:
     inline const std::string getFullStatName() const
     {
         std::string stat_full_name_rtn = getCompName() + "." + stat_name_;
-        if ( stat_sub_id_ != "" ) stat_full_name_rtn += "." + stat_sub_id_;
+        if ( stat_sub_id_ != "" ) {
+            stat_full_name_rtn += '.';
+            stat_full_name_rtn += stat_sub_id_;
+        }
         return stat_full_name_rtn;
     } // Return comp_name.stat_name.sub_id or comp_name.stat_name
 

--- a/src/sst/core/statapi/statoutputcsv.cc
+++ b/src/sst/core/statapi/statoutputcsv.cc
@@ -68,7 +68,7 @@ StatisticOutputCSV::startOfSimulation()
 
     // Initialize the OutputBufferArray with std::string objects
     for ( FieldInfoArray_t::iterator it_v = getFieldInfoArray().begin(); it_v != getFieldInfoArray().end(); it_v++ ) {
-        m_OutputBufferArray.push_back(std::string(""));
+        m_OutputBufferArray.push_back("");
     }
 
     if ( true == m_outputTopHeader ) {
@@ -109,7 +109,7 @@ StatisticOutputCSV::startOfSimulation()
         while ( it_v != getFieldInfoArray().end() ) {
             statField    = *it_v;
             outputBuffer = statField->getFieldName();
-            outputBuffer += ".";
+            outputBuffer += '.';
             outputBuffer += getFieldTypeShortName(statField->getFieldType());
 
             // Increment the iterator

--- a/src/sst/core/statapi/statoutputhdf5.cc
+++ b/src/sst/core/statapi/statoutputhdf5.cc
@@ -291,7 +291,9 @@ StatisticOutputHDF5::StatisticInfo::finalizeCurrentStatistic()
         /* Ignore - group already exists.*/
     }
 
-    std::string statName = objName + "/" + statistic->getStatName();
+    std::string statName = objName;
+    statName += "/";
+    statName += statistic->getStatName();
 
     if ( statistic->getStatSubId().length() > 0 ) {
         try {
@@ -302,7 +304,8 @@ StatisticOutputHDF5::StatisticInfo::finalizeCurrentStatistic()
         catch ( const H5::FileIException& ie ) {
             /* Ignore - group already exists. */
         }
-        statName += "/" + statistic->getStatSubId();
+        statName += '/';
+        statName += statistic->getStatSubId();
     }
 
     /* Create dataspace & Dataset */
@@ -544,7 +547,8 @@ StatisticOutputHDF5::GroupInfo::GroupStat::GroupStat(GroupInfo* group, Statistic
         catch ( const H5::FileIException& ie ) {
             /* Ignore - group already exists. */
         }
-        statPath += "/" + stat->getStatSubId();
+        statPath += '/';
+        statPath += stat->getStatSubId();
     }
 }
 

--- a/src/sst/core/statapi/statoutputtxt.cc
+++ b/src/sst/core/statapi/statoutputtxt.cc
@@ -88,7 +88,7 @@ StatisticOutputTextBase::startOfSimulation()
         while ( it_v != getFieldInfoArray().end() ) {
             statField = *it_v;
             m_outputBuffer += statField->getStatName();
-            m_outputBuffer += ".";
+            m_outputBuffer += '.';
             m_outputBuffer += statField->getFieldName();
 
             // Increment the iterator

--- a/src/sst/core/testElements/coreTest_MemPoolTest.h
+++ b/src/sst/core/testElements/coreTest_MemPoolTest.h
@@ -40,7 +40,7 @@ public:
 
     std::string toString() const override
     {
-        return std::string("MemPoolTestEvent1 to be delivered at ") + std::to_string(getDeliveryTime());
+        return "MemPoolTestEvent1 to be delivered at " + std::to_string(getDeliveryTime());
     }
 
 private:
@@ -64,7 +64,7 @@ public:
 
     std::string toString() const override
     {
-        return std::string("MemPoolTestEvent2 to be delivered at ") + std::to_string(getDeliveryTime());
+        return "MemPoolTestEvent2 to be delivered at " + std::to_string(getDeliveryTime());
     }
 
 private:
@@ -88,7 +88,7 @@ public:
 
     std::string toString() const override
     {
-        return std::string("MemPoolTestEvent3 to be delivered at ") + std::to_string(getDeliveryTime());
+        return "MemPoolTestEvent3 to be delivered at " + std::to_string(getDeliveryTime());
     }
 
 private:
@@ -112,7 +112,7 @@ public:
 
     std::string toString() const override
     {
-        return std::string("MemPoolTestEvent4 to be delivered at ") + std::to_string(getDeliveryTime());
+        return "MemPoolTestEvent4 to be delivered at " + std::to_string(getDeliveryTime());
     }
 
 private:

--- a/src/sst/core/testElements/coreTest_OverheadMeasure.cc
+++ b/src/sst/core/testElements/coreTest_OverheadMeasure.cc
@@ -28,7 +28,7 @@ OverheadMeasure::OverheadMeasure(ComponentId_t id, Params& params) :
     ports_    = 0;
     while ( !done ) {
         std::string port_name("left_");
-        port_name     = port_name + std::to_string(ports_);
+        port_name += std::to_string(ports_);
         auto* handler = new Event::Handler2<OverheadMeasure, &OverheadMeasure::handleEvent, int>(this, ports_);
         Link* link    = configureLink(port_name, "1ns", handler);
         ++ports_;
@@ -40,7 +40,7 @@ OverheadMeasure::OverheadMeasure(ComponentId_t id, Params& params) :
 
     while ( !done ) {
         std::string port_name("right_");
-        port_name     = port_name + std::to_string(ports_);
+        port_name += std::to_string(ports_);
         auto* handler = new Event::Handler2<OverheadMeasure, &OverheadMeasure::handleEvent, int>(this, ports_);
         Link* link    = configureLink(port_name, "1ns", handler);
         ++ports_;

--- a/src/sst/core/testElements/coreTest_SharedObjectComponent.cc
+++ b/src/sst/core/testElements/coreTest_SharedObjectComponent.cc
@@ -262,7 +262,8 @@ coreTestSharedObjectsComponent::setup()
                     out.fatal(CALL_INFO, 100, "ERROR: SharedArray data is messed up\n");
                 }
                 if ( checkpoint ) {
-                    arrstr += std::to_string(x) + " ";
+                    arrstr += std::to_string(x);
+                    arrstr += ' ';
                 }
             }
             if ( checkpoint ) {
@@ -302,7 +303,11 @@ coreTestSharedObjectsComponent::setup()
                     out.fatal(CALL_INFO, 100, "ERROR: SharedArray data is messed up\n");
                 }
                 if ( checkpoint ) {
-                    mapstr += "(" + std::to_string(x.first) + "," + std::to_string(x.second) + ") ";
+                    mapstr += '(';
+                    mapstr += std::to_string(x.first);
+                    mapstr += ',';
+                    mapstr += std::to_string(x.second);
+                    mapstr += ") ";
                 }
             }
             if ( checkpoint ) {
@@ -321,7 +326,8 @@ coreTestSharedObjectsComponent::setup()
                     out.fatal(CALL_INFO, 100, "ERROR: SharedSet data is messed up\n");
                 }
                 if ( checkpoint ) {
-                    setstr += std::to_string(x.key) + " ";
+                    setstr += std::to_string(x.key);
+                    setstr += ' ';
                 }
             }
             if ( checkpoint ) {
@@ -342,7 +348,8 @@ coreTestSharedObjectsComponent::finish()
     if ( test_array ) {
         std::string arrstr;
         for ( auto x : array ) {
-            arrstr += std::to_string(x) + " ";
+            arrstr += std::to_string(x);
+            arrstr += ' ';
         }
         out.output("@ Finish, Array = %s\n", arrstr.c_str());
     }
@@ -356,14 +363,19 @@ coreTestSharedObjectsComponent::finish()
     else if ( test_map ) {
         std::string mapstr;
         for ( auto x : map ) {
-            mapstr += "(" + std::to_string(x.first) + "," + std::to_string(x.second) + ") ";
+            mapstr += '(';
+            mapstr += std::to_string(x.first);
+            mapstr += ',';
+            mapstr += std::to_string(x.second);
+            mapstr += ") ";
         }
         out.output("@ Finish, Map = %s\n", mapstr.c_str());
     }
     else if ( test_set ) {
         std::string setstr;
         for ( auto x : set ) {
-            setstr += std::to_string(x.key) + " ";
+            setstr += std::to_string(x.key);
+            setstr += ' ';
         }
         out.output("@ Finish, Set = %s\n", setstr.c_str());
     }

--- a/src/sst/core/testElements/coreTest_SubComponent.cc
+++ b/src/sst/core/testElements/coreTest_SubComponent.cc
@@ -43,7 +43,7 @@ SubComponentLoader::SubComponentLoader(ComponentId_t id, Params& params) :
 
     if ( unnamed_sub != "" ) {
         for ( int i = 0; i < num_subcomps; ++i ) {
-            params.insert("port_name", std::string("port") + std::to_string(i));
+            params.insert("port_name", "port" + std::to_string(i));
             params.insert("verbose", params.find<std::string>("verbose", "0"));
             SubCompInterface* sci = loadAnonymousSubComponent<SubCompInterface>(
                 unnamed_sub, "mySubComp", i, ComponentInfo::SHARE_PORTS | ComponentInfo::INSERT_STATS, params);
@@ -84,7 +84,7 @@ SubCompSlot::SubCompSlot(ComponentId_t id, Params& params) :
 
     if ( unnamed_sub != "" ) {
         for ( int i = 0; i < num_subcomps; ++i ) {
-            params.insert("port_name", std::string("slot_port") + std::to_string(i));
+            params.insert("port_name", "slot_port" + std::to_string(i));
             params.insert("verbose", params.find<std::string>("verbose", "0"));
             SubCompInterface* sci = loadAnonymousSubComponent<SubCompInterface>(
                 unnamed_sub, "mySubCompSlot", i, ComponentInfo::SHARE_PORTS | ComponentInfo::INSERT_STATS, params);

--- a/src/sst/core/util/filesystem.cc
+++ b/src/sst/core/util/filesystem.cc
@@ -184,10 +184,10 @@ Filesystem::createUniqueDirectory(std::filesystem::path dir_name)
         do {
             ++num;
             p2 = path;
-            p2 += fs::path(std::string("_") + std::to_string(num));
+            p2 += fs::path("_" + std::to_string(num));
         } while ( exists(p2) ); // Ensure the new directory name is unique
 
-        path += fs::path(std::string("_") + std::to_string(num));
+        path += fs::path("_" + std::to_string(num));
     }
 
     // This will throw an exception if the path is not writeable


### PR DESCRIPTION
**This is less important than** https://github.com/sstsimulator/sst-core/pull/1518, and should only be merged after it.

This gets rid of warnings generated by `scripts/clang-tidy.sh --checks performance-inefficient-string-concatenation`.

`clang-tidy` can detect, but not auto-fix these inefficient string concatenations. I did it by hand, to get rid of the warnings. It is best to append (`+=`) to a `std::string` variable and then `std::move()` it, than it is to create a large string concatenation expression, because it does not need to allocate and deallocate memory for each temporary string expression, and it only needs to append to the same string variable repeatedly.
