### PR TITLE
Update and fix JSON parsing to pass core tests when translated to JSON

### DIFF
--- a/src/sst/core/model/Makefile.inc
+++ b/src/sst/core/model/Makefile.inc
@@ -55,6 +55,7 @@ sst_core_python_sources = \
 	model/python/pymodel_portmodule.cc
 
 sst_core_json_sources = \
+  model/json/jsonstates.h \
   model/json/jsonmodel.h \
   model/json/jsonmodel.cc
 

--- a/src/sst/core/model/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/jsonConfigOutput.cc
@@ -19,8 +19,6 @@
 #include "sst/core/simulation_impl.h"
 #include "sst/core/util/filesystem.h"
 
-#include "nlohmann/json.hpp"
-
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
@@ -88,200 +86,118 @@ JSONConfigGraphOutput::outputLinks(ConfigGraph* graph, std::ofstream& ofs)
 void
 JSONConfigGraphOutput::outputComponents(const Config* cfg, ConfigGraph* graph, std::ofstream& ofs)
 {
-    const auto& compMap = graph->getComponentMap();
-    size_t      count   = 0;
-    if ( const_cast<ConfigComponentMap_t&>(compMap).size() == 0 ) {
+    const auto& comp_map = graph->getComponentMap();
+    size_t      count    = 0;
+    if ( const_cast<ConfigComponentMap_t&>(comp_map).size() == 0 ) {
         ofs << "\"components\": null,\n";
     }
     else {
         ofs << "\"components\": [\n";
-        for ( const auto& compItr : compMap ) {
+        for ( const auto& comp_itr : comp_map ) {
             count++;
-            auto compRecord = nlohmann::ordered_json::object();
+            auto comp_record = nlohmann::ordered_json::object();
 
             // top-level objects
-            compRecord["name"] = compItr->name;
-            compRecord["type"] = compItr->type;
+            comp_record["name"] = comp_itr->name;
+            comp_record["type"] = comp_itr->type;
+
+            // statistics options
+            if ( comp_itr->enabledAllStats ) {
+                comp_record["statistics_options"]["enable_all_statistics"] = true;
+            }
+            if ( comp_itr->statLoadLevel != STATISTICLOADLEVELUNINITIALIZED ) {
+                comp_record["statistics_options"]["statistic_load_level"] = comp_itr->statLoadLevel;
+            }
 
             // params
-            for ( auto const& paramsItr : compItr->getParamsLocalKeys() ) {
-                compRecord["params"][paramsItr] = compItr->params.find<std::string>(paramsItr);
+            for ( auto const& params_itr : comp_itr->getParamsLocalKeys() ) {
+                comp_record["params"][params_itr] = comp_itr->params.find<std::string>(params_itr);
             }
 
             // params_shared_sets
-            if ( compItr->getSubscribedSharedParamSets().size() > 0 ) {
-                auto paramSharedSetArray = nlohmann::ordered_json::array();
-                for ( auto const& paramsItr : compItr->getSubscribedSharedParamSets() ) {
-                    paramSharedSetArray.push_back(paramsItr);
+            if ( comp_itr->getSubscribedSharedParamSets().size() > 0 ) {
+                auto shared_params_array = nlohmann::ordered_json::array();
+                for ( auto const& paramsItr : comp_itr->getSubscribedSharedParamSets() ) {
+                    shared_params_array.push_back(paramsItr);
                 }
-                compRecord["params_shared_sets"] = paramSharedSetArray;
-            }
-
-            // subcomponents
-            if ( compItr->subComponents.size() > 0 ) {
-                auto subCompObjArray = nlohmann::ordered_json::array();
-                for ( auto const& scItr : compItr->subComponents ) {
-                    auto subCompRecord = nlohmann::ordered_json::object();
-
-                    subCompRecord["slot_name"]   = scItr->name;
-                    subCompRecord["slot_number"] = scItr->slot_num;
-                    subCompRecord["type"]        = scItr->type;
-
-                    // params
-                    for ( auto const& subParamsItr : scItr->getParamsLocalKeys() ) {
-                        subCompRecord["params"][subParamsItr] = scItr->params.find<std::string>(subParamsItr);
-                    }
-
-                    // params_shared_sets
-                    if ( scItr->getSubscribedSharedParamSets().size() > 0 ) {
-                        auto scParamSharedSetArray = nlohmann::json::array();
-                        for ( auto const& paramsItr : scItr->getSubscribedSharedParamSets() ) {
-                            scParamSharedSetArray.push_back(paramsItr);
-                        }
-                        subCompRecord["params_shared_sets"] = scParamSharedSetArray;
-                    }
-
-                    // subsubcomponents
-                    if ( scItr->subComponents.size() > 0 ) {
-                        auto subSubCompObjArray = nlohmann::ordered_json::array();
-
-                        for ( auto const& subScItr : scItr->subComponents ) {
-                            auto subSubCompRecord = nlohmann::ordered_json::object();
-
-                            subSubCompRecord["slot_name"]   = subScItr->name;
-                            subSubCompRecord["slot_number"] = subScItr->slot_num;
-                            subSubCompRecord["type"]        = subScItr->type;
-
-                            // params
-                            for ( auto const& subParamsItr : subScItr->getParamsLocalKeys() ) {
-                                subSubCompRecord["params"][subParamsItr] =
-                                    subScItr->params.find<std::string>(subParamsItr);
-                            }
-
-                            // params_shared_sets
-                            if ( subScItr->getSubscribedSharedParamSets().size() > 0 ) {
-                                auto scParamSharedSetArray = nlohmann::ordered_json::array();
-                                for ( auto const& paramsItr : subScItr->getSubscribedSharedParamSets() ) {
-                                    scParamSharedSetArray.push_back(paramsItr);
-                                }
-                                subSubCompRecord["params_shared_sets"] = scParamSharedSetArray;
-                            }
-
-                            // statistics
-                            if ( subScItr->enabledStatNames.size() > 0 ) {
-                                auto scStatObjArray = nlohmann::ordered_json::array();
-                                for ( auto const& pair : subScItr->enabledStatNames ) {
-                                    auto statRecord = nlohmann::ordered_json::object();
-
-                                    auto* si = subScItr->findStatistic(pair.second);
-                                    if ( si->shared ) {
-                                        if ( sharedStatMap.find(si->id) == sharedStatMap.end() ) {
-                                            std::string name =
-                                                "statObj" + std::to_string(sharedStatMap.size()) + "_" + si->name;
-                                            sharedStatMap[si->id].assign(name);
-                                            statRecord["name"] = name;
-                                        }
-                                        else {
-                                            std::string name   = sharedStatMap.find(si->id)->second;
-                                            statRecord["name"] = name;
-                                        }
-                                    }
-                                    else {
-                                        auto const& name   = pair.first;
-                                        statRecord["name"] = name;
-                                    }
-
-                                    for ( auto const& parmItr : si->params.getKeys() ) {
-                                        statRecord["params"][parmItr] = si->params.find<std::string>(parmItr);
-                                    }
-
-                                    scStatObjArray.push_back(statRecord);
-                                }
-                                subSubCompRecord["statistics"] = scStatObjArray;
-                            }
-                            subSubCompObjArray.push_back(subSubCompRecord);
-                        }
-
-                        subCompRecord["subcomponents"] = subSubCompObjArray;
-                    }
-
-                    // statistics
-                    if ( scItr->enabledStatNames.size() > 0 ) {
-                        auto scStatObjArray = nlohmann::ordered_json::array();
-                        for ( auto const& pair : scItr->enabledStatNames ) {
-                            auto statRecord = nlohmann::ordered_json::object();
-
-                            auto* si = scItr->findStatistic(pair.second);
-                            if ( si->shared ) {
-                                if ( sharedStatMap.find(si->id) == sharedStatMap.end() ) {
-                                    std::string name =
-                                        "statObj" + std::to_string(sharedStatMap.size()) + "_" + si->name;
-                                    sharedStatMap[si->id].assign(name);
-                                    statRecord["name"] = name;
-                                }
-                                else {
-                                    std::string name   = sharedStatMap.find(si->id)->second;
-                                    statRecord["name"] = name;
-                                }
-                            }
-                            else {
-                                auto const& name   = pair.first;
-                                statRecord["name"] = name;
-                            }
-
-                            for ( auto const& parmItr : si->params.getKeys() ) {
-                                statRecord["params"][parmItr] = si->params.find<std::string>(parmItr);
-                            }
-
-                            scStatObjArray.push_back(statRecord);
-                        }
-                        subCompRecord["statistics"] = scStatObjArray;
-                    }
-                    subCompObjArray.push_back(subCompRecord);
-                }
-                compRecord["subcomponents"] = subCompObjArray;
+                comp_record["params_shared_sets"] = shared_params_array;
             }
 
             // statistics
-            if ( compItr->enabledStatNames.size() > 0 ) {
-                auto statObjArray = nlohmann::ordered_json::array();
-                for ( auto const& pair : compItr->enabledStatNames ) {
-                    auto statRecord = nlohmann::ordered_json::object();
+            if ( comp_itr->enabledStatNames.size() > 0 ) {
+                auto stats_array = nlohmann::ordered_json::array();
+                for ( auto const& pair : comp_itr->enabledStatNames ) {
+                    auto stat_record = nlohmann::ordered_json::object();
 
-                    auto* si = compItr->findStatistic(pair.second);
-                    if ( si->shared ) {
-                        if ( sharedStatMap.find(si->id) == sharedStatMap.end() ) {
-                            std::string name = "statObj" + std::to_string(sharedStatMap.size()) + "_" + si->name;
-                            sharedStatMap[si->id].assign(name);
-                            statRecord["name"] = name;
-                        }
-                        else {
-                            std::string name   = sharedStatMap.find(si->id)->second;
-                            statRecord["name"] = name;
-                        }
+                    auto* stat = comp_itr->findStatistic(pair.second);
+                    if ( stat->shared ) {
+                        stat_record["shared"]      = true;
+                        stat_record["shared_name"] = stat->name;
                     }
-                    else {
-                        auto const& name   = pair.first;
-                        statRecord["name"] = name;
+                    stat_record["name"] = pair.first;
+
+                    for ( auto const& param_itr : stat->params.getKeys() ) {
+                        stat_record["params"][param_itr] = stat->params.find<std::string>(param_itr);
                     }
 
-                    for ( auto const& parmItr : si->params.getKeys() ) {
-                        statRecord["params"][parmItr] = si->params.find<std::string>(parmItr);
-                    }
-
-                    statObjArray.push_back(statRecord);
+                    stats_array.push_back(stat_record);
                 }
-                compRecord["statistics"] = statObjArray;
+                comp_record["statistics"] = stats_array;
+            }
+
+
+            // subcomponents
+            if ( comp_itr->subComponents.size() > 0 ) {
+                auto subcomp_array = nlohmann::ordered_json::array();
+                for ( auto const& sub_itr : comp_itr->subComponents ) {
+                    auto sub_record = outputSubComponent(sub_itr, ofs);
+                    subcomp_array.push_back(sub_record);
+                }
+                comp_record["subcomponents"] = subcomp_array;
             }
 
             // partition info
             if ( cfg->output_partition() ) {
-                compRecord["partition"]["rank"]   = compItr->rank.rank;
-                compRecord["partition"]["thread"] = compItr->rank.thread;
+                comp_record["partition"]["rank"]   = comp_itr->rank.rank;
+                comp_record["partition"]["thread"] = comp_itr->rank.thread;
             }
 
-            ofs << compRecord.dump(2);
-            if ( count == const_cast<ConfigComponentMap_t&>(compMap).size() ) {
+            // port modules
+            if ( comp_itr->port_modules.size() > 0 ) {
+                auto port_modules_array = nlohmann::ordered_json::array();
+                for ( auto const& pm_itr : comp_itr->port_modules ) {
+                    for ( auto const& port_vec_itr : pm_itr.second ) {
+                        auto pm_record    = nlohmann::ordered_json::object();
+                        pm_record["port"] = pm_itr.first;
+                        pm_record["type"] = port_vec_itr.type;
+                        if ( port_vec_itr.stat_load_level != STATISTICLOADLEVELUNINITIALIZED ) {
+                            pm_record["statistics_options"]["statistic_load_level"]  = port_vec_itr.stat_load_level;
+                            pm_record["statistics_options"]["enable_all_statistics"] = true;
+                        }
+                        for ( auto const& param : port_vec_itr.params.getKeys() ) {
+                            pm_record["params"][param] = port_vec_itr.params.find<std::string>(param);
+                        }
+
+                        if ( !port_vec_itr.per_stat_configs.empty() ) {
+                            auto stats_array = nlohmann::ordered_json::array();
+                            for ( auto const& stat_cfg : port_vec_itr.per_stat_configs ) {
+                                auto stat_record    = nlohmann::ordered_json::object();
+                                stat_record["name"] = stat_cfg.first;
+                                for ( auto const& param_itr : stat_cfg.second.getKeys() ) {
+                                    stat_record["params"][param_itr] = stat_cfg.second.find<std::string>(param_itr);
+                                }
+                                stats_array.push_back(stat_record);
+                            }
+                            pm_record["statistics"] = stats_array;
+                        }
+                        port_modules_array.push_back(pm_record);
+                    }
+                }
+                comp_record["port_modules"] = port_modules_array;
+            }
+
+            ofs << comp_record.dump(2);
+            if ( count == const_cast<ConfigComponentMap_t&>(comp_map).size() ) {
                 ofs << "\n";
             }
             else {
@@ -290,6 +206,107 @@ JSONConfigGraphOutput::outputComponents(const Config* cfg, ConfigGraph* graph, s
         }
         ofs << "],\n";
     }
+}
+
+nlohmann::ordered_json
+JSONConfigGraphOutput::outputSubComponent(ConfigComponent* sub, std::ofstream& ofs)
+{
+    auto record = nlohmann::ordered_json::object();
+
+    record["slot_name"]   = sub->name;
+    record["slot_number"] = sub->slot_num;
+    record["type"]        = sub->type;
+
+    // general statistics options
+    if ( sub->enabledAllStats ) {
+        record["statistics_options"]["enable_all_statistics"] = sub->enabledAllStats;
+    }
+    if ( sub->statLoadLevel != STATISTICLOADLEVELUNINITIALIZED ) {
+        record["statistics_options"]["statistic_load_level"] = sub->statLoadLevel;
+    }
+
+    // params
+    for ( auto const& param : sub->getParamsLocalKeys() ) {
+        record["params"][param] = sub->params.find<std::string>(param);
+    }
+
+    // params_shared_sets
+    if ( sub->getSubscribedSharedParamSets().size() > 0 ) {
+        auto shared_params = nlohmann::json::array();
+        for ( auto const& param : sub->getSubscribedSharedParamSets() ) {
+            shared_params.push_back(param);
+        }
+        record["params_shared_sets"] = shared_params;
+    }
+
+    // statistics
+    if ( sub->enabledStatNames.size() > 0 ) {
+        auto stats_array = nlohmann::ordered_json::array();
+        for ( auto const& pair : sub->enabledStatNames ) {
+            auto  stat_record = nlohmann::ordered_json::object();
+            auto* stat        = sub->findStatistic(pair.second);
+            if ( stat->shared ) {
+                stat_record["shared"]      = true;
+                stat_record["shared_name"] = stat->name;
+            }
+            stat_record["name"] = pair.first;
+
+            // stat params
+            for ( auto const& param_itr : stat->params.getKeys() ) {
+                stat_record["params"][param_itr] = stat->params.find<std::string>(param_itr);
+            }
+
+            stats_array.push_back(stat_record);
+        }
+        record["statistics"] = stats_array;
+    }
+
+    // subsubcomponents (recursive)
+    if ( sub->subComponents.size() > 0 ) {
+        auto subcomp_array = nlohmann::ordered_json::array();
+
+        for ( auto const& sub_ptr : sub->subComponents ) {
+            auto sub_record = outputSubComponent(sub_ptr, ofs);
+            subcomp_array.push_back(sub_record);
+        }
+        record["subcomponents"] = subcomp_array;
+    }
+
+    // port modules
+    if ( sub->port_modules.size() > 0 ) {
+        auto port_modules_array = nlohmann::ordered_json::array();
+        for ( auto const& pm_itr : sub->port_modules ) {
+            for ( auto const& port_vec_itr : pm_itr.second ) {
+                auto pm_record    = nlohmann::ordered_json::object();
+                pm_record["port"] = pm_itr.first;
+                pm_record["type"] = port_vec_itr.type;
+                if ( port_vec_itr.stat_load_level != STATISTICLOADLEVELUNINITIALIZED ) {
+                    pm_record["statistics_options"]["statistic_load_level"]  = port_vec_itr.stat_load_level;
+                    pm_record["statistics_options"]["enable_all_statistics"] = true;
+                }
+                for ( auto const& param : port_vec_itr.params.getKeys() ) {
+                    pm_record["params"][param] = port_vec_itr.params.find<std::string>(param);
+                }
+
+                if ( !port_vec_itr.per_stat_configs.empty() ) {
+                    auto stats_array = nlohmann::ordered_json::array();
+                    for ( auto const& stat_cfg : port_vec_itr.per_stat_configs ) {
+                        auto stat_record    = nlohmann::ordered_json::object();
+                        stat_record["name"] = stat_cfg.first;
+                        for ( auto const& param_itr : stat_cfg.second.getKeys() ) {
+                            stat_record["params"][param_itr] = stat_cfg.second.find<std::string>(param_itr);
+                        }
+                        stats_array.push_back(stat_record);
+                    }
+                    pm_record["statistics"] = stats_array;
+                }
+                port_modules_array.push_back(pm_record);
+            }
+        }
+        record["port_modules"] = port_modules_array;
+    }
+
+    return record;
 }
 
 void
@@ -322,6 +339,7 @@ JSONConfigGraphOutput::outputStatisticsGroups(ConfigGraph* graph, std::ofstream&
                 }
             }
 
+            auto statsArray = nlohmann::ordered_json::array();
             for ( auto& i : grp.second.statMap ) {
                 if ( !i.second.empty() ) {
                     auto statRecord    = nlohmann::ordered_json::object();
@@ -329,9 +347,10 @@ JSONConfigGraphOutput::outputStatisticsGroups(ConfigGraph* graph, std::ofstream&
                     for ( auto const& param : i.second.getKeys() ) {
                         statRecord["params"][param] = i.second.find<std::string>(param);
                     }
-                    sgRecord["statistics"] = statRecord;
+                    statsArray.push_back(statRecord);
                 }
             }
+            sgRecord["statistics"] = statsArray;
 
             if ( grp.second.components.size() > 0 ) {
                 auto compArray = nlohmann::ordered_json::array();
@@ -389,26 +408,22 @@ JSONConfigGraphOutput::outputSharedParams(std::ofstream& ofs)
     size_t      count = 0;
     const auto& set   = getSharedParamSetNames();
 
+    auto param_sets = nlohmann::ordered_json::object();
+
     if ( set.size() > 0 ) {
         ofs << "\"shared_params\":";
 
         for ( const auto& s : set ) {
             count++;
             auto record = nlohmann::ordered_json::object();
-            ofs << "\"" << s << "\":\n";
             for ( const auto& kvp : getSharedParamSet(s) ) {
                 if ( kvp.first != "<set_name>" ) {
                     record[kvp.first] = kvp.second;
                 }
             }
-            ofs << record.dump(2);
-            if ( count == set.size() ) {
-                ofs << "\n},\n";
-            }
-            else {
-                ofs << "\n}\n";
-            }
+            param_sets[s] = record;
         }
+        ofs << param_sets.dump(2);
         ofs << ",\n";
     }
 }
@@ -467,6 +482,4 @@ JSONConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph)
     ofs << "}\n";
     ofs.flush();
     ofs.close();
-
-    sharedStatMap.clear();
 }

--- a/src/sst/core/model/cfgoutput/jsonConfigOutput.h
+++ b/src/sst/core/model/cfgoutput/jsonConfigOutput.h
@@ -17,6 +17,8 @@
 #include "sst/core/model/configGraph.h"
 #include "sst/core/util/filesystem.h"
 
+#include "nlohmann/json.hpp"
+
 #include <map>
 #include <string>
 
@@ -30,16 +32,18 @@ public:
     virtual void generate(const Config* cfg, ConfigGraph* graph) override;
 
 private:
-    std::map<SST::StatisticId_t, std::string> sharedStatMap;
+    std::map<SST::StatisticId_t, std::string>
+        shared_stat_map_; // Used to identify shared stat objects vs. stats that map to those objects
 
     std::string pathStr;
 
-    void outputProgramOptions(const Config* cfg, std::ofstream& ofs);
-    void outputSharedParams(std::ofstream& ofs);
-    void outputStatisticsOptions(ConfigGraph* graph, std::ofstream& ofs);
-    void outputStatisticsGroups(ConfigGraph* graph, std::ofstream& ofs);
-    void outputComponents(const Config* cfg, ConfigGraph* graph, std::ofstream& ofs);
-    void outputLinks(ConfigGraph* graph, std::ofstream& ofs);
+    void                   outputProgramOptions(const Config* cfg, std::ofstream& ofs);
+    void                   outputSharedParams(std::ofstream& ofs);
+    void                   outputStatisticsOptions(ConfigGraph* graph, std::ofstream& ofs);
+    void                   outputStatisticsGroups(ConfigGraph* graph, std::ofstream& ofs);
+    void                   outputComponents(const Config* cfg, ConfigGraph* graph, std::ofstream& ofs);
+    nlohmann::ordered_json outputSubComponent(ConfigComponent* sub, std::ofstream& ofs);
+    void                   outputLinks(ConfigGraph* graph, std::ofstream& ofs);
 };
 
 } // namespace SST::Core

--- a/src/sst/core/model/configComponent.cc
+++ b/src/sst/core/model/configComponent.cc
@@ -18,6 +18,7 @@
 #include "sst/core/factory.h"
 #include "sst/core/from_string.h"
 #include "sst/core/model/configGraph.h"
+#include "sst/core/model/sstmodel.h"
 #include "sst/core/namecheck.h"
 #include "sst/core/simulation_impl.h"
 #include "sst/core/timeLord.h"

--- a/src/sst/core/model/json/jsonmodel.cc
+++ b/src/sst/core/model/json/jsonmodel.cc
@@ -32,7 +32,7 @@ SSTConfigSaxHandler::findComponentIdByName(const std::string& name, bool& succes
 
     if ( name.length() == 0 ) {
         error_str_ = "Error: Name given to findComponentIdByName is null";
-        success  = false;
+        success    = false;
         return id;
     }
 
@@ -40,7 +40,7 @@ SSTConfigSaxHandler::findComponentIdByName(const std::string& name, bool& succes
     comp = graph_->findComponentByName(name);
     if ( comp == nullptr ) {
         error_str_ = "Error: Unable to locate component by name: " + name;
-        success  = false;
+        success    = false;
         return id;
     }
 
@@ -123,7 +123,7 @@ SSTConfigSaxHandler::boolean(bool val)
         }
         else {
             error_str_ = "Unexpected key/boolean value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in Link '" + shadow_link_.name + "'";
+                         "' in Link '" + shadow_link_.name + "'";
             return false;
         }
         break;
@@ -137,8 +137,8 @@ SSTConfigSaxHandler::boolean(bool val)
         }
         else {
             error_str_ = "Unexpected key/boolean value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in 'statistics' belonging to '" + shadow_component_stack_.front().name +
-                       "' or one of its subcomponents";
+                         "' in 'statistics' belonging to '" + shadow_component_stack_.front().name +
+                         "' or one of its subcomponents";
             return false;
         }
         break;
@@ -150,13 +150,13 @@ SSTConfigSaxHandler::boolean(bool val)
         }
         else {
             error_str_ = "Unexpected key/boolean value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in 'statistics' object in component tree '" + shadow_component_stack_[0].name;
+                         "' in 'statistics' object in component tree '" + shadow_component_stack_[0].name;
             return false;
         }
         break;
     default:
         error_str_ = "Parsed a boolean '" + std::to_string(val) + "'in an unexpected parser state " +
-                   StateString[(int)current_state_] + ". Last key was: " + current_key_;
+                     StateString[(int)current_state_] + ". Last key was: " + current_key_;
         return false;
     }
     return true;
@@ -172,7 +172,7 @@ SSTConfigSaxHandler::number_integer(json::number_integer_t val)
         }
         else {
             error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in statistic_options object.";
+                         "' in statistic_options object.";
             return false;
         }
         break;
@@ -185,7 +185,7 @@ SSTConfigSaxHandler::number_integer(json::number_integer_t val)
         }
         else {
             error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in partition object.";
+                         "' in partition object.";
             return false;
         }
         break;
@@ -195,7 +195,7 @@ SSTConfigSaxHandler::number_integer(json::number_integer_t val)
         }
         else {
             error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in 'subcomponents' object in component tree '" + shadow_component_stack_[0].name;
+                         "' in 'subcomponents' object in component tree '" + shadow_component_stack_[0].name;
             return false;
         }
         break;
@@ -206,7 +206,7 @@ SSTConfigSaxHandler::number_integer(json::number_integer_t val)
         }
         else {
             error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in 'statistic_options' object in component tree '" + shadow_component_stack_[0].name;
+                         "' in 'statistic_options' object in component tree '" + shadow_component_stack_[0].name;
             return false;
         }
         break;
@@ -216,7 +216,7 @@ SSTConfigSaxHandler::number_integer(json::number_integer_t val)
         }
         else {
             error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in 'subcomponents' object in component tree '" + shadow_component_stack_[0].name;
+                         "' in 'subcomponents' object in component tree '" + shadow_component_stack_[0].name;
             return false;
         }
         break;
@@ -229,13 +229,13 @@ SSTConfigSaxHandler::number_integer(json::number_integer_t val)
         }
         else {
             error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in right side of link '" + shadow_link_.name + "'.";
+                         "' in right side of link '" + shadow_link_.name + "'.";
             return false;
         }
         break;
     default:
         error_str_ = "Parsed an integer '" + std::to_string(val) + "' in an unexpected parser state " +
