### PR TITLE
Pin Python version used in pre-commit GitHub Actions job

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,4 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
       - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Previously, the Python being used for the pre-commit job was the latest of whatever is inside the runner, and some updates to `testtools` must not be playing nice with this version.  It also gets rid of the following warning:

```
Warning: Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file.
Warning: .python-version doesn't exist.
Warning: The `python-version` input is not set.  The version of Python currently in `PATH` will be used.
```

```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 2

/home/runner/.cache/pre-commit/repok5qo7zw2/py_env-python3.12/lib/python3.12/site-packages/testtools/__init__.py:138: error: Assignment expressions are only supported in Python 3.8 and greater  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```

This appears to be related to https://github.com/sstsimulator/sst-core/pull/1384 but isn't; that PR isn't required for this one, but it does make sense for the version here to match the minimum supported version by SST.