### PR TITLE
Recalculate sync interval after init()

### DIFF
--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -316,6 +316,28 @@ public:
     */
     bool isConfigured() { return type != UNINITIALIZED; }
 
+    /**
+       Get the latency on the link in units of core atomic time base
+
+       NOTE: This is a core only API and not part of the public stable API
+    */
+    SimTime_t getLatency() { return latency; }
+
+    /**
+       Get the delivery_info for the link
+
+       NOTE: This is a core only API and not part of the public stable API
+    */
+    uintptr_t getDeliveryInfo() { return delivery_info; }
+
+    /**
+       Get the pair_link
+
+       NOTE: This is a core only API and not part of the public stable API
+    */
+    Link* getPairLink() { return pair_link; }
+
+
 #ifdef __SST_DEBUG_EVENT_TRACKING__
     void setSendingComponentInfo(const std::string& comp_in, const std::string& type_in, const std::string& port_in)
     {

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -648,6 +648,11 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
             barrier.wait();
             if ( tid == 0 ) Simulation_impl::basicPerf.endRegion("init");
 
+            /*
+              After init() we need to check to see if the sync interval has changed
+            */
+            sim->updateSyncInterval();
+
             /* Run Set */
             if ( tid == 0 ) Simulation_impl::basicPerf.beginRegion("setup");
             sim->setup();

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -1253,6 +1253,18 @@ Simulation_impl::finish()
     stat_engine.endOfSimulation();
 }
 
+void
+Simulation_impl::updateSyncInterval()
+{
+    syncManager->findThreadSyncInterval();
+
+    if ( my_rank.thread == 0 ) {
+        syncManager->findRankSyncInterval();
+    }
+    initBarrier.wait();
+}
+
+
 /* Signal monitor */
 void
 Simulation_impl::notifySignal()

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -240,6 +240,8 @@ public:
 
     void finish();
 
+    void updateSyncInterval();
+
     /** Adjust clocks and time to reflect precise simulation end time which
         may differ in parallel simulations from the time simulation end is detected.
      */