-                   StateString[(int)current_state_] + ". Last key was: " + current_key_;
+                     StateString[(int)current_state_] + ". Last key was: " + current_key_;
         return false;
     }
     return true;
@@ -251,7 +251,7 @@ SSTConfigSaxHandler::number_unsigned(json::number_unsigned_t val)
         }
         else {
             error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in statistic_options object.";
+                         "' in statistic_options object.";
             return false;
         }
         break;
@@ -264,7 +264,7 @@ SSTConfigSaxHandler::number_unsigned(json::number_unsigned_t val)
         }
         else {
             error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in partition object.";
+                         "' in partition object.";
             return false;
         }
         break;
@@ -274,7 +274,7 @@ SSTConfigSaxHandler::number_unsigned(json::number_unsigned_t val)
         }
         else {
             error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in 'subcomponents' object in component tree '" + shadow_component_stack_[0].name;
+                         "' in 'subcomponents' object in component tree '" + shadow_component_stack_[0].name;
             return false;
         }
         break;
@@ -285,7 +285,7 @@ SSTConfigSaxHandler::number_unsigned(json::number_unsigned_t val)
         }
         else {
             error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in 'statistic_options' object in component tree '" + shadow_component_stack_[0].name;
+                         "' in 'statistic_options' object in component tree '" + shadow_component_stack_[0].name;
             return false;
         }
         break;
@@ -295,7 +295,7 @@ SSTConfigSaxHandler::number_unsigned(json::number_unsigned_t val)
         }
         else {
             error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in 'subcomponents' object in component tree '" + shadow_component_stack_[0].name;
+                         "' in 'subcomponents' object in component tree '" + shadow_component_stack_[0].name;
             return false;
         }
         break;
@@ -308,13 +308,13 @@ SSTConfigSaxHandler::number_unsigned(json::number_unsigned_t val)
         }
         else {
             error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
-                       "' in right side of link '" + shadow_link_.name + "'.";
+                         "' in right side of link '" + shadow_link_.name + "'.";
             return false;
         }
         break;
     default:
         error_str_ = "Parsed an integer '" + std::to_string(val) + "' in an unexpected parser state " +
-                   StateString[(int)current_state_] + ". Last key was: " + current_key_;
+                     StateString[(int)current_state_] + ". Last key was: " + current_key_;
         return false;
     }
     return true;
@@ -355,7 +355,7 @@ SSTConfigSaxHandler::string(std::string& val)
         }
         else {
             error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
-                       "' in 'statistics_options' object. Expected key 'statistic_output'.";
+                         "' in 'statistics_options' object. Expected key 'statistic_output'.";
             return false;
         }
         break;
@@ -379,8 +379,8 @@ SSTConfigSaxHandler::string(std::string& val)
         }
         else {
             error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
-                       "' in 'component' object with name (if already parsed): '" +
-                       shadow_component_stack_.back().name + "'. Expected key 'name' or 'type'.";
+                         "' in 'component' object with name (if already parsed): '" +
+                         shadow_component_stack_.back().name + "'. Expected key 'name' or 'type'.";
             return false;
         }
         break;
@@ -393,8 +393,8 @@ SSTConfigSaxHandler::string(std::string& val)
         }
         else {
             error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
-                       "' in 'subcomponent' object in component '" + shadow_component_stack_[0].name +
-                       "'. Expected key 'slot_name' or 'type'.";
+                         "' in 'subcomponent' object in component '" + shadow_component_stack_[0].name +
+                         "'. Expected key 'slot_name' or 'type'.";
             return false;
         }
         break;
@@ -407,8 +407,8 @@ SSTConfigSaxHandler::string(std::string& val)
         }
         else {
             error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
-                       "' in 'port_module' object in component '" + shadow_component_stack_[0].name +
-                       "'. Expected key 'port' or 'type'.";
+                         "' in 'port_module' object in component '" + shadow_component_stack_[0].name +
+                         "'. Expected key 'port' or 'type'.";
             return false;
         }
         break;
@@ -437,8 +437,8 @@ SSTConfigSaxHandler::string(std::string& val)
         }
         else {
             error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
-                       "' in 'statistics' object in component tree '" + shadow_component_stack_[0].name +
-                       "'. Expected key 'name' or 'shared_name'.";
+                         "' in 'statistics' object in component tree '" + shadow_component_stack_[0].name +
+                         "'. Expected key 'name' or 'shared_name'.";
             return false;
         }
         break;
@@ -448,7 +448,7 @@ SSTConfigSaxHandler::string(std::string& val)
         }
         else {
             error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
-                       "' in 'statistics_group' object. Expected key 'name'.";
+                         "' in 'statistics_group' object. Expected key 'name'.";
         }
         break;
     case State::Comp_Stat_Params:
@@ -466,8 +466,8 @@ SSTConfigSaxHandler::string(std::string& val)
         }
         else {
             error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
-                       "' in 'link' object. Link name is (may be blank if not parsed yet): '" + shadow_link_.name +
-                       "'. Expected key 'name'.";
+                         "' in 'link' object. Link name is (may be blank if not parsed yet): '" + shadow_link_.name +
+                         "'. Expected key 'name'.";
             return false;
         }
         break;
@@ -477,8 +477,8 @@ SSTConfigSaxHandler::string(std::string& val)
             shadow_link_.leftcomp = findComponentIdByName(val, success);
             if ( !success ) {
                 error_str_ = "Error: Unable to locate component ID for component '" + val + "' in left side of link '" +
-                           shadow_link_.name +
-                           "'. Ensure components are declared prior to link instantiation in your input file.";
+                             shadow_link_.name +
+                             "'. Ensure components are declared prior to link instantiation in your input file.";
                 return false;
             }
         }
@@ -490,8 +490,8 @@ SSTConfigSaxHandler::string(std::string& val)
         }
         else {
             error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
-                       "' in left side of link named '" + shadow_link_.name +
-                       "'. Expected key 'port', 'latency', or 'component'.";
+                         "' in left side of link named '" + shadow_link_.name +
+                         "'. Expected key 'port', 'latency', or 'component'.";
             return false;
         }
         break;
@@ -500,9 +500,9 @@ SSTConfigSaxHandler::string(std::string& val)
             bool success;
             shadow_link_.rightcomp = findComponentIdByName(val, success);
             if ( !success ) {
-                error_str_ = "Error: Unable to locate component ID for component '" + val + "' in right side of link '" +
-                           shadow_link_.name +
-                           "'. Ensure components are declared prior to link instantiation in your input file.";
+                error_str_ = "Error: Unable to locate component ID for component '" + val +
+                             "' in right side of link '" + shadow_link_.name +
+                             "'. Ensure components are declared prior to link instantiation in your input file.";
                 return false;
             }
         }
@@ -514,8 +514,8 @@ SSTConfigSaxHandler::string(std::string& val)
         }
         else {
             error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
-                       "' in right side of link named '" + shadow_link_.name +
-                       "'. Expected key 'port', 'latency', 'component'.";
+                         "' in right side of link named '" + shadow_link_.name +
+                         "'. Expected key 'port', 'latency', 'component'.";
             return false;
         }
         break;
@@ -532,7 +532,7 @@ SSTConfigSaxHandler::string(std::string& val)
         }
         else {
             error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
-                       "' in statistics_group. Expected key 'name' or 'frequency'.";
+                         "' in statistics_group. Expected key 'name' or 'frequency'.";
             return false;
         }
         break;
@@ -544,7 +544,7 @@ SSTConfigSaxHandler::string(std::string& val)
         }
         else {
             error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
-                       "' in statistics_group output object. Expected key 'type'.";
+                         "' in statistics_group output object. Expected key 'type'.";
             return false;
         }
         break;
@@ -556,9 +556,10 @@ SSTConfigSaxHandler::string(std::string& val)
         bool success = false;
         current_stat_group_->addComponent(findComponentIdByName(val, success));
         if ( !success ) {
-            error_str_ = "Error: Unable to locate component ID for component '" + val +
-                       "' in statistics group component list for group " + current_stat_group_->name +
-                       ". Ensure components are declared prior to adding them to a statistic group in your input file.";
+            error_str_ =
+                "Error: Unable to locate component ID for component '" + val +
+                "' in statistics group component list for group " + current_stat_group_->name +
+                ". Ensure components are declared prior to adding them to a statistic group in your input file.";
             return false;
         }
         break;
@@ -568,8 +569,8 @@ SSTConfigSaxHandler::string(std::string& val)
         break;
     default:
         error_str_ = "Error: Parser encountered a string token in state '" + StateString[(int)current_state_] +
-                   "'. This case is not handled and may be an error in the JSON file. Key/value pair is '" +
-                   current_key_ + "'/'" + val + "'.";
+                     "'. This case is not handled and may be an error in the JSON file. Key/value pair is '" +
+                     current_key_ + "'/'" + val + "'.";
         return false;
     }
     return true;
@@ -630,10 +631,11 @@ SSTConfigSaxHandler::start_object([[maybe_unused]] std::size_t elements)
     case State::SubComp_Params_key: // Parse params
         // Assert that component/subcomponent is constructed
         if ( shadow_component_stack_.back().comp == nullptr ) {
-            error_str_ = "Error: Encountered new (sub)component section before (sub)component was constructed. Ensure "
-                       "that subcomponent required keys (name, type, slot_name,  etc.) are listed first in the object "
-                       "before other keys. Component tree name is (if already parsed) '" +
-                       shadow_component_stack_[0].name + "'.";
+            error_str_ =
+                "Error: Encountered new (sub)component section before (sub)component was constructed. Ensure "
+                "that subcomponent required keys (name, type, slot_name,  etc.) are listed first in the object "
+                "before other keys. Component tree name is (if already parsed) '" +
+                shadow_component_stack_[0].name + "'.";
             return false;
         }
         break;
@@ -642,8 +644,8 @@ SSTConfigSaxHandler::start_object([[maybe_unused]] std::size_t elements)
         break;
     default:
         error_str_ = "Error: Parser encountered a '{' token in state '" + StateString[(int)current_state_] +
-                   "'. This case is not handled and may be an error in the JSON file. Last key was '" + current_key_ +
-                   "'.";
+                     "'. This case is not handled and may be an error in the JSON file. Last key was '" + current_key_ +
+                     "'.";
         return false;
     }
     current_state_ = NextStateObjOrArray[(int)current_state_];
@@ -705,7 +707,7 @@ SSTConfigSaxHandler::end_object()
                     ConfigStatistic* cs = shadow_component_stack_.back().comp->createStatistic();
                     if ( cs == nullptr ) {
                         error_str_ = "Error: Failed to create shared statistic '" + shadow_statistic_.shared_name +
-                                   "' on '" + shadow_component_stack_.back().name + "'.";
+                                     "' on '" + shadow_component_stack_.back().name + "'.";
                         return false;
                     }
                     cs->params.insert(shadow_statistic_.params);
@@ -718,8 +720,8 @@ SSTConfigSaxHandler::end_object()
                 if ( !shadow_component_stack_.back().comp->reuseStatistic(
                          shadow_statistic_.name, cs_iter->second->id) ) {
                     error_str_ = "Error: Attempting to link statistic '" + shadow_statistic_.name + "' to '" +
-                               shadow_statistic_.shared_name + "' in component '" +
-                               shadow_component_stack_.front().name + "' but unable to complete the linking.";
+                                 shadow_statistic_.shared_name + "' in component '" +
+                                 shadow_component_stack_.front().name + "' but unable to complete the linking.";
                     return false;
                 }
             }
@@ -774,8 +776,8 @@ SSTConfigSaxHandler::end_object()
     }
     default:
         error_str_ = "Error: Parser encountered a '}' token in state '" + StateString[(int)current_state_] +
-                   "'. This case is not handled and may be an error in the JSON file. Last key was '" + current_key_ +
-                   "'.";
+                     "'. This case is not handled and may be an error in the JSON file. Last key was '" + current_key_ +
+                     "'.";
         return false;
     }
     current_state_ = ParentState[(int)current_state_];
@@ -792,15 +794,16 @@ SSTConfigSaxHandler::start_array([[maybe_unused]] std::size_t elements)
     case State::SubCompArray_key:
         if ( shadow_component_stack_.back().comp == nullptr ) {
             error_str_ = "Error: Encountered (sub)component's subcomponents array before the 'type' and 'name' keys in "
-                       "component '" +
-                       shadow_component_stack_.back().name + "'";
+                         "component '" +
+                         shadow_component_stack_.back().name + "'";
             return false;
         }
         break;
     case State::LinkArray_key:
         if ( !found_components_ ) {
-            error_str_ = "Error: Encountered 'links' section before 'components' section. Put the 'links' section after "
-                       "'components' in your input file";
+            error_str_ =
+                "Error: Encountered 'links' section before 'components' section. Put the 'links' section after "
+                "'components' in your input file";
             return false;
         }
         break;
@@ -817,8 +820,8 @@ SSTConfigSaxHandler::start_array([[maybe_unused]] std::size_t elements)
         break;
     default:
         error_str_ = "Error: Parser encountered a '[' token in state '" + StateString[(int)current_state_] +
-                   "'. This case is not handled and may be an error in the JSON file. Last key was '" + current_key_ +
-                   "'.";
+                     "'. This case is not handled and may be an error in the JSON file. Last key was '" + current_key_ +
+                     "'.";
         return false;
     }
     current_state_ = NextStateObjOrArray[(int)current_state_];
@@ -862,8 +865,8 @@ SSTConfigSaxHandler::end_array()
         break;
     default:
         error_str_ = "Error: Parser encountered a ']' token in state '" + StateString[(int)current_state_] +
-                   "'. This case is not handled and may be an error in the JSON file. Last key was '" + current_key_ +
-                   "'.";
+                     "'. This case is not handled and may be an error in the JSON file. Last key was '" + current_key_ +
+                     "'.";
         return false;
     }
     return true;
@@ -912,8 +915,8 @@ SSTConfigSaxHandler::key(std::string& val)
         }
         else { // Error: Unexpected key
             error_str_ = "Error: Encountered unexpected key '" + val +
-                       "' in state Root. Expected keys are 'program_options', 'shared_params', 'statistics_options', "
-                       "'statistics_group', 'components', or 'links'.\n";
+                         "' in state Root. Expected keys are 'program_options', 'shared_params', 'statistics_options', "
+                         "'statistics_group', 'components', or 'links'.\n";
             return false;
         }
         break;
@@ -936,9 +939,10 @@ SSTConfigSaxHandler::key(std::string& val)
         break;
     case State::StatGroup:
         if ( !current_stat_group_ && val != "name" ) {
-            error_str_ = "Error: First key/value pair in a statistics_group object must be the group name. Expected key "
-                       "'name' and got '" +
-                       val + "'";
+            error_str_ =
+                "Error: First key/value pair in a statistics_group object must be the group name. Expected key "
+                "'name' and got '" +
+                val + "'";
             return false;
         }
         if ( val == "output" ) {
@@ -982,7 +986,7 @@ SSTConfigSaxHandler::key(std::string& val)
                                   // type & name are encountered
             if ( shadow_component_stack_.back().comp == nullptr ) {
                 error_str_ = "Error: Encountered key '" + val + "' before the 'type' and 'name' keys in component '" +
-                           shadow_component_stack_.back().name + "'.";
+                             shadow_component_stack_.back().name + "'.";
                 return false;
             }
         }
@@ -1058,8 +1062,8 @@ SSTConfigSaxHandler::key(std::string& val)
         break;
     default:
         error_str_ = "Error: Parser encountered a key token in state '" + StateString[(int)current_state_] +
-                   "'. This case is not handled and may be an error in the JSON file. Key is '" + val +
-                   "' and last valid key was '" + current_key_ + "'.";
+                     "'. This case is not handled and may be an error in the JSON file. Key is '" + val +
+                     "' and last valid key was '" + current_key_ + "'.";
         return false;
     }
     current_key_ = val;
@@ -1075,10 +1079,10 @@ SSTConfigSaxHandler::constructSubComponent()
 {
     if ( shadow_component_stack_.back().name == "" || shadow_component_stack_.back().type == "" ) {
         error_str_ = "Error: Unable to construct subcomponent in component '" + shadow_component_stack_[0].name +
-                   "'. Missing name or type ('" + shadow_component_stack_.back().name + "', '" +
-                   shadow_component_stack_.back().type +
-                   "'). The usual cause of this error is failing to place name and type at the beginning of a "
-                   "component object.\n";
+                     "'. Missing name or type ('" + shadow_component_stack_.back().name + "', '" +
+                     shadow_component_stack_.back().type +
+                     "'). The usual cause of this error is failing to place name and type at the beginning of a "
+                     "component object.\n";
         return;
     }
     shadow_component_stack_.back().comp =
@@ -1092,9 +1096,9 @@ SSTConfigSaxHandler::constructPortModule()
 {
     if ( shadow_port_module_.port == "" || shadow_port_module_.type == "" ) {
         error_str_ = "Error: Unable to construct port_module in component tree '" + shadow_component_stack_[0].name +
-                   "'. Missing port or type ('" + shadow_port_module_.port + "', '" + shadow_port_module_.type +
-                   "'). The usual cause of this error is failing to place port and type at the beginning of a "
-                   "port_module object.\n";
+                     "'. Missing port or type ('" + shadow_port_module_.port + "', '" + shadow_port_module_.type +
+                     "'). The usual cause of this error is failing to place port and type at the beginning of a "
+                     "port_module object.\n";
         return;
     }
     size_t pm_id = (shadow_component_stack_.back().comp)
@@ -1112,9 +1116,9 @@ SSTConfigSaxHandler::constructComponent()
 {
     if ( shadow_component_stack_.back().name == "" || shadow_component_stack_.back().type == "" ) {
         error_str_ = "Error: Unable to construct component. Missing name or type ('" +
-                   shadow_component_stack_.back().name + "', '" + shadow_component_stack_.back().type +
-                   "'). The usual cause of this error is failing to place name and type at the beginning of a "
-                   "component object.\n";
+                     shadow_component_stack_.back().name + "', '" + shadow_component_stack_.back().type +
+                     "'). The usual cause of this error is failing to place name and type at the beginning of a "
+                     "component object.\n";
         return;
     }
     ComponentId_t id = graph_->addComponent(shadow_component_stack_.back().name, shadow_component_stack_.back().type);

--- a/src/sst/core/model/json/jsonmodel.cc
+++ b/src/sst/core/model/json/jsonmodel.cc
@@ -22,7 +22,6 @@ DISABLE_WARN_STRICT_ALIASING
 
 using namespace SST;
 using namespace SST::Core;
-using namespace SST::Core;
 
 ComponentId_t
 SSTConfigSaxHandler::findComponentIdByName(const std::string& name, bool& success)

--- a/src/sst/core/model/json/jsonmodel.cc
+++ b/src/sst/core/model/json/jsonmodel.cc
@@ -22,597 +22,1170 @@ DISABLE_WARN_STRICT_ALIASING
 
 using namespace SST;
 using namespace SST::Core;
+using namespace SST::Core;
 
 ComponentId_t
-SSTConfigSaxHandler::findComponentIdByName(const std::string& Name, bool& success)
+SSTConfigSaxHandler::findComponentIdByName(const std::string& name, bool& success)
 {
-    ComponentId_t    Id   = -1;
-    ConfigComponent* Comp = nullptr;
+    ComponentId_t    id   = UNSET_COMPONENT_ID;
+    ConfigComponent* comp = nullptr;
 
-    if ( Name.length() == 0 ) {
-        errorStr = "Error: Name given to findComponentIdByName is null";
+    if ( name.length() == 0 ) {
+        error_str_ = "Error: Name given to findComponentIdByName is null";
         success  = false;
-        return Id;
+        return id;
     }
 
     // first, find the component pointer from the name
-    Comp = graph->findComponentByName(Name);
-    if ( Comp == nullptr ) {
-        errorStr = "Error finding component ID by name: " + Name;
+    comp = graph_->findComponentByName(name);
+    if ( comp == nullptr ) {
+        error_str_ = "Error: Unable to locate component by name: " + name;
         success  = false;
-        return Id;
+        return id;
     }
 
     success = true;
-    return Comp->id;
-}
-
-std::string
-SSTConfigSaxHandler::getCurrentPath() const
-{
-    std::string path;
-    for ( size_t i = 0; i < path_stack.size(); ++i ) {
-        if ( i > 0 ) path += ".";
-        path += path_stack[i];
-    }
-    return path;
+    return comp->id;
 }
 
 const std::map<std::string, std::string>
 SSTConfigSaxHandler::getProgramOptions()
 {
-    return ProgramOptions;
-}
-
-void
-SSTConfigSaxHandler::processValue(const json& value)
-{
-    std::string path = getCurrentPath();
-
-    if ( current_state == PROGRAM_OPTIONS ) {
-        if ( value.get<std::string>() == "false" ) {
-            ProgramOptions[current_key] = "0";
-        }
-        else if ( value.get<std::string>() == "true" ) {
-            ProgramOptions[current_key] = "1";
-        }
-        else {
-            ProgramOptions[current_key] = value.get<std::string>();
-        }
-    }
-    else if ( current_state == STATISTICS_OPTIONS ) {
-        if ( current_key == "statisticLoadLevel" && value.is_number_integer() ) {
-            graph->setStatisticLoadLevel(value.get<int>());
-        }
-        else if ( current_key == "statisticOutput" && value.is_string() ) {
-            graph->setStatisticOutput(value.get<std::string>());
-        }
-        else if ( path.find("statistics_options.params") != std::string::npos && value.is_string() ) {
-            graph->addStatisticOutputParameter(current_key, value.get<std::string>());
-        }
-    }
-    else if ( current_state == SHARED_PARAMS ) {
-        graph->addSharedParam(current_shared_name, current_key, value.get<std::string>());
-    }
-    else if ( current_state == COMPONENTS ) {
-        if ( current_key == "rank" && value.is_number_integer() ) {
-            current_comp_rank = value.get<unsigned int>();
-        }
-        else if ( current_key == "thread" && value.is_number_integer() ) {
-            RankInfo Rank(current_comp_rank, value.get<unsigned int>());
-            current_component->setRank(Rank);
-        }
-        else if ( path.find("params_shared_sets") != std::string::npos && value.is_string() ) {
-            current_component->addSharedParamSet(value.get<std::string>());
-        }
-        else if ( current_key == "slot_number" && in_comp_subcomp && value.is_number_integer() ) {
-            subcomp_slot = value.get<int>();
-        }
-        else if ( current_key == "params_shared_sets" && in_comp_subcomp && value.is_string() ) {
-            current_sub_component->addSharedParamSet(value.get<std::string>());
-        }
-    }
-    else if ( current_state == LINKS ) {
-        if ( current_key == "noCut" && value.is_boolean() ) {
-            no_cut = value.get<bool>();
-        }
-        else if ( current_key == "nonlocal" && value.is_boolean() ) {
-            nonlocal = value.get<bool>();
-        }
-        else if ( in_right_link && nonlocal ) {
-            if ( current_key == "rank" ) {
-                right_rank = value.get<int>();
-            }
-            else if ( current_key == "thread" ) {
-                right_thread = value.get<int>();
-            }
-        }
-    }
-    path_stack.pop_back();
+    return program_options_;
 }
 
 bool
 SSTConfigSaxHandler::null()
 {
+    // null passed instead of an object or array
+    switch ( current_state_ ) {
+    case State::ProgramOptions_key:
+    case State::SharedParams_key:
+    case State::SharedParams_object_key:
+    case State::StatOptions_key:
+    case State::StatOptions_Params_key:
+    case State::StatGroupsArray_key:
+    case State::StatGroup_Output_key:
+    case State::StatGroup_Output_Params_key:
+    case State::StatGroup_StatArray_key:
+    case State::StatGroup_Stat_Params_key:
+    case State::CompArray_key:
+    case State::Comp_Params_key:
+    case State::Comp_StatOptions_key:
+    case State::Comp_StatOptions_Params_key:
+    case State::Comp_StatArray_key:
+    case State::Comp_Stat_Params_key:
+    case State::Comp_SharedParamsArray_key:
+    case State::Comp_Partition_key:
+    case State::PortMod_Params_key:
+    case State::PortMod_StatOptions_key:
+    case State::PortMod_StatOptions_Params_key:
+    case State::PortMod_StatArray_key:
+    case State::PortMod_Stat_Params_key:
+    case State::PortMod_SharedParamsArray_key:
+    case State::SubComp_Params_key:
+    case State::SubComp_StatOptions_key:
+    case State::SubComp_StatOptions_Params_key:
+    case State::SubComp_StatArray_key:
+    case State::SubComp_Stat_Params_key:
+    case State::SubComp_SharedParamsArray_key:
+    case State::LinkArray_key:
+    case State::Link_Left_key:
+    case State::Link_Right_key:
+        current_state_ = ParentState[(int)current_state_];
+        break;
+    case State::SubCompArray_key:
+    case State::PortModArray_key:
+        if ( shadow_component_stack_.size() == 1 ) {
+            current_state_ = State::Comp;
+        }
+        else {
+            current_state_ = State::SubComp;
+        }
+        break;
+    default:
+        error_str_ = "Parsed a null in an unexpected parser state " + StateString[(int)current_state_];
+        return false;
+    }
     return true;
 }
 
 bool
 SSTConfigSaxHandler::boolean(bool val)
 {
-    json j_val = val;
-    processValue(j_val);
+    switch ( current_state_ ) {
+    case State::Link:
+        if ( current_key_ == "noCut" || current_key_ == "no_cut" ) {
+            shadow_link_.nocut = val;
+        }
+        else if ( current_key_ == "nonlocal" ) {
+            shadow_link_.nonlocal = val;
+        }
+        else {
+            error_str_ = "Unexpected key/boolean value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in Link '" + shadow_link_.name + "'";
+            return false;
+        }
+        break;
+    case State::Comp_StatOptions:
+    case State::SubComp_StatOptions:
+    case State::PortMod_StatOptions:
+        if ( current_key_ == "enable_all_stats" || current_key_ == "enable_all_statistics" ) {
+            if ( val ) {
+                shadow_statistic_.name = STATALLFLAG;
+            }
+        }
+        else {
+            error_str_ = "Unexpected key/boolean value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in 'statistics' belonging to '" + shadow_component_stack_.front().name +
+                       "' or one of its subcomponents";
+            return false;
+        }
+        break;
+    case State::Comp_Stat:
+    case State::SubComp_Stat:
+    case State::PortMod_Stat:
+        if ( current_key_ == "shared" ) {
+            shadow_statistic_.shared = val;
+        }
+        else {
+            error_str_ = "Unexpected key/boolean value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in 'statistics' object in component tree '" + shadow_component_stack_[0].name;
+            return false;
+        }
+        break;
+    default:
+        error_str_ = "Parsed a boolean '" + std::to_string(val) + "'in an unexpected parser state " +
+                   StateString[(int)current_state_] + ". Last key was: " + current_key_;
+        return false;
+    }
     return true;
 }
 
 bool
 SSTConfigSaxHandler::number_integer(json::number_integer_t val)
 {
-    json j_val = val;
-    processValue(j_val);
+    switch ( current_state_ ) {
+    case State::StatOptions:
+        if ( current_key_ == "statisticLoadLevel" || current_key_ == "statistic_load_level" ) {
+            graph_->setStatisticLoadLevel(val);
+        }
+        else {
+            error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in statistic_options object.";
+            return false;
+        }
+        break;
+    case State::Comp_Partition:
+        if ( current_key_ == "rank" ) {
+            rank_.rank = val;
+        }
+        else if ( current_key_ == "thread" ) {
+            rank_.thread = val;
+        }
+        else {
+            error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in partition object.";
+            return false;
+        }
+        break;
+    case State::SubComp:
+        if ( current_key_ == "slot_number" ) {
+            shadow_component_stack_.back().slot_number = val;
+        }
+        else {
+            error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in 'subcomponents' object in component tree '" + shadow_component_stack_[0].name;
+            return false;
+        }
+        break;
+    case State::Comp_StatOptions:
+    case State::SubComp_StatOptions:
+        if ( current_key_ == "statistic_load_level" ) {
+            shadow_component_stack_.back().comp->setStatisticLoadLevel(val);
+        }
+        else {
+            error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in 'statistic_options' object in component tree '" + shadow_component_stack_[0].name;
+            return false;
+        }
+        break;
+    case State::PortMod_StatOptions:
+        if ( current_key_ == "statistic_load_level" ) {
+            shadow_port_module_.stat_load_level = val;
+        }
+        else {
+            error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in 'subcomponents' object in component tree '" + shadow_component_stack_[0].name;
+            return false;
+        }
+        break;
+    case State::Link_Right:
+        if ( current_key_ == "rank" ) {
+            shadow_link_.rank = val;
+        }
+        else if ( current_key_ == "thread" ) {
+            shadow_link_.thread = val;
+        }
+        else {
+            error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in right side of link '" + shadow_link_.name + "'.";
+            return false;
+        }
+        break;
+    default:
+        error_str_ = "Parsed an integer '" + std::to_string(val) + "' in an unexpected parser state " +
+                   StateString[(int)current_state_] + ". Last key was: " + current_key_;
+        return false;
+    }
     return true;
 }
 
 bool
 SSTConfigSaxHandler::number_unsigned(json::number_unsigned_t val)
 {
-    json j_val = val;
-    processValue(j_val);
+    switch ( current_state_ ) {
+    case State::StatOptions:
+        if ( current_key_ == "statisticLoadLevel" || current_key_ == "statistic_load_level" ) {
+            graph_->setStatisticLoadLevel(val);
+        }
+        else {
+            error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in statistic_options object.";
+            return false;
+        }
+        break;
+    case State::Comp_Partition:
+        if ( current_key_ == "rank" ) {
+            rank_.rank = val;
+        }
+        else if ( current_key_ == "thread" ) {
+            rank_.thread = val;
+        }
+        else {
+            error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in partition object.";
+            return false;
+        }
+        break;
+    case State::SubComp:
+        if ( current_key_ == "slot_number" ) {
+            shadow_component_stack_.back().slot_number = val;
+        }
+        else {
+            error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in 'subcomponents' object in component tree '" + shadow_component_stack_[0].name;
+            return false;
+        }
+        break;
+    case State::Comp_StatOptions:
+    case State::SubComp_StatOptions:
+        if ( current_key_ == "statistic_load_level" ) {
+            shadow_component_stack_.back().comp->setStatisticLoadLevel(val);
+        }
+        else {
+            error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in 'statistic_options' object in component tree '" + shadow_component_stack_[0].name;
+            return false;
+        }
+        break;
+    case State::PortMod_StatOptions:
+        if ( current_key_ == "statistic_load_level" ) {
+            shadow_port_module_.stat_load_level = val;
+        }
+        else {
+            error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in 'subcomponents' object in component tree '" + shadow_component_stack_[0].name;
+            return false;
+        }
+        break;
+    case State::Link_Right:
+        if ( current_key_ == "rank" ) {
+            shadow_link_.rank = val;
+        }
+        else if ( current_key_ == "thread" ) {
+            shadow_link_.thread = val;
+        }
+        else {
+            error_str_ = "Unexpected key/integer value pair: '" + current_key_ + "'/'" + std::to_string(val) +
+                       "' in right side of link '" + shadow_link_.name + "'.";
+            return false;
+        }
+        break;
+    default:
+        error_str_ = "Parsed an integer '" + std::to_string(val) + "' in an unexpected parser state " +
+                   StateString[(int)current_state_] + ". Last key was: " + current_key_;
+        return false;
+    }
     return true;
 }
 
 bool
-SSTConfigSaxHandler::number_float(json::number_float_t val, [[maybe_unused]] const std::string& str)
+SSTConfigSaxHandler::number_float([[maybe_unused]] json::number_float_t val, [[maybe_unused]] const std::string& str)
 {
-    json j_val = val;
-    processValue(j_val);
-    return true;
+    error_str_ = "Parsed a float '" + str + "'in an unexpected parser state " + StateString[(int)current_state_];
+    return false;
 }
 
 bool
 SSTConfigSaxHandler::binary([[maybe_unused]] json::binary_t& val)
 {
-    return true;
+    error_str_ = "Parsed a binary value in an unexpected parser state " + StateString[(int)current_state_];
+    return false;
 }
 
 bool
 SSTConfigSaxHandler::string(std::string& val)
 {
-    json j_val = val;
-    processValue(j_val);
-
-    // handle specific string assignment based upon context
-    if ( current_state == COMPONENTS ) {
-        if ( current_key == "name" && !in_comp_stats ) {
-            current_comp_name = val;
+    switch ( current_state_ ) {
+    case State::ProgramOptions:
+        if ( val == "false" ) {
+            program_options_[current_key_] = "0";
         }
-        else if ( current_key == "type" && !in_comp_stats && !in_comp_subcomp ) {
-            current_comp_id   = graph->addComponent(current_comp_name, val);
-            current_component = graph->findComponent(current_comp_id);
+        else if ( val == "true" ) {
+            program_options_[current_key_] = "1";
         }
-        else if ( in_comp_params && !in_comp_subcomp ) {
-            current_component->addParameter(current_key, val, false);
+        else {
+            program_options_[current_key_] = val;
         }
-        else if ( current_key == "name" && in_comp_stats ) {
-            current_comp_stat_name = val;
+        break;
+    case State::StatOptions:
+        if ( current_key_ == "statisticOutput" || current_key_ == "statistic_output" ) {
+            graph_->setStatisticOutput(val);
         }
-        else if ( in_comp_stats && in_comp_stats_params ) {
-            current_stat_params.insert(current_key, val);
+        else {
+            error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
+                       "' in 'statistics_options' object. Expected key 'statistic_output'.";
+            return false;
         }
-        else if ( current_key == "slot_name" ) {
-            current_subcomp_name = val;
-        }
-        else if ( current_key == "type" && in_comp_subcomp ) {
-            current_subcomp_type = val;
-            current_sub_component =
-                Parents.top()->addSubComponent(current_subcomp_name, current_subcomp_type, subcomp_slot);
-        }
-        else if ( in_comp_subcomp_params ) {
-            current_sub_component->addParameter(current_key, val, false);
-        }
-    }
-    else if ( current_state == LINKS ) {
-        if ( current_key == "name" ) {
-            link_name = val;
-        }
-        else if ( in_left_link ) {
-            if ( current_key == "component" ) {
-                left_comp = val;
-            }
-            else if ( current_key == "port" ) {
-                left_port = val;
-            }
-            else if ( current_key == "latency" ) {
-                left_latency = val;
+        break;
+    case State::StatOptions_Params:
+        graph_->addStatisticOutputParameter(current_key_, val);
+        break;
+    case State::Comp:
+        if ( current_key_ == "name" ) {
+            shadow_component_stack_.back().name = val;
+            if ( shadow_component_stack_.back().comp == nullptr && shadow_component_stack_.back().type != "" ) {
+                constructComponent();
+                if ( shadow_component_stack_.back().comp == nullptr ) return false;
             }
         }
-        else if ( in_right_link ) {
-            if ( current_key == "component" ) {
-                right_comp = val;
-            }
-            else if ( current_key == "port" ) {
-                right_port = val;
-            }
-            else if ( current_key == "latency" ) {
-                right_latency = val;
+        else if ( current_key_ == "type" ) {
+            shadow_component_stack_.back().type = val;
+            if ( shadow_component_stack_.back().comp == nullptr && shadow_component_stack_.back().name != "" ) {
+                constructComponent();
+                if ( shadow_component_stack_.back().comp == nullptr ) return false;
             }
         }
-    }
-    else if ( current_state == STATISTICS_GROUP ) {
-        if ( in_grp_stats_output ) {
-            if ( current_key == "type" ) {
-                auto& statOuts = graph->getStatOutputs();
-                statOuts.emplace_back(ConfigStatOutput(val));
-                current_stat_group->setOutput(statOuts.size() - 1);
-            }
-            else if ( in_grp_stats_output_params ) {
-                auto& statOuts = graph->getStatOutputs();
-                statOuts.back().addParameter(current_key, val);
-            }
+        else {
+            error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
+                       "' in 'component' object with name (if already parsed): '" +
+                       shadow_component_stack_.back().name + "'. Expected key 'name' or 'type'.";
+            return false;
         }
-        else if ( in_grp_stats_def ) {
-            if ( current_key == "name" ) {
-                current_grp_stat_name = val;
-            }
-            else if ( in_grp_stats_def_params ) {
-                current_stat_params.insert(current_key, val);
-            }
+        break;
+    case State::SubComp:
+        if ( current_key_ == "slot_name" ) {
+            shadow_component_stack_.back().name = val;
         }
-        else if ( in_grp_stats_comps ) {
-            bool success = false;
-            current_stat_group->addComponent(findComponentIdByName(val, success));
+        else if ( current_key_ == "type" ) {
+            shadow_component_stack_.back().type = val;
+        }
+        else {
+            error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
+                       "' in 'subcomponent' object in component '" + shadow_component_stack_[0].name +
+                       "'. Expected key 'slot_name' or 'type'.";
+            return false;
+        }
+        break;
+    case State::PortMod:
+        if ( current_key_ == "port" ) {
+            shadow_port_module_.port = val;
+        }
+        else if ( current_key_ == "type" ) {
+            shadow_port_module_.type = val;
+        }
+        else {
+            error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
+                       "' in 'port_module' object in component '" + shadow_component_stack_[0].name +
+                       "'. Expected key 'port' or 'type'.";
+            return false;
+        }
+        break;
+    case State::Comp_Params:
+    case State::SubComp_Params:
+        shadow_component_stack_.back().comp->addParameter(current_key_, val, false);
+        break;
+    case State::PortMod_Params:
+        shadow_port_module_.pm->addParameter(current_key_, val);
+        break;
+    case State::Comp_SharedParamsArray:
+    case State::SubComp_SharedParamsArray:
+        shadow_component_stack_.back().comp->addSharedParamSet(val);
+        break;
+    case State::PortMod_SharedParamsArray:
+        shadow_port_module_.shared_param_sets.push_back(val);
+        break;
+    case State::Comp_Stat:
+    case State::SubComp_Stat:
+    case State::PortMod_Stat:
+        if ( current_key_ == "name" ) {
+            shadow_statistic_.name = val;
+        }
+        else if ( current_key_ == "shared_name" ) {
+            shadow_statistic_.shared_name = val;
+        }
+        else {
+            error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
+                       "' in 'statistics' object in component tree '" + shadow_component_stack_[0].name +
+                       "'. Expected key 'name' or 'shared_name'.";
+            return false;
+        }
+        break;
+    case State::StatGroup_Stat:
+        if ( current_key_ == "name" ) {
+            shadow_statistic_.name = val;
+        }
+        else {
+            error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
+                       "' in 'statistics_group' object. Expected key 'name'.";
+        }
+        break;
+    case State::Comp_Stat_Params:
+    case State::SubComp_Stat_Params:
+    case State::PortMod_Stat_Params:
+    case State::StatGroup_Stat_Params:
+    case State::Comp_StatOptions_Params:
+    case State::SubComp_StatOptions_Params:
+    case State::PortMod_StatOptions_Params:
+        shadow_statistic_.params.insert(current_key_, val);
+        break;
+    case State::Link:
+        if ( current_key_ == "name" ) {
+            shadow_link_.name = val;
+        }
+        else {
+            error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
+                       "' in 'link' object. Link name is (may be blank if not parsed yet): '" + shadow_link_.name +
+                       "'. Expected key 'name'.";
+            return false;
+        }
+        break;
+    case State::Link_Left:
+        if ( current_key_ == "component" ) {
+            bool success;
+            shadow_link_.leftcomp = findComponentIdByName(val, success);
             if ( !success ) {
+                error_str_ = "Error: Unable to locate component ID for component '" + val + "' in left side of link '" +
+                           shadow_link_.name +
+                           "'. Ensure components are declared prior to link instantiation in your input file.";
                 return false;
             }
         }
-        else if ( current_key == "name" ) {
-            current_stat_group = graph->getStatGroup(val);
-            if ( current_stat_group == nullptr ) {
-                errorStr = "Error creating statistics group from: " + val;
+        else if ( current_key_ == "port" ) {
+            shadow_link_.leftport = val;
+        }
+        else if ( current_key_ == "latency" ) {
+            shadow_link_.leftlat = val;
+        }
+        else {
+            error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
+                       "' in left side of link named '" + shadow_link_.name +
+                       "'. Expected key 'port', 'latency', or 'component'.";
+            return false;
+        }
+        break;
+    case State::Link_Right:
+        if ( current_key_ == "component" ) {
+            bool success;
+            shadow_link_.rightcomp = findComponentIdByName(val, success);
+            if ( !success ) {
+                error_str_ = "Error: Unable to locate component ID for component '" + val + "' in right side of link '" +
+                           shadow_link_.name +
+                           "'. Ensure components are declared prior to link instantiation in your input file.";
                 return false;
             }
         }
-        else if ( current_key == "frequency" ) {
-            if ( !current_stat_group->setFrequency(val) ) {
-                errorStr = "Error setting frequency for statistics group: " + val;
+        else if ( current_key_ == "port" ) {
+            shadow_link_.rightport = val;
+        }
+        else if ( current_key_ == "latency" ) {
+            shadow_link_.rightlat = val;
+        }
+        else {
+            error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
+                       "' in right side of link named '" + shadow_link_.name +
+                       "'. Expected key 'port', 'latency', 'component'.";
+            return false;
+        }
+        break;
+    case State::StatGroup:
+        if ( current_key_ == "name" ) {
+            current_stat_group_ = graph_->getStatGroup(val);
+            if ( current_stat_group_ == nullptr ) {
+                error_str_ = "Error creating statistics group from name: " + val;
                 return false;
             }
         }
+        else if ( current_key_ == "frequency" ) {
+            current_stat_group_->setFrequency(val);
+        }
+        else {
+            error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
+                       "' in statistics_group. Expected key 'name' or 'frequency'.";
+            return false;
+        }
+        break;
+    case State::StatGroup_Output:
+        if ( current_key_ == "type" ) {
+            auto& stat_outputs = graph_->getStatOutputs();
+            stat_outputs.emplace_back(ConfigStatOutput(val));
+            current_stat_group_->setOutput(stat_outputs.size() - 1);
+        }
+        else {
+            error_str_ = "Error: Unexpected key/string value pair: '" + current_key_ + "'/'" + val +
+                       "' in statistics_group output object. Expected key 'type'.";
+            return false;
+        }
+        break;
+    case State::StatGroup_Output_Params:
+        graph_->getStatOutputs().back().addParameter(current_key_, val);
+        break;
+    case State::StatGroup_CompArray:
+    {
+        bool success = false;
+        current_stat_group_->addComponent(findComponentIdByName(val, success));
+        if ( !success ) {
+            error_str_ = "Error: Unable to locate component ID for component '" + val +
+                       "' in statistics group component list for group " + current_stat_group_->name +
+                       ". Ensure components are declared prior to adding them to a statistic group in your input file.";
+            return false;
+        }
+        break;
     }
-
+    case State::SharedParams_object:
+        graph_->addSharedParam(current_shared_name_, current_key_, val);
+        break;
+    default:
+        error_str_ = "Error: Parser encountered a string token in state '" + StateString[(int)current_state_] +
+                   "'. This case is not handled and may be an error in the JSON file. Key/value pair is '" +
+                   current_key_ + "'/'" + val + "'.";
+        return false;
+    }
     return true;
 }
 
+// Passes number of elements in object (-1 if unknown)
+// Generally each state transitions to next and prepares/clears any data structures that will be used by the object
 bool
-SSTConfigSaxHandler::start_object(std::size_t elements)
+SSTConfigSaxHandler::start_object([[maybe_unused]] std::size_t elements)
 {
-    if ( elements == 0 ) {
-        return true;
+    switch ( current_state_ ) {
+    case State::Entry:                          // Begin parsing -> Root
+    case State::ProgramOptions_key:             // Parse program options -> ProgramOptions
+    case State::SharedParams_key:               // Parse object containing sets of shared params -> SharedParams_object
+    case State::SharedParams_object_key:        // Parse shared params set -> SharedParams_object
+    case State::StatOptions_key:                // Parse statistic options
+    case State::StatOptions_Params_key:         // Parse params -> StatOptions_Params
+    case State::StatGroup_Output_key:           // Parse output config -> StatGroup_Output
+    case State::StatGroup_Output_Params_key:    // Parse params -> StatGroup_Output_Params
+    case State::StatGroup_StatArray:            // Parse statistic -> StatGroup_Stat
+    case State::StatGroup_Stat_Params_key:      // Parse params -> STATGRP_OBJ_STATOPT_PARAMS
+    case State::Comp_StatOptions_Params_key:    // Parse params
+    case State::Comp_Stat_Params_key:           // Parse params
+    case State::PortMod_Params_key:             // Parse params
+    case State::PortMod_Stat_Params_key:        // Parse params
+    case State::PortMod_StatOptions_Params_key: // Parse params
+    case State::SubComp_StatOptions_Params_key: // Parse params
+    case State::SubComp_Stat_Params_key:        // Parse params
+    case State::Link_Left_key:                  // Parse link left
+    case State::Link_Right_key:                 // Parse link right
+        break;
+    case State::StatGroupsArray: // Parse a statistic group -> StatGroup
+        current_stat_group_ = nullptr;
+        break;
+    case State::CompArray:    // Parse a component
+    case State::SubCompArray: // Parse a subcomponent
+        shadow_component_stack_.emplace_back();
+        break;
+    case State::Comp_Partition_key: // Parse partition
+        rank_.rank   = -1;
+        rank_.thread = -1;
+        break;
+    case State::PortModArray: // Parse port module
+        shadow_port_module_.reset();
+        break;
+    case State::Comp_StatArray:    // Parse statstic object
+    case State::SubComp_StatArray: // Parse statstic object
+    case State::PortMod_StatArray:
+    case State::PortMod_StatOptions_key: // Parse statistic options (params)
+        shadow_statistic_.reset();
+        break;
+    // These component/subcomponent sections require that the component/subcomponent be constructed
+    case State::Comp_StatOptions_key:    // Parse statistic options (params)
+    case State::SubComp_StatOptions_key: // Parse statistic options (params)
+        shadow_statistic_.reset();
+        // fall-thru
+    case State::Comp_Params_key:    // Parse params
+    case State::SubComp_Params_key: // Parse params
+        // Assert that component/subcomponent is constructed
+        if ( shadow_component_stack_.back().comp == nullptr ) {
+            error_str_ = "Error: Encountered new (sub)component section before (sub)component was constructed. Ensure "
+                       "that subcomponent required keys (name, type, slot_name,  etc.) are listed first in the object "
+                       "before other keys. Component tree name is (if already parsed) '" +
+                       shadow_component_stack_[0].name + "'.";
+            return false;
+        }
+        break;
+    case State::LinkArray: // Parse a link
+        shadow_link_.reset();
+        break;
+    default:
+        error_str_ = "Error: Parser encountered a '{' token in state '" + StateString[(int)current_state_] +
+                   "'. This case is not handled and may be an error in the JSON file. Last key was '" + current_key_ +
+                   "'.";
+        return false;
     }
-
-    context_stack.push(json::value_t::object);
-
-    if ( !path_stack.empty() ) {
-        std::string current_section = path_stack[path_stack.size() - 1];
-
-        if ( current_section == "program_options" ) {
-            current_state = PROGRAM_OPTIONS;
-        }
-        else if ( current_section == "shared_params" ) {
-            current_state = SHARED_PARAMS;
-            if ( !in_shared_params_object && path_stack.size() == 2 ) {
-                current_shared_name     = path_stack[1];
-                in_shared_params_object = true;
-            }
-        }
-        else if ( current_section == "statistics_options" ) {
-            current_state = STATISTICS_OPTIONS;
-        }
-        else if ( current_state == STATISTICS_GROUP ) {
-            if ( current_section == "output" ) {
-                in_grp_stats_output = true;
-            }
-            else if ( current_section == "params" && in_grp_stats_output ) {
-                in_grp_stats_output_params = true;
-            }
-            else if ( current_section == "params" && in_grp_stats_def ) {
-                in_grp_stats_def_params = true;
-            }
-        }
-        else if ( current_state == COMPONENTS ) {
-            if ( current_section == "params" && !in_comp_stats && !in_comp_subcomp ) {
-                in_comp_params = true;
-            }
-            else if ( current_section == "params" && in_comp_stats ) {
-                in_comp_stats_params = true;
-            }
-            else if ( current_section == "params" && in_comp_subcomp ) {
-                in_comp_subcomp_params = true;
-            }
-        }
-        else if ( current_state == LINKS ) {
-            if ( current_section == "left" ) {
-                in_left_link = true;
-            }
-            else if ( current_section == "right" ) {
-                in_right_link = true;
-            }
-        }
-    }
-
+    current_state_ = NextStateObjOrArray[(int)current_state_];
     return true;
 }
 
 bool
 SSTConfigSaxHandler::end_object()
 {
-    if ( !context_stack.empty() ) {
-        context_stack.pop();
-    }
-
-    // handle each object completion
-    if ( current_state == PROGRAM_OPTIONS ) {
-        current_state = ROOT;
-    }
-    else if ( current_state == STATISTICS_OPTIONS && current_key != "params" ) {
-        current_state = ROOT;
-    }
-    else if ( current_state == SHARED_PARAMS && in_shared_params_object && path_stack.size() == 2 ) {
-        in_shared_params_object = false;
-    }
-    else if ( current_state == STATISTICS_GROUP && in_grp_stats_output && in_grp_stats_output_params ) {
-        in_grp_stats_output_params = false;
-        current_stat_params.clear();
-    }
-    else if ( current_state == STATISTICS_GROUP && in_grp_stats_output ) {
-        in_grp_stats_output = false;
-    }
-    else if ( current_state == STATISTICS_GROUP && in_grp_stats_def && in_grp_stats_def_params ) {
-        in_grp_stats_def_params = false;
-        current_stat_params.clear();
-    }
-    else if ( current_state == STATISTICS_GROUP && in_grp_stats_def ) {
-        current_stat_group->addStatistic(current_grp_stat_name, current_stat_params);
-        current_stat_params.clear();
+    switch ( current_state_ ) {
+    case State::Root:
+    case State::ProgramOptions:
+    case State::SharedParams:
+    case State::SharedParams_object:
+    case State::StatOptions:
+    case State::StatOptions_Params:
+    case State::StatGroup:
+    case State::StatGroup_Output:
+    case State::StatGroup_Output_Params:
+    case State::StatGroup_Stat_Params:
+    case State::Comp_Params:
+    case State::SubComp_Params:
+    case State::PortMod_Params:
+    case State::Comp_Stat_Params:
+    case State::SubComp_Stat_Params:
+    case State::PortMod_Stat_Params:
+    case State::Link_Left:
+    case State::Link_Right:
+        break;
+    case State::Comp_Partition:
+        shadow_component_stack_.back().comp->setRank(rank_);
+        break;
+    case State::StatGroup_Stat:
+    {
+        // Add stat to group
+        current_stat_group_->addStatistic(shadow_statistic_.name, shadow_statistic_.params);
         bool        verified = false;
         std::string reason;
-        std::tie(verified, reason) = current_stat_group->verifyStatsAndComponents(graph);
+        std::tie(verified, reason) = current_stat_group_->verifyStatsAndComponents(graph_);
         if ( !verified ) {
-            errorStr = "Error verifying statistics and components: " + reason;
+            error_str_ = "Error verifying statistics and components: " + reason;
             return false;
         }
+        break;
     }
-    else if ( current_state == COMPONENTS && in_comp_params ) {
-        in_comp_params = false;
-    }
-    else if ( current_state == COMPONENTS && in_comp_stats && in_comp_stats_params ) {
-        current_component->enableStatistic(current_comp_stat_name, current_stat_params);
-        in_comp_stats_params = false;
-        current_stat_params.clear();
-    }
-    else if ( current_state == COMPONENTS && in_comp_stats_params && in_comp_subcomp ) {
-        current_sub_component->enableStatistic(current_comp_stat_name, current_stat_params);
-        in_comp_stats_params = false;
-        current_stat_params.clear();
-    }
-    else if ( current_state == COMPONENTS && in_comp_subcomp && in_comp_subcomp_params ) {
-        in_comp_subcomp_params = false;
-    }
-    else if ( current_state == LINKS ) {
-        if ( in_left_link ) {
-            in_left_link = false;
-        }
-        else if ( in_right_link ) {
-            in_right_link = false;
-        }
-        else {
-            LinkId_t link_id = graph->createLink(link_name.c_str(), nullptr);
-            if ( no_cut ) graph->setLinkNoCut(link_id);
-
-            // left side
-            ComponentId_t CompID  = -1;
-            bool          success = false;
-            CompID                = findComponentIdByName(left_comp, success);
-            if ( !success ) {
-                return false;
-            }
-            graph->addLink(CompID, link_id, left_port.c_str(), left_latency.c_str());
-
-            // right side
-            if ( nonlocal ) {
-                graph->addNonLocalLink(link_id, right_rank, right_thread);
-            }
-            else {
-                success = false;
-                CompID  = findComponentIdByName(right_comp, success);
-                if ( !success ) {
+    case State::Comp:
+        shadow_component_stack_.pop_back();
+        current_shared_stats_.clear();
+        break;
+    case State::Comp_Stat:
+    case State::SubComp_Stat:
+    case State::Comp_StatOptions:
+    case State::SubComp_StatOptions:
+        if ( shadow_statistic_.name != "" ) { // Generally name="" if in StatOptions but didn't enable_all_stats
+            if ( shadow_statistic_.shared ) {
+                auto cs_iter = current_shared_stats_.find(shadow_statistic_.shared_name);
+                if ( cs_iter == current_shared_stats_.end() ) {
+                    // Have not yet created tis shared statistic object
+                    ConfigStatistic* cs = shadow_component_stack_.back().comp->createStatistic();
+                    if ( cs == nullptr ) {
+                        error_str_ = "Error: Failed to create shared statistic '" + shadow_statistic_.shared_name +
+                                   "' on '" + shadow_component_stack_.back().name + "'.";
+                        return false;
+                    }
+                    cs->params.insert(shadow_statistic_.params);
+                    cs->shared = true;
+                    cs->name   = shadow_statistic_.shared_name;
+                    current_shared_stats_.insert(std::make_pair(shadow_statistic_.shared_name, cs));
+                    cs_iter = current_shared_stats_.find(shadow_statistic_.shared_name);
+                }
+                // Shared statistic that maps to existing statistic object
+                if ( !shadow_component_stack_.back().comp->reuseStatistic(
+                         shadow_statistic_.name, cs_iter->second->id) ) {
+                    error_str_ = "Error: Attempting to link statistic '" + shadow_statistic_.name + "' to '" +
+                               shadow_statistic_.shared_name + "' in component '" +
+                               shadow_component_stack_.front().name + "' but unable to complete the linking.";
                     return false;
                 }
-                graph->addLink(CompID, link_id, right_port.c_str(), right_latency.c_str());
             }
-            no_cut       = false;
-            nonlocal     = false;
-            right_rank   = -1;
-            right_thread = -1;
+            else {
+                // Regular (unshared) statistic
+                shadow_component_stack_.back().comp->enableStatistic(shadow_statistic_.name, shadow_statistic_.params);
+            }
         }
+        shadow_statistic_.reset();
+        break;
+    case State::PortMod_Stat:
+    case State::PortMod_StatOptions:
+        // Portmodules don't do shared stats. An empty name is treated as an not-enabled statistic.
+        if ( shadow_statistic_.name == STATALLFLAG ) {
+            shadow_port_module_.pm->enableAllStatistics(shadow_statistic_.params);
+        }
+        else if ( shadow_statistic_.name != "" ) {
+            shadow_port_module_.pm->enableStatistic(shadow_statistic_.name, shadow_statistic_.params);
+        }
+        break;
+    case State::PortMod:
+    {
+        if ( shadow_port_module_.pm == nullptr ) {
+            constructPortModule();
+        }
+        if ( shadow_port_module_.stat_load_level != STATISTICLOADLEVELUNINITIALIZED ) {
+            shadow_port_module_.pm->setStatisticLoadLevel(shadow_port_module_.stat_load_level);
+        }
+        break;
     }
+    case State::SubComp:
+        if ( shadow_component_stack_.back().comp == nullptr ) {
+            constructSubComponent();
+            if ( !shadow_component_stack_.back().comp ) return false;
+        }
+        shadow_component_stack_.pop_back();
+        break;
+    case State::Link:
+    {
+        LinkId_t id = graph_->createLink(shadow_link_.name.c_str(), nullptr);
+        if ( shadow_link_.nocut ) graph_->setLinkNoCut(id);
+        graph_->addLink(shadow_link_.leftcomp, id, shadow_link_.leftport.c_str(), shadow_link_.leftlat.c_str());
 
-    if ( !path_stack.empty() ) {
-        path_stack.pop_back();
+        if ( shadow_link_.nonlocal ) {
+            graph_->addNonLocalLink(id, shadow_link_.rank, shadow_link_.thread);
+        }
+        else {
+            graph_->addLink(shadow_link_.rightcomp, id, shadow_link_.rightport.c_str(), shadow_link_.rightlat.c_str());
+        }
+        shadow_link_.reset();
+        break;
     }
-
+    default:
+        error_str_ = "Error: Parser encountered a '}' token in state '" + StateString[(int)current_state_] +
+                   "'. This case is not handled and may be an error in the JSON file. Last key was '" + current_key_ +
+                   "'.";
+        return false;
+    }
+    current_state_ = ParentState[(int)current_state_];
     return true;
 }
 
 bool
 SSTConfigSaxHandler::start_array([[maybe_unused]] std::size_t elements)
 {
-    context_stack.push(json::value_t::array);
-    array_depth++;
-
-    if ( current_state == ROOT ) {
-        // top-level array elements
-        if ( current_key == "components" ) {
-            current_state   = COMPONENTS;
-            foundComponents = true;
+    switch ( current_state_ ) {
+    case State::CompArray_key:
+        found_components_ = true;
+        break;
+    case State::SubCompArray_key:
+        if ( shadow_component_stack_.back().comp == nullptr ) {
+            error_str_ = "Error: Encountered (sub)component's subcomponents array before the 'type' and 'name' keys in "
+                       "component '" +
+                       shadow_component_stack_.back().name + "'";
+            return false;
         }
-        else if ( current_key == "shared_params" ) {
-            current_state = SHARED_PARAMS;
+        break;
+    case State::LinkArray_key:
+        if ( !found_components_ ) {
+            error_str_ = "Error: Encountered 'links' section before 'components' section. Put the 'links' section after "
+                       "'components' in your input file";
+            return false;
         }
-        else if ( current_key == "statistics_group" ) {
-            current_state = STATISTICS_GROUP;
-            if ( !foundComponents ) {
-                errorStr = "Encountered statistics_group before components; components must be loaded before "
-                           "statistics_groups";
-                return false;
-            }
-        }
-        else if ( current_key == "links" ) {
-            current_state = LINKS;
-        }
+        break;
+    case State::PortModArray_key:
+    case State::Comp_StatArray_key:
+    case State::SubComp_StatArray_key:
+    case State::PortMod_StatArray_key:
+    case State::Comp_SharedParamsArray_key:
+    case State::SubComp_SharedParamsArray_key:
+    case State::PortMod_SharedParamsArray_key:
+    case State::StatGroupsArray_key:
+    case State::StatGroup_StatArray_key:
+    case State::StatGroup_CompArray_key:
+        break;
+    default:
+        error_str_ = "Error: Parser encountered a '[' token in state '" + StateString[(int)current_state_] +
+                   "'. This case is not handled and may be an error in the JSON file. Last key was '" + current_key_ +
+                   "'.";
+        return false;
     }
-    else if ( current_state == STATISTICS_GROUP ) {
-        // array elements within statistics_group
-        if ( current_key == "statistics" ) {
-            in_grp_stats_def = true;
-        }
-        else if ( current_key == "components" ) {
-            in_grp_stats_comps = true;
-        }
-    }
-    else if ( current_state == COMPONENTS ) {
-        // array elements within components
-        if ( current_key == "statistics" ) {
-            in_comp_stats = true;
-        }
-        else if ( current_key == "subcomponents" && in_comp_subcomp ) {
-            in_comp_subsubcomp = true;
-            Parents.push(current_sub_component);
-        }
-        else if ( current_key == "subcomponents" ) {
-            in_comp_subcomp = true;
-            Parents.push(current_component);
-        }
-    }
-
+    current_state_ = NextStateObjOrArray[(int)current_state_];
     return true;
 }
 
 bool
 SSTConfigSaxHandler::end_array()
 {
-    if ( current_state == SHARED_PARAMS ) {
-        current_state = ROOT;
+    switch ( current_state_ ) {
+    case State::CompArray:
+    case State::LinkArray:
+    case State::Comp_StatArray:
+    case State::SubComp_StatArray:
+    case State::PortMod_StatArray:
+    case State::Comp_SharedParamsArray:
+    case State::SubComp_SharedParamsArray:
+    case State::PortMod_SharedParamsArray:
+    case State::StatGroupsArray:
+    case State::StatGroup_StatArray:
+    case State::StatGroup_CompArray:
+    case State::StatGroup_Output_Params:
+    case State::StatGroup_Stat_Params:
+    case State::Comp_Params:
+    case State::SubComp_Params:
+    case State::PortMod_Params:
+    case State::Comp_Stat_Params:
+    case State::SubComp_Stat_Params:
+    case State::PortMod_Stat_Params:
+    case State::Comp_Partition:
+        current_state_ = ParentState[(int)current_state_];
+        break;
+    case State::SubCompArray:
+    case State::PortModArray:
+        if ( shadow_component_stack_.size() == 1 ) {
+            current_state_ = State::Comp;
+        }
+        else {
+            current_state_ = State::SubComp;
+        }
+        break;
+    default:
+        error_str_ = "Error: Parser encountered a ']' token in state '" + StateString[(int)current_state_] +
+                   "'. This case is not handled and may be an error in the JSON file. Last key was '" + current_key_ +
+                   "'.";
+        return false;
     }
-    else if ( current_state == STATISTICS_GROUP && in_grp_stats_comps ) {
-        in_grp_stats_comps = false;
-    }
-    else if ( current_state == STATISTICS_GROUP && in_grp_stats_def ) {
-        in_grp_stats_def = false;
-    }
-    else if ( current_state == STATISTICS_GROUP ) {
-        current_state = ROOT;
-    }
-    else if ( current_state == COMPONENTS && in_comp_stats ) {
-        in_comp_stats = false;
-    }
-    else if ( current_state == COMPONENTS && in_comp_subsubcomp ) {
-        in_comp_subsubcomp = false;
-        Parents.pop();
-    }
-    else if ( current_state == COMPONENTS && in_comp_subcomp ) {
-        in_comp_subcomp = false;
-        Parents.pop();
-    }
-    else if ( current_state == COMPONENTS ) {
-        current_state = ROOT;
-    }
-    else if ( current_state == LINKS ) {
-        current_state = ROOT;
-    }
-
-    if ( !context_stack.empty() ) {
-        context_stack.pop();
-    }
-    array_depth--;
     return true;
 }
 
 bool
 SSTConfigSaxHandler::key(std::string& val)
 {
-    current_key = val;
-    path_stack.push_back(val);
+    switch ( current_state_ ) {
+    case State::ProgramOptions:
+    case State::SharedParams_object:
+    case State::StatOptions_Params:
+    case State::Link_Left:
+    case State::Link_Right:
+    case State::StatGroup_Output_Params:
+    case State::StatGroup_Stat_Params:
+    case State::Comp_Params:
+    case State::Comp_StatOptions_Params:
+    case State::Comp_Stat_Params:
+    case State::Comp_Partition:
+    case State::SubComp_Params:
+    case State::SubComp_StatOptions_Params:
+    case State::SubComp_Stat_Params:
+    case State::PortMod_Params:
+    case State::PortMod_StatOptions_Params:
+    case State::PortMod_Stat_Params:
+        break;
+    case State::Root:
+        if ( val == "program_options" ) {
+            current_state_ = State::ProgramOptions_key;
+        }
+        else if ( val == "shared_params" ) {
+            current_state_ = State::SharedParams_key;
+        }
+        else if ( val == "statistics_options" ) {
+            current_state_ = State::StatOptions_key;
+        }
+        else if ( val == "statistics_group" ) {
+            current_state_ = State::StatGroupsArray_key;
+        }
+        else if ( val == "components" ) {
+            current_state_ = State::CompArray_key;
+        }
+        else if ( val == "links" ) {
+            current_state_ = State::LinkArray_key;
+        }
+        else { // Error: Unexpected key
+            error_str_ = "Error: Encountered unexpected key '" + val +
+                       "' in state Root. Expected keys are 'program_options', 'shared_params', 'statistics_options', "
+                       "'statistics_group', 'components', or 'links'.\n";
+            return false;
+        }
+        break;
+    case State::SharedParams:
+        current_shared_name_ = val;
+        current_state_       = State::SharedParams_object_key;
+        break;
+    case State::StatOptions:
+    case State::Comp_StatOptions:
+    case State::SubComp_StatOptions:
+    case State::PortMod_StatOptions:
+    case State::Comp_Stat:
+    case State::SubComp_Stat:
+    case State::PortMod_Stat:
+    case State::StatGroup_Output:
+    case State::StatGroup_Stat:
+        if ( val == "params" ) {
+            current_state_ = NextStateParams[(int)current_state_];
+        }
+        break;
+    case State::StatGroup:
+        if ( !current_stat_group_ && val != "name" ) {
+            error_str_ = "Error: First key/value pair in a statistics_group object must be the group name. Expected key "
+                       "'name' and got '" +
+                       val + "'";
+            return false;
+        }
+        if ( val == "output" ) {
+            current_state_ = State::StatGroup_Output_key;
+        }
+        else if ( val == "statistics" ) {
+            current_state_ = State::StatGroup_StatArray_key;
+        }
+        else if ( val == "components" ) {
+            current_state_ = State::StatGroup_CompArray_key;
+        }
+        break;
+    case State::Comp:
+    {
+        bool assert_existance = true;
+        if ( val == "params" ) {
+            current_state_ = State::Comp_Params_key;
+        }
+        else if ( val == "statistics_options" ) {
+            current_state_ = State::Comp_StatOptions_key;
+        }
+        else if ( val == "statistics" ) {
+            current_state_ = State::Comp_StatArray_key;
+        }
+        else if ( val == "subcomponents" ) {
+            current_state_ = State::SubCompArray_key;
+        }
+        else if ( val == "params_shared_sets" ) {
+            current_state_ = State::Comp_SharedParamsArray_key;
+        }
+        else if ( val == "partition" ) {
+            current_state_ = State::Comp_Partition_key;
+        }
+        else if ( val == "port_modules" ) {
+            current_state_ = State::PortModArray_key;
+        }
+        else {
+            assert_existance = false;
+        }
+        if ( assert_existance ) { // To enter next state, component MUST already exist. Component is built as soon as
+                                  // type & name are encountered
+            if ( shadow_component_stack_.back().comp == nullptr ) {
+                error_str_ = "Error: Encountered key '" + val + "' before the 'type' and 'name' keys in component '" +
+                           shadow_component_stack_.back().name + "'.";
+                return false;
+            }
+        }
+        break;
+    }
+    case State::PortMod:
+    {
+        bool assert_existance = true;
+        if ( val == "params" ) {
+            current_state_ = State::PortMod_Params_key;
+        }
+        else if ( val == "statistics_options" ) {
+            current_state_ = State::PortMod_StatOptions_key;
+        }
+        else if ( val == "statistics" ) {
+            current_state_ = State::PortMod_StatArray_key;
+        }
+        else if ( val == "params_shared_sets" ) {
+            current_state_ = State::PortMod_SharedParamsArray_key;
+        }
+        else {
+            assert_existance = false;
+        }
+        if ( assert_existance ) {
+            if ( shadow_port_module_.pm == nullptr ) {
+                constructPortModule();
+            }
+        }
+        break;
+    }
+    case State::SubComp:
+    {
+        bool assert_existance = true;
+        if ( val == "params" ) {
+            current_state_ = State::SubComp_Params_key;
+        }
+        else if ( val == "statistics_options" ) {
+            current_state_ = State::SubComp_StatOptions_key;
+        }
+        else if ( val == "statistics" ) {
+            current_state_ = State::SubComp_StatArray_key;
+        }
+        else if ( val == "subcomponents" ) {
+            current_state_ = State::SubCompArray_key;
+        }
+        else if ( val == "params_shared_sets" ) {
+            current_state_ = State::SubComp_SharedParamsArray_key;
+        }
+        else if ( val == "port_modules" ) {
+            current_state_ = State::PortModArray_key;
+        }
+        else {
+            assert_existance = false;
+        }
+        if ( assert_existance ) { // To enter next state, component MUST already exist. Component is built as soon as
+                                  // type & name are encountered
+            if ( shadow_component_stack_.back().comp == nullptr ) {
+                constructSubComponent();
+                if ( shadow_component_stack_.back().comp == nullptr ) {
+                    return false; // error_str_ provided by constructSubComponent function
+                }
+            }
+        }
+        break;
+    }
+    case State::Link:
+        if ( val == "left" ) {
+            current_state_ = State::Link_Left_key;
+        }
+        else if ( val == "right" ) {
+            current_state_ = State::Link_Right_key;
+        }
+        break;
+    default:
+        error_str_ = "Error: Parser encountered a key token in state '" + StateString[(int)current_state_] +
+                   "'. This case is not handled and may be an error in the JSON file. Key is '" + val +
+                   "' and last valid key was '" + current_key_ + "'.";
+        return false;
+    }
+    current_key_ = val;
     return true;
 }
 
+// Internal function used to construct a subcomponent
+// All calls to this function are guarded or occur in a state that ensures that:
+//  (a) shadow_component_stack_.back().comp == nullptr
+//  (b) shadow_component_stack_.size() > 1
 void
-SSTConfigSaxHandler::setConfigGraph(ConfigGraph* g)
+SSTConfigSaxHandler::constructSubComponent()
 {
-    graph = g;
+    if ( shadow_component_stack_.back().name == "" || shadow_component_stack_.back().type == "" ) {
+        error_str_ = "Error: Unable to construct subcomponent in component '" + shadow_component_stack_[0].name +
+                   "'. Missing name or type ('" + shadow_component_stack_.back().name + "', '" +
+                   shadow_component_stack_.back().type +
+                   "'). The usual cause of this error is failing to place name and type at the beginning of a "
+                   "component object.\n";
+        return;
+    }
+    shadow_component_stack_.back().comp =
+        shadow_component_stack_[shadow_component_stack_.size() - 2].comp->addSubComponent(
+            shadow_component_stack_.back().name, shadow_component_stack_.back().type,
+            shadow_component_stack_.back().slot_number);
+}
+
+void
+SSTConfigSaxHandler::constructPortModule()
+{
+    if ( shadow_port_module_.port == "" || shadow_port_module_.type == "" ) {
+        error_str_ = "Error: Unable to construct port_module in component tree '" + shadow_component_stack_[0].name +
+                   "'. Missing port or type ('" + shadow_port_module_.port + "', '" + shadow_port_module_.type +
+                   "'). The usual cause of this error is failing to place port and type at the beginning of a "
+                   "port_module object.\n";
+        return;
+    }
+    size_t pm_id = (shadow_component_stack_.back().comp)
+                       ->addPortModule(shadow_port_module_.port, shadow_port_module_.type, shadow_port_module_.params);
+    shadow_port_module_.pm =
+        &((shadow_component_stack_.back().comp)->port_modules.find(shadow_port_module_.port)->second[pm_id]);
+}
+
+// Internal function used to construct a component
+// All calls to this function are guarded or occur in a state that ensures that:
+// (a) shadow_component_stack_.back().comp == nullptr
+// (b) shadow_component_stack_.size() == 1
+void
+SSTConfigSaxHandler::constructComponent()
+{
+    if ( shadow_component_stack_.back().name == "" || shadow_component_stack_.back().type == "" ) {
+        error_str_ = "Error: Unable to construct component. Missing name or type ('" +
+                   shadow_component_stack_.back().name + "', '" + shadow_component_stack_.back().type +
+                   "'). The usual cause of this error is failing to place name and type at the beginning of a "
+                   "component object.\n";
+        return;
+    }
+    ComponentId_t id = graph_->addComponent(shadow_component_stack_.back().name, shadow_component_stack_.back().type);
+    shadow_component_stack_.back().comp = graph_->findComponent(id);
+}
+
+void
+SSTConfigSaxHandler::setConfigGraph(ConfigGraph* graph)
+{
+    graph_ = graph;
 }
 
 bool
 SSTConfigSaxHandler::parse_error(std::size_t position, const std::string& last_token, const json::exception& ex)
 {
-    errorPos = position;
-    errorStr = last_token + " : " + ex.what();
+    error_pos_ = position;
+    error_str_ = last_token + " : " + ex.what();
     return false;
 }
 
 SSTJSONModelDefinition::SSTJSONModelDefinition(
-    const std::string& script_file, int verbosity, Config* configObj, double start_time) :
-    SSTModelDescription(configObj),
-    scriptName(script_file),
-    output(nullptr),
-    config(configObj),
-    graph(nullptr),
-    nextComponentId(0),
-    start_time(start_time)
+    const std::string& script_file, int verbosity, Config* config_obj, double start_time) :
+    SSTModelDescription(config_obj),
+    script_name_(script_file),
+    output_(nullptr),
+    config_(config_obj),
+    graph_(nullptr),
+    start_time_(start_time)
 {
-    output = new Output("SSTJSONModel: ", verbosity, 0, SST::Output::STDOUT);
+    output_ = new Output("SSTJSONModel: ", verbosity, 0, SST::Output::STDOUT);
 
-    graph = new ConfigGraph();
-    if ( !graph ) {
-        output->fatal(CALL_INFO, 1, "Could not create graph object in JSON loader.\n");
+    graph_ = new ConfigGraph();
+    if ( !graph_ ) {
+        output_->fatal(CALL_INFO, 1, "Could not create graph object in JSON loader.\n");
     }
 
-    output->verbose(CALL_INFO, 2, 0, "SST loading a JSON model from script: %s\n", script_file.c_str());
+    output_->verbose(CALL_INFO, 2, 0, "SST loading a JSON model from script: %s\n", script_file.c_str());
 }
 
 SSTJSONModelDefinition::~SSTJSONModelDefinition()
 {
-    delete output;
+    delete output_;
 }
 
 ConfigGraph*
 SSTJSONModelDefinition::createConfigGraph()
 {
     // open the file
-    std::ifstream ifs(scriptName.c_str());
+    std::ifstream ifs(script_name_.c_str());
     if ( !ifs.is_open() ) {
-        output->fatal(CALL_INFO, 1, "Error opening JSON model from script: %s\n", scriptName.c_str());
+        output_->fatal(CALL_INFO, 1, "Error opening JSON model from script: %s\n", script_name_.c_str());
         return nullptr;
     }
 
     // create the SAX handler
     SSTConfigSaxHandler handler;
-    handler.setConfigGraph(graph);
+    handler.setConfigGraph(graph_);
     bool result = json::sax_parse(ifs, &handler);
     if ( !result ) {
-        output->fatal(CALL_INFO, 1, "Error parsing json file at position %lu: (%s)\n", handler.errorPos,
-            handler.errorStr.c_str());
+        output_->fatal(CALL_INFO, 1, "Error parsing json file at position %lu: (%s)\n", handler.error_pos_,
+            handler.error_str_.c_str());
         return nullptr;
     }
 
     // set the program options
-    auto ProgramOptions = handler.getProgramOptions();
-    for ( const auto& [key, value] : ProgramOptions ) {
+    auto options = handler.getProgramOptions();
+    for ( const auto& [key, value] : options ) {
         setOptionFromModel(key, value);
     }
 
     // close the file
     ifs.close();
-
-    return graph;
+    return graph_;
 }

--- a/src/sst/core/model/json/jsonmodel.h
+++ b/src/sst/core/model/json/jsonmodel.h
@@ -14,12 +14,12 @@
 #ifndef SST_CORE_MODEL_JSON_JSONMODEL_H
 #define SST_CORE_MODEL_JSON_JSONMODEL_H
 
-#include "sst/core/component.h"
 #include "sst/core/config.h"
 #include "sst/core/cputimer.h"
 #include "sst/core/factory.h"
 #include "sst/core/memuse.h"
 #include "sst/core/model/configGraph.h"
+#include "sst/core/model/json/jsonstates.h"
 #include "sst/core/model/sstmodel.h"
 #include "sst/core/output.h"
 #include "sst/core/rankInfo.h"
@@ -37,6 +37,8 @@
 #include <vector>
 
 using namespace SST;
+using namespace SST::Core;
+using namespace SST::Core::JSONParser;
 using json = nlohmann::json;
 
 namespace SST::Core {
@@ -63,78 +65,112 @@ public:
     const std::map<std::string, std::string> getProgramOptions();
 
     // error state
-    std::size_t errorPos;
-    std::string errorStr;
+    std::size_t error_pos_;
+    std::string error_str_;
 
 private:
-    // Current parsing state for major sections
-    enum ParseState {
-        ROOT,
-        PROGRAM_OPTIONS,
-        SHARED_PARAMS,
-        STATISTICS_OPTIONS,
-        STATISTICS_GROUP,
-        COMPONENTS,
-        LINKS
-    } current_state = ROOT;
+    // Helpers for constructing objects
+    void constructComponent();
+    void constructSubComponent();
+    void constructPortModule();
 
-    ConfigGraph* graph;
+    // Holds information needed to construct a component or subcomponent
+    struct JSONShadowComponent
+    {
+        std::string           name        = ""; // Component or slot name
+        std::string           type        = ""; // Type
+        unsigned              slot_number = 0;  // Slot number for subcomponents
+        SST::ConfigComponent* comp        = nullptr;
+    };
 
-    std::vector<std::string>           path_stack;
-    std::stack<json::value_t>          context_stack;
-    std::stack<ConfigComponent*>       Parents;
-    std::map<std::string, std::string> ProgramOptions;
+    struct JSONShadowStatistic
+    {
+        std::string name = "";
+        Params      params;
+        bool        shared      = false;
+        std::string shared_name = "";
 
-    std::string current_key;
-    std::string current_shared_name;
-    std::string current_comp_name;
-    std::string current_comp_stat_name;
-    std::string current_subcomp_name;
-    std::string current_subcomp_type;
-    std::string current_grp_stat_name;
-    std::string link_name;
-    std::string left_comp;
-    std::string left_port;
-    std::string left_latency;
-    std::string right_comp;
-    std::string right_port;
-    std::string right_latency;
-    bool        no_cut   = false;
-    bool        nonlocal = false;
-    uint32_t    current_comp_rank;
-    int         subcomp_slot = -1;
-    int         right_rank   = -1;
-    int         right_thread = -1;
+        void reset()
+        {
+            name = "";
+            params.clear();
+            shared      = false;
+            shared_name = "";
+        }
+    };
 
-    // FSM values
-    bool foundComponents            = false;
-    bool in_shared_params_object    = false;
-    bool in_comp_params             = false;
-    bool in_comp_stats              = false;
-    bool in_comp_stats_params       = false;
-    bool in_comp_subcomp            = false;
-    bool in_comp_subsubcomp         = false;
-    bool in_comp_subcomp_params     = false;
-    bool in_grp_stats_output        = false;
-    bool in_grp_stats_output_params = false;
-    bool in_grp_stats_def           = false;
-    bool in_grp_stats_def_params    = false;
-    bool in_grp_stats_comps         = false;
-    bool in_left_link               = false;
-    bool in_right_link              = false;
+    struct JSONShadowLink
+    {
+        std::string        name      = "";
+        bool               nocut     = false;
+        bool               nonlocal  = false;
+        // Left side
+        SST::ComponentId_t leftcomp  = -1;
+        std::string        leftport  = "";
+        std::string        leftlat   = "";
+        // Right side if not nonlocal
+        SST::ComponentId_t rightcomp = -1;
+        std::string        rightport = "";
+        std::string        rightlat  = "";
+        // Right side if nonlocal
+        int                rank      = -1;
+        int                thread    = -1;
 
-    int array_depth = 0;
+        void reset()
+        {
+            name      = "";
+            nocut     = false;
+            nonlocal  = false;
+            leftcomp  = -1;
+            leftport  = "";
+            leftlat   = "";
+            rightcomp = -1;
+            rightport = "";
+            rightlat  = "";
+            rank      = -1;
+            thread    = -1;
+        }
+    };
 
-    ComponentId_t    current_comp_id;
-    ConfigStatGroup* current_stat_group;
-    ConfigComponent* current_component;
-    ConfigComponent* current_sub_component;
-    Params           current_stat_params;
+    struct JSONShadowPortModule
+    {
+        std::string              port = "";
+        std::string              type = "";
+        Params                   params;
+        uint8_t                  stat_load_level = STATISTICLOADLEVELUNINITIALIZED;
+        std::vector<std::string> shared_param_sets;
+        ConfigPortModule*        pm = nullptr;
 
-    // internal parsing methods
-    std::string   getCurrentPath() const;
-    void          processValue(const json& value);
-    ComponentId_t findComponentIdByName(const std::string& Name, bool& success);
+        void reset()
+        {
+            port = "";
+            type = "";
+            params.clear();
+            stat_load_level = STATISTICLOADLEVELUNINITIALIZED;
+            shared_param_sets.clear();
+            pm = nullptr;
+        }
+    };
+
+    ConfigGraph* graph_;
+
+    State                                   current_state_ = State::Entry;
+    std::vector<JSONShadowComponent>        shadow_component_stack_;
+    JSONShadowStatistic                     shadow_statistic_;
+    JSONShadowLink                          shadow_link_;
+    JSONShadowPortModule                    shadow_port_module_;
+    ConfigStatGroup*                        current_stat_group_;
+    std::map<std::string, ConfigStatistic*> current_shared_stats_;
+
+    std::map<std::string, std::string> program_options_;
+
+    std::string current_key_;
+    std::string current_shared_name_;
+    RankInfo    rank_;
+
+    bool found_components_ = false; // components must be declared before links
+
+    ComponentId_t findComponentIdByName(const std::string& name, bool& success);
 };
 
 class SSTJSONModelDefinition : public SSTModelDescription
@@ -156,12 +192,11 @@ public:
     ConfigGraph* createConfigGraph() override;
 
 protected:
-    std::string   scriptName;
-    Output*       output;
-    Config*       config;
-    ConfigGraph*  graph;
-    ComponentId_t nextComponentId;
-    double        start_time;
+    std::string  script_name_;
+    Output*      output_;
+    Config*      config_;
+    ConfigGraph* graph_;
+    double       start_time_;
 };
 
 } // namespace SST::Core

--- a/src/sst/core/model/json/jsonstates.h
+++ b/src/sst/core/model/json/jsonstates.h
@@ -16,246 +16,247 @@
 
 namespace SST::Core::JSONParser {
 
-    // X-macros to generate state transition tables
-    // Hierarchical states are expanded to form a single state name by appending the nested state names with an underscore
-    // State tuple is: state, parent state, next state on object/array open or Invalid, next state on 'params' key
-    // Note that 'Invalid' just means that either (a) there is no transition or (b) the transition table can't be used to determine the transition
-    // '*_key' states indicate that the keyword for the next state has been seen and an object or array will be opened next
+// X-macros to generate state transition tables
+// Hierarchical states are expanded to form a single state name by appending the nested state names with an underscore
+// State tuple is: state, parent state, next state on object/array open or Invalid, next state on 'params' key
+// Note that 'Invalid' just means that either (a) there is no transition or (b) the transition table can't be used to
+// determine the transition
+// '*_key' states indicate that the keyword for the next state has been seen and an object or array will be opened next
 
-    #define X_STATES \
-        /* Entry (start state) */\
-        X(Entry, Invalid, Root, Invalid)\
-        /* In root object */\
-        X(Root, Entry, Invalid, Invalid)\
-    /* ------------------------- */\
-    /* Major Section: 'program_options' */\
-    /* ------------------------- */\
-        /* Section keyword seen */\
-        X(ProgramOptions_key, Root, ProgramOptions, Invalid)\
-        /* In section object */\
-        X(ProgramOptions, Root, Invalid, Invalid)\
-    /* ------------------------- */\
-    /* Major Section: 'shared_params' - object containing name/object pairs */\
-    /* ------------------------- */\
-        /* Section keyword seen */\
-        X(SharedParams_key, Root, SharedParams, Invalid)\
-        /* In section's root object */\
-        X(SharedParams, Root, SharedParams_object_key, Invalid)\
-        /* Got name of next shared_param object */\
-        X(SharedParams_object_key, SharedParams, SharedParams_object, Invalid)\
-        /* In a shared_param object */\
-        X(SharedParams_object, SharedParams, Invalid, Invalid)\
-    /* ------------------------- */\
-    /* Major section: 'statistics_options' */\
-    /* ------------------------- */\
-        /* Section keyword seen */\
-        X(StatOptions_key, Root, StatOptions, Invalid)\
-        /* In 'statistics_options' object*/\
-        X(StatOptions, Root, Invalid, StatOptions_Params_key)\
-        /* 'params' keyword seen */\
-        X(StatOptions_Params_key, StatOptions, StatOptions_Params, Invalid)\
-        /* In params object*/\
-        X(StatOptions_Params, StatOptions, Invalid, Invalid)\
-    /* ------------------------- */\
-    /* Major section: 'statistics_group' */\
-    /* ------------------------- */\
-        /* 'statistics_group' keyword seen */\
-        X(StatGroupsArray_key, Root, StatGroupsArray, Invalid)\
-        /* In 'statistics_group' array */\
-        X(StatGroupsArray, Root, StatGroup, Invalid)\
-        /* In a statistics group object */\
-        X(StatGroup, StatGroupsArray, Invalid, Invalid)\
-        /* 'output' keyword seen */\
-        X(StatGroup_Output_key, StatGroup, StatGroup_Output, Invalid)\
-        /* In output object */\
-        X(StatGroup_Output, StatGroup, Invalid, StatGroup_Output_Params_key)\
-        /* 'params' keyword seen */\
-        X(StatGroup_Output_Params_key, StatGroup_Output, StatGroup_Output_Params, Invalid)\
-        /* In params object */\
-        X(StatGroup_Output_Params, StatGroup_Output, Invalid, Invalid)\
-        /* 'statistics' keyword seen */\
-        X(StatGroup_StatArray_key, StatGroup, StatGroup_StatArray, Invalid)\
-        /* In statistics array */\
-        X(StatGroup_StatArray, StatGroup, StatGroup_Stat, Invalid)\
-        /* In a statistic object */\
-        X(StatGroup_Stat, StatGroup_StatArray, Invalid, StatGroup_Stat_Params_key)\
-        /* 'params' keyword seen */\
-        X(StatGroup_Stat_Params_key, StatGroup_Stat, StatGroup_Stat_Params, Invalid)\
-        /* In params object */\
-        X(StatGroup_Stat_Params, StatGroup_Stat, Invalid, Invalid)\
-        /* 'components' keyword seen */\
-        X(StatGroup_CompArray_key, StatGroup, StatGroup_CompArray, Invalid)\
-        /* In components array */\
-        X(StatGroup_CompArray, StatGroup, Invalid, Invalid)\
-    /* ------------------------- */\
-    /* Major section: 'components'*/\
-    /* ------------------------- */\
-        /* 'components' keyword seen */\
-        X(CompArray_key, Root, CompArray, Invalid)\
-        /* In components array */\
-        X(CompArray, Root, Comp, Invalid)\
-        /* In a component object */\
-        X(Comp, CompArray, Invalid, Comp_Params_key)\
-        /* 'params' keyword seen */\
-        X(Comp_Params_key, Comp, Comp_Params, Invalid)\
-        /* In params object */\
-        X(Comp_Params, Comp, Invalid, Invalid)\
-        /* 'statistics_options' keyword seen */\
-        X(Comp_StatOptions_key, Comp, Comp_StatOptions, Invalid)\
-        /* In 'statistics_options' object*/\
-        X(Comp_StatOptions, Comp, Invalid, Comp_StatOptions_Params_key)\
-        /* 'params' keyword seen */\
-        X(Comp_StatOptions_Params_key, Comp_StatOptions, Comp_StatOptions_Params, Invalid)\
-        /* In params object*/\
-        X(Comp_StatOptions_Params, Comp_StatOptions, Invalid, Invalid)\
-        /* 'statistics' keyword seen */\
-        X(Comp_StatArray_key, Comp, Comp_StatArray, Invalid)\
-        /* 'In statistics arrray */\
-        X(Comp_StatArray, Comp, Comp_Stat, Invalid)\
-        /* In statistic object */\
-        X(Comp_Stat, Comp_StatArray, Invalid, Comp_Stat_Params_key)\
-        /* 'params' keyword seen */\
-        X(Comp_Stat_Params_key, Comp_Stat, Comp_Stat_Params, Invalid)\
-        /* In params object */\
-        X(Comp_Stat_Params, Comp_Stat, Invalid, Invalid)\
-        /* 'shared_params' keyword seen */\
-        X(Comp_SharedParamsArray_key, Comp, Comp_SharedParamsArray, Invalid)\
-        /* In shared_params array */\
-        X(Comp_SharedParamsArray, Comp, Invalid, Invalid)\
-        /* In partition object */\
-        X(Comp_Partition_key, Comp, Comp_Partition, Invalid)\
-        /* 'partition' keyword seen */\
-        X(Comp_Partition, Comp, Invalid, Invalid)\
-    /* ------------------------- */\
-    /* Major SubSection: 'port_modules' in a component or subcomponent */\
-    /* ------------------------- */\
-        /* 'port_module' keyword seen */\
-        X(PortModArray_key, Invalid, PortModArray, Invalid)\
-        /* In port_module array */\
-        X(PortModArray, Invalid, PortMod, Invalid)\
-        /* In port_module object */\
-        X(PortMod, PortModArray, Invalid, PortMod_Params)\
-        /* 'params' keyword seen*/\
-        X(PortMod_Params_key, PortMod, PortMod_Params, Invalid)\
-        /* In params object */\
-        X(PortMod_Params, PortMod, Invalid, Invalid)\
-        /* 'shared_params' keyword seen */\
-        X(PortMod_SharedParamsArray_key, PortMod, PortMod_SharedParamsArray, Invalid)\
-        /* In shared_params array */\
-        X(PortMod_SharedParamsArray, PortMod, Invalid, Invalid)\
-        /* 'statistics' keyword seen */\
-        X(PortMod_StatArray_key, PortMod, PortMod_StatArray, Invalid)\
-        /* In statistics section */\
-        X(PortMod_StatArray, PortMod, PortMod_Stat, Invalid)\
-        /* In statistic object */\
-        X(PortMod_Stat, PortMod_StatArray, Invalid, PortMod_Stat_Params_key)\
-        /* 'params' keyword seen */\
-        X(PortMod_Stat_Params_key, PortMod_Stat, PortMod_Stat_Params, Invalid)\
-        /* In params object */\
-        X(PortMod_Stat_Params, PortMod_Stat, Invalid, Invalid)\
-        /* 'statistics_options' keyword seen */\
-        X(PortMod_StatOptions_key, PortMod, PortMod_StatOptions, Invalid)\
-        /* In 'statistics_options' object*/\
-        X(PortMod_StatOptions, PortMod, Invalid, PortMod_StatOptions_Params_key)\
-        /* 'params' keyword seen */\
-        X(PortMod_StatOptions_Params_key, PortMod_StatOptions, PortMod_StatOptions_Params, Invalid)\
-        /* In params object*/\
-        X(PortMod_StatOptions_Params, PortMod_StatOptions, Invalid, Invalid)\
-    /* ------------------------- */\
-    /* Major SubSection: 'subcomponents' in a component or subcomponent */\
-    /* Stack of currently open component objects indicates the nesting of parent (sub)components */\
-    /* ------------------------- */\
-        /* 'subcomponents' keyword seen */\
-        X(SubCompArray_key, Invalid, SubCompArray, Invalid)\
-        /* In subcomponents array */\
-        X(SubCompArray, Invalid, SubComp, Invalid)\
-        /* In subcomponent object */\
-        X(SubComp, SubCompArray, Invalid, SubComp_Params_key)\
-        /* 'params' keyword seen */\
-        X(SubComp_Params_key, SubComp, SubComp_Params, Invalid)\
-        /* In params object */\
-        X(SubComp_Params, SubComp, Invalid, Invalid)\
-        /* 'statistics_options' keyword seen */\
-        X(SubComp_StatOptions_key, SubComp, SubComp_StatOptions, Invalid)\
-        /* In 'statistics_options' object*/\
-        X(SubComp_StatOptions, SubComp, Invalid, SubComp_StatOptions_Params_key)\
-        /* 'params' keyword seen */\
-        X(SubComp_StatOptions_Params_key, SubComp_StatOptions, SubComp_StatOptions_Params, Invalid)\
-        /* In params object*/\
-        X(SubComp_StatOptions_Params, SubComp_StatOptions, Invalid, Invalid)\
-        /* 'statistics' keyword seen */\
-        X(SubComp_StatArray_key, SubComp, SubComp_StatArray, Invalid)\
-        /* 'In statistics arrray */\
-        X(SubComp_StatArray, SubComp, SubComp_Stat, Invalid)\
-        /* In statistic object */\
-        X(SubComp_Stat, SubComp_StatArray, Invalid, SubComp_Stat_Params_key)\
-        /* 'params' keyword seen */\
-        X(SubComp_Stat_Params_key, SubComp_Stat, SubComp_Stat_Params, Invalid)\
-        /* In params object */\
-        X(SubComp_Stat_Params, SubComp_Stat, Invalid, Invalid)\
-        /* 'shared_params' keyword seen */\
-        X(SubComp_SharedParamsArray_key, SubComp, SubComp_SharedParamsArray, Invalid)\
-        /* In shared_params array */\
-        X(SubComp_SharedParamsArray, SubComp, Invalid, Invalid)\
-    /* ------------------------- */\
-    /* Major section: 'links' */\
-    /* ------------------------- */\
-        /* 'links' key seen */\
-        X(LinkArray_key, Root, LinkArray, Invalid)\
-        /* In links array */\
-        X(LinkArray, Root, Link, Invalid)\
-        /* In a link object */\
-        X(Link, LinkArray, Invalid, Invalid)\
-        /* 'left' key seen */\
-        X(Link_Left_key, Link, Link_Left, Invalid)\
-        /* In left object */\
-        X(Link_Left, Link, Invalid, Invalid)\
-        /* 'right' key seen */\
-        X(Link_Right_key, Link, Link_Right, Invalid)\
-        /* In right object */\
-        X(Link_Right, Link, Invalid, Invalid)\
-    /* ------------------------- */\
-    /* Invalid state */\
-    /* ------------------------- */\
-        X(Invalid, Invalid, Invalid, Invalid)
+#define X_STATES                                                                                    \
+    /* Entry (start state) */                                                                       \
+    X(Entry, Invalid, Root, Invalid)                                                                \
+    /* In root object */                                                                            \
+    X(Root, Entry, Invalid, Invalid)                                                                \
+    /* ------------------------- */                                                                 \
+    /* Major Section: 'program_options' */                                                          \
+    /* ------------------------- */                                                                 \
+    /* Section keyword seen */                                                                      \
+    X(ProgramOptions_key, Root, ProgramOptions, Invalid)                                            \
+    /* In section object */                                                                         \
+    X(ProgramOptions, Root, Invalid, Invalid)                                                       \
+    /* ------------------------- */                                                                 \
+    /* Major Section: 'shared_params' - object containing name/object pairs */                      \
+    /* ------------------------- */                                                                 \
+    /* Section keyword seen */                                                                      \
+    X(SharedParams_key, Root, SharedParams, Invalid)                                                \
+    /* In section's root object */                                                                  \
+    X(SharedParams, Root, SharedParams_object_key, Invalid)                                         \
+    /* Got name of next shared_param object */                                                      \
+    X(SharedParams_object_key, SharedParams, SharedParams_object, Invalid)                          \
+    /* In a shared_param object */                                                                  \
+    X(SharedParams_object, SharedParams, Invalid, Invalid)                                          \
+    /* ------------------------- */                                                                 \
+    /* Major section: 'statistics_options' */                                                       \
+    /* ------------------------- */                                                                 \
+    /* Section keyword seen */                                                                      \
+    X(StatOptions_key, Root, StatOptions, Invalid)                                                  \
+    /* In 'statistics_options' object*/                                                             \
+    X(StatOptions, Root, Invalid, StatOptions_Params_key)                                           \
+    /* 'params' keyword seen */                                                                     \
+    X(StatOptions_Params_key, StatOptions, StatOptions_Params, Invalid)                             \
+    /* In params object*/                                                                           \
+    X(StatOptions_Params, StatOptions, Invalid, Invalid)                                            \
+    /* ------------------------- */                                                                 \
+    /* Major section: 'statistics_group' */                                                         \
+    /* ------------------------- */                                                                 \
+    /* 'statistics_group' keyword seen */                                                           \
+    X(StatGroupsArray_key, Root, StatGroupsArray, Invalid)                                          \
+    /* In 'statistics_group' array */                                                               \
+    X(StatGroupsArray, Root, StatGroup, Invalid)                                                    \
+    /* In a statistics group object */                                                              \
+    X(StatGroup, StatGroupsArray, Invalid, Invalid)                                                 \
+    /* 'output' keyword seen */                                                                     \
+    X(StatGroup_Output_key, StatGroup, StatGroup_Output, Invalid)                                   \
+    /* In output object */                                                                          \
+    X(StatGroup_Output, StatGroup, Invalid, StatGroup_Output_Params_key)                            \
+    /* 'params' keyword seen */                                                                     \
+    X(StatGroup_Output_Params_key, StatGroup_Output, StatGroup_Output_Params, Invalid)              \
+    /* In params object */                                                                          \
+    X(StatGroup_Output_Params, StatGroup_Output, Invalid, Invalid)                                  \
+    /* 'statistics' keyword seen */                                                                 \
+    X(StatGroup_StatArray_key, StatGroup, StatGroup_StatArray, Invalid)                             \
+    /* In statistics array */                                                                       \
+    X(StatGroup_StatArray, StatGroup, StatGroup_Stat, Invalid)                                      \
+    /* In a statistic object */                                                                     \
+    X(StatGroup_Stat, StatGroup_StatArray, Invalid, StatGroup_Stat_Params_key)                      \
+    /* 'params' keyword seen */                                                                     \
+    X(StatGroup_Stat_Params_key, StatGroup_Stat, StatGroup_Stat_Params, Invalid)                    \
+    /* In params object */                                                                          \
+    X(StatGroup_Stat_Params, StatGroup_Stat, Invalid, Invalid)                                      \
+    /* 'components' keyword seen */                                                                 \
+    X(StatGroup_CompArray_key, StatGroup, StatGroup_CompArray, Invalid)                             \
+    /* In components array */                                                                       \
+    X(StatGroup_CompArray, StatGroup, Invalid, Invalid)                                             \
+    /* ------------------------- */                                                                 \
+    /* Major section: 'components'*/                                                                \
+    /* ------------------------- */                                                                 \
+    /* 'components' keyword seen */                                                                 \
+    X(CompArray_key, Root, CompArray, Invalid)                                                      \
+    /* In components array */                                                                       \
+    X(CompArray, Root, Comp, Invalid)                                                               \
+    /* In a component object */                                                                     \
+    X(Comp, CompArray, Invalid, Comp_Params_key)                                                    \
+    /* 'params' keyword seen */                                                                     \
+    X(Comp_Params_key, Comp, Comp_Params, Invalid)                                                  \
+    /* In params object */                                                                          \
+    X(Comp_Params, Comp, Invalid, Invalid)                                                          \
+    /* 'statistics_options' keyword seen */                                                         \
+    X(Comp_StatOptions_key, Comp, Comp_StatOptions, Invalid)                                        \
+    /* In 'statistics_options' object*/                                                             \
+    X(Comp_StatOptions, Comp, Invalid, Comp_StatOptions_Params_key)                                 \
+    /* 'params' keyword seen */                                                                     \
+    X(Comp_StatOptions_Params_key, Comp_StatOptions, Comp_StatOptions_Params, Invalid)              \
+    /* In params object*/                                                                           \
+    X(Comp_StatOptions_Params, Comp_StatOptions, Invalid, Invalid)                                  \
+    /* 'statistics' keyword seen */                                                                 \
+    X(Comp_StatArray_key, Comp, Comp_StatArray, Invalid)                                            \
+    /* 'In statistics arrray */                                                                     \
+    X(Comp_StatArray, Comp, Comp_Stat, Invalid)                                                     \
+    /* In statistic object */                                                                       \
+    X(Comp_Stat, Comp_StatArray, Invalid, Comp_Stat_Params_key)                                     \
+    /* 'params' keyword seen */                                                                     \
+    X(Comp_Stat_Params_key, Comp_Stat, Comp_Stat_Params, Invalid)                                   \
+    /* In params object */                                                                          \
+    X(Comp_Stat_Params, Comp_Stat, Invalid, Invalid)                                                \
+    /* 'shared_params' keyword seen */                                                              \
+    X(Comp_SharedParamsArray_key, Comp, Comp_SharedParamsArray, Invalid)                            \
+    /* In shared_params array */                                                                    \
+    X(Comp_SharedParamsArray, Comp, Invalid, Invalid)                                               \
+    /* In partition object */                                                                       \
+    X(Comp_Partition_key, Comp, Comp_Partition, Invalid)                                            \
+    /* 'partition' keyword seen */                                                                  \
+    X(Comp_Partition, Comp, Invalid, Invalid)                                                       \
+    /* ------------------------- */                                                                 \
+    /* Major SubSection: 'port_modules' in a component or subcomponent */                           \
+    /* ------------------------- */                                                                 \
+    /* 'port_module' keyword seen */                                                                \
+    X(PortModArray_key, Invalid, PortModArray, Invalid)                                             \
+    /* In port_module array */                                                                      \
+    X(PortModArray, Invalid, PortMod, Invalid)                                                      \
+    /* In port_module object */                                                                     \
+    X(PortMod, PortModArray, Invalid, PortMod_Params)                                               \
+    /* 'params' keyword seen*/                                                                      \
+    X(PortMod_Params_key, PortMod, PortMod_Params, Invalid)                                         \
+    /* In params object */                                                                          \
+    X(PortMod_Params, PortMod, Invalid, Invalid)                                                    \
+    /* 'shared_params' keyword seen */                                                              \
+    X(PortMod_SharedParamsArray_key, PortMod, PortMod_SharedParamsArray, Invalid)                   \
+    /* In shared_params array */                                                                    \
+    X(PortMod_SharedParamsArray, PortMod, Invalid, Invalid)                                         \
+    /* 'statistics' keyword seen */                                                                 \
+    X(PortMod_StatArray_key, PortMod, PortMod_StatArray, Invalid)                                   \
+    /* In statistics section */                                                                     \
+    X(PortMod_StatArray, PortMod, PortMod_Stat, Invalid)                                            \
+    /* In statistic object */                                                                       \
+    X(PortMod_Stat, PortMod_StatArray, Invalid, PortMod_Stat_Params_key)                            \
+    /* 'params' keyword seen */                                                                     \
+    X(PortMod_Stat_Params_key, PortMod_Stat, PortMod_Stat_Params, Invalid)                          \
+    /* In params object */                                                                          \
+    X(PortMod_Stat_Params, PortMod_Stat, Invalid, Invalid)                                          \
+    /* 'statistics_options' keyword seen */                                                         \
+    X(PortMod_StatOptions_key, PortMod, PortMod_StatOptions, Invalid)                               \
+    /* In 'statistics_options' object*/                                                             \
+    X(PortMod_StatOptions, PortMod, Invalid, PortMod_StatOptions_Params_key)                        \
+    /* 'params' keyword seen */                                                                     \
+    X(PortMod_StatOptions_Params_key, PortMod_StatOptions, PortMod_StatOptions_Params, Invalid)     \
+    /* In params object*/                                                                           \
+    X(PortMod_StatOptions_Params, PortMod_StatOptions, Invalid, Invalid)                            \
+    /* ------------------------- */                                                                 \
+    /* Major SubSection: 'subcomponents' in a component or subcomponent */                          \
+    /* Stack of currently open component objects indicates the nesting of parent (sub)components */ \
+    /* ------------------------- */                                                                 \
+    /* 'subcomponents' keyword seen */                                                              \
+    X(SubCompArray_key, Invalid, SubCompArray, Invalid)                                             \
+    /* In subcomponents array */                                                                    \
+    X(SubCompArray, Invalid, SubComp, Invalid)                                                      \
+    /* In subcomponent object */                                                                    \
+    X(SubComp, SubCompArray, Invalid, SubComp_Params_key)                                           \
+    /* 'params' keyword seen */                                                                     \
+    X(SubComp_Params_key, SubComp, SubComp_Params, Invalid)                                         \
+    /* In params object */                                                                          \
+    X(SubComp_Params, SubComp, Invalid, Invalid)                                                    \
+    /* 'statistics_options' keyword seen */                                                         \
+    X(SubComp_StatOptions_key, SubComp, SubComp_StatOptions, Invalid)                               \
+    /* In 'statistics_options' object*/                                                             \
+    X(SubComp_StatOptions, SubComp, Invalid, SubComp_StatOptions_Params_key)                        \
+    /* 'params' keyword seen */                                                                     \
+    X(SubComp_StatOptions_Params_key, SubComp_StatOptions, SubComp_StatOptions_Params, Invalid)     \
+    /* In params object*/                                                                           \
+    X(SubComp_StatOptions_Params, SubComp_StatOptions, Invalid, Invalid)                            \
+    /* 'statistics' keyword seen */                                                                 \
+    X(SubComp_StatArray_key, SubComp, SubComp_StatArray, Invalid)                                   \
+    /* 'In statistics arrray */                                                                     \
+    X(SubComp_StatArray, SubComp, SubComp_Stat, Invalid)                                            \
+    /* In statistic object */                                                                       \
+    X(SubComp_Stat, SubComp_StatArray, Invalid, SubComp_Stat_Params_key)                            \
+    /* 'params' keyword seen */                                                                     \
+    X(SubComp_Stat_Params_key, SubComp_Stat, SubComp_Stat_Params, Invalid)                          \
+    /* In params object */                                                                          \
+    X(SubComp_Stat_Params, SubComp_Stat, Invalid, Invalid)                                          \
+    /* 'shared_params' keyword seen */                                                              \
+    X(SubComp_SharedParamsArray_key, SubComp, SubComp_SharedParamsArray, Invalid)                   \
+    /* In shared_params array */                                                                    \
+    X(SubComp_SharedParamsArray, SubComp, Invalid, Invalid)                                         \
+    /* ------------------------- */                                                                 \
+    /* Major section: 'links' */                                                                    \
+    /* ------------------------- */                                                                 \
+    /* 'links' key seen */                                                                          \
+    X(LinkArray_key, Root, LinkArray, Invalid)                                                      \
+    /* In links array */                                                                            \
+    X(LinkArray, Root, Link, Invalid)                                                               \
+    /* In a link object */                                                                          \
+    X(Link, LinkArray, Invalid, Invalid)                                                            \
+    /* 'left' key seen */                                                                           \
+    X(Link_Left_key, Link, Link_Left, Invalid)                                                      \
+    /* In left object */                                                                            \
+    X(Link_Left, Link, Invalid, Invalid)                                                            \
+    /* 'right' key seen */                                                                          \
+    X(Link_Right_key, Link, Link_Right, Invalid)                                                    \
+    /* In right object */                                                                           \
+    X(Link_Right, Link, Invalid, Invalid)                                                           \
+    /* ------------------------- */                                                                 \
+    /* Invalid state */                                                                             \
+    /* ------------------------- */                                                                 \
+    X(Invalid, Invalid, Invalid, Invalid)
 
 // Parser states
 enum class State {
-#define X(a,b,c,d) a,
+#define X(a, b, c, d) a,
     X_STATES
 #undef X
 };
 
 // Parent states for each parser state
 static const State ParentState[] = {
-#define X(a,b,c,d) State::b,
+#define X(a, b, c, d) State::b,
     X_STATES
 #undef X
 };
 
 // Next states when an array or object is started for each parser state
 static const State NextStateObjOrArray[] = {
-#define X(a,b,c,d) State::c,
+#define X(a, b, c, d) State::c,
     X_STATES
 #undef X
 };
 
 // Next states when 'params' key is encountered for each parser state
 static const State NextStateParams[] = {
-#define X(a,b,c,d) State::d,
+#define X(a, b, c, d) State::d,
     X_STATES
 #undef X
 };
 
 // Strings for error output
 static const std::string StateString[] = {
-#define X(a,b,c,d) #a ,
+#define X(a, b, c, d) #a,
     X_STATES
 #undef X
 };
 
 #undef X_STATES
 
-} // Namespace SST::Core
+} // namespace SST::Core::JSONParser
 
 #endif

--- a/src/sst/core/model/json/jsonstates.h
+++ b/src/sst/core/model/json/jsonstates.h
@@ -1,0 +1,261 @@
+// -*- c++ -*-
+
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_MODEL_JSON_JSONSTATES_H
+#define SST_CORE_MODEL_JSON_JSONSTATES_H
+
+namespace SST::Core::JSONParser {
+
+    // X-macros to generate state transition tables
+    // Hierarchical states are expanded to form a single state name by appending the nested state names with an underscore
+    // State tuple is: state, parent state, next state on object/array open or Invalid, next state on 'params' key
+    // Note that 'Invalid' just means that either (a) there is no transition or (b) the transition table can't be used to determine the transition
+    // '*_key' states indicate that the keyword for the next state has been seen and an object or array will be opened next
+
+    #define X_STATES \
+        /* Entry (start state) */\
+        X(Entry, Invalid, Root, Invalid)\
+        /* In root object */\
+        X(Root, Entry, Invalid, Invalid)\
+    /* ------------------------- */\
+    /* Major Section: 'program_options' */\
+    /* ------------------------- */\
+        /* Section keyword seen */\
+        X(ProgramOptions_key, Root, ProgramOptions, Invalid)\
+        /* In section object */\
+        X(ProgramOptions, Root, Invalid, Invalid)\
+    /* ------------------------- */\
+    /* Major Section: 'shared_params' - object containing name/object pairs */\
+    /* ------------------------- */\
+        /* Section keyword seen */\
+        X(SharedParams_key, Root, SharedParams, Invalid)\
+        /* In section's root object */\
+        X(SharedParams, Root, SharedParams_object_key, Invalid)\
+        /* Got name of next shared_param object */\
+        X(SharedParams_object_key, SharedParams, SharedParams_object, Invalid)\
+        /* In a shared_param object */\
+        X(SharedParams_object, SharedParams, Invalid, Invalid)\
+    /* ------------------------- */\
+    /* Major section: 'statistics_options' */\
+    /* ------------------------- */\
+        /* Section keyword seen */\
+        X(StatOptions_key, Root, StatOptions, Invalid)\
+        /* In 'statistics_options' object*/\
+        X(StatOptions, Root, Invalid, StatOptions_Params_key)\
+        /* 'params' keyword seen */\
+        X(StatOptions_Params_key, StatOptions, StatOptions_Params, Invalid)\
+        /* In params object*/\
+        X(StatOptions_Params, StatOptions, Invalid, Invalid)\
+    /* ------------------------- */\
+    /* Major section: 'statistics_group' */\
+    /* ------------------------- */\
+        /* 'statistics_group' keyword seen */\
+        X(StatGroupsArray_key, Root, StatGroupsArray, Invalid)\
+        /* In 'statistics_group' array */\
+        X(StatGroupsArray, Root, StatGroup, Invalid)\
+        /* In a statistics group object */\
+        X(StatGroup, StatGroupsArray, Invalid, Invalid)\
+        /* 'output' keyword seen */\
+        X(StatGroup_Output_key, StatGroup, StatGroup_Output, Invalid)\
+        /* In output object */\
+        X(StatGroup_Output, StatGroup, Invalid, StatGroup_Output_Params_key)\
+        /* 'params' keyword seen */\
+        X(StatGroup_Output_Params_key, StatGroup_Output, StatGroup_Output_Params, Invalid)\
+        /* In params object */\
+        X(StatGroup_Output_Params, StatGroup_Output, Invalid, Invalid)\
+        /* 'statistics' keyword seen */\
+        X(StatGroup_StatArray_key, StatGroup, StatGroup_StatArray, Invalid)\
+        /* In statistics array */\
+        X(StatGroup_StatArray, StatGroup, StatGroup_Stat, Invalid)\
+        /* In a statistic object */\
+        X(StatGroup_Stat, StatGroup_StatArray, Invalid, StatGroup_Stat_Params_key)\
+        /* 'params' keyword seen */\
+        X(StatGroup_Stat_Params_key, StatGroup_Stat, StatGroup_Stat_Params, Invalid)\
+        /* In params object */\
+        X(StatGroup_Stat_Params, StatGroup_Stat, Invalid, Invalid)\
+        /* 'components' keyword seen */\
+        X(StatGroup_CompArray_key, StatGroup, StatGroup_CompArray, Invalid)\
+        /* In components array */\
+        X(StatGroup_CompArray, StatGroup, Invalid, Invalid)\
+    /* ------------------------- */\
+    /* Major section: 'components'*/\
+    /* ------------------------- */\
+        /* 'components' keyword seen */\
+        X(CompArray_key, Root, CompArray, Invalid)\
+        /* In components array */\
+        X(CompArray, Root, Comp, Invalid)\
+        /* In a component object */\
+        X(Comp, CompArray, Invalid, Comp_Params_key)\
+        /* 'params' keyword seen */\
+        X(Comp_Params_key, Comp, Comp_Params, Invalid)\
+        /* In params object */\
+        X(Comp_Params, Comp, Invalid, Invalid)\
+        /* 'statistics_options' keyword seen */\
+        X(Comp_StatOptions_key, Comp, Comp_StatOptions, Invalid)\
+        /* In 'statistics_options' object*/\
+        X(Comp_StatOptions, Comp, Invalid, Comp_StatOptions_Params_key)\
+        /* 'params' keyword seen */\
+        X(Comp_StatOptions_Params_key, Comp_StatOptions, Comp_StatOptions_Params, Invalid)\
+        /* In params object*/\
+        X(Comp_StatOptions_Params, Comp_StatOptions, Invalid, Invalid)\
+        /* 'statistics' keyword seen */\
+        X(Comp_StatArray_key, Comp, Comp_StatArray, Invalid)\
+        /* 'In statistics arrray */\
+        X(Comp_StatArray, Comp, Comp_Stat, Invalid)\
+        /* In statistic object */\
+        X(Comp_Stat, Comp_StatArray, Invalid, Comp_Stat_Params_key)\
+        /* 'params' keyword seen */\
+        X(Comp_Stat_Params_key, Comp_Stat, Comp_Stat_Params, Invalid)\
+        /* In params object */\
+        X(Comp_Stat_Params, Comp_Stat, Invalid, Invalid)\
+        /* 'shared_params' keyword seen */\
+        X(Comp_SharedParamsArray_key, Comp, Comp_SharedParamsArray, Invalid)\
+        /* In shared_params array */\
+        X(Comp_SharedParamsArray, Comp, Invalid, Invalid)\
+        /* In partition object */\
+        X(Comp_Partition_key, Comp, Comp_Partition, Invalid)\
+        /* 'partition' keyword seen */\
+        X(Comp_Partition, Comp, Invalid, Invalid)\
+    /* ------------------------- */\
+    /* Major SubSection: 'port_modules' in a component or subcomponent */\
+    /* ------------------------- */\
+        /* 'port_module' keyword seen */\
+        X(PortModArray_key, Invalid, PortModArray, Invalid)\
+        /* In port_module array */\
+        X(PortModArray, Invalid, PortMod, Invalid)\
+        /* In port_module object */\
+        X(PortMod, PortModArray, Invalid, PortMod_Params)\
+        /* 'params' keyword seen*/\
+        X(PortMod_Params_key, PortMod, PortMod_Params, Invalid)\
+        /* In params object */\
+        X(PortMod_Params, PortMod, Invalid, Invalid)\
+        /* 'shared_params' keyword seen */\
+        X(PortMod_SharedParamsArray_key, PortMod, PortMod_SharedParamsArray, Invalid)\
+        /* In shared_params array */\
+        X(PortMod_SharedParamsArray, PortMod, Invalid, Invalid)\
+        /* 'statistics' keyword seen */\
+        X(PortMod_StatArray_key, PortMod, PortMod_StatArray, Invalid)\
+        /* In statistics section */\
+        X(PortMod_StatArray, PortMod, PortMod_Stat, Invalid)\
+        /* In statistic object */\
+        X(PortMod_Stat, PortMod_StatArray, Invalid, PortMod_Stat_Params_key)\
+        /* 'params' keyword seen */\
+        X(PortMod_Stat_Params_key, PortMod_Stat, PortMod_Stat_Params, Invalid)\
+        /* In params object */\
+        X(PortMod_Stat_Params, PortMod_Stat, Invalid, Invalid)\
+        /* 'statistics_options' keyword seen */\
+        X(PortMod_StatOptions_key, PortMod, PortMod_StatOptions, Invalid)\
+        /* In 'statistics_options' object*/\
+        X(PortMod_StatOptions, PortMod, Invalid, PortMod_StatOptions_Params_key)\
+        /* 'params' keyword seen */\
+        X(PortMod_StatOptions_Params_key, PortMod_StatOptions, PortMod_StatOptions_Params, Invalid)\
+        /* In params object*/\
+        X(PortMod_StatOptions_Params, PortMod_StatOptions, Invalid, Invalid)\
+    /* ------------------------- */\
+    /* Major SubSection: 'subcomponents' in a component or subcomponent */\
+    /* Stack of currently open component objects indicates the nesting of parent (sub)components */\
+    /* ------------------------- */\
+        /* 'subcomponents' keyword seen */\
+        X(SubCompArray_key, Invalid, SubCompArray, Invalid)\
+        /* In subcomponents array */\
+        X(SubCompArray, Invalid, SubComp, Invalid)\
+        /* In subcomponent object */\
+        X(SubComp, SubCompArray, Invalid, SubComp_Params_key)\
+        /* 'params' keyword seen */\
+        X(SubComp_Params_key, SubComp, SubComp_Params, Invalid)\
+        /* In params object */\
+        X(SubComp_Params, SubComp, Invalid, Invalid)\
+        /* 'statistics_options' keyword seen */\
+        X(SubComp_StatOptions_key, SubComp, SubComp_StatOptions, Invalid)\
+        /* In 'statistics_options' object*/\
+        X(SubComp_StatOptions, SubComp, Invalid, SubComp_StatOptions_Params_key)\
+        /* 'params' keyword seen */\
+        X(SubComp_StatOptions_Params_key, SubComp_StatOptions, SubComp_StatOptions_Params, Invalid)\
+        /* In params object*/\
+        X(SubComp_StatOptions_Params, SubComp_StatOptions, Invalid, Invalid)\
+        /* 'statistics' keyword seen */\
+        X(SubComp_StatArray_key, SubComp, SubComp_StatArray, Invalid)\
+        /* 'In statistics arrray */\
+        X(SubComp_StatArray, SubComp, SubComp_Stat, Invalid)\
+        /* In statistic object */\
+        X(SubComp_Stat, SubComp_StatArray, Invalid, SubComp_Stat_Params_key)\
+        /* 'params' keyword seen */\
+        X(SubComp_Stat_Params_key, SubComp_Stat, SubComp_Stat_Params, Invalid)\
+        /* In params object */\
+        X(SubComp_Stat_Params, SubComp_Stat, Invalid, Invalid)\
+        /* 'shared_params' keyword seen */\
+        X(SubComp_SharedParamsArray_key, SubComp, SubComp_SharedParamsArray, Invalid)\
+        /* In shared_params array */\
+        X(SubComp_SharedParamsArray, SubComp, Invalid, Invalid)\
+    /* ------------------------- */\
+    /* Major section: 'links' */\
+    /* ------------------------- */\
+        /* 'links' key seen */\
+        X(LinkArray_key, Root, LinkArray, Invalid)\
+        /* In links array */\
+        X(LinkArray, Root, Link, Invalid)\
+        /* In a link object */\
+        X(Link, LinkArray, Invalid, Invalid)\
+        /* 'left' key seen */\
+        X(Link_Left_key, Link, Link_Left, Invalid)\
+        /* In left object */\
+        X(Link_Left, Link, Invalid, Invalid)\
+        /* 'right' key seen */\
+        X(Link_Right_key, Link, Link_Right, Invalid)\
+        /* In right object */\
+        X(Link_Right, Link, Invalid, Invalid)\
+    /* ------------------------- */\
+    /* Invalid state */\
+    /* ------------------------- */\
+        X(Invalid, Invalid, Invalid, Invalid)
+
+// Parser states
+enum class State {
+#define X(a,b,c,d) a,
+    X_STATES
+#undef X
+};
+
+// Parent states for each parser state
+static const State ParentState[] = {
+#define X(a,b,c,d) State::b,
+    X_STATES
+#undef X
+};
+
+// Next states when an array or object is started for each parser state
+static const State NextStateObjOrArray[] = {
+#define X(a,b,c,d) State::c,
+    X_STATES
+#undef X
+};
+
+// Next states when 'params' key is encountered for each parser state
+static const State NextStateParams[] = {
+#define X(a,b,c,d) State::d,
+    X_STATES
+#undef X
+};
+
+// Strings for error output
+static const std::string StateString[] = {
+#define X(a,b,c,d) #a ,
+    X_STATES
+#undef X
+};
+
+#undef X_STATES
+
+} // Namespace SST::Core
+
+#endif

--- a/src/sst/core/model/sstmodel.h
+++ b/src/sst/core/model/sstmodel.h
@@ -24,6 +24,8 @@ namespace SST {
 class Config;
 class ConfigGraph;
 
+#define STATALLFLAG "--ALLSTATS--"
+
 /** Base class for Model Generation
  */
 class SSTModelDescription

--- a/src/sst/core/portModule.h
+++ b/src/sst/core/portModule.h
@@ -74,7 +74,7 @@ public:
        returned from this function will be passed into the eventSent()
        function.
 
-       The default implemenation will just return 0 and only needs to
+       The default implementation will just return 0 and only needs to
        be overwritten if the module needs any of the metadata and/or
        needs to return a unique key.
 

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -51,7 +51,6 @@ namespace SST {
 void SST_Exit(int exit_code);
 
 #define _SIM_DBG(fmt, args...) __DBG(DBG_SIM, Sim, fmt, ##args)
-#define STATALLFLAG            "--ALLSTATS--"
 
 class Activity;
 class CheckpointAction;

--- a/tests/subcomponent_tests/test_sc_2u2u.py
+++ b/tests/subcomponent_tests/test_sc_2u2u.py
@@ -35,24 +35,24 @@ loader0.enableAllStatistics()
 
 sub0_0 = loader0.setSubComponent("mySubComp", "coreTestElement.SubCompSlot",0)
 
-sub0_0_0 = sub0_0.setSubComponent("mySubCompSlot","coreTestElement.SubCompSender",0);
+sub0_0_0 = sub0_0.setSubComponent("mySubCompSlot","coreTestElement.SubCompSender",0)
 sub0_0_0.addParam("sendCount", 15)
 sub0_0_0.addParam("verbose", verbose)
 sub0_0_0.enableAllStatistics()
 
-sub0_0_1 = sub0_0.setSubComponent("mySubCompSlot","coreTestElement.SubCompSender",1);
+sub0_0_1 = sub0_0.setSubComponent("mySubCompSlot","coreTestElement.SubCompSender",1)
 sub0_0_1.addParam("sendCount", 15)
 sub0_0_1.addParam("verbose", verbose)
 sub0_0_1.enableAllStatistics()
 
 sub0_1 = loader0.setSubComponent("mySubComp", "coreTestElement.SubCompSlot",1)
 
-sub0_1_0 = sub0_1.setSubComponent("mySubCompSlot","coreTestElement.SubCompSender_alias",0);
+sub0_1_0 = sub0_1.setSubComponent("mySubCompSlot","coreTestElement.SubCompSender_alias",0)
 sub0_1_0.addParam("sendCount", 15)
 sub0_1_0.addParam("verbose", verbose)
 sub0_1_0.enableAllStatistics()
 
-sub0_1_1 = sub0_1.setSubComponent("mySubCompSlot","coreTestElement.SubCompSender_alias",1);
+sub0_1_1 = sub0_1.setSubComponent("mySubCompSlot","coreTestElement.SubCompSender_alias",1)
 sub0_1_1.addParam("sendCount", 15)
 sub0_1_1.addParam("verbose", verbose)
 sub0_1_1.enableAllStatistics()


### PR DESCRIPTION
This updates the JSON streaming parser to (a) fix some known bugs and (b) pass most of the SST core testsuite including support for statistic enables, port modules, arbitrarily nested subcomponents, etc. 

Specific updates include:
* Moved definition of `STATALLFLAG` to sstmodel.h since it is used only for configuration
* Added `statistics_options` sections to components, subcomponents, portmodules to allow global statistic configuration for those elements without needing to explicitly list statistics
* JSON output previously stopped after 2 levels of nested subcomponents; it now supports arbitrary nesting
* States in streaming parser are stored as a single state var rather than a combo of a state + bools
* Port modules are supported in both JSON output and input
* Added snakecase versions of camelcase keywords so that all keywords in json can be specified in snakecase (usability improvement). Did not remove camelcase versions.
* Added more error checking to JSON parsing, particularly for unexpected tokens.
