### PR TITLE
Skip test on Rocky 10

### DIFF
--- a/src/sst/core/testingframework/sst_unittest_support.py
+++ b/src/sst/core/testingframework/sst_unittest_support.py
@@ -2257,7 +2257,7 @@ def _read_os_release(filepath: str) -> Tuple[str, str]:
     for line in lines:
         if line.strip() and not line.startswith("#"):
             key, value = line.strip().split("=", 1)
-            entries[key] = value
+            entries[key] = value.strip("\"")
     return entries["ID"], entries.get("VERSION_ID", "")
 
 

--- a/tests/testsuite_default_Checkpoint.py
+++ b/tests/testsuite_default_Checkpoint.py
@@ -87,11 +87,12 @@ class testcase_Checkpoint(SSTTestCase):
     def test_Checkpoint_SharedObject_set(self) -> None:
         self.checkpoint_test_template("SharedObject", 2, 2, modelparams="--param=object_type:set --param=num_entities:12 --param=full_initialization:true --param=checkpoint:true", outstr = "SharedObject_set")
 
+    @unittest.skipIf(host_os_get_distribution_type() == OS_DIST_ROCKY and host_os_get_distribution_version() == "10", "This test fails on Rocky 10")
     def test_Checkpoint_Statistics_basic(self) -> None:
-        self.checkpoint_test_template("StatisticsComponent_basic");
+        self.checkpoint_test_template("StatisticsComponent_basic")
 
     def test_Checkpoint_Statistics_basic_n2one(self) -> None:
-        self.checkpoint_test_template("StatisticsComponent_basic", n_to_one=True);
+        self.checkpoint_test_template("StatisticsComponent_basic", n_to_one=True)
 
     def test_Checkpoint_sc_2u2u_n2one(self) -> None:
         self.checkpoint_test_template("sc_2u2u", 1, 2, subcomp=True, modelparams="1", n_to_one=True)


### PR DESCRIPTION
Slight floating point differences appear on Rocky 10 which causes our tests to fail.