--- a/src/sst/core/sync/rankSyncParallelSkip.cc
+++ b/src/sst/core/sync/rankSyncParallelSkip.cc
@@ -54,8 +54,8 @@ RankSyncParallelSkip::RankSyncParallelSkip(RankInfo num_ranks) :
     slaveExchangeDoneBarrier(num_ranks.thread),
     allDoneBarrier(num_ranks.thread)
 {
-    max_period     = Simulation_impl::getSimulation()->getMinPartTC();
-    myNextSyncTime = max_period.getFactor();
+    max_period     = Simulation_impl::getSimulation()->getMinPartTC().getFactor();
+    myNextSyncTime = max_period;
     recv_count     = new int[num_ranks_.thread];
     for ( uint32_t i = 0; i < num_ranks_.thread; i++ ) {
         recv_count[i] = 0;
@@ -373,7 +373,7 @@ RankSyncParallelSkip::exchange_master(int UNUSED(thread))
     SimTime_t min_time;
     MPI_Allreduce(&input, &min_time, 1, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
 
-    myNextSyncTime = min_time + max_period.getFactor();
+    myNextSyncTime = min_time + max_period;
 
     /* Exchange signals */
     int32_t local_signals[3]  = { sig_end_, sig_usr_, sig_alrm_ };

--- a/src/sst/core/sync/rankSyncSerialSkip.cc
+++ b/src/sst/core/sync/rankSyncSerialSkip.cc
@@ -47,8 +47,8 @@ RankSyncSerialSkip::RankSyncSerialSkip(RankInfo num_ranks) :
     mpiWaitTime(0.0),
     deserializeTime(0.0)
 {
-    max_period     = Simulation_impl::getSimulation()->getMinPartTC();
-    myNextSyncTime = max_period.getFactor();
+    max_period     = Simulation_impl::getSimulation()->getMinPartTC().getFactor();
+    myNextSyncTime = max_period;
 }
 
 RankSyncSerialSkip::~RankSyncSerialSkip()
@@ -251,7 +251,7 @@ RankSyncSerialSkip::exchange()
     SimTime_t min_time;
     MPI_Allreduce(&input, &min_time, 1, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
 
-    myNextSyncTime = min_time + max_period.getFactor();
+    myNextSyncTime = min_time + max_period;
 
     int32_t local_signals[3]  = { sig_end_, sig_usr_, sig_alrm_ };
     int32_t global_signals[3] = { 0, 0, 0 };

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -26,6 +26,7 @@
 #include "sst/core/sync/threadSyncDirectSkip.h"
 #include "sst/core/sync/threadSyncSimpleSkip.h"
 #include "sst/core/timeConverter.h"
+#include "sst/core/util/bit_util.h"
 
 #include <atomic>
 #include <cinttypes>
@@ -127,8 +128,6 @@ public:
 
     SimTime_t getNextSyncTime() override { return nextSyncTime; }
 
-    TimeConverter getMaxPeriod() { return max_period; }
-
     uint64_t getDataSize() const override { return 0; }
 
     // Don't want to reset time for Empty Sync
@@ -176,6 +175,18 @@ public:
     /** Serialization for checkpoint support */
 };
 
+SimTime_t
+ThreadSync::updateMinimumLatency(SimTime_t lat)
+{
+    static Core::ThreadSafe::Spinlock lock;
+    static SimTime_t                  min_latency = bit_util::type_max<SimTime_t>;
+
+    std::scoped_lock slock(lock);
+    if ( lat < min_latency ) min_latency = lat;
+
+    return min_latency;
+}
+
 void
 RankSync::exchangeLinkInfo(uint32_t UNUSED_WO_MPI(my_rank))
 {
@@ -222,12 +233,10 @@ RankSync::exchangeLinkInfo(uint32_t UNUSED_WO_MPI(my_rank))
             link->pair_link->setDeliveryInfo(data[x].second);
         }
         data.clear();
-        link_maps[i].clear();
     }
 
     for ( uint32_t i = my_rank + 1; i < num_ranks_.rank; ++i ) {
         // I'm the low rank, so send it first
-        // std::map<std::string, uintptr_t> data;
         std::vector<std::pair<LinkId_t, uintptr_t>> data;
 
         // Sort the links before sending/receiving
@@ -259,9 +268,111 @@ RankSync::exchangeLinkInfo(uint32_t UNUSED_WO_MPI(my_rank))
             link->pair_link->setDeliveryInfo(data[x].second);
         }
         data.clear();
-        link_maps[i].clear();
     }
 #endif
+}
+
+SimTime_t
+RankSync::findSyncInterval(uint32_t UNUSED_WO_MPI(my_rank))
+{
+    // We need to find the lowest latency link globally.  Get the lowest for this rank, then we'll do a global reduction
+    // to get the final result.
+    SimTime_t low_latency = bit_util::type_max<SimTime_t>;
+
+    // Function will not compile if MPI is not configured
+#ifdef SST_CONFIG_HAVE_MPI
+    // Need to exchange with each partner.  For those with lower
+    // ranks, I will recv first, then send.  For those with higher
+    // ranks, I will send first, then recv.
+    for ( uint32_t i = 0; i < my_rank; ++i ) {
+        // Need to update the data in link_maps with the total send latency on the link and then switch it to contain
+        // the remote link ptr
+        for ( auto& x : link_maps[i] ) {
+            // Get the link ptr
+            Link* local = reinterpret_cast<Link*>(x.second);
+
+            // We are going to get just the send latency, which is contained in local->pair_link.  The local Link will
+            // only have latency if addRecvLatency() was called, but we will account for that later.
+            SimTime_t latency = local->pair_link->latency;
+
+            // Update the data
+            x.first  = latency;
+            // The ptr to the remote link is in pair_link->delivery_info
+            x.second = local->pair_link->delivery_info;
+
+            // We don't need to resort the data because it comes across with a uintptr_t version of the local pointer to
+            // the Link.
+        }
+
+        std::vector<std::pair<SimTime_t, uintptr_t>> data;
+
+        // I'm the high rank, so recv is first
+        Comms::recv(i, 0, data);
+        Comms::send(i, 0, link_maps[i]);
+
+        // Process the data. Get the Link and the send latency and add any addional receive latency that was added with
+        // addRecvLatency(). Compare again current minimum and update if necessary.
+
+        for ( auto& x : data ) {
+            Link* local = reinterpret_cast<Link*>(x.second);
+
+            // Added receive latency is found in local->latency
+            SimTime_t total_latency = x.first + local->latency;
+            if ( total_latency < low_latency ) low_latency = total_latency;
+        }
+        // Clear data for the next iteration
+        data.clear();
+
+        // We're done with the data in link_maps[i]
+        link_maps[i].clear();
+    }
+    for ( uint32_t i = my_rank + 1; i < num_ranks_.rank; ++i ) {
+        // Need to update the data in link_maps with the total send latency on the link and then switch it to contain
+        // the remote link ptr
+        for ( auto& x : link_maps[i] ) {
+            // Get the link ptr
+            Link* local = reinterpret_cast<Link*>(x.second);
+
+            // We are going to get just the send latency, which is contained in local->pair_link.  The local Link will
+            // only have latency if addRecvLatency() was called, but we will account for that later.
+            SimTime_t latency = local->pair_link->latency;
+
+            // Update the data
+            x.first  = latency;
+            // The ptr to the remote link is in pair_link->delivery_info
+            x.second = local->pair_link->delivery_info;
+
+            // We don't need to resort the data because it comes across with a uintptr_t version of the local pointer to
+            // the Link.
+        }
+
+        std::vector<std::pair<SimTime_t, uintptr_t>> data;
+
+        // I'm the low rank, so send is first
+        Comms::send(i, 0, link_maps[i]);
+        Comms::recv(i, 0, data);
+
+        // Process the data. Get the Link and the send latency and add any addional receive latency that was added with
+        // addRecvLatency(). Compare again current minimum and update if necessary.
+
+        for ( auto& x : data ) {
+            Link* local = reinterpret_cast<Link*>(x.second);
+
+            // Added receive latency is found in local->latency
+            SimTime_t total_latency = x.first + local->latency;
+            if ( total_latency < low_latency ) low_latency = total_latency;
+        }
+        // Clear data for the next iteration
+        data.clear();
+
+        // We're done with the data in link_maps[i]
+        link_maps[i].clear();
+    }
+
+    SimTime_t local_low = low_latency;
+    MPI_Allreduce(&local_low, &low_latency, 1, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
+#endif
+    return low_latency;
 }
 
 // Class used to hold the list of profile tools installed in the SyncManager
@@ -386,6 +497,22 @@ void
 SyncManager::exchangeLinkInfo()
 {
     rankSync_->exchangeLinkInfo(rank_.rank);
+}
+
+SimTime_t
+SyncManager::findRankSyncInterval()
+{
+    SimTime_t interval = rankSync_->findSyncInterval(rank_.rank);
+    rankSync_->setMaxPeriod(interval);
+    return interval;
+}
+
+SimTime_t
+SyncManager::findThreadSyncInterval()
+{
+    SimTime_t interval = threadSync_->findSyncInterval();
+    threadSync_->setMaxPeriod(interval);
+    return interval;
 }
 
 void

--- a/src/sst/core/sync/syncManager.h
+++ b/src/sst/core/sync/syncManager.h
@@ -53,6 +53,7 @@ public:
     /** Register a Link which this Sync Object is responsible for */
     virtual ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, Link* link) = 0;
     void                   exchangeLinkInfo(uint32_t my_rank);
