### PR TITLE
Link id update

### DIFF
--- a/src/sst/core/impl/partitioners/simplepart.cc
+++ b/src/sst/core/impl/partitioners/simplepart.cc
@@ -235,7 +235,7 @@ SimplePartitioner::performPartition(PartitionGraph* graph)
                 // ConfigLink* theLink = (*linkItr);
                 PartitionLink& theLink = linkMap[*linkItr];
                 compConnectMap->insert(
-                    std::pair<ComponentId_t, SimTime_t>(theLink.component[1], theLink.getMinLatency()));
+                    std::pair<ComponentId_t, SimTime_t>(theLink.component_[1], theLink.getMinLatency()));
             }
         }
 

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -80,7 +80,7 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
     // Need a pointer to my simulation object
     Simulation_impl* sim = Simulation_impl::getSimulation();
 
-    // In order to uniquely identify links on restart, we need to
+    // For restarts that use the same parallelism, we need to
     // track the rank of the link and its pair link.  For regular
     // links, they are the same, but for sync link pairs, the pair
     // link will be on a different rank.  For self links, this
@@ -109,53 +109,14 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
 
         SST_SER(type);
 
-        /*
-          Unique Identifiers
-
-          For non-selflinks, we need to be able to create a unique
-          identifier so we can connect the pairs on restart.  The
-          unique identifiers are created using the MPI rank and point
-          of the link cast as a uintptr_t.
-
-          For regular links, we only store the rank once since both
-          links in the pair are on the same rank.
-
-          For SYNC links, the local link only knows the remote link by
-          it's pair link, so we will use that pointer for the unique
-          ID.
-
-          For self links, no rank info is stored since we don't need
-          to create a unique ID
-        */
-
         if ( type == SYNC || type == REG ) {
             SST_SER(my_rank);
 
-            uintptr_t ptr;
-            if ( type == SYNC )
-                ptr = reinterpret_cast<uintptr_t>(s->pair_link);
-            else
-                ptr = reinterpret_cast<uintptr_t>(s);
-
-            SST_SER(ptr);
-
             if ( type == SYNC ) {
-                // The unique ID for the remote links is constructed from
-                // the rank of the remote pair link and its pointer on
-                // that rank.  The remote pointer is stored in
-                // delivery_info and we can get the remote rank from the
-                // sync queue.
+                // Get rank for pair
                 SyncQueue* q = dynamic_cast<SyncQueue*>(s->send_queue);
                 pair_rank    = q->getToRank();
                 SST_SER(pair_rank);
-                SST_SER(s->delivery_info);
-            }
-            else {
-                // Unique ID for my pair link is my rank and pair_link
-                // pointer.  Rank is already stored, just store pair
-                // pointer
-                uintptr_t pair_ptr = reinterpret_cast<uintptr_t>(s->pair_link);
-                SST_SER(pair_ptr);
             }
         } // if ( type == SYNC || type == REG )
 
@@ -280,35 +241,28 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
         */
         bool is_orig_sync = (type == 3);
 
-        /*
-          Unique identifiers
-
-          Get the ranks and tags for this link and its pair link
-        */
         RankInfo my_restart_rank   = sim->getRank();
         RankInfo pair_restart_rank = my_restart_rank;
 
-        uintptr_t my_tag;
-        uintptr_t pair_tag;
 
         if ( type == SYNC || type == REG ) {
             SST_SER(my_rank);
-            SST_SER(my_tag);
 
             if ( type == SYNC )
                 SST_SER(pair_rank);
             else
                 pair_rank = my_rank;
-
-            SST_SER(pair_tag);
         }
 
+
+        LinkId_t link_id;
+        SST_SER(link_id);
 
         /*
           Determine current sync state
         */
         if ( type != SELF ) {
-            pair_restart_rank = sim->getRankForLinkOnRestart(pair_rank, pair_tag);
+            pair_restart_rank = sim->getRankForLinkOnRestart(pair_rank, link_id);
 
             // If pair_restart_rank.rank == UNASSIGNED, then we have
             // the same paritioning as the checkpoint and the ranks
@@ -317,6 +271,7 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
         }
 
         bool is_restart_sync = (my_restart_rank != pair_restart_rank);
+
 
         /*
           Create or get link from tracker
@@ -330,14 +285,12 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
             ser.unpacker().report_new_pointer(reinterpret_cast<uintptr_t>(s));
         }
         else {
-            auto&                     link_tracker   = sim->link_restart_tracking;
-            std::pair<int, uintptr_t> my_unique_id   = std::make_pair(my_rank.rank, my_tag);
-            std::pair<int, uintptr_t> pair_unique_id = std::make_pair(pair_rank.rank, pair_tag);
+            auto& link_tracker = sim->link_restart_tracking;
 
-            if ( !is_restart_sync && link_tracker.count(my_unique_id) ) {
+            if ( !is_restart_sync && link_tracker.count(link_id) ) {
                 // Get my link and erase it from the map
-                s = link_tracker[my_unique_id];
-                link_tracker.erase(my_unique_id);
+                s = link_tracker[link_id];
+                link_tracker.erase(link_id);
             }
             else {
                 // Create a link pair and set s to the left link
@@ -350,11 +303,11 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
                 s->pair_link->setLatency(0);
 
                 // Put my pair link in the tracking map
-                link_tracker[pair_unique_id] = s->pair_link;
+                link_tracker[link_id] = s->pair_link;
             }
         }
 
-        SST_SER(s->id);
+        s->id = link_id;
 
         /*
           Get the metadata for the link
@@ -462,17 +415,15 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
             s->pair_link->tag  = s->tag;
 
             s->pair_link->defaultTimeBase = 1;
+            s->pair_link->id              = s->id;
 
-            // Need to register with the SyncManager, but first
-            // need to create a unique name
-            std::string    uname = s->createUniqueGlobalLinkName(my_rank, my_tag, pair_rank, pair_tag);
-            ActivityQueue* sync_q =
-                sim->syncManager->registerLink(pair_restart_rank, my_restart_rank, uname, s->pair_link);
-            s->send_queue = sync_q;
+            // Need to register with the SyncManager
+            ActivityQueue* sync_q = sim->syncManager->registerLink(pair_restart_rank, my_restart_rank, s->pair_link);
+            s->send_queue         = sync_q;
         }
     } break;
     case serializer::MAP:
-        // TODO: Implement Link mapping mode
+        // No current plans to make Links mappable
         break;
     }
 }

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -415,7 +415,7 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
             s->pair_link->tag  = s->tag;
 
             s->pair_link->defaultTimeBase = 1;
-            s->pair_link->id              = s->id;
+            s->pair_link->id              = s->getId();
 
             // Need to register with the SyncManager
             ActivityQueue* sync_q = sim->syncManager->registerLink(pair_restart_rank, my_restart_rank, s->pair_link);

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -499,7 +499,7 @@ Link::Link() :
     current_time(Simulation_impl::getSimulation()->currentSimCycle),
     type(UNINITIALIZED),
     mode(INIT),
-    tag(type_max<uint32_t>),
+    tag(bit_util::type_max<uint32_t>),
     attached_tools(nullptr)
 {}
 

--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -127,6 +127,7 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
           For self links, no rank info is stored since we don't need
           to create a unique ID
         */
+
         if ( type == SYNC || type == REG ) {
             SST_SER(my_rank);
 
@@ -157,6 +158,13 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
                 SST_SER(pair_ptr);
             }
         } // if ( type == SYNC || type == REG )
+
+
+        // Serialize the ID for the Link
+        if ( !s->has_tool_list )
+            SST_SER(s->id);
+        else
+            SST_SER((*s->attached_tools)[0].second);
 
         /*
           Store the metadata for this link
@@ -217,24 +225,31 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
 
         // Determine how many serializable tools there are
         Link::ToolList tools;
-        if ( s->attached_tools ) {
-            for ( auto x : *s->attached_tools ) {
-                if ( dynamic_cast<SST::Core::Serialization::serializable*>(x.first) ) {
-                    tools.push_back(x);
+
+        if ( s->has_tool_list ) {
+            for ( auto x = ++s->attached_tools->begin(); x != s->attached_tools->end(); ++x ) {
+                if ( dynamic_cast<SST::Core::Serialization::serializable*>(x->first) ) {
+                    tools.push_back(*x);
                 }
             }
         }
         size_t tool_count = tools.size();
-        SST_SER(tool_count);
-        if ( tool_count > 0 ) {
-            // Serialize each tool, then call
-            // serializeEventAttachPointKey() to serialize any data
-            // associated with the key
-            for ( auto x : tools ) {
-                SST::Core::Serialization::serializable* obj =
-                    dynamic_cast<SST::Core::Serialization::serializable*>(x.first);
-                SST_SER(obj);
-                x.first->serializeEventAttachPointKey(ser, x.second);
+
+        // Need to determine if we'll have any tools attached on restart. We only have tools when tool_count > 0
+        bool restart_tools = (tool_count > 0);
+        SST_SER(restart_tools);
+
+        if ( restart_tools ) {
+            SST_SER(tool_count);
+            if ( tool_count > 0 ) {
+                // Serialize each tool, then call serializeEventAttachPointKey() to serialize any data associated with
+                // the key
+                for ( auto x : tools ) {
+                    SST::Core::Serialization::serializable* obj =
+                        dynamic_cast<SST::Core::Serialization::serializable*>(x.first);
+                    SST_SER(obj);
+                    x.first->serializeEventAttachPointKey(ser, x.second);
+                }
             }
         }
 
@@ -339,6 +354,8 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
             }
         }
 
+        SST_SER(s->id);
+
         /*
           Get the metadata for the link
         */
@@ -401,13 +418,20 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
             s->pair_link->latency += latency;
         }
 
