### PR TITLE
Break StatisticId_t dependence on ComponentId_t

### DIFF
--- a/src/sst/core/model/configComponent.cc
+++ b/src/sst/core/model/configComponent.cc
@@ -201,8 +201,10 @@ ConfigComponent::getNextSubComponentID()
 StatisticId_t
 ConfigComponent::getNextStatisticID()
 {
-    uint16_t statId = nextStatID++;
-    return STATISTIC_ID_CREATE(id, statId);
+    if ( getParent() ) {
+        return getParent()->getNextStatisticID();
+    }
+    return next_stat_id++;
 }
 
 ConfigComponent*
@@ -267,16 +269,14 @@ ConfigComponent::addParameter(const std::string& key, const std::string& value, 
 ConfigStatistic*
 ConfigComponent::createStatistic()
 {
-    StatisticId_t stat_id = getNextStatisticID();
-
-    auto*            parent = getParent();
-    ConfigStatistic* cs     = nullptr;
+    auto* parent = getParent();
     if ( parent ) {
-        cs = parent->insertStatistic(stat_id);
+        return parent->createStatistic();
     }
-    else {
-        cs = &statistics_[stat_id];
-    }
+
+    StatisticId_t    stat_id = getNextStatisticID();
+    ConfigStatistic* cs      = &statistics_[stat_id];
+
     cs->id = stat_id;
     return cs;
 }
@@ -331,9 +331,9 @@ ConfigComponent::enableStatistic(const std::string& statisticName, const SST::Pa
 }
 
 bool
-ConfigComponent::reuseStatistic(const std::string& statisticName, StatisticId_t sid)
+ConfigComponent::reuseStatistic(const std::string& statistic_name, StatisticId_t sid)
 {
-    if ( statisticName == STATALLFLAG ) {
+    if ( statistic_name == STATALLFLAG ) {
         // We cannot use reuseStatistic with STATALLFLAG
         Output::getDefaultObject().fatal(CALL_INFO, 1, "Cannot reuse a Statistic with STATALLFLAG as parameter");
         return false;
@@ -344,10 +344,10 @@ ConfigComponent::reuseStatistic(const std::string& statisticName, StatisticId_t 
         comp = comp->getParent();
     }
 
-    if ( !Factory::getFactory()->DoesComponentInfoStatisticNameExist(type, statisticName) ) {
+    if ( !Factory::getFactory()->DoesComponentInfoStatisticNameExist(type, statistic_name) ) {
         Output::getDefaultObject().fatal(CALL_INFO, 1,
             "Failed to create statistic '%s' on '%s' of type '%s' - this is not a valid statistic\n",
-            statisticName.c_str(), name.c_str(), type.c_str());
+            statistic_name.c_str(), name.c_str(), type.c_str());
         return false;
     }
 
@@ -357,7 +357,7 @@ ConfigComponent::reuseStatistic(const std::string& statisticName, StatisticId_t 
         return false;
     }
     else {
-        enabledStatNames[statisticName] = sid;
+        enabledStatNames[statistic_name] = sid;
         return true;
     }
 }

--- a/src/sst/core/model/configComponent.h
+++ b/src/sst/core/model/configComponent.h
@@ -104,9 +104,9 @@ public:
 
     std::vector<ConfigComponent*> subComponents; /*!< List of subcomponents */
     std::vector<double>           coords;
-    uint16_t nextSubID;  /*!< Next subID to use for children, if component, if subcomponent, subid of parent */
-    uint16_t nextStatID; /*!< Next statID to use for children */
-    bool     visited;    /*! Used when traversing graph to indicate component was visited already */
+    uint16_t nextSubID;        /*!< Next subID to use for children, if component, if subcomponent, subid of parent */
+    uint64_t next_stat_id = 1; /*!< Next statID to use */
+    bool     visited;          /*! Used when traversing graph to indicate component was visited already */
 
     static constexpr ComponentId_t null_id = std::numeric_limits<ComponentId_t>::max();
 
@@ -202,7 +202,7 @@ public:
         SST_SER(subComponents);
         SST_SER(coords);
         SST_SER(nextSubID);
-        SST_SER(nextStatID);
+        SST_SER(next_stat_id);
     }
 
     ImplementSerializable(SST::ConfigComponent)
@@ -230,8 +230,7 @@ private:
         rank(rank),
         statLoadLevel(STATISTICLOADLEVELUNINITIALIZED),
         enabledAllStats(false),
-        nextSubID(1),
-        nextStatID(1)
+        nextSubID(1)
     {
         coords.resize(3, 0.0);
     }
@@ -247,8 +246,7 @@ private:
         rank(rank),
         statLoadLevel(STATISTICLOADLEVELUNINITIALIZED),
         enabledAllStats(false),
-        nextSubID(parent_subid),
-        nextStatID(parent_subid)
+        nextSubID(parent_subid)
     {
         coords.resize(3, 0.0);
     }

--- a/src/sst/core/model/configGraph.cc
+++ b/src/sst/core/model/configGraph.cc
@@ -457,10 +457,9 @@ ConfigGraph::findComponentByName(const std::string& name)
 }
 
 ConfigStatistic*
-ConfigGraph::findStatistic(StatisticId_t id) const
+ConfigGraph::findStatistic(ComponentId_t comp_id, StatisticId_t stat_id) const
 {
-    ComponentId_t cfg_id = CONFIG_COMPONENT_ID_MASK(id);
-    return findComponent(cfg_id)->findStatistic(id);
+    return findComponent(comp_id)->findStatistic(stat_id);
 }
 
 

--- a/src/sst/core/model/configGraph.h
+++ b/src/sst/core/model/configGraph.h
@@ -166,7 +166,7 @@ public:
     ConfigComponent*       findComponentByName(const std::string& name);
     const ConfigComponent* findComponent(ComponentId_t) const;
 
-    ConfigStatistic* findStatistic(StatisticId_t) const;
+    ConfigStatistic* findStatistic(ComponentId_t, StatisticId_t) const;
 
     /** Return the map of links */
     ConfigLinkMap_t& getLinkMap() { return links_; }

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -1504,9 +1504,9 @@ SST::Core::pythonToCppParams(PyObject* statParamDict)
 }
 
 PyObject*
-SST::Core::buildStatisticObject(StatisticId_t id)
+SST::Core::buildStatisticObject(ComponentId_t comp_id, StatisticId_t stat_id)
 {
-    PyObject* argList = Py_BuildValue("(k)", id);
+    PyObject* argList = Py_BuildValue("kk", comp_id, stat_id);
     PyObject* statObj = PyObject_CallObject((PyObject*)&PyModel_StatType, argList);
     Py_DECREF(argList);
     return statObj;
@@ -1517,7 +1517,7 @@ SST::Core::buildEnabledStatistic(
     ConfigComponent* cc, const char* statName, PyObject* statParamDict, bool apply_to_children)
 {
     ConfigStatistic* cs = cc->enableStatistic(statName, pythonToCppParams(statParamDict), apply_to_children);
-    return buildStatisticObject(cs->id);
+    return buildStatisticObject(cc->id, cs->id);
 }
 
 PyObject*
@@ -1534,7 +1534,7 @@ SST::Core::buildEnabledStatistics(ConfigComponent* cc, PyObject* statList, PyObj
         PyObject*        pyname     = PyObject_Str(pylistitem);
         std::string      name       = SST_ConvertToCppString(pyname);
         ConfigStatistic* cs         = cc->enableStatistic(name, params, apply_to_children);
-        PyObject*        statObj    = buildStatisticObject(cs->id);
+        PyObject*        statObj    = buildStatisticObject(cc->id, cs->id);
         PyList_SetItem(statList, x, statObj);
         Py_XDECREF(pyname);
     }

--- a/src/sst/core/model/python/pymodel.h
+++ b/src/sst/core/model/python/pymodel.h
@@ -178,7 +178,7 @@ private:
 
 std::map<std::string, std::string> generateStatisticParameters(PyObject* statParamDict);
 SST::Params                        pythonToCppParams(PyObject* statParamDict);
-PyObject*                          buildStatisticObject(StatisticId_t id);
+PyObject*                          buildStatisticObject(ComponentId_t comp_id, StatisticId_t stat_id);
 PyObject*                          buildEnabledStatistic(
                              ConfigComponent* cc, const char* statName, PyObject* statParamDict, bool apply_to_children);
 PyObject* buildEnabledStatistics(ConfigComponent* cc, PyObject* statList, PyObject* paramDict, bool apply_to_children);

--- a/src/sst/core/model/python/pymodel_comp.cc
+++ b/src/sst/core/model/python/pymodel_comp.cc
@@ -562,7 +562,7 @@ compCreateStatistic(PyObject* self, PyObject* args)
     cs->shared = true;
     cs->name   = name;
 
-    return buildStatisticObject(cs->id);
+    return buildStatisticObject(comp->id, cs->id);
 }
 
 static PyObject*

--- a/src/sst/core/model/python/pymodel_stat.cc
+++ b/src/sst/core/model/python/pymodel_stat.cc
@@ -37,21 +37,26 @@ extern "C" {
 StatisticId_t
 PyStatistic::getID()
 {
-    return id;
+    return stat_id;
 }
 
 ConfigStatistic*
 PyStatistic::getStat()
 {
-    return gModel->getGraph()->findStatistic(id);
+    // ComponentId_t cid = CONFIG_COMPONENT_ID_MASK(stat_id);
+    return gModel->getGraph()->findStatistic(comp_id, stat_id);
 }
 
 int
 PyStatistic::compare(PyStatistic* other)
 {
-    if ( id < other->id )
+    if ( comp_id < other->comp_id )
         return -1;
-    else if ( id > other->id )
+    else if ( comp_id > other->comp_id )
+        return 1;
+    else if ( stat_id < other->stat_id )
+        return -1;
+    else if ( stat_id > other->stat_id )
         return 1;
     else
         return 0;
@@ -60,14 +65,12 @@ PyStatistic::compare(PyStatistic* other)
 static int
 statInit(StatisticPy_t* self, PyObject* args, PyObject* UNUSED(kwds))
 {
-    StatisticId_t id = 0;
-    if ( !PyArg_ParseTuple(args, "k", &id) ) return -1;
+    ComponentId_t sid = 0;
+    StatisticId_t cid = 0;
+    if ( !PyArg_ParseTuple(args, "kk", &cid, &sid) ) return -1;
 
-    PyStatistic* obj = new PyStatistic(id);
+    PyStatistic* obj = new PyStatistic(cid, sid);
     self->obj        = obj;
-
-    // gModel->getOutput()->verbose(CALL_INFO, 3, 0, "Creating statistic [%s]]\n",
-    // getStat((PyObject*)self)->name.c_str());
 
     return 0;
 }

--- a/src/sst/core/model/python/pymodel_stat.h
+++ b/src/sst/core/model/python/pymodel_stat.h
@@ -31,10 +31,12 @@ struct PyStatistic;
 
 struct PyStatistic
 {
-    StatisticId_t id;
+    ComponentId_t comp_id;
+    StatisticId_t stat_id;
 
-    explicit PyStatistic(StatisticId_t id) :
-        id(id)
+    explicit PyStatistic(ComponentId_t cid, StatisticId_t sid) :
+        comp_id(cid),
+        stat_id(sid)
     {}
     virtual ~PyStatistic() {}
     ConfigStatistic* getStat();


### PR DESCRIPTION
Make StatisticId_t independent of ComponentId_t. StatisticId_t is still unique per component tree but no longer has the component ID embedded in it. IDs are now assigned by the parent component of a component tree. The new overhead affects Python configs that use shared or explicit statistics and stores an extra ComponentId_t in each PyStatistic for lookup purposes. The json parser does not need to lookup a component when parsing statistics so it is unaffected.

I minimized formatting updates due to the pending json parser PR.