+    SimTime_t              findSyncInterval(uint32_t my_rank);
 
     virtual void execute(int thread)                                              = 0;
     virtual void exchangeLinkUntimedData(int thread, std::atomic<int>& msg_count) = 0;
@@ -68,16 +69,26 @@ public:
 
     virtual void setRestartTime(SimTime_t time) { nextSyncTime = time; }
 
-    TimeConverter getMaxPeriod() { return max_period; }
+    void      setMaxPeriod(SimTime_t period) { max_period = period; }
+    SimTime_t getMaxPeriod() { return max_period; }
 
     virtual uint64_t getDataSize() const = 0;
 
 protected:
     SimTime_t      nextSyncTime;
-    TimeConverter  max_period;
+    SimTime_t      max_period;
     const RankInfo num_ranks_;
 
-    std::vector<std::vector<std::pair<LinkId_t, uintptr_t>>> link_maps;
+    /**
+       This uses uint64_t because it is used for two different types of data at different times:
+
+       1 - LinkId_t when doing the Link pointer exchange
+
+       2 - SimTime_t when doing the Sync interval optimization
+
+       In both cases, the uintptr_t is a pointer to a Link
+    */
+    std::vector<std::vector<std::pair<uint64_t, uintptr_t>>> link_maps;
 
     void finalizeConfiguration(Link* link) { link->finalizeConfiguration(); }
 
@@ -111,16 +122,20 @@ public:
     virtual SimTime_t getNextSyncTime() { return nextSyncTime; }
     virtual void      setRestartTime(SimTime_t time) { nextSyncTime = time; }
 
-    void          setMaxPeriod(TimeConverter* period) { max_period = period; }
-    TimeConverter getMaxPeriod() { return max_period; }
+    void      setMaxPeriod(SimTime_t period) { max_period = period; }
+    SimTime_t getMaxPeriod() { return max_period; }
 
     /** Register a Link which this Sync Object is responsible for */
     virtual void           registerLink(Link* link)                = 0;
     virtual ActivityQueue* registerRemoteLink(int tid, Link* link) = 0;
 
+    virtual SimTime_t findSyncInterval() { return bit_util::type_max<SimTime_t>; }
+
+    static SimTime_t updateMinimumLatency(SimTime_t lat = bit_util::type_max<SimTime_t>);
+
 protected:
-    SimTime_t     nextSyncTime;
-    TimeConverter max_period;
+    SimTime_t nextSyncTime;
+    SimTime_t max_period;
 
     void finalizeConfiguration(Link* link) { link->finalizeConfiguration(); }
 
@@ -144,6 +159,8 @@ public:
     /** Register a Link which this Sync Object is responsible for */
     ActivityQueue* registerLink(const RankInfo& to_rank, const RankInfo& from_rank, Link* link);
     void           exchangeLinkInfo();
+    SimTime_t      findRankSyncInterval();
+    SimTime_t      findThreadSyncInterval();
     void           execute() override;
 
     /** Cause an exchange of Initialization Data to occur */

--- a/src/sst/core/sync/threadSyncSimpleSkip.cc
+++ b/src/sst/core/sync/threadSyncSimpleSkip.cc
@@ -50,8 +50,8 @@ ThreadSyncSimpleSkip::ThreadSyncSimpleSkip(int num_threads, int thread, Simulati
     else
         single_rank = true;
 
-    my_max_period = sim->getInterThreadMinLatency();
-    nextSyncTime  = my_max_period;
+    max_period   = sim->getInterThreadMinLatency();
+    nextSyncTime = max_period;
 }
 
 ThreadSyncSimpleSkip::~ThreadSyncSimpleSkip()
@@ -69,7 +69,8 @@ void
 ThreadSyncSimpleSkip::registerLink(Link* link)
 {
     std::scoped_lock slock(lock);
-    auto             iter = link_map.find(link->getId());
+    link_vec.push_back(link->getPairLink());
+    auto iter = link_map.find(link->getId());
     if ( iter == link_map.end() ) {
         // I have initialized first, so just put the id and link in
         // the map
@@ -128,7 +129,7 @@ ThreadSyncSimpleSkip::after()
     // Use this nextSyncTime computation for skipping
 
     auto nextmin     = sim->getLocalMinimumNextActivityTime();
-    auto nextminPlus = nextmin + my_max_period;
+    auto nextminPlus = nextmin + max_period;
     nextSyncTime     = nextmin > nextminPlus ? nextmin : nextminPlus;
 }
 
@@ -179,6 +180,26 @@ ThreadSyncSimpleSkip::getDataSize() const
 {
     size_t count = 0;
     return count;
+}
+
+SimTime_t
+ThreadSyncSimpleSkip::findSyncInterval()
+{
+    SimTime_t min_lat = bit_util::type_max<SimTime_t>;
+    // Need to look through all my links and find the minimum latency
+    for ( auto* x : link_vec ) {
+        // I need to see if addRecvLatency() was called on the remote side of the link.  We have a pointer to that Link
+        // (as a uintptr_t) in delivery_info.
+        SimTime_t latency = x->getLatency() + reinterpret_cast<Link*>(x->getDeliveryInfo())->getLatency();
+        if ( latency < min_lat ) min_lat = latency;
+    }
+
+    link_vec.clear();
+    updateMinimumLatency(min_lat);
+
+    // Need to barrier, then return the minimum latency
+    barrier[0].wait();
+    return updateMinimumLatency();
 }
 
 void

--- a/src/sst/core/sync/threadSyncSimpleSkip.h
+++ b/src/sst/core/sync/threadSyncSimpleSkip.h
@@ -64,6 +64,8 @@ public:
 
     uint64_t getDataSize() const;
 
+    SimTime_t findSyncInterval() override;
+
 
     // static void disable() { disabled = true; barrier.disable(); }
 
@@ -74,8 +76,11 @@ private:
     // the link is properly initialized with the remote data.
     std::unordered_map<LinkId_t, Link*> link_map;
 
+    // Need to keep a list of all the Links in order to do the sync interval optimization after the init() phase. After
+    // than optimization pass completes, the vector can be cleared.
+    std::vector<Link*> link_vec;
+
     std::vector<ThreadSyncQueue*>    queues;
-    SimTime_t                        my_max_period;
     int                              num_threads;
     int                              thread;
     static SimTime_t                 localMinimumNextActivityTime;

--- a/src/sst/core/timeConverter.h
+++ b/src/sst/core/timeConverter.h
@@ -19,6 +19,7 @@
 namespace SST {
 
 class TimeLord;
+class SyncManager;
 
 /**
    A class to convert between a component's view of time and the
@@ -28,6 +29,7 @@ class TimeConverter
 {
 
     friend class TimeLord;
+    friend class SyncManager;
     friend class SST::Core::Serialization::serialize_impl<TimeConverter>;
     friend class SST::Core::Serialization::serialize_impl<TimeConverter*>;
 


### PR DESCRIPTION
Added a check after the init() phase to reassess the sync interval. For simulations where the minimum cross-partition latency changed to calls to Link::addSendLatency() and Link::addRecvLatency(), the sync interval can be extended to the new minimum cross-partition latency.