-        /*
-          Restore attached tools
-        */
-        size_t tool_count;
-        SST_SER(tool_count);
-        if ( tool_count > 0 ) {
-            s->attached_tools = new Link::ToolList();
+        SST_SER(s->has_tool_list);
+
+        if ( s->has_tool_list ) {
+            /*
+              Restore attached tools
+            */
+            size_t tool_count;
+            SST_SER(tool_count);
+
+            // If has_tool_list is true, then tool_count is greater than 0
+            Link::ToolList* tools = new Link::ToolList();
+            tools->emplace_back(nullptr, s->id);
+            s->attached_tools = tools;
+            s->has_tool_list  = true;
             for ( size_t i = 0; i < tool_count; ++i ) {
                 SST::Core::Serialization::serializable* tool;
                 uintptr_t                               key;
@@ -417,9 +441,7 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
                 s->attached_tools->emplace_back(ap, key);
             }
         }
-        else {
-            s->attached_tools = nullptr;
-        }
+
 
         /*
           Deserialize the events targetting this link
@@ -477,7 +499,7 @@ private:
 };
 
 
-Link::Link(LinkId_t tag) :
+Link::Link(LinkId_t id) :
     send_queue(nullptr),
     delivery_info(0),
     defaultTimeBase(0),
@@ -486,8 +508,8 @@ Link::Link(LinkId_t tag) :
     current_time(Simulation_impl::getSimulation()->currentSimCycle),
     type(UNINITIALIZED),
     mode(INIT),
-    tag(tag),
-    attached_tools(nullptr)
+    tag(0),
+    id(id)
 {}
 
 Link::Link() :
@@ -499,8 +521,7 @@ Link::Link() :
     current_time(Simulation_impl::getSimulation()->currentSimCycle),
     type(UNINITIALIZED),
     mode(INIT),
-    tag(bit_util::type_max<uint32_t>),
-    attached_tools(nullptr)
+    tag(bit_util::type_max<uint32_t>)
 {}
 
 Link::~Link()
@@ -514,7 +535,7 @@ Link::~Link()
         if ( SYNC == pair_link->type ) delete pair_link;
     }
 
-    if ( attached_tools ) delete attached_tools;
+    if ( has_tool_list ) delete attached_tools;
 }
 
 void
@@ -683,9 +704,10 @@ Link::send_impl(SimTime_t delay, Event* event)
     event->addRecvComponent(pair_link->comp, pair_link->ctype, pair_link->port);
 #endif
 
-    if ( attached_tools ) {
-        for ( auto& x : *attached_tools ) {
-            x.first->eventSent(x.second, event);
+    if ( has_tool_list ) {
+        // First entry just holds the Link id, so we can skip it
+        for ( auto x = ++attached_tools->begin(); x != attached_tools->end(); ++x ) {
+            x->first->eventSent(x->second, event);
             // Check to see if the event was deleted.  If so, return.
             if ( nullptr == event ) return;
         }
@@ -840,17 +862,23 @@ Link::createUniqueGlobalLinkName(RankInfo local_rank, uintptr_t local_ptr, RankI
 void
 Link::attachTool(AttachPoint* tool, const AttachPointMetaData& mdata)
 {
-    if ( !attached_tools ) attached_tools = new ToolList();
+    if ( !has_tool_list ) {
+        auto tools = new ToolList();
+        tools->emplace_back(nullptr, id);
+        attached_tools = tools;
+        has_tool_list  = true;
+    }
     auto key = tool->registerLinkAttachTool(mdata);
-    attached_tools->push_back(std::make_pair(tool, key));
+    attached_tools->emplace_back(tool, key);
 }
 
 void
 Link::detachTool(AttachPoint* tool)
 {
-    if ( !attached_tools ) return;
+    if ( !has_tool_list ) return;
 
-    for ( auto x = attached_tools->begin(); x != attached_tools->end(); ++x ) {
+    // First entry just holds the Link id, so we can skip it
+    for ( auto x = ++attached_tools->begin(); x != attached_tools->end(); ++x ) {
         if ( x->first == tool ) {
             attached_tools->erase(x);
             break;

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -341,7 +341,7 @@ protected:
     */
     void setTag(uint32_t new_tag)
     {
-        if ( tag != type_max<uint32_t> ) pair_link->tag = new_tag;
+        if ( tag != bit_util::type_max<uint32_t> ) pair_link->tag = new_tag;
 
         // Interleaved links
         // pair_link->tag = new_tag;

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -431,7 +431,7 @@ private:
        If it sends to a TimeVortex (or DirectLinkQueue), it is the value used for enforce_link_order (if that feature is
        enabled).
     */
-    explicit Link(uint32_t tag);
+    explicit Link(LinkId_t id);
 
     Link(const Link& l);
 

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -56,7 +56,7 @@ class SST::Core::Serialization::serialize_impl<Link*>
 class alignas(64) Link
 {
     enum Type_t : uint16_t { POLL, HANDLER, SYNC, UNINITIALIZED };
-    enum Mode_t : uint16_t { INIT, RUN, COMPLETE };
+    enum Mode_t : uint8_t { INIT, RUN, COMPLETE };
 
     friend class SST::Core::Serialization::serialize_impl<Link*>;
 
@@ -280,7 +280,13 @@ public:
 
        @return the unique ID for this Link
     */
-    LinkId_t getId() { return tag; }
+    LinkId_t getId()
+    {
+        if ( has_tool_list )
+            return (*attached_tools)[0].second;
+        else
+            return id;
+    }
 
     /**
        Return the default timebase for this Link
@@ -418,6 +424,7 @@ private:
     SimTime_t& current_time;
     Type_t     type;
     Mode_t     mode;
+    bool       has_tool_list = false;
     uint32_t   tag;
 
     /**
@@ -432,8 +439,6 @@ private:
        enabled).
     */
     explicit Link(LinkId_t id);
-
-    Link(const Link& l);
 
     /**
        Specifies that this Link has no callback, and is poll-based only
@@ -458,7 +463,44 @@ private:
 
 
     using ToolList = std::vector<std::pair<AttachPoint*, uintptr_t>>;
-    ToolList* attached_tools;
+
+    /**
+       We need to keep the Link object to 64-bits so we need to keep the ID and the attached tools in the same 8-bytes.
+       This will normally hold the 64-bit id for the link, but if we have attached tools, then the id for the Link will
+       be stored in the first entry of the attached_tools list.
+
+       The has_tool_list member variable stores which data is currently stored in this union.  If has_tool_list is true,
+       then the union's attached_tools variable is currently active.  Otherwise, it is storing the Link id.
+    */
+    union {
+        /**
+           The Link id is a globally unique id.  For serial loads, the ids start at 1 and increment for each new Link.
+
+           On a parallel load, the top 32-bits is filled with the MPI rank and the bottom 32-bits start at 1 and
+           increment for each new rank.  The ids for links that cross a rank boundary need to be reconciled so that the
+           Link objects on both ranks agree on the ID.  This is done by having the "lower" rank send the Link name and
+           it's id for the Link to the "higher" rank, which will then use that id for the Link. "Higher" and "lower" are
+           determined in a way that hopefully spreads out the MPI traffic across all the ranks and isn't just a direct
+           greater/less than comparison. It is determined as follows:
+
+           1 - A rank is lower than the N/2 ranks after it, wrapping around to 0 when needed.
+
+           2 - A rank is higher than the N/2 ranks before it, wrapping around to N-1 when needed.
+
+          The id is used in several places:
+          - When exchanging Link pointers to put in the delivery_info field
+          - As the global name for connecting links on a restart from checkpoint
+
+        */
+        LinkId_t id;
+
+        /**
+           This stores any tools connected to the Link::AttachPoint.  The first entry in the list will always contain
+           the Link id since the pointer to the attached_tools list is now using that memory location.
+         */
+        ToolList* attached_tools;
+    };
+
 
     /**
        Manually set the default time base

--- a/src/sst/core/linkPair.h
+++ b/src/sst/core/linkPair.h
@@ -24,44 +24,29 @@ class LinkPair
 {
 public:
     /** Create a new LinkPair.  This is used when the endpoints are in the same partition.
-     * @param order Value used to enforce the link order.
-     */
-    explicit LinkPair(LinkId_t order) :
-        left(new Link(order)),
-        right(new Link(order))
-    {
-        my_id = order;
 
+        @param id ID of the link
+    */
+    explicit LinkPair(LinkId_t id) :
+        left(new Link(id)),
+        right(new Link(id))
+    {
         left->pair_link  = right;
         right->pair_link = left;
     }
 
     /** Create a new LinkPair.  This is used on restart.
-     * @param order Value used to enforce the link order.
-     */
+
+        @param order Value used to enforce the link order.
+    */
     LinkPair() :
         left(new Link()),
         right(new Link())
     {
-        my_id = -1;
-
         left->pair_link  = right;
         right->pair_link = left;
     }
 
-    /** Create a new LinkPair.  This is used when the endpoints are in different partitions.
-     * @param order Value used to enforce the link order.
-     * @param remote_tag Used to look up the correct link on the other side.
-     */
-    LinkPair(LinkId_t order, LinkId_t remote_tag) :
-        left(new Link(remote_tag)),
-        right(new Link(order))
-    {
-        my_id = order;
-
-        left->pair_link  = right;
-        right->pair_link = left;
-    }
 
     virtual ~LinkPair() {}
 
@@ -78,8 +63,6 @@ public:
 private:
     Link* left;
     Link* right;
-
-    LinkId_t my_id;
 };
 
 } // namespace SST

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -55,6 +55,7 @@ REENABLE_WARNING
 #include "sst/core/timeVortex.h"
 #include "sst/core/timingOutput.h"
 #include "sst/core/unitAlgebra.h"
+#include "sst/core/util/bit_util.h"
 
 #include <cinttypes>
 #include <csignal>
@@ -73,6 +74,7 @@ REENABLE_WARNING
 #include "sst/core/model/cfgoutput/pythonConfigOutput.h"
 
 using namespace SST::Core;
+using namespace SST::bit_util;
 using namespace SST::Partition;
 using namespace SST;
 
@@ -1138,8 +1140,10 @@ main(int argc, char* argv[])
 
         Distribute the graph.  This phase splits up the graph and
         distributes it to all the ranks.  This phase is skipped for
-        serial jobs, normal jobs that were loaded in parallel, and for
-        restarted jobs that have no repartitioning.
+        serial jobs and for restarted jobs that have no repartitioning.
+
+        Normal jobs that were loaded in parallel need to exchange unique
+        Link IDs so that the IDs are shared across partitions.
     ***************************************************************************/
     Simulation_impl::basicPerf.beginRegion("graph-distribution");
 
@@ -1203,6 +1207,152 @@ main(int argc, char* argv[])
         catch ( const std::exception& e ) {
             g_output.fatal(CALL_INFO, -1, "Error encountered during graph broadcast: %s\n", e.what());
         }
+    }
+    else if ( cfg.parallel_load() ) {
+        // Get all the nonlocal links from the graph
+        std::vector<ConfigLink*> link_vector;
+        graph->getNonLocalLinks(link_vector);
+
+        // Now sort the list based first on remote rank, then on name.  We know these are all nonlocal, so the remote
+        // rank is stored in component_[1]
+        std::sort(link_vector.begin(), link_vector.end(), [](ConfigLink const* a, ConfigLink const* b) {
+            if ( a->component_[1] != b->component_[1] ) return a->component_[1] < b->component_[1];
+            return a->name_ < b->name_;
+        });
+
+        // For every rank I am "less than", send my info.  For every rank I am "greater than", receive their data.  For
+        // N ranks, I'm "less than" the the N/2 ranks following me (wrapping to zero when necessary) and "greater than"
+        // the N/2 ranks preceding me (wrapping to N-1 when necessary).
+
+        // Stores the data I need to send.  The string is the link name and the LinkId_t is the globally unique ID
+        std::vector<std::pair<std::string, LinkId_t>> send_vec;
+
+        // Buffer to receive data in.  The string is the link name and the LinkId_t is the globally unique ID
+        std::vector<std::pair<std::string, LinkId_t>> recv_vec;
+
+        // Rank I will be sending to.  This will be adjusted at the top of each iteration through the loop
+        uint32_t send_rank = myRank.rank;
+
+        // Rank I will receive from.  This will be adjusted at the top of each iteration through the loop
+        uint32_t recv_rank = myRank.rank;
+
+        // There are two ways the following while look can end:
+        //
+        // 1 - For jobs with an even number of ranks, you can detect the last iteration when send_rank == recv_rank
+        // after incrementing send_rank and decrementing recv_rank. In this case, you still need to send data from half
+        // of the ranks to the other half.  The "lower" rank will send and the "higher" will receive.
+        //
+        // 2 - For jobs with an odd number of ranks, you detect that you are complete by incrementing send_rank and
+        // comparing to recv_rank.  If that are equal, then you've made it all the way around and are done (no more
+        // exchanges needed).
+        bool done = false;
+        while ( !done ) {
+            // Increment the send_rank and check it against recv_rank. If these are equal at this point, then we have an
+            // odd number of ranks and we have completed all of our exchanges
+            ++send_rank;
+            if ( send_rank == world_size.rank ) send_rank = 0;
+            if ( send_rank == recv_rank ) break;
+
+            // Decrement the recv_rank.  If send_rank == recv_rank at this point, then we have an even number of ranks,
+            // we are on our last iteration, and half of the ranks will only send and the other half will only receive.
+            --recv_rank;
+            if ( recv_rank == type_max<uint32_t> ) recv_rank = world_size.rank - 1;
+
+            if ( send_rank == recv_rank ) {
+                // I send if send_rank >= world_size.rank / 2 and receive otherwise
+                if ( send_rank >= world_size.rank / 2 )
+                    recv_rank = type_max<uint32_t>;
+                else
+                    send_rank = type_max<uint32_t>;
+                // End after this time through
+                done = true;
+            }
+
+            // If we are sending, fill send_vec
+            if ( send_rank != type_max<uint32_t> ) {
+                // Find the possible start of links connected to rank send_rank.  Note that if there are no links to
+                // send_rank, that this will return an iterator to the next rank that does have connected links.
+                auto send_lower = std::lower_bound(link_vector.begin(), link_vector.end(), send_rank,
+                    [](ConfigLink const* link, uint32_t r) { return link->component_[1] < r; });
+
+                // Now walk through all the links until we hit one from a rank other than send_rank.  Note that
+                // send_lower could point to a rank other than send_rank if we are not connected to any links on that
+                // rank.  The logic below accounts for that case and will just entirely skip the while loop.
+                while ( send_lower != link_vector.end() && (*send_lower)->component_[1] == send_rank ) {
+                    send_vec.emplace_back((*send_lower)->name_, (*send_lower)->id_);
+                    ++send_lower;
+                }
+
+                // Now send the data
+                Comms::send(send_rank, 0, send_vec);
+                send_vec.clear();
+            }
+
+            // Get data if we are receiving
+            if ( recv_rank != type_max<uint32_t> ) {
+                Comms::recv(recv_rank, 0, recv_vec);
+
+                // Now, fix up the IDs for the received links
+
+                // Get the lower bound for links connected to rank recv_rank.  Note that if no links are connected to
+                // that rank, then recv_lower may point to a Link connected to a different rank than expected
+                auto recv_lower = std::lower_bound(link_vector.begin(), link_vector.end(), recv_rank,
+                    [](ConfigLink const* link, uint32_t r) { return link->component_[1] < r; });
+
+                // Check to see if we are expecting anything from this rank. If not, make sure recv_lower is equal to
+                // end()
+                if ( recv_lower != link_vector.end() && (*recv_lower)->component_[1] != recv_rank )
+                    recv_lower = link_vector.end();
+
+                // Do the first error check.  We have links we're expecting from recv_rank, but it didn't send us any
+                if ( recv_lower != link_vector.end() && recv_vec.size() == 0 ) {
+                    g_output.fatal(CALL_INFO, EXIT_FAILURE,
+                        "Rank %" PRIu32 " expecting a link named %s from rank %" PRIu32 ", but did not get one\n",
+                        myRank.rank, (*recv_lower)->name_.c_str(), recv_rank);
+                }
+
+                for ( auto [remote_name, id] : recv_vec ) {
+                    // If recv_lower == end(), then we ran out of things to check, which means we got an unexpected link
+                    if ( recv_lower == link_vector.end() ) {
+                        g_output.fatal(CALL_INFO, EXIT_FAILURE,
+                            "Rank %" PRIu32 " received unexpected link from rank %" PRIu32 ": %s\n", myRank.rank,
+                            recv_rank, remote_name.c_str());
+                    }
+                    // Check to make sure the names match
+                    std::string const& local_name = (*recv_lower)->name_;
+                    if ( remote_name != local_name ) {
+                        // Two possibilities: Received unexpected link, or didn't receive expected link.  We check by
+                        // looking at which link is alphabetically first
+
+                        if ( remote_name < local_name ) {
+                            g_output.fatal(CALL_INFO, EXIT_FAILURE,
+                                "Rank %" PRIu32 " received unexpected link from rank %" PRIu32 ": %s\n", myRank.rank,
+                                recv_rank, remote_name.c_str());
+                        }
+                        else {
+                            g_output.fatal(CALL_INFO, EXIT_FAILURE,
+                                "Rank %" PRIu32 " did not receive expected link from rank %" PRIu32 ": %s\n",
+                                myRank.rank, recv_rank, local_name.c_str());
+                        }
+                    }
+
+                    // Need to change the link ID in the component and in the link
+                    graph->updateLinkId(*recv_lower, id);
+                    ++recv_lower;
+                }
+
+                // Last error check: See if I'm expecting any more that I didn't get
+                if ( recv_lower != link_vector.end() && (*recv_lower)->component_[1] == recv_rank ) {
+                    g_output.fatal(CALL_INFO, EXIT_FAILURE,
+                        "Rank %" PRIu32 " did not receive expected link from rank %" PRIu32 ": %s\n", myRank.rank,
+                        recv_rank, (*recv_lower)->name_.c_str());
+                }
+                recv_vec.clear();
+            }
+        }
+        // We changed some of the keys in the link map, so we need to force a resort
+        graph->resortLinkMap();
+        SST_MPI_Barrier(MPI_COMM_WORLD);
     }
 #endif
     ////// End Broadcast Graph //////
@@ -1294,7 +1444,7 @@ main(int argc, char* argv[])
     MemPoolAccessor::initializeGlobalData(world_size.thread, cfg.cache_align_mempools());
 #endif
 
-    // On restart, need to intialize SharedObjectManager, stats_config_ and load libraries from the checkpoint
+    // On restart, need to initialize SharedObjectManager, stats_config_ and load libraries from the checkpoint
     if ( restart ) graph->restoreRestartData();
 
     std::vector<std::thread>     threads(world_size.thread);

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -1246,6 +1246,19 @@ main(int argc, char* argv[])
         // comparing to recv_rank.  If that are equal, then you've made it all the way around and are done (no more
         // exchanges needed).
         bool done = false;
+
+        // Vector to serialize data into
+        std::vector<char> send_buf;
+
+        // Vector to receive data into
+        std::vector<char> recv_buf;
+
+        // Serializer for packing/unpacking the transfer buffer
+        SST::Core::Serialization::serializer ser;
+
+        // MPI requests for MPI_Waitall. 0 & 1 are send requests, 2 is the bulk receive request
+        MPI_Request req[3];
+
         while ( !done ) {
             // Increment the send_rank and check it against recv_rank. If these are equal at this point, then we have an
             // odd number of ranks and we have completed all of our exchanges
@@ -1278,19 +1291,52 @@ main(int argc, char* argv[])
                 // Now walk through all the links until we hit one from a rank other than send_rank.  Note that
                 // send_lower could point to a rank other than send_rank if we are not connected to any links on that
                 // rank.  The logic below accounts for that case and will just entirely skip the while loop.
-                while ( send_lower != link_vector.end() && (*send_lower)->component_[1] == send_rank ) {
-                    send_vec.emplace_back((*send_lower)->name_, (*send_lower)->id_);
-                    ++send_lower;
+
+                // Need to go through the list twice.  Once to size and once to pack
+                size_t count = 0;
+                for ( int i = 0; i < 2; ++i ) {
+                    auto send_lower_iter = send_lower;
+
+                    // Set the serialization mode
+                    if ( i == 0 ) {
+                        ser.start_sizing();
+                    }
+                    else {
+                        size_t size = ser.size();
+                        send_buf.resize(size);
+                        ser.start_packing(send_buf.data(), size);
+                    }
+                    SST_SER(count);
+                    while ( send_lower_iter != link_vector.end() && (*send_lower_iter)->component_[1] == send_rank ) {
+                        SST_SER((*send_lower_iter)->name_);
+                        SST_SER((*send_lower_iter)->id_);
+                        ++send_lower_iter;
+                        ++count;
+                    }
                 }
 
                 // Now send the data
-                Comms::send(send_rank, 0, send_vec);
-                send_vec.clear();
+                int64_t size = send_buf.size();
+                MPI_Isend(&size, 1, MPI_INT64_T, send_rank, 0, MPI_COMM_WORLD, &req[0]);
+                MPI_Isend(send_buf.data(), size, MPI_BYTE, send_rank, 1, MPI_COMM_WORLD, &req[1]);
             }
 
             // Get data if we are receiving
             if ( recv_rank != type_max<uint32_t> ) {
-                Comms::recv(recv_rank, 0, recv_vec);
+                int64_t    size;
+                MPI_Status status;
+                MPI_Recv(&size, 1, MPI_INT64_T, recv_rank, 0, MPI_COMM_WORLD, &status);
+
+                recv_buf.resize(size);
+                MPI_Irecv(recv_buf.data(), size, MPI_BYTE, recv_rank, 1, MPI_COMM_WORLD, &req[2]);
+
+                // Need to wait for all MPI send/recv to finish.  If we didn't send, only wait on the recvs
+                if ( send_rank == type_max<uint32_t> ) {
+                    MPI_Waitall(1, &req[2], MPI_STATUSES_IGNORE);
+                }
+                else {
+                    MPI_Waitall(3, req, MPI_STATUSES_IGNORE);
+                }
 
                 // Now, fix up the IDs for the received links
 
@@ -1305,14 +1351,23 @@ main(int argc, char* argv[])
                     recv_lower = link_vector.end();
 
                 // Do the first error check.  We have links we're expecting from recv_rank, but it didn't send us any
-                if ( recv_lower != link_vector.end() && recv_vec.size() == 0 ) {
+                if ( recv_lower != link_vector.end() && size == 0 ) {
                     g_output.fatal(CALL_INFO, EXIT_FAILURE,
                         "Rank %" PRIu32 " expecting a link named %s from rank %" PRIu32 ", but did not get one\n",
                         myRank.rank, (*recv_lower)->name_.c_str(), recv_rank);
                 }
 
-                for ( auto [remote_name, id] : recv_vec ) {
-                    // If recv_lower == end(), then we ran out of things to check, which means we got an unexpected link
+                // Get the number of links received
+                size_t count = 0;
+                ser.start_unpacking(recv_buf.data(), size);
+                SST_SER(count);
+
+                for ( size_t i = 0; i < count; ++i ) {
+                    std::string remote_name;
+                    LinkId_t    id = 0;
+                    SST_SER(remote_name);
+                    SST_SER(id);
+
                     if ( recv_lower == link_vector.end() ) {
                         g_output.fatal(CALL_INFO, EXIT_FAILURE,
                             "Rank %" PRIu32 " received unexpected link from rank %" PRIu32 ": %s\n", myRank.rank,
@@ -1348,6 +1403,10 @@ main(int argc, char* argv[])
                         recv_rank, (*recv_lower)->name_.c_str());
                 }
                 recv_vec.clear();
+            }
+            else {
+                // No receives, but we need to wait on the sends
+                MPI_Waitall(2, req, MPI_STATUSES_IGNORE);
             }
         }
         // We changed some of the keys in the link map, so we need to force a resort

--- a/src/sst/core/model/cfgoutput/dotConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/dotConfigOutput.cc
@@ -112,8 +112,8 @@ DotConfigGraphOutput::generateDot(const ConfigComponent* comp, const ConfigLinkM
         }
         for ( LinkId_t i : comp->links ) {
             const ConfigLink* link = linkMap[i];
-            const int         port = (link->component[0] == comp->id) ? 0 : 1;
-            fprintf(outputFile, "<%s> Port: %s", link->port[port].c_str(), link->port[port].c_str());
+            const int         port = (link->component_[0] == comp->id) ? 0 : 1;
+            fprintf(outputFile, "<%s> Port: %s", link->port_[port].c_str(), link->port_[port].c_str());
             if ( j > 1 ) {
                 fprintf(outputFile, " |\n");
             }
@@ -138,26 +138,26 @@ DotConfigGraphOutput::generateDot(const ConfigLink* link, const uint32_t dot_ver
 {
     UnitAlgebra tb = Simulation_impl::getTimeLord()->getTimeBase();
 
-    int minLatIdx = (link->latency[0] <= link->latency[1]) ? 0 : 1;
+    int minLatIdx = (link->latency_[0] <= link->latency_[1]) ? 0 : 1;
 
-    auto tmp = tb * link->latency[minLatIdx];
+    auto tmp = tb * link->latency_[minLatIdx];
 
 
     // Link name and latency displayed. Connected to specific port on component
     if ( dot_verbosity >= 8 ) {
-        fprintf(outputFile, "%" PRIu64 ":\"%s\" -- %" PRIu64 ":\"%s\" [label=\"%s\\n%s\"]; \n", link->component[0],
-            link->port[0].c_str(), link->component[1], link->port[1].c_str(), link->name.c_str(),
+        fprintf(outputFile, "%" PRIu64 ":\"%s\" -- %" PRIu64 ":\"%s\" [label=\"%s\\n%s\"]; \n", link->component_[0],
+            link->port_[0].c_str(), link->component_[1], link->port_[1].c_str(), link->name_.c_str(),
             tmp.toStringBestSI().c_str());
 
         // No link name or latency. Connected to specific port on component
     }
     else if ( dot_verbosity >= 6 ) {
-        fprintf(outputFile, "%" PRIu64 ":\"%s\" -- %" PRIu64 ":\"%s\"\n", link->component[0], link->port[0].c_str(),
-            link->component[1], link->port[1].c_str());
+        fprintf(outputFile, "%" PRIu64 ":\"%s\" -- %" PRIu64 ":\"%s\"\n", link->component_[0], link->port_[0].c_str(),
+            link->component_[1], link->port_[1].c_str());
 
         // No link name or latency. Connected to component NOT port
     }
     else {
-        fprintf(outputFile, "%" PRIu64 " -- %" PRIu64 "\n", link->component[0], link->component[1]);
+        fprintf(outputFile, "%" PRIu64 " -- %" PRIu64 "\n", link->component_[0], link->component_[1]);
     }
 }

--- a/src/sst/core/model/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/jsonConfigOutput.cc
@@ -54,23 +54,23 @@ JSONConfigGraphOutput::outputLinks(ConfigGraph* graph, std::ofstream& ofs)
             count++;
 
             // general link key:val pairs
-            linkRecord["name"]     = linkItr->name;
-            linkRecord["noCut"]    = linkItr->no_cut;
-            linkRecord["nonlocal"] = linkItr->nonlocal;
+            linkRecord["name"]     = linkItr->name_;
+            linkRecord["noCut"]    = linkItr->no_cut_;
+            linkRecord["nonlocal"] = linkItr->nonlocal_;
 
             // left link
-            linkRecord["left"]["component"] = graph->findComponent(linkItr->component[0])->getFullName();
-            linkRecord["left"]["port"]      = linkItr->port[0];
+            linkRecord["left"]["component"] = graph->findComponent(linkItr->component_[0])->getFullName();
+            linkRecord["left"]["port"]      = linkItr->port_[0];
             linkRecord["left"]["latency"]   = linkItr->latency_str(0);
 
             // right link
-            if ( linkItr->nonlocal ) {
-                linkRecord["right"]["rank"]   = linkItr->component[1];
-                linkRecord["right"]["thread"] = linkItr->latency[1];
+            if ( linkItr->nonlocal_ ) {
+                linkRecord["right"]["rank"]   = linkItr->component_[1];
+                linkRecord["right"]["thread"] = linkItr->latency_[1];
             }
             else {
-                linkRecord["right"]["component"] = graph->findComponent(linkItr->component[1])->getFullName();
-                linkRecord["right"]["port"]      = linkItr->port[1];
+                linkRecord["right"]["component"] = graph->findComponent(linkItr->component_[1])->getFullName();
+                linkRecord["right"]["port"]      = linkItr->port_[1];
                 linkRecord["right"]["latency"]   = linkItr->latency_str(1);
             }
 

--- a/src/sst/core/model/cfgoutput/pythonConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/pythonConfigOutput.cc
@@ -123,17 +123,17 @@ PythonConfigGraphOutput::generateCommonLink(const char* objName, const ConfigCom
         const ConfigLink* link = getGraph()->getLinkMap()[linkID];
 
         // only create the link if the component is the LHS of the port connection
-        if ( link->component[0] == comp->id ) {
+        if ( link->component_[0] == comp->id ) {
             int   srcIdx     = 0;
             int   destIdx    = 1;
-            char* esPortName = makeEscapeSafe(link->port[srcIdx].c_str());
+            char* esPortName = makeEscapeSafe(link->port_[srcIdx].c_str());
             char* destName   = nullptr;
 
-            const std::string& linkName = getLinkObject(linkID, link->name, link->no_cut);
+            const std::string& linkName = getLinkObject(linkID, link->name_, link->no_cut_);
 
-            if ( !link->nonlocal ) {
-                char* edPortName = makeEscapeSafe(link->port[destIdx].c_str());
-                auto  destComp   = getGraph()->findComponent(link->component[1]);
+            if ( !link->nonlocal_ ) {
+                char* edPortName = makeEscapeSafe(link->port_[destIdx].c_str());
+                auto  destComp   = getGraph()->findComponent(link->component_[1]);
                 destName         = generateCompName(destComp);
 
 
@@ -145,8 +145,8 @@ PythonConfigGraphOutput::generateCommonLink(const char* objName, const ConfigCom
                 free(edPortName);
             }
             else {
-                int rank   = link->component[1];
-                int thread = link->latency[1];
+                int rank   = link->component_[1];
+                int thread = link->latency_[1];
                 fprintf(outputFile, "%s.connectNonLocal((%s, \"%s\", \"%s\"),(%d, %d))\n", linkName.c_str(), objName,
                     esPortName, link->latency_str(srcIdx).c_str(), rank, thread);
             }

--- a/src/sst/core/model/cfgoutput/xmlConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/xmlConfigOutput.cc
@@ -76,11 +76,11 @@ XMLConfigGraphOutput::generateXML(
     const std::string& indent, const ConfigLink* link, const ConfigComponentMap_t& compMap) const
 {
 
-    const ConfigComponent* link_left  = compMap[link->component[0]];
-    const ConfigComponent* link_right = compMap[link->component[1]];
+    const ConfigComponent* link_left  = compMap[link->component_[0]];
+    const ConfigComponent* link_right = compMap[link->component_[1]];
 
     fprintf(outputFile,
         "%s<link id=\"%s\" name=\"%s\"\n%s%sleft=\"%s\" right=\"%s\"\n%s%sleftport=\"%s\" rightport=\"%s\"/>\n",
-        indent.c_str(), link->name.c_str(), link->name.c_str(), indent.c_str(), "   ", link_left->name.c_str(),
-        link_right->name.c_str(), indent.c_str(), "   ", link->port[0].c_str(), link->port[1].c_str());
+        indent.c_str(), link->name_.c_str(), link->name_.c_str(), indent.c_str(), "   ", link_left->name.c_str(),
+        link_right->name.c_str(), indent.c_str(), "   ", link->port_[0].c_str(), link->port_[1].c_str());
 }

--- a/src/sst/core/model/configComponent.cc
+++ b/src/sst/core/model/configComponent.cc
@@ -580,27 +580,27 @@ ConfigComponent::checkPorts() const
         const ConfigLink* link = graph_links[links[i]];
         for ( int j = 0; j < 2; j++ ) {
             // If this is a nonlocal link, then there is no port to check for index 1
-            if ( link->nonlocal && j == 1 ) continue;
-            if ( link->component[j] == id ) {
+            if ( link->nonlocal_ && j == 1 ) continue;
+            if ( link->component_[j] == id ) {
                 // If port is not found, print an error
-                if ( !Factory::getFactory()->isPortNameValid(type, link->port[j]) ) {
+                if ( !Factory::getFactory()->isPortNameValid(type, link->port_[j]) ) {
                     // For now this is not a fatal error
                     // found_error = true;
                     Output::getDefaultObject().fatal(CALL_INFO, 1,
                         "ERROR:  Attempting to connect to unknown port: %s, "
                         "in component %s of type %s.\n",
-                        link->port[j].c_str(), name.c_str(), type.c_str());
+                        link->port_[j].c_str(), name.c_str(), type.c_str());
                 }
 
                 // Check for multiple links hooked to port
-                auto ret = ports.insert(std::make_pair(link->port[j], link->name));
+                auto ret = ports.insert(std::make_pair(link->port_[j], link->name_));
                 if ( !ret.second ) {
                     // Check to see if this is a loopback link
-                    if ( ret.first->second != link->name )
+                    if ( ret.first->second != link->name_ )
                         // Not a loopback link, fatal...
                         Output::getDefaultObject().fatal(CALL_INFO, 1,
-                            "ERROR: Port %s of Component %s connected to two links: %s, %s.\n", link->port[j].c_str(),
-                            name.c_str(), link->name.c_str(), ret.first->second.c_str());
+                            "ERROR: Port %s of Component %s connected to two links: %s, %s.\n", link->port_[j].c_str(),
+                            name.c_str(), link->name_.c_str(), ret.first->second.c_str());
                 }
             }
         }

--- a/src/sst/core/model/configComponent.cc
+++ b/src/sst/core/model/configComponent.cc
@@ -569,6 +569,17 @@ ConfigComponent::clearAllLinks()
 }
 
 void
+ConfigComponent::replaceLinkId(LinkId_t old_id, LinkId_t new_id)
+{
+    for ( auto& x : links ) {
+        if ( x == old_id ) {
+            x = new_id;
+            break;
+        }
+    }
+}
+
+void
 ConfigComponent::checkPorts() const
 {
     std::map<std::string, std::string> ports;

--- a/src/sst/core/model/configComponent.h
+++ b/src/sst/core/model/configComponent.h
@@ -182,6 +182,15 @@ public:
     */
     std::vector<LinkId_t> clearAllLinks();
 
+    /**
+       Update a Link that has had its ID changed
+
+       @param old_id Old id to replace
+
+       @param new_id New id to use
+    */
+    void replaceLinkId(LinkId_t old_id, LinkId_t new_id);
+
     void serialize_order(SST::Core::Serialization::serializer& ser) override
     {
         SST_SER(id);

--- a/src/sst/core/model/configGraph.cc
+++ b/src/sst/core/model/configGraph.cc
@@ -21,6 +21,7 @@
 #include "sst/core/model/configStatistic.h"
 #include "sst/core/namecheck.h"
 #include "sst/core/simulation_impl.h"
+#include "sst/core/sst_mpi.h"
 #include "sst/core/timeLord.h"
 #include "sst/core/warnmacros.h"
 
@@ -75,6 +76,7 @@ namespace SST {
 ConfigGraph::ConfigGraph() :
     nextComponentId(0)
 {
+    link_rank_mask = (LinkId_t)SST_MPI_GetRank() << 32;
     links_.clear();
     comps_.clear();
     // Init the statistic output settings
@@ -276,6 +278,42 @@ ConfigGraph::checkForStructuralErrors()
     return found_error;
 }
 
+void
+ConfigGraph::getNonLocalLinks(std::vector<ConfigLink*>& vec)
+{
+    for ( auto* x : links_ ) {
+        if ( x->nonlocal_ ) vec.push_back(x);
+    }
+}
+
+void
+ConfigGraph::updateLinkId(ConfigLink* link, LinkId_t new_id)
+{
+    // First need to change the IDs in any connected components
+    if ( link->component_[0] != UNSET_COMPONENT_ID ) {
+        // Get the component
+        ConfigComponent* comp = findComponent(link->component_[0]);
+        comp->replaceLinkId(link->id_, new_id);
+    }
+
+    if ( !link->nonlocal_ && link->component_[1] != UNSET_COMPONENT_ID ) {
+        // Get the component
+        ConfigComponent* comp = findComponent(link->component_[1]);
+        comp->replaceLinkId(link->id_, new_id);
+    }
+
+    // NOTE: this changes the key for the links_ map, which means we will need to resort the SparseVectorMap before
+    // accessing it
+    link->id_ = new_id;
+}
+
+void
+ConfigGraph::resortLinkMap()
+{
+    links_.sort();
+}
+
+
 ComponentId_t
 ConfigGraph::addComponent(const std::string& name, const std::string& type)
 {
@@ -395,7 +433,7 @@ LinkId_t
 ConfigGraph::createLink(const char* name, const char* latency)
 {
     checkForValidLinkName(name);
-    LinkId_t    id   = (LinkId_t)links_.size();
+    LinkId_t    id   = (LinkId_t)links_.size() | link_rank_mask;
     ConfigLink* link = new ConfigLink(id, name);
     links_.insert(link);
     if ( latency ) {

--- a/src/sst/core/model/configGraph.cc
+++ b/src/sst/core/model/configGraph.cc
@@ -173,21 +173,21 @@ ConfigGraph::checkRanks(RankInfo ranks)
     for ( auto& link : links_ ) {
         RankInfo r0(-1, -1);
         RankInfo r1(-1, -1);
-        r0 = comps_[COMPONENT_ID_MASK(link->component[0])]->rank;
+        r0 = comps_[COMPONENT_ID_MASK(link->component_[0])]->rank;
 
-        if ( link->nonlocal ) {
-            r1.rank   = link->component[1];
-            r1.thread = link->latency[1];
+        if ( link->nonlocal_ ) {
+            r1.rank   = link->component_[1];
+            r1.thread = link->latency_[1];
         }
         else {
-            r1 = comps_[COMPONENT_ID_MASK(link->component[1])]->rank;
+            r1 = comps_[COMPONENT_ID_MASK(link->component_[1])]->rank;
         }
 
         if ( r0.rank != r1.rank ) {
-            link->cross_rank = true;
+            link->cross_rank_ = true;
         }
         else if ( r0.thread != r1.thread ) {
-            link->cross_thread = true;
+            link->cross_thread_ = true;
         }
     }
 
@@ -244,21 +244,22 @@ ConfigGraph::checkForStructuralErrors()
         /*
           Two conditions we need to look for:
 
-          1 - Unused link.  This happens when order == 0 and we are NOT a nonlocal link
+          1 - Unused link.  This happens when component_[0] is unset and we are NOT a nonlocal link
 
-          2 - Dangling link.  This happens when order == 0 and we are a nonlocal link, or when order == 0 and we are NOT
-              a nonlocal link
+          2 - Dangling link.  This happens when component_[0] is unset and we are a nonlocal link, or when component_[0]
+              is set and component_[1] is unset and we are NOT a nonlocal link
         */
-        if ( clink->order == 0 ) {
-            if ( !clink->nonlocal )
-                output.output("WARNING:  Found unused link: %s\n", clink->name.c_str());
+        if ( clink->component_[0] == UNSET_COMPONENT_ID ) {
+            if ( !clink->nonlocal_ )
+                output.output("WARNING:  Found unused link: %s\n", clink->name_.c_str());
             else
-                output.output("WARNING:  Found dangling nonlocal link: %s\n", clink->name.c_str());
+                output.output("WARNING:  Found dangling nonlocal link: %s\n", clink->name_.c_str());
             found_error = true;
         }
-        else if ( clink->order == 1 && !clink->nonlocal ) {
+        // If we do this check, we know component_[0] is set
+        else if ( clink->component_[1] == UNSET_COMPONENT_ID && !clink->nonlocal_ ) {
             output.output("WARNING:  Found dangling link: %s.  It is connected on one side to component %s.\n",
-                clink->name.c_str(), comps_[clink->component[0]]->name.c_str());
+                clink->name_.c_str(), comps_[clink->component_[0]]->name.c_str());
             found_error = true;
         }
     }
@@ -331,31 +332,31 @@ ConfigGraph::addLink(ComponentId_t comp_id, LinkId_t link_id, const char* port, 
 
     // Check to make sure the link has not been referenced too many
     // times.
-    if ( link->order >= 2 ) {
-        output.fatal(
-            CALL_INFO, 1, "ERROR: Parsing SDL file: Link %s referenced more than two times\n", link->name.c_str());
-    }
-    else if ( link->order == 1 && link->nonlocal ) {
+    if ( link->component_[0] != UNSET_COMPONENT_ID && link->nonlocal_ ) {
         output.fatal(CALL_INFO, 1,
             "ERROR: Parsing SDL file: Attempting to connect second component to link %s which is set as non-local\n",
-            link->name.c_str());
+            link->name_.c_str());
+    }
+    else if ( link->component_[0] != UNSET_COMPONENT_ID && link->component_[1] != UNSET_COMPONENT_ID ) {
+        output.fatal(
+            CALL_INFO, 1, "ERROR: Parsing SDL file: Link %s referenced more than two times\n", link->name_.c_str());
     }
 
     // Check to make sure that a latency was specified, either in the
     // call or at ConfigLink construct time
-    if ( nullptr == latency_str && link->latency[0] == 0 ) {
+    if ( nullptr == latency_str && link->latency_[0] == 0 ) {
         output.fatal(CALL_INFO, 1, "ERROR: Parsing SDL file: Connecting link with no latency assigned: %s\n",
-            link->name.c_str());
+            link->name_.c_str());
     }
 
     // Update link information
-    int index              = link->order++;
-    link->component[index] = comp_id;
-    link->port[index]      = port;
+    int index               = link->component_[0] == UNSET_COMPONENT_ID ? 0 : 1;
+    link->component_[index] = comp_id;
+    link->port_[index]      = port;
 
     // A nullptr for latency_str means use the latency specified at
     // link creation
-    if ( latency_str ) link->latency[index] = ConfigLink::getIndexForLatency(latency_str);
+    if ( latency_str ) link->latency_[index] = ConfigLink::getIndexForLatency(latency_str);
 
     // Need to add this link to the ConfigComponent's link list.
     // Check to make sure the link doesn't already exist in the
@@ -364,9 +365,9 @@ ConfigGraph::addLink(ComponentId_t comp_id, LinkId_t link_id, const char* port, 
     // first reference to the link, or if link->component[0] is not
     // equal to the current component sent into this call, then it is
     // not already in the list.
-    if ( link->order == 1 || link->component[0] != comp_id ) {
+    if ( index == 0 || link->component_[0] != comp_id ) {
         auto compLinks = &findComponent(comp_id)->links;
-        compLinks->push_back(link->id);
+        compLinks->push_back(link->id_);
     }
 }
 
@@ -374,19 +375,19 @@ void
 ConfigGraph::addNonLocalLink(LinkId_t link_id, int rank, int thread)
 {
     ConfigLink* link = links_[link_id];
-    if ( link->nonlocal ) {
+    if ( link->nonlocal_ ) {
         output.fatal(CALL_INFO, 1,
             "ERROR: Parsing SDL file: Trying to set link %s as as non-local, which is already set to non-local\n",
-            link->name.c_str());
+            link->name_.c_str());
     }
-    else if ( link->order == 2 ) {
+    else if ( link->component_[1] != UNSET_COMPONENT_ID ) {
         output.fatal(CALL_INFO, 1,
             "ERROR: Parsing SDL file: Link %s being set as non-local, but is already connected to two components\n",
-            link->name.c_str());
+            link->name_.c_str());
     }
-    link->nonlocal     = true;
-    link->component[1] = rank;
-    link->latency[1]   = thread;
+    link->nonlocal_     = true;
+    link->component_[1] = rank;
+    link->latency_[1]   = thread;
 }
 
 
@@ -398,9 +399,9 @@ ConfigGraph::createLink(const char* name, const char* latency)
     ConfigLink* link = new ConfigLink(id, name);
     links_.insert(link);
     if ( latency ) {
-        uint32_t index   = ConfigLink::getIndexForLatency(latency);
-        link->latency[0] = index;
-        link->latency[1] = index;
+        uint32_t index    = ConfigLink::getIndexForLatency(latency);
+        link->latency_[0] = index;
+        link->latency_[1] = index;
     }
     return id;
 }
@@ -408,7 +409,7 @@ ConfigGraph::createLink(const char* name, const char* latency)
 void
 ConfigGraph::setLinkNoCut(LinkId_t link_id)
 {
-    links_[link_id]->no_cut = true;
+    links_[link_id]->no_cut_ = true;
 }
 
 bool
@@ -477,12 +478,12 @@ ConfigGraph::GraphFilter::operator()(ConfigLink* link)
     // Need to see if the link is connected to components in the
     // old and/or new graph
     RankInfo ranks[2];
-    ranks[0] = ograph_->findComponent(link->component[0])->rank;
-    if ( link->nonlocal ) {
+    ranks[0] = ograph_->findComponent(link->component_[0])->rank;
+    if ( link->nonlocal_ ) {
         ranks[1].rank = -1;
     }
     else {
-        ranks[1] = ograph_->findComponent(link->component[1])->rank;
+        ranks[1] = ograph_->findComponent(link->component_[1])->rank;
     }
 
     // Check to see which components are in which sets
@@ -509,7 +510,7 @@ ConfigGraph::GraphFilter::operator()(ConfigLink* link)
         // Connected in original graph, not in new. Just return it
 
         // See if link needs to be set as nonlocal
-        if ( !link->nonlocal && (c0_in_orig ^ c1_in_orig) ) {
+        if ( !link->nonlocal_ && (c0_in_orig ^ c1_in_orig) ) {
             // Only one side is in the set. Figure out which one and set the link as nonlocal
             int index = c0_in_orig ? 0 : 1;
             link->setAsNonLocal(index, ranks[(index + 1) % 2]);
@@ -521,7 +522,7 @@ ConfigGraph::GraphFilter::operator()(ConfigLink* link)
         ngraph_->links_.insert(link);
 
         // See if link needs to be set as nonlocal
-        if ( !link->nonlocal && (c0_in_new ^ c1_in_new) ) {
+        if ( !link->nonlocal_ && (c0_in_new ^ c1_in_new) ) {
             // Only one side is in the set. Figure out which one and set the link as nonlocal
             int index = c0_in_new ? 0 : 1;
             link->setAsNonLocal(index, ranks[(index + 1) % 2]);
@@ -675,7 +676,7 @@ ConfigGraph::getMinimumPartitionLatency()
     SimTime_t graph_min_part = std::numeric_limits<SimTime_t>::max();
 
     for ( auto& link : links_ ) {
-        if ( link->cross_rank ) {
+        if ( link->cross_rank_ ) {
             SimTime_t min_lat = link->getMinLatency();
             if ( min_lat < graph_min_part ) {
                 graph_min_part = min_lat;
@@ -706,13 +707,13 @@ ConfigGraph::getPartitionGraph()
     for ( ConfigLinkMap_t::iterator it = links_.begin(); it != links_.end(); ++it ) {
         const ConfigLink* link = *it;
 
-        const ConfigComponent* comp0 = comps_[COMPONENT_ID_MASK(link->component[0])];
-        const ConfigComponent* comp1 = comps_[COMPONENT_ID_MASK(link->component[1])];
+        const ConfigComponent* comp0 = comps_[COMPONENT_ID_MASK(link->component_[0])];
+        const ConfigComponent* comp1 = comps_[COMPONENT_ID_MASK(link->component_[1])];
 
         plinks.insert(PartitionLink(*link));
 
-        pcomps[comp0->id]->links.push_back(link->id);
-        pcomps[comp1->id]->links.push_back(link->id);
+        pcomps[comp0->id]->links.push_back(link->id_);
+        pcomps[comp1->id]->links.push_back(link->id_);
     }
     return graph;
 }
@@ -767,12 +768,12 @@ ConfigGraph::getCollapsedPartitionGraph()
             for ( LinkId_t id : comp->allLinks() ) {
                 const ConfigLink* link = links_[id];
 
-                if ( group.find(COMPONENT_ID_MASK(link->component[0])) == group.end() ||
-                     group.find(COMPONENT_ID_MASK(link->component[1])) == group.end() ) {
-                    pcomp->links.push_back(link->id);
+                if ( group.find(COMPONENT_ID_MASK(link->component_[0])) == group.end() ||
+                     group.find(COMPONENT_ID_MASK(link->component_[1])) == group.end() ) {
+                    pcomp->links.push_back(link->id_);
                 }
                 else {
-                    deleted_links.insert(link->id);
+                    deleted_links.insert(link->id_);
                 }
             }
         }
@@ -786,7 +787,7 @@ ConfigGraph::getCollapsedPartitionGraph()
     // This will insert in order since the iterator is from a
     // SparseVectorMap.
     for ( ConfigLinkMap_t::iterator i = links_.begin(); i != links_.end(); ++i ) {
-        if ( deleted_links.find((*i)->id) == deleted_links.end() ) plinks.insert(*(*i));
+        if ( deleted_links.find((*i)->id_) == deleted_links.end() ) plinks.insert(*(*i));
     }
 
     // Just need to fix up the component fields for the links.  Do
@@ -797,8 +798,8 @@ ConfigGraph::getCollapsedPartitionGraph()
         PartitionComponent* pcomp = *i;
         for ( LinkIdMap_t::iterator j = pcomp->links.begin(); j != pcomp->links.end(); ++j ) {
             PartitionLink& plink = plinks[*j];
-            if ( pcomp->group.contains(plink.component[0]) ) plink.component[0] = pcomp->id;
-            if ( pcomp->group.contains(plink.component[1]) ) plink.component[1] = pcomp->id;
+            if ( pcomp->group.contains(plink.component_[0]) ) plink.component_[0] = pcomp->id;
+            if ( pcomp->group.contains(plink.component_[1]) ) plink.component_[1] = pcomp->id;
         }
     }
 
@@ -834,10 +835,10 @@ ConfigGraph::getConnectedNoCutComps(ComponentId_t start, std::set<ComponentId_t>
 
         // If this is a no_cut link, need to follow it to next
         // component if next component is not already in group
-        if ( link->no_cut ) {
+        if ( link->no_cut_ ) {
             ComponentId_t id = COMPONENT_ID_MASK(
-                (COMPONENT_ID_MASK(link->component[0]) == COMPONENT_ID_MASK(start) ? link->component[1]
-                                                                                   : link->component[0]));
+                (COMPONENT_ID_MASK(link->component_[0]) == COMPONENT_ID_MASK(start) ? link->component_[1]
+                                                                                    : link->component_[0]));
             // Check to see if this id is already in the group.  We
             // can do it one of two ways: check the visited variable,
             // or see if it is in the group set already.  We look in

--- a/src/sst/core/model/configGraph.h
+++ b/src/sst/core/model/configGraph.h
@@ -158,6 +158,11 @@ public:
     /** Return the map of components */
     ConfigComponentMap_t& getComponentMap() { return comps_; }
 
+    void getNonLocalLinks(std::vector<ConfigLink*>& vec);
+
+    void updateLinkId(ConfigLink* link, LinkId_t new_id);
+    void resortLinkMap();
+
     const std::map<std::string, ConfigStatGroup>& getStatGroups() const;
     ConfigStatGroup*                              getStatGroup(const std::string& name);
 
@@ -232,7 +237,8 @@ public:
 private:
     friend class Simulation_impl;
 
-    Output output;
+    Output   output;
+    LinkId_t link_rank_mask = 0;
 
     ComponentId_t nextComponentId;
 

--- a/src/sst/core/model/configLink.cc
+++ b/src/sst/core/model/configLink.cc
@@ -24,6 +24,7 @@
 #include <utility>
 
 namespace SST {
+
 std::map<std::string, uint32_t> ConfigLink::lat_to_index;
 
 uint32_t
@@ -64,7 +65,7 @@ ConfigLink::latency_str(uint32_t index) const
 {
     static TimeLord* timelord = Simulation_impl::getTimeLord();
     UnitAlgebra      tb       = timelord->getTimeBase();
-    auto             tmp      = tb * latency[index];
+    auto             tmp      = tb * latency_[index];
     return tmp.toStringBestSI();
 }
 
@@ -74,30 +75,30 @@ ConfigLink::setAsNonLocal(int which_local, RankInfo remote_rank_info)
     // First, if which_local != 0, we need to swap the data for index
     // 0 and 1
     if ( which_local == 1 ) {
-        std::swap(component[0], component[1]);
-        std::swap(port[0], port[1]);
-        std::swap(latency[0], latency[1]);
+        std::swap(component_[0], component_[1]);
+        std::swap(port_[0], port_[1]);
+        std::swap(latency_[0], latency_[1]);
     }
 
     // Now add remote annotations.  Rank goes in component[1], thread
     // goes in latency[1], port[1] is not needed
-    component[1] = remote_rank_info.rank;
-    latency[1]   = remote_rank_info.thread;
-    port[1].clear();
+    component_[1] = remote_rank_info.rank;
+    latency_[1]   = remote_rank_info.thread;
+    port_[1].clear();
 
-    nonlocal = true;
+    nonlocal_ = true;
 }
 
 void
 ConfigLink::updateLatencies()
 {
     // Need to clean up some elements before we can test for zero latency
-    if ( order >= 1 ) {
-        latency[0] = ConfigLink::getLatencyFromIndex(latency[0]);
+    if ( component_[0] != UNSET_COMPONENT_ID ) {
+        latency_[0] = ConfigLink::getLatencyFromIndex(latency_[0]);
     }
     // If this is nonlocal, latency[1] holds the remote thread instead of the latency
-    if ( order >= 2 && !nonlocal ) {
-        latency[1] = ConfigLink::getLatencyFromIndex(latency[1]);
+    if ( !nonlocal_ && component_[1] != UNSET_COMPONENT_ID ) {
+        latency_[1] = ConfigLink::getLatencyFromIndex(latency_[1]);
     }
 }
 

--- a/src/sst/core/model/configLink.h
+++ b/src/sst/core/model/configLink.h
@@ -52,8 +52,8 @@ public:
        the order they are attached in.  If the link is marked as
        non-local, then component[1] holds the rank of the remote
        component.
-     */
-    ComponentId_t component[2] = { 0, 0 }; /*!< IDs of the connected components */
+    */
+    ComponentId_t component_[2] = { UNSET_COMPONENT_ID, UNSET_COMPONENT_ID }; /*!< IDs of the connected components */
 
     /**
        This is a dual purpose data member.
@@ -75,55 +75,40 @@ public:
 
        If the link is marked as non-local, then latency[1] holds the
        thread of the remote component.
-     */
-    SimTime_t latency[2] = { 0, 0 };
+    */
+    SimTime_t latency_[2] = { 0, 0 };
 
     /**
-       Name of the link.  This is used in three cases:
+       Name of the link.  This is used in two ways:
 
        Errors - if an error is found in the graph construction, the
        name is used to report the error to the user
-
-       Link ordering - the event ordering for links is based on the
-       alphabetized name of the links.  The links are sorted by name
-       and order is assigned linearly starting at 1
 
        Parallel load - for parallel load, links that cross partition
        boundaries are connected by matching link names
 
        Link names are not carried over to the simulation objects
-     */
-    std::string name;
+    */
+    std::string name_;
 
     /**
        id of the link.  This is used primarily to find the link in ConfigGraph::links.  For parallel loads, the link ID
        is only unique on a given rank, not globally.
 
        The ID's are not carried over to the simulation objects
-     */
-    LinkId_t id = 0;
-
-    /**
-       This is a dual purpose data member.  During graph construction,
-       it counts the number of components currently referencing this
-       link.  After graph construction, it is assigned the value used
-       to enforce ordering of events based on the links they were sent
-       on.
-
-       @see Activity::setOrderTag, Link::tag
-     */
-    LinkId_t order = 0;
+    */
+    LinkId_t id_ = 0;
 
     /**
        Name of the ports the link is connected to.  The indices match
        the ones used in the component array
-     */
-    std::string port[2];
+    */
+    std::string port_[2];
 
     /**
        Whether or not this link is set to be no-cut
-     */
-    bool no_cut = false;
+    */
+    bool no_cut_ = false;
 
     /**
        Whether this link crosses the graph boundary and is connected
@@ -132,17 +117,17 @@ public:
        for the arrays) and the rank for the remote component will be
        stored in component[1] and the thread in latency[1].
     */
-    bool nonlocal = false;
+    bool nonlocal_ = false;
 
     /**
        Set to true if this is a cross rank link
-     */
-    bool cross_rank = false;
+    */
+    bool cross_rank_ = false;
 
     /**
        Set to true if this is a cross thread link on same rank
     */
-    bool cross_thread = false;
+    bool cross_thread_ = false;
 
     /********* ^^ Member variables ^^ ***********/
 
@@ -150,23 +135,23 @@ public:
     /**
        Function used when storing ConfigLinks in a SparseVectorMap
     */
-    inline LinkId_t key() const { return id; }
+    inline LinkId_t key() const { return id_; }
 
     /**
        Return the minimum latency of this link (from both sides).  For non local links, it will return the local latency
     */
     SimTime_t getMinLatency() const
     {
-        if ( nonlocal ) return latency[0];
-        if ( latency[0] < latency[1] ) return latency[0];
-        return latency[1];
+        if ( nonlocal_ ) return latency_[0];
+        if ( latency_[0] < latency_[1] ) return latency_[0];
+        return latency_[1];
     }
 
     /**
        Gets the latency as a string from the id stored in latency[].  This is only allowed to be called during graph
        construction.  After post-graph construction checks, the latency[] array no longer hold indices to the strings.
 
-       @see latency
+       @see latency_
     */
     std::string latency_str(uint32_t index) const;
 
@@ -185,14 +170,14 @@ public:
     */
     void print(std::ostream& os) const
     {
-        os << "Link " << name << " (id = " << id << ")" << std::endl;
-        os << "  nonlocal = " << nonlocal << std::endl;
-        os << "  component[0] = " << component[0] << std::endl;
-        os << "  port[0] = " << port[0] << std::endl;
-        os << "  latency[0] = " << latency[0] << std::endl;
-        os << "  component[1] = " << component[1] << std::endl;
-        os << "  port[1] = " << port[1] << std::endl;
-        os << "  latency[1] = " << latency[1] << std::endl;
+        os << "Link " << name_ << " (id = " << id_ << ")" << std::endl;
+        os << "  nonlocal = " << nonlocal_ << std::endl;
+        os << "  component[0] = " << component_[0] << std::endl;
+        os << "  port[0] = " << port_[0] << std::endl;
+        os << "  latency[0] = " << latency_[0] << std::endl;
+        os << "  component[1] = " << component_[1] << std::endl;
+        os << "  port[1] = " << port_[1] << std::endl;
+        os << "  latency[1] = " << latency_[1] << std::endl;
     }
 
     /* Do not use.  For serialization only */
@@ -203,45 +188,29 @@ public:
      */
     void serialize_order(SST::Core::Serialization::serializer& ser) /*override*/
     {
-        SST_SER(id);
-        SST_SER(name);
-        SST_SER(component[0]);
-        SST_SER(component[1]);
-        SST_SER(port[0]);
-        SST_SER(port[1]);
-        SST_SER(latency[0]);
-        SST_SER(latency[1]);
-        SST_SER(order);
-        SST_SER(nonlocal);
-        SST_SER(no_cut);
-        SST_SER(cross_rank);
-        SST_SER(cross_thread);
+        SST_SER(id_);
+        SST_SER(name_);
+        SST_SER(component_);
+        SST_SER(port_);
+        SST_SER(latency_);
+        SST_SER(nonlocal_);
+        SST_SER(no_cut_);
+        SST_SER(cross_rank_);
+        SST_SER(cross_thread_);
     }
 
 private:
     friend class ConfigGraph;
     explicit ConfigLink(LinkId_t id) :
-        id(id),
-        no_cut(false)
-    {
-        order = 0;
-
-        // Initialize the component data items
-        component[0] = ULONG_MAX;
-        component[1] = ULONG_MAX;
-    }
+        id_(id),
+        no_cut_(false)
+    {}
 
     ConfigLink(LinkId_t id, const std::string& n) :
-        id(id),
-        no_cut(false)
-    {
-        order = 0;
-        name  = n;
-
-        // Initialize the component data items
-        component[0] = ULONG_MAX;
-        component[1] = ULONG_MAX;
-    }
+        name_(n),
+        id_(id),
+        no_cut_(false)
+    {}
 
     void updateLatencies();
 };
@@ -250,38 +219,38 @@ private:
 class PartitionLink
 {
 public:
-    LinkId_t      id;
-    ComponentId_t component[2];
-    SimTime_t     latency[2];
-    bool          no_cut;
+    LinkId_t      id_;
+    ComponentId_t component_[2];
+    SimTime_t     latency_[2];
+    bool          no_cut_;
 
     PartitionLink(const ConfigLink& cl)
     {
-        id           = cl.id;
-        component[0] = cl.component[0];
-        component[1] = cl.component[1];
-        latency[0]   = cl.latency[0];
-        latency[1]   = cl.latency[1];
-        no_cut       = cl.no_cut;
+        id_           = cl.id_;
+        component_[0] = cl.component_[0];
+        component_[1] = cl.component_[1];
+        latency_[0]   = cl.latency_[0];
+        latency_[1]   = cl.latency_[1];
+        no_cut_       = cl.no_cut_;
     }
 
-    inline LinkId_t key() const { return id; }
+    inline LinkId_t key() const { return id_; }
 
     /** Return the minimum latency of this link (from both sides) */
     SimTime_t getMinLatency() const
     {
-        if ( latency[0] < latency[1] ) return latency[0];
-        return latency[1];
+        if ( latency_[0] < latency_[1] ) return latency_[0];
+        return latency_[1];
     }
 
     /** Print the Link information */
     void print(std::ostream& os) const
     {
-        os << "    Link " << id << std::endl;
-        os << "      component[0] = " << component[0] << std::endl;
-        os << "      latency[0] = " << latency[0] << std::endl;
-        os << "      component[1] = " << component[1] << std::endl;
-        os << "      latency[1] = " << latency[1] << std::endl;
+        os << "    Link " << id_ << std::endl;
+        os << "      component[0] = " << component_[0] << std::endl;
+        os << "      latency[0] = " << latency_[0] << std::endl;
+        os << "      component[1] = " << component_[1] << std::endl;
+        os << "      latency[1] = " << latency_[1] << std::endl;
     }
 };
 

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -810,7 +810,7 @@ Simulation_impl::prepareLinks(ConfigGraph& graph, const RankInfo& myRank, SimTim
 
             // For local, just register link with threadSync object so
             // it can map link_id to link*
-            ActivityQueue* sync_q = syncManager->registerLink(rank[remote], rank[local], clink->name_, lp.getRight());
+            ActivityQueue* sync_q = syncManager->registerLink(rank[remote], rank[local], lp.getRight());
 
             lp.getLeft()->send_queue = sync_q;
             lp.getRight()->setAsSyncLink();

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -592,12 +592,12 @@ Simulation_impl::processGraphInfo(ConfigGraph& graph, const RankInfo& UNUSED(myR
         for ( auto iter = links.begin(); iter != links.end(); ++iter ) {
             ConfigLink* clink = *iter;
             // If link is nonlocal, then doesn't affect interthread latencies
-            if ( clink->nonlocal ) continue;
+            if ( clink->nonlocal_ ) continue;
 
             // If link is not nonlocal, see if it crosses a thread boundary
             RankInfo rank[2];
-            rank[0] = comps[COMPONENT_ID_MASK(clink->component[0])]->rank;
-            rank[1] = comps[COMPONENT_ID_MASK(clink->component[1])]->rank;
+            rank[0] = comps[COMPONENT_ID_MASK(clink->component_[0])]->rank;
+            rank[1] = comps[COMPONENT_ID_MASK(clink->component_[1])]->rank;
             // We only care about links that are on my rank, but
             // different threads
 
@@ -683,13 +683,13 @@ Simulation_impl::prepareLinks(ConfigGraph& graph, const RankInfo& myRank, SimTim
     for ( ConfigLinkMap_t::const_iterator iter = graph.links_.begin(); iter != graph.links_.end(); ++iter ) {
         ConfigLink* clink = *iter;
         RankInfo    rank[2];
-        rank[0] = graph.comps_[COMPONENT_ID_MASK(clink->component[0])]->rank;
-        if ( clink->nonlocal ) {
-            rank[1].rank   = clink->component[1];
-            rank[1].thread = clink->latency[1];
+        rank[0] = graph.comps_[COMPONENT_ID_MASK(clink->component_[0])]->rank;
+        if ( clink->nonlocal_ ) {
+            rank[1].rank   = clink->component_[1];
+            rank[1].thread = clink->latency_[1];
         }
         else {
-            rank[1] = graph.comps_[COMPONENT_ID_MASK(clink->component[1])]->rank;
+            rank[1] = graph.comps_[COMPONENT_ID_MASK(clink->component_[1])]->rank;
         }
 
         if ( rank[0] != myRank && rank[1] != myRank ) {
@@ -699,43 +699,43 @@ Simulation_impl::prepareLinks(ConfigGraph& graph, const RankInfo& myRank, SimTim
         // Same rank, same thread
         else if ( rank[0] == rank[1] ) {
             // Check to see if this is loopback link
-            if ( clink->component[0] == clink->component[1] && clink->port[0] == clink->port[1] ) {
+            if ( clink->component_[0] == clink->component_[1] && clink->port_[0] == clink->port_[1] ) {
                 // This is a loopback, so there is only one link
-                Link* link      = new Link(clink->order);
+                Link* link      = new Link(clink->id_);
                 link->pair_link = link;
-                link->setLatency(clink->latency[0]);
+                link->setLatency(clink->latency_[0]);
 
                 // Add this link to the appropriate LinkMap
-                ComponentInfo* cinfo = compInfoMap.getByID(clink->component[0]);
+                ComponentInfo* cinfo = compInfoMap.getByID(clink->component_[0]);
                 if ( cinfo == nullptr ) {
                     // This shouldn't happen and is an error
                     sim_output.fatal(CALL_INFO, 1, "Couldn't find ComponentInfo in map. component ID = %" PRIx64 "\n",
-                        clink->component[0]);
+                        clink->component_[0]);
                 }
-                cinfo->getLinkMap()->insertLink(clink->port[0], link);
+                cinfo->getLinkMap()->insertLink(clink->port_[0], link);
             }
             else {
                 // Create a LinkPair to represent this link
-                LinkPair lp(clink->order);
+                LinkPair lp(clink->id_);
 
-                lp.getLeft()->setLatency(clink->latency[0]);
-                lp.getRight()->setLatency(clink->latency[1]);
+                lp.getLeft()->setLatency(clink->latency_[0]);
+                lp.getRight()->setLatency(clink->latency_[1]);
 
                 // Add this link to the appropriate LinkMap
-                ComponentInfo* cinfo = compInfoMap.getByID(clink->component[0]);
+                ComponentInfo* cinfo = compInfoMap.getByID(clink->component_[0]);
                 if ( cinfo == nullptr ) {
                     // This shouldn't happen and is an error
                     sim_output.fatal(CALL_INFO, 1, "Couldn't find ComponentInfo in map. component ID = %" PRIx64 "\n",
-                        clink->component[0]);
+                        clink->component_[0]);
                 }
-                cinfo->getLinkMap()->insertLink(clink->port[0], lp.getLeft());
+                cinfo->getLinkMap()->insertLink(clink->port_[0], lp.getLeft());
 
-                cinfo = compInfoMap.getByID(clink->component[1]);
+                cinfo = compInfoMap.getByID(clink->component_[1]);
                 if ( cinfo == nullptr ) {
                     // This shouldn't happen and is an error
                     sim_output.fatal(CALL_INFO, 1, "Couldn't find ComponentInfo in map.");
                 }
-                cinfo->getLinkMap()->insertLink(clink->port[1], lp.getRight());
+                cinfo->getLinkMap()->insertLink(clink->port_[1], lp.getRight());
             }
         }
         // If we are on same rank, different threads and we are doing
@@ -749,33 +749,33 @@ Simulation_impl::prepareLinks(ConfigGraph& graph, const RankInfo& myRank, SimTim
                 local = 1;
             }
 
-            Link* link = new Link(clink->order);
-            link->setLatency(clink->latency[local]);
+            Link* link = new Link(clink->id_);
+            link->setLatency(clink->latency_[local]);
 
             // Need to mutex to access cross_thread_links
             {
                 std::scoped_lock lock(cross_thread_lock);
-                if ( cross_thread_links.find(clink->id) != cross_thread_links.end() ) {
+                if ( cross_thread_links.find(clink->id_) != cross_thread_links.end() ) {
                     // The other side already initialized.  Hook them
                     // together as a pair.
-                    Link* other_link      = cross_thread_links[clink->id];
+                    Link* other_link      = cross_thread_links[clink->id_];
                     link->pair_link       = other_link;
                     other_link->pair_link = link;
                     // Remove entry from map
-                    cross_thread_links.erase(clink->id);
+                    cross_thread_links.erase(clink->id_);
                 }
                 else {
                     // Nothing to do until the other side is created.
                     // Just add myself to the map so the other side can
                     // find me later.
-                    cross_thread_links[clink->id] = link;
+                    cross_thread_links[clink->id_] = link;
                 }
             }
-            ComponentInfo* cinfo = compInfoMap.getByID(clink->component[local]);
+            ComponentInfo* cinfo = compInfoMap.getByID(clink->component_[local]);
             if ( cinfo == nullptr ) {
                 sim_output.fatal(CALL_INFO, 1, "Couldn't find ComponentInfo in map.");
             }
-            cinfo->getLinkMap()->insertLink(clink->port[local], link);
+            cinfo->getLinkMap()->insertLink(clink->port_[local], link);
         }
         // If the components are not in the same thread, then the
         // SyncManager will handle things
@@ -791,26 +791,26 @@ Simulation_impl::prepareLinks(ConfigGraph& graph, const RankInfo& myRank, SimTim
             }
 
             // Create a LinkPair to represent this link
-            LinkPair lp(clink->order);
+            LinkPair lp(clink->id_);
 
-            lp.getLeft()->setLatency(clink->latency[local]);
+            lp.getLeft()->setLatency(clink->latency_[local]);
             lp.getRight()->setLatency(0);
             lp.getRight()->setDefaultTimeBase(minPartToTC(1));
 
             // Add this link to the appropriate LinkMap for the local component
-            ComponentInfo* cinfo = compInfoMap.getByID(clink->component[local]);
+            ComponentInfo* cinfo = compInfoMap.getByID(clink->component_[local]);
             if ( cinfo == nullptr ) {
                 // This shouldn't happen and is an error
                 sim_output.fatal(CALL_INFO, 1, "Couldn't find ComponentInfo in map.");
             }
-            cinfo->getLinkMap()->insertLink(clink->port[local], lp.getLeft());
+            cinfo->getLinkMap()->insertLink(clink->port_[local], lp.getLeft());
 
             // Need to register with both of the syncs (the ones for
             // both local and remote thread)
 
             // For local, just register link with threadSync object so
             // it can map link_id to link*
-            ActivityQueue* sync_q = syncManager->registerLink(rank[remote], rank[local], clink->name, lp.getRight());
+            ActivityQueue* sync_q = syncManager->registerLink(rank[remote], rank[local], clink->name_, lp.getRight());
 
             lp.getLeft()->send_queue = sync_q;
             lp.getRight()->setAsSyncLink();

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -422,7 +422,7 @@ public:
        between checkpoint and restart and the original rank info
        stored in the checkpoint should be used.
      */
-    RankInfo getRankForLinkOnRestart(RankInfo rank, uintptr_t UNUSED(tag))
+    RankInfo getRankForLinkOnRestart(RankInfo rank, LinkId_t UNUSED(id))
     {
         if ( serial_restart_ ) return RankInfo(0, 0);
         return RankInfo(rank.rank, rank.thread);
@@ -667,15 +667,15 @@ public:
     static std::vector<Simulation_impl*>                         instanceVec_;
 
     /******** Checkpoint/restart tracking data structures ***********/
-    std::map<std::pair<int, uintptr_t>, Link*> link_restart_tracking;
-    std::map<uintptr_t, uintptr_t>             event_handler_restart_tracking;
-    uint32_t                                   checkpoint_id_       = 0;
-    std::string                                checkpoint_prefix_   = "";
-    std::string                                globalOutputFileName = "";
-    std::string                                version_             = "";
-    std::string                                arch_                = "";
-    std::string                                os_                  = "";
-    bool                                       serial_restart_      = false;
+    std::map<LinkId_t, Link*>      link_restart_tracking;
+    std::map<uintptr_t, uintptr_t> event_handler_restart_tracking;
+    uint32_t                       checkpoint_id_       = 0;
+    std::string                    checkpoint_prefix_   = "";
+    std::string                    globalOutputFileName = "";
+    std::string                    version_             = "";
+    std::string                    arch_                = "";
+    std::string                    os_                  = "";
+    bool                           serial_restart_      = false;
 
     // Config object used by the simulation
     static Config       config;

--- a/src/sst/core/sst_mpi.cc
+++ b/src/sst/core/sst_mpi.cc
@@ -50,3 +50,15 @@ SST_MPI_Allgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, voi
     return 0;
 #endif
 }
+
+int
+SST_MPI_GetRank()
+{
+#ifdef SST_CONFIG_HAVE_MPI
+    int myrank = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+    return myrank;
+#else
+    return 0;
+#endif
+}

--- a/src/sst/core/sst_mpi.h
+++ b/src/sst/core/sst_mpi.h
@@ -133,4 +133,5 @@ int SST_MPI_Barrier(MPI_Comm comm);
 int SST_MPI_Allgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
     MPI_Datatype recvtype, MPI_Comm comm);
 
+int SST_MPI_GetRank();
 #endif

--- a/src/sst/core/sst_types.h
+++ b/src/sst/core/sst_types.h
@@ -12,6 +12,8 @@
 #ifndef SST_CORE_SST_TYPES_H
 #define SST_CORE_SST_TYPES_H
 
+#include "sst/core/util/bit_util.h"
+
 #include <cstdint>
 #include <iosfwd>
 #include <limits>
@@ -20,50 +22,163 @@
 
 namespace SST {
 
-using ComponentId_t  = uint64_t;
-using StatisticId_t  = uint64_t;
-using LinkId_t       = uint32_t;
-using HandlerId_t    = uint64_t;
-using Cycle_t        = uint64_t;
-using SimTime_t      = uint64_t;
-using Time_t         = double;
+/**********************************************************************
+ *  Common types used by SST
+ **********************************************************************/
+using ComponentId_t = uint64_t;
+using StatisticId_t = uint64_t;
+using LinkId_t      = uint32_t;
+using HandlerId_t   = uint64_t;
+using Cycle_t       = uint64_t;
+using SimTime_t     = uint64_t;
+using Time_t        = double;
+
 /* PorModuleId_t is a <port name,index> pair*/
 using PortModuleId_t = std::pair<std::string, size_t>;
 
+// Macro to use when printing SimTime_t in printf or Output
 #define PRI_SIMTIME PRIu64
 
+// Flag used to indicate that a version of *EnableAll* was used to enable stats in an object
 static constexpr StatisticId_t STATALL_ID = std::numeric_limits<StatisticId_t>::max();
 
-#define MAX_SIMTIME_T 0xFFFFFFFFFFFFFFFFl
+constexpr SimTime_t MAX_SIMTIME_T = SST::bit_util::type_max<ComponentId_t>;
 
-/* Subcomponent IDs are in the high-16 bits of the Component ID */
-#define UNSET_COMPONENT_ID                      0xFFFFFFFFFFFFFFFFULL
-#define UNSET_STATISTIC_ID                      0xFFFFFFFFFFFFFFFFULL
-#define COMPONENT_ID_BITS                       32
-#define COMPONENT_ID_MASK(x)                    ((x) & 0xFFFFFFFFULL)
-#define SUBCOMPONENT_ID_BITS                    16
-#define SUBCOMPONENT_ID_MASK(x)                 ((x) >> COMPONENT_ID_BITS)
-#define SUBCOMPONENT_ID_CREATE(compId, sCompId) ((((uint64_t)(sCompId)) << COMPONENT_ID_BITS) | (compId))
-#define CONFIG_COMPONENT_ID_BITS                (COMPONENT_ID_BITS + SUBCOMPONENT_ID_BITS)
-#define CONFIG_COMPONENT_ID_MASK(x)             ((x) & 0xFFFFFFFFFFFFULL)
-#define STATISTIC_ID_CREATE(compId, statId)     ((((uint64_t)(statId)) << CONFIG_COMPONENT_ID_BITS) | (compId))
-#define COMPDEFINED_SUBCOMPONENT_ID_MASK(x)     ((x) >> 63)
-#define COMPDEFINED_SUBCOMPONENT_ID_CREATE(compId, sCompId) \
-    ((((uint64_t)(sCompId)) << COMPONENT_ID_BITS) | (compId) | 0x8000000000000000ULL)
+/**********************************************************************
+ *  constexpr variable and inline functions used to build ID for
+ *  generating the various IDs for elements
+ *
+ *  The Component and Statistic IDs use subfields in the following way:
+ *  31:0  - Bottom 30 bits are the ID of the parent Component
+ *  47:32 - The next 16 bits is the ID of a SubComponent with that
+ *          component
+ *  63:48 - The top 16 bits are unused for Component IDs, but they are
+ *          used to uniquely identify a statistic with a (Sub)Component
+ **********************************************************************/
 
-using watts  = double;
-using joules = double;
-using farads = double;
-using volts  = double;
+/** Value used to indicate a Component's ID has not yet been set */
+constexpr ComponentId_t UNSET_COMPONENT_ID = SST::bit_util::type_max<ComponentId_t>;
+
+/** Value used to indicate a Statistic's ID has not yet been set */
+constexpr StatisticId_t UNSET_STATISTIC_ID = SST::bit_util::type_max<StatisticId_t>;
+
+/** Number of bits used for the parent component base ID */
+constexpr size_t COMPONENT_ID_BITS = 32;
+
+/**
+   Gets the parent Component base ID from a general (i.e. either Component or SubComponent) ID
+
+   @param complete_id The complete Component ID, including any SubComponent ID
+
+   @return Parent Component base ID
+*/
+inline ComponentId_t
+COMPONENT_ID_MASK(ComponentId_t complete_id)
+{
+    return complete_id & SST::bit_util::lower_mask<ComponentId_t, COMPONENT_ID_BITS>;
+}
+
+/** Number of bits used to store the ID of a SubComponent and part of the complete ID */
+constexpr size_t SUBCOMPONENT_ID_BITS = 16;
+
+/**
+   Get the SubComponent portion of the Component ID
+
+   @param complete_id The complete Component ID, including any SubComponent ID
+
+   @return SubComponent portion of the Component ID
+*/
+inline ComponentId_t
+SUBCOMPONENT_ID_MASK(ComponentId_t complete_id)
+{
+    return (complete_id >> COMPONENT_ID_BITS) & SST::bit_util::lower_mask<ComponentId_t, SUBCOMPONENT_ID_BITS>;
+}
+
+/**
+   Create a component ID from the specified base Component ID and SubComponent ID
+
+   @param comp_id Base ID of the parent Component
+
+   @param sub_comp_id ID of the SubComponent with the Component
+
+   @return Complete ID of the SubComponent
+*/
+inline ComponentId_t
+SUBCOMPONENT_ID_CREATE(ComponentId_t comp_id, ComponentId_t sub_comp_id)
+{
+    return (sub_comp_id << COMPONENT_ID_BITS) | comp_id;
+}
+
+/** Number of bits in the complete Component ID */
+constexpr size_t CONFIG_COMPONENT_ID_BITS = (COMPONENT_ID_BITS + SUBCOMPONENT_ID_BITS);
+
+/**
+   Gets the Complete Component ID (Component + SubComponent portions), masking out any Statistic ID that may be in the
+   upper bits
+
+   @param complete_id Complete ID (including any Statistic ID)
+
+   @return Component portion of the ID with any Statistic ID masked out
+*/
+inline ComponentId_t
+CONFIG_COMPONENT_ID_MASK(ComponentId_t complete_id)
+{
+    return complete_id & SST::bit_util::lower_mask<ComponentId_t, COMPONENT_ID_BITS + SUBCOMPONENT_ID_BITS>;
+}
+
+/**
+   Create a Statistic ID from the complete ComponentID and ID of the Statistic within that Component
+
+   @param comp_id Complete ID of the Component + SubComponent
+
+   @param stat_id Statistic ID
+
+   @return Combined ID for the Statistic
+*/
+inline StatisticId_t
+STATISTIC_ID_CREATE(ComponentId_t comp_id, StatisticId_t stat_id)
+{
+    return (stat_id << CONFIG_COMPONENT_ID_BITS) | comp_id;
+}
+
+/**
+   Determine whether a SubComponent is Component Defined (i.e. anonymous) or not
+
+   @param complete_id Component Component ID for the SubComponent
+
+   @return True if SubComponent is Anonymous, false otherwise
+*/
+inline bool
+COMPDEFINED_SUBCOMPONENT_ID_MASK(ComponentId_t complete_id)
+{
+    return complete_id >> (sizeof(ComponentId_t) * 8 - 1);
+}
+
+/**
+   Create a component ID from the specified base Component ID and SubComponent ID, with the component defined
+   (i.e. anonymous) bit set.
+
+   @param comp_id Base ID of the parent Component
+
+   @param sub_comp_id ID of the SubComponent
+
+   @return Complete ID for the SubComponent with the component defined bit set
+*/
+inline ComponentId_t
+COMPDEFINED_SUBCOMPONENT_ID_CREATE(ComponentId_t comp_id, ComponentId_t sub_comp_id)
+{
+    return (sub_comp_id << COMPONENT_ID_BITS) | comp_id | SST::bit_util::upper_mask<ComponentId_t, 1>;
+}
+
+using watts [[deprecated("watts will be removed in SST 17")]]   = double;
+using joules [[deprecated("joules will be removed in SST 17")]] = double;
+using farads [[deprecated("farads will be removed in SST 17")]] = double;
+using volts [[deprecated("volts will be removed in SST 17")]]   = double;
 
 #ifndef LIKELY
 #define LIKELY(x)   __builtin_expect((int)(x), 1)
 #define UNLIKELY(x) __builtin_expect((int)(x), 0)
 #endif
-
-/* Template to get the maximum value of a type */
-template <typename T>
-inline constexpr T type_max = std::numeric_limits<T>::max();
 
 enum class SimulationRunMode {
     UNKNOWN, /*!< Unknown mode - Invalid for running */

--- a/src/sst/core/sst_types.h
+++ b/src/sst/core/sst_types.h
@@ -27,7 +27,7 @@ namespace SST {
  **********************************************************************/
 using ComponentId_t = uint64_t;
 using StatisticId_t = uint64_t;
-using LinkId_t      = uint32_t;
+using LinkId_t      = uint64_t;
 using HandlerId_t   = uint64_t;
 using Cycle_t       = uint64_t;
 using SimTime_t     = uint64_t;

--- a/src/sst/core/sync/rankSyncParallelSkip.cc
+++ b/src/sst/core/sync/rankSyncParallelSkip.cc
@@ -84,8 +84,7 @@ RankSyncParallelSkip::~RankSyncParallelSkip()
 }
 
 ActivityQueue*
-RankSyncParallelSkip::registerLink(
-    const RankInfo& to_rank, const RankInfo& from_rank, const std::string& name, Link* link)
+RankSyncParallelSkip::registerLink(const RankInfo& to_rank, const RankInfo& from_rank, Link* link)
 {
     std::scoped_lock slock(lock);
 
@@ -113,7 +112,7 @@ RankSyncParallelSkip::registerLink(
         comm_recv_map[remote_rank_local_thread].local_size   = 4096;
     }
 
-    link_maps[to_rank.rank][name] = reinterpret_cast<uintptr_t>(link);
+    link_maps[to_rank.rank].emplace_back(link->getId(), reinterpret_cast<uintptr_t>(link));
 #ifdef __SST_DEBUG_EVENT_TRACKING__
     link->setSendingComponentInfo("SYNC", "SYNC", "");
 #endif

--- a/src/sst/core/sync/rankSyncParallelSkip.h
+++ b/src/sst/core/sync/rankSyncParallelSkip.h
@@ -36,9 +36,8 @@ public:
     virtual ~RankSyncParallelSkip();
 
     /** Register a Link which this Sync Object is responsible for */
-    ActivityQueue* registerLink(
-        const RankInfo& to_rank, const RankInfo& from_rank, const std::string& name, Link* link) override;
-    void execute(int thread) override;
+    ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, Link* link) override;
+    void           execute(int thread) override;
 
     /** Cause an exchange of Untimed Data to occur */
     void exchangeLinkUntimedData(int thread, std::atomic<int>& msg_count) override;

--- a/src/sst/core/sync/rankSyncSerialSkip.cc
+++ b/src/sst/core/sync/rankSyncSerialSkip.cc
@@ -64,8 +64,7 @@ RankSyncSerialSkip::~RankSyncSerialSkip()
 }
 
 ActivityQueue*
-RankSyncSerialSkip::registerLink(
-    const RankInfo& to_rank, const RankInfo& UNUSED(from_rank), const std::string& name, Link* link)
+RankSyncSerialSkip::registerLink(const RankInfo& to_rank, const RankInfo& UNUSED(from_rank), Link* link)
 {
     std::scoped_lock slock(lock);
 
@@ -80,7 +79,7 @@ RankSyncSerialSkip::registerLink(
         queue = comm_map[to_rank.rank].squeue;
     }
 
-    link_maps[to_rank.rank][name] = reinterpret_cast<uintptr_t>(link);
+    link_maps[to_rank.rank].emplace_back(link->getId(), reinterpret_cast<uintptr_t>(link));
 #ifdef __SST_DEBUG_EVENT_TRACKING__
     link->setSendingComponentInfo("SYNC", "SYNC", "");
 #endif
@@ -222,7 +221,6 @@ RankSyncSerialSkip::exchange()
         deserializeTime += SST::Core::Profile::getElapsed(deserialStart);
 
         for ( unsigned int j = 0; j < activities.size(); j++ ) {
-
             Event*    ev    = static_cast<Event*>(activities[j]);
             SimTime_t delay = ev->getDeliveryTime() - current_cycle;
             getDeliveryLink(ev)->send(delay, ev);

--- a/src/sst/core/sync/rankSyncSerialSkip.h
+++ b/src/sst/core/sync/rankSyncSerialSkip.h
@@ -34,9 +34,8 @@ public:
     virtual ~RankSyncSerialSkip();
 
     /** Register a Link which this Sync Object is responsible for */
-    ActivityQueue* registerLink(
-        const RankInfo& to_rank, const RankInfo& from_rank, const std::string& name, Link* link) override;
-    void execute(int thread) override;
+    ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, Link* link) override;
+    void           execute(int thread) override;
 
     /** Cause an exchange of Untimed Data to occur */
     void exchangeLinkUntimedData(int thread, std::atomic<int>& msg_count) override;

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -85,8 +85,8 @@ public:
     ~EmptyRankSync() = default;
 
     /** Register a Link which this Sync Object is responsible for */
-    ActivityQueue* registerLink(const RankInfo& UNUSED(to_rank), const RankInfo& UNUSED(from_rank),
-        const std::string& UNUSED(name), Link* UNUSED(link)) override
+    ActivityQueue* registerLink(
+        const RankInfo& UNUSED(to_rank), const RankInfo& UNUSED(from_rank), Link* UNUSED(link)) override
     {
         return nullptr;
     }
@@ -167,11 +167,8 @@ public:
     }
 
     /** Register a Link which this Sync Object is responsible for */
-    void           registerLink(const std::string& UNUSED(name), Link* UNUSED(link)) override {}
-    ActivityQueue* registerRemoteLink(int UNUSED(tid), const std::string& UNUSED(name), Link* UNUSED(link)) override
-    {
-        return nullptr;
-    }
+    void           registerLink(Link* UNUSED(link)) override {}
+    ActivityQueue* registerRemoteLink(int UNUSED(tid), Link* UNUSED(link)) override { return nullptr; }
 
     // Don't want to reset time for Empty Sync
     void setRestartTime(SimTime_t UNUSED(time)) override {}
@@ -194,22 +191,35 @@ RankSync::exchangeLinkInfo(uint32_t UNUSED_WO_MPI(my_rank))
     for ( uint32_t i = 0; i < my_rank; ++i ) {
         // I'm the high rank, so recv is first
         // std::map<std::string, uintptr_t> data;
-        std::vector<std::pair<std::string, uintptr_t>> data;
+        std::vector<std::pair<LinkId_t, uintptr_t>> data;
+
+        // Sort the links before sending/receiving
+        std::sort(link_maps[i].begin(), link_maps[i].end(),
+            [](std::pair<LinkId_t, uintptr_t> const& a, std::pair<LinkId_t, uintptr_t> const& b) {
+                return a.first < b.first;
+            });
 
         Comms::recv(i, 0, data);
         Comms::send(i, 0, link_maps[i]);
 
-        // Process the data
-        for ( auto x : data ) {
-            auto it = link_maps[i].find(x.first);
-            if ( it == link_maps[i].end() ) {
-                // No matching link found
-                Simulation_impl::getSimulationOutput().output(
-                    "WARNING: Unmatched link found in rank link exchange: %s (from rank %d to rank %d)\n",
-                    x.first.c_str(), i, my_rank);
+        // Process the data.  Both lists are sorted by ID, so the corresponding entries in the lists should be the same
+        // Link.  For serial loaded and partitioned runs, this should be correct by construction (i.e. we had a valid
+        // ConfigGraph so each partition will have the correct links).  For parallel loads, this was also checked during
+        // the exchange to settle on the link ID for cross partition links.
+
+        // First check to make sure the vectors are the same size
+        if ( data.size() != link_maps[i].size() ) {
+            Simulation_impl::getSimulationOutput().fatal(CALL_INFO, EXIT_FAILURE,
+                "ERROR: Number of links in link exchange not the same for ranks %d and %d\n", i, my_rank);
+        }
+
+        for ( size_t x = 0; x < data.size(); ++x ) {
+            if ( data[x].first != link_maps[i][x].first ) {
+                Simulation_impl::getSimulationOutput().fatal(CALL_INFO, EXIT_FAILURE,
+                    "ERROR: Unmatched links in link exchange for ranks %d and %d\n", i, my_rank);
             }
-            Link* link = reinterpret_cast<Link*>(it->second);
-            link->pair_link->setDeliveryInfo(x.second);
+            Link* link = reinterpret_cast<Link*>(link_maps[i][x].second);
+            link->pair_link->setDeliveryInfo(data[x].second);
         }
         data.clear();
         link_maps[i].clear();
@@ -218,22 +228,35 @@ RankSync::exchangeLinkInfo(uint32_t UNUSED_WO_MPI(my_rank))
     for ( uint32_t i = my_rank + 1; i < num_ranks_.rank; ++i ) {
         // I'm the low rank, so send it first
         // std::map<std::string, uintptr_t> data;
-        std::vector<std::pair<std::string, uintptr_t>> data;
+        std::vector<std::pair<LinkId_t, uintptr_t>> data;
+
+        // Sort the links before sending/receiving
+        std::sort(link_maps[i].begin(), link_maps[i].end(),
+            [](std::pair<LinkId_t, uintptr_t> const& a, std::pair<LinkId_t, uintptr_t> const& b) {
+                return a.first < b.first;
+            });
 
         Comms::send(i, 0, link_maps[i]);
         Comms::recv(i, 0, data);
 
-        // Process the data
-        for ( auto x : data ) {
-            auto it = link_maps[i].find(x.first);
-            if ( it == link_maps[i].end() ) {
-                // No matching link found
-                Simulation_impl::getSimulationOutput().output(
-                    "WARNING: Unmatched link found in rank link exchange: %s (from rank %d to rank %d)\n",
-                    x.first.c_str(), i, my_rank);
+        // Process the data.  Both lists are sorted by ID, so the corresponding entries in the lists should be the same
+        // Link.  For serial loaded and partitioned runs, this should be correct by construction (i.e. we had a valid
+        // ConfigGraph so each partition will have the correct links).  For parallel loads, this was also checked during
+        // the exchange to settle on the link ID for cross partition links.
+
+        // First check to make sure the vectors are the same size
+        if ( data.size() != link_maps[i].size() ) {
+            Simulation_impl::getSimulationOutput().fatal(CALL_INFO, EXIT_FAILURE,
+                "ERROR: Number of links in link exchange not the same for ranks %d and %d\n", i, my_rank);
+        }
+
+        for ( size_t x = 0; x < data.size(); ++x ) {
+            if ( data[x].first != link_maps[i][x].first ) {
+                Simulation_impl::getSimulationOutput().fatal(CALL_INFO, EXIT_FAILURE,
+                    "ERROR: Unmatched links in link exchange for ranks %d and %d\n", i, my_rank);
             }
-            Link* link = reinterpret_cast<Link*>(it->second);
-            link->pair_link->setDeliveryInfo(x.second);
+            Link* link = reinterpret_cast<Link*>(link_maps[i][x].second);
+            link->pair_link->setDeliveryInfo(data[x].second);
         }
         data.clear();
         link_maps[i].clear();
@@ -335,7 +358,7 @@ SyncManager::SyncManager()
 
 /** Register a Link which this Sync Object is responsible for */
 ActivityQueue*
-SyncManager::registerLink(const RankInfo& to_rank, const RankInfo& from_rank, const std::string& name, Link* link)
+SyncManager::registerLink(const RankInfo& to_rank, const RankInfo& from_rank, Link* link)
 {
     if ( to_rank == from_rank ) {
         return nullptr; // This should never happen
@@ -347,15 +370,15 @@ SyncManager::registerLink(const RankInfo& to_rank, const RankInfo& from_rank, co
         // side of the link
 
         // For the local ThreadSync, just need to register the link
-        threadSync_->registerLink(name, link);
+        threadSync_->registerLink(link);
 
         // Need to get target queue from the remote ThreadSync
         ThreadSync* remoteSync = Simulation_impl::instanceVec_[to_rank.thread]->syncManager->threadSync_;
-        return remoteSync->registerRemoteLink(from_rank.thread, name, link);
+        return remoteSync->registerRemoteLink(from_rank.thread, link);
     }
     else {
         // Different rank.  Send info onto the RankSync
-        return rankSync_->registerLink(to_rank, from_rank, name, link);
+        return rankSync_->registerLink(to_rank, from_rank, link);
     }
 }
 

--- a/src/sst/core/sync/syncManager.h
+++ b/src/sst/core/sync/syncManager.h
@@ -51,9 +51,8 @@ public:
     virtual ~RankSync() {}
 
     /** Register a Link which this Sync Object is responsible for */
-    virtual ActivityQueue* registerLink(
-        const RankInfo& to_rank, const RankInfo& from_rank, const std::string& name, Link* link) = 0;
-    void exchangeLinkInfo(uint32_t my_rank);
+    virtual ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, Link* link) = 0;
+    void                   exchangeLinkInfo(uint32_t my_rank);
 
     virtual void execute(int thread)                                              = 0;
     virtual void exchangeLinkUntimedData(int thread, std::atomic<int>& msg_count) = 0;
@@ -78,7 +77,7 @@ protected:
     TimeConverter  max_period;
     const RankInfo num_ranks_;
 
-    std::vector<std::map<std::string, uintptr_t>> link_maps;
+    std::vector<std::vector<std::pair<LinkId_t, uintptr_t>>> link_maps;
 
     void finalizeConfiguration(Link* link) { link->finalizeConfiguration(); }
 
@@ -116,8 +115,8 @@ public:
     TimeConverter getMaxPeriod() { return max_period; }
 
     /** Register a Link which this Sync Object is responsible for */
-    virtual void           registerLink(const std::string& name, Link* link)                = 0;
-    virtual ActivityQueue* registerRemoteLink(int tid, const std::string& name, Link* link) = 0;
+    virtual void           registerLink(Link* link)                = 0;
+    virtual ActivityQueue* registerRemoteLink(int tid, Link* link) = 0;
 
 protected:
     SimTime_t     nextSyncTime;
@@ -143,10 +142,9 @@ public:
     virtual ~SyncManager() = default;
 
     /** Register a Link which this Sync Object is responsible for */
-    ActivityQueue* registerLink(
-        const RankInfo& to_rank, const RankInfo& from_rank, const std::string& name, Link* link);
-    void exchangeLinkInfo();
-    void execute() override;
+    ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, Link* link);
+    void           exchangeLinkInfo();
+    void           execute() override;
 
     /** Cause an exchange of Initialization Data to occur */
     void exchangeLinkUntimedData(std::atomic<int>& msg_count);

--- a/src/sst/core/sync/threadSyncDirectSkip.h
+++ b/src/sst/core/sync/threadSyncDirectSkip.h
@@ -59,11 +59,8 @@ public:
     SimTime_t getNextSyncTime() override { return nextSyncTime - 1; }
 
     /** Register a Link which this Sync Object is responsible for */
-    void           registerLink(const std::string& UNUSED(name), Link* UNUSED(link)) override {}
-    ActivityQueue* registerRemoteLink(int UNUSED(id), const std::string& UNUSED(name), Link* UNUSED(link)) override
-    {
-        return nullptr;
-    }
+    void           registerLink(Link* UNUSED(link)) override {}
+    ActivityQueue* registerRemoteLink(int UNUSED(id), Link* UNUSED(link)) override { return nullptr; }
 
     uint64_t getDataSize() const;
 

--- a/src/sst/core/sync/threadSyncSimpleSkip.cc
+++ b/src/sst/core/sync/threadSyncSimpleSkip.cc
@@ -66,14 +66,14 @@ ThreadSyncSimpleSkip::~ThreadSyncSimpleSkip()
 }
 
 void
-ThreadSyncSimpleSkip::registerLink(const std::string& name, Link* link)
+ThreadSyncSimpleSkip::registerLink(Link* link)
 {
     std::scoped_lock slock(lock);
-    auto             iter = link_map.find(name);
+    auto             iter = link_map.find(link->getId());
     if ( iter == link_map.end() ) {
-        // I have initialized first, so just put the name and link in
+        // I have initialized first, so just put the id and link in
         // the map
-        link_map[name] = link;
+        link_map[link->getId()] = link;
     }
     else {
         // I already have the remote info, so initialize the link data
@@ -84,14 +84,14 @@ ThreadSyncSimpleSkip::registerLink(const std::string& name, Link* link)
 }
 
 ActivityQueue*
-ThreadSyncSimpleSkip::registerRemoteLink(int tid, const std::string& name, Link* link)
+ThreadSyncSimpleSkip::registerRemoteLink(int tid, Link* link)
 {
     std::scoped_lock slock(lock);
-    auto             iter = link_map.find(name);
+    auto             iter = link_map.find(link->getId());
     if ( iter == link_map.end() ) {
-        // I have initialized first, so just put the name and link in
+        // I have initialized first, so just put the id and link in
         // the map
-        link_map[name] = link;
+        link_map[link->getId()] = link;
     }
     else {
         // I already have the local info, so initialize the link data

--- a/src/sst/core/sync/threadSyncSimpleSkip.h
+++ b/src/sst/core/sync/threadSyncSimpleSkip.h
@@ -59,8 +59,8 @@ public:
     void prepareForComplete() override;
 
     /** Register a Link which this Sync Object is responsible for */
-    void           registerLink(const std::string& name, Link* link) override;
-    ActivityQueue* registerRemoteLink(int tid, const std::string& name, Link* link) override;
+    void           registerLink(Link* link) override;
+    ActivityQueue* registerRemoteLink(int tid, Link* link) override;
 
     uint64_t getDataSize() const;
 
@@ -72,7 +72,7 @@ private:
     // remote data.  It will hold whichever thread registers the link
     // first and will be removed after the second thread registers and
     // the link is properly initialized with the remote data.
-    std::unordered_map<std::string, Link*> link_map;
+    std::unordered_map<LinkId_t, Link*> link_map;
 
     std::vector<ThreadSyncQueue*>    queues;
     SimTime_t                        my_max_period;

--- a/src/sst/core/util/Makefile.inc
+++ b/src/sst/core/util/Makefile.inc
@@ -12,6 +12,7 @@ sst_core_sources += \
 	util/filesystem.cc
 
 nobase_dist_sst_HEADERS += \
+	util/bit_util.h \
 	util/smartTextFormatter.h \
 	util/filesystem.h
 

--- a/src/sst/core/util/bit_util.h
+++ b/src/sst/core/util/bit_util.h
@@ -1,0 +1,55 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_SST_UTLI_BIT_UTIL_H
+#define SST_CORE_SST_UTLI_BIT_UTIL_H
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+namespace SST::bit_util {
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+// Templates to get the maximum value of a type                                                    //
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+   Gets the maximum value of a type.  This version can take the variable of the type to infer the needed type.
+
+   @param var Unused in function.  Only used to infer the correct type
+
+   @return Maximum value of the templated type
+*/
+// template <typename T>
+// constexpr T type_max_v(T& var [[maybe_unused]])
+// {
+//     static_assert(std::is_integral<T>::value, "Template parameter must be an integral type.");
+//     return std::numeric_limits<T>::max();
+// }
+
+template <typename T>
+constexpr T type_max = std::numeric_limits<T>::max();
+
+// Mask with the specified number of top bits set to all ones
+template <typename T, unsigned N = sizeof(T) * 8 / 2>
+inline constexpr T upper_mask = ~static_cast<T>(0) << ((sizeof(T) * 8) - N);
+
+// Mask with the specified number of bottom bits set to all ones
+template <typename T, unsigned N = sizeof(T) * 8 / 2>
+inline constexpr T lower_mask =
+    static_cast<T>(~static_cast<typename std::make_unsigned<T>::type>(0) >> ((sizeof(T) * 8) - N));
+
+
+} // namespace SST::bit_util
+
+#endif // SST_CORE_SST_TYPES_H


### PR DESCRIPTION
Make Link IDs globally unique and store them in the Link object.  Change to using the ID when doing Link pointer exchange and link discovery on restart.