### PR TITLE
Unique link order

### DIFF
--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -686,7 +686,7 @@ BaseComponent::configureLink_impl(const std::string& name, SimTime_t timebase, E
             }
         }
         tmp->setDefaultTimeBase(timebase);
-        tmp->setTag(getNextLinkOrder());
+        tmp->setTag(sim_->getNextLinkOrderTag());
 #ifdef __SST_DEBUG_EVENT_TRACKING__
         tmp->setSendingComponentInfo(my_info_->getName(), my_info_->getType(), name);
 #endif
@@ -842,12 +842,6 @@ void
 BaseComponent::pushValidParams(Params& params, const std::string& type)
 {
     params.pushAllowedKeys(Factory::getFactory()->getParamNames(type));
-}
-
-uint32_t
-BaseComponent::getNextLinkOrder()
-{
-    return getParentComponent()->getNextLinkOrder();
 }
 
 

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -597,12 +597,6 @@ private:
 
 
     /**
-       Gets the next value or the order field of the link.  The ordering of events based on links will be based on
-       the order that configureLink() is called.
-    */
-    virtual uint32_t getNextLinkOrder();
-
-    /**
        Handles the profile points, default timebase, handler tracking and checkpointing.
 
        @param tc TimeConverter representing the period of the clock

--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -59,12 +59,6 @@ public:
 protected:
     friend class SubComponent;
     Component() = default; // For Serialization only
-
-private:
-
-    uint32_t getNextLinkOrder() override { return next_event_order_++; }
-
-    uint32_t next_event_order_ = 1;
 };
 
 } // namespace SST

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -527,6 +527,14 @@ public:
     std::string             interactive_msg_;
     SimTime_t               stop_at_ = 0;
 
+    uint32_t next_link_order_tag_ = 1;
+
+    /**
+       Gets the next value for the order field of the link.  The ordering of events based on links will be based on
+       the order that configureLink() is called.
+    */
+    uint32_t getNextLinkOrderTag() { return next_link_order_tag_++; }
+
     // OneShotManager
     Core::OneShotManager one_shot_manager_;
 


### PR DESCRIPTION
Make the order tag in links unique across a partition. This will keep ordering within a Component tree the same as it currently is, but has advantages in TimeVortex sorting since less events will match order tags.
