### PR TITLE
Remote link discovery

### DIFF
--- a/src/sst/core/link.cc
+++ b/src/sst/core/link.cc
@@ -33,6 +33,8 @@
 
 namespace SST {
 
+bool Link::is_restart_same_parallelism = false;
+
 void
 SST::Core::Serialization::serialize_impl<Link*>::serialize_events(
     serializer& ser, uintptr_t delivery_info, ActivityQueue* queue)
@@ -270,8 +272,9 @@ SST::Core::Serialization::serialize_impl<Link*>::operator()(Link*& s, serializer
             if ( pair_restart_rank.rank == RankInfo::UNASSIGNED ) pair_restart_rank = pair_rank;
         }
 
-        bool is_restart_sync = (my_restart_rank != pair_restart_rank);
-
+        // Need to know if this link is a sync link or not.  We can only do this if the restart uses the exact
+        // rank/thread counts as the checkpoint.  This info is stored in Link::is_restart_same_parallelism
+        bool is_restart_sync = (Link::is_restart_same_parallelism && my_restart_rank != pair_restart_rank);
 
         /*
           Create or get link from tracker

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -316,27 +316,6 @@ public:
     */
     bool isConfigured() { return type != UNINITIALIZED; }
 
-    /**
-       Get the latency on the link in units of core atomic time base
-
-       NOTE: This is a core only API and not part of the public stable API
-    */
-    SimTime_t getLatency() { return latency; }
-
-    /**
-       Get the delivery_info for the link
-
-       NOTE: This is a core only API and not part of the public stable API
-    */
-    uintptr_t getDeliveryInfo() { return delivery_info; }
-
-    /**
-       Get the pair_link
-
-       NOTE: This is a core only API and not part of the public stable API
-    */
-    Link* getPairLink() { return pair_link; }
-
 
 #ifdef __SST_DEBUG_EVENT_TRACKING__
     void setSendingComponentInfo(const std::string& comp_in, const std::string& type_in, const std::string& port_in)
@@ -378,6 +357,23 @@ protected:
         // if ( tag != type_max<uint32_t> ) pair_link->tag = new_tag;
         // else pair_link->tag = 0x80000000 | new_tag;
     }
+
+    /**
+       Get the latency on the link in units of core atomic time base
+
+       NOTE: This is a core only API and not part of the public stable API
+    */
+    SimTime_t getLatency() { return latency; }
+
+    /**
+       Get the delivery_info for the link
+    */
+    uintptr_t getDeliveryInfo() { return delivery_info; }
+
+    /**
+       Get the pair_link
+    */
+    Link* getPairLink() { return pair_link; }
 
     /**
        Sends an Event over a Link with an additional delay specified with a TimeConverter. I.e. the total delay is the

--- a/src/sst/core/link.h
+++ b/src/sst/core/link.h
@@ -402,6 +402,12 @@ protected:
         event->updateDeliveryInfo(delivery_info);
     }
 
+    /**
+       Variable used by Link restarts to know whether stored rank data for remote links is still valid (i.e. did we
+       restart with the exact same rank/thread count or not).
+    */
+    static bool is_restart_same_parallelism;
+
     // Since Links are found in pairs, I will keep all the information
     // needed for me to send and deliver an event to the other side of
     // the Link.  That means, that I mostly keep my pair's

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -518,13 +518,24 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
     if ( restart ) {
 
         // Finish parsing checkpoint for restart
-        sim->restart();
+        sim->restart(info.graph);
 
         barrier.wait();
 
         if ( info.myRank.thread == 0 ) {
             sim->exchangeLinkInfo();
         }
+
+        barrier.wait();
+
+        // Need to detect the sync intervals
+        if ( info.myRank.thread == 0 ) {
+            sim->findRankSyncInterval();
+        }
+
+        barrier.wait();
+
+        sim->findThreadSyncInterval();
 
         barrier.wait();
 

--- a/src/sst/core/model/configGraph.cc
+++ b/src/sst/core/model/configGraph.cc
@@ -627,12 +627,13 @@ ConfigGraph::splitGraph(const std::set<uint32_t>& orig_rank_set, const std::set<
         graph = new ConfigGraph();
 
         // Need to copy over any restart data
-        graph->cpt_ranks           = cpt_ranks;
-        graph->cpt_currentSimCycle = cpt_currentSimCycle;
-        graph->cpt_currentPriority = cpt_currentPriority;
-        graph->cpt_minPart         = cpt_minPart;
-        graph->cpt_minPartTC       = cpt_minPartTC;
-        graph->cpt_max_event_id    = cpt_max_event_id;
+        graph->cpt_ranks            = cpt_ranks;
+        graph->cpt_currentSimCycle  = cpt_currentSimCycle;
+        graph->cpt_currentPriority  = cpt_currentPriority;
+        graph->cpt_minPart          = cpt_minPart;
+        graph->cpt_minPartTC        = cpt_minPartTC;
+        graph->cpt_max_event_id     = cpt_max_event_id;
+        graph->cpt_remap_partitions = cpt_remap_partitions;
 
         graph->cpt_libnames       = cpt_libnames;
         graph->cpt_shared_objects = cpt_shared_objects;

--- a/src/sst/core/model/configGraph.h
+++ b/src/sst/core/model/configGraph.h
@@ -211,6 +211,7 @@ public:
         SST_SER(cpt_minPart);
         SST_SER(cpt_minPartTC);
         SST_SER(cpt_max_event_id);
+        SST_SER(cpt_remap_partitions);
 
         SST_SER(*(cpt_libnames.get()));
         SST_SER(*(cpt_shared_objects.get()));
@@ -225,7 +226,8 @@ public:
     int           cpt_currentPriority = 0;
     SimTime_t     cpt_minPart         = std::numeric_limits<SimTime_t>::max();
     TimeConverter cpt_minPartTC;
-    uint64_t      cpt_max_event_id = 0;
+    uint64_t      cpt_max_event_id     = 0;
+    bool          cpt_remap_partitions = false;
 
     std::shared_ptr<std::set<std::string>> cpt_libnames       = std::make_shared<std::set<std::string>>();
     std::shared_ptr<std::vector<char>>     cpt_shared_objects = std::make_shared<std::vector<char>>();

--- a/src/sst/core/model/restart/sstcptmodel.cc
+++ b/src/sst/core/model/restart/sstcptmodel.cc
@@ -129,7 +129,7 @@ SSTCPTModelDefinition::createConfigGraph()
             Output::getDefaultObject().fatal(CALL_INFO, 1,
                 "Rank or thread counts do not match checkpoint. Checkpoint/restart requires that the total parallelism "
                 "be the same between a checkpoint and restart (i.e. ranks * threads is the same for both).  Checkpoint "
-                "was create with %" PRIu32 " ranks and %" PRIu32 " threads. Serial restarts are also permitted.\n",
+                "was created with %" PRIu32 " ranks and %" PRIu32 " threads. Serial restarts are also permitted.\n",
                 graph->cpt_ranks.rank, graph->cpt_ranks.thread);
         }
     }

--- a/src/sst/core/model/restart/sstcptmodel.cc
+++ b/src/sst/core/model/restart/sstcptmodel.cc
@@ -121,11 +121,17 @@ SSTCPTModelDefinition::createConfigGraph()
     if ( (cfg.num_ranks() != graph->cpt_ranks.rank || cfg.num_threads() != graph->cpt_ranks.thread) &&
          !(cfg.num_threads() == 1 && cfg.num_ranks() == 1) ) {
 
-        Output::getDefaultObject().fatal(CALL_INFO, 1,
-            "Rank or thread counts do not match checkpoint. "
-            "Checkpoint requires %" PRIu32 " ranks and %" PRIu32 " threads. "
-            "Serial restarts are also permitted.\n",
-            graph->cpt_ranks.rank, graph->cpt_ranks.thread);
+        // We can proceed if the total number of partitions is the same, otherwise, error
+        if ( (cfg.num_ranks() * cfg.num_threads()) == (graph->cpt_ranks.rank * graph->cpt_ranks.thread) ) {
+            graph->cpt_remap_partitions = true;
+        }
+        else {
+            Output::getDefaultObject().fatal(CALL_INFO, 1,
+                "Rank or thread counts do not match checkpoint. Checkpoint/restart requires that the total parallelism "
+                "be the same between a checkpoint and restart (i.e. ranks * threads is the same for both).  Checkpoint "
+                "was create with %" PRIu32 " ranks and %" PRIu32 " threads. Serial restarts are also permitted.\n",
+                graph->cpt_ranks.rank, graph->cpt_ranks.thread);
+        }
     }
     /******** ^^ Works for regular and N->1 restart ^^ ***********/
 

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -2092,7 +2092,7 @@ Simulation_impl::restart(ConfigGraph* graph)
     // Need to set Link::is_restart_same_parallelism flag. If we aren't doing a serial restart or a remap, then we must
     // have the same parallelism or we would have errored before getting here.  The variable is static, but all threads
     // will set it since they will all set it to the same thing.  This will avoid the need for a barrier while ensuring
-    // that all threadss will see the proper value.
+    // that all threads will see the proper value.
     if ( !serial_restart_ && !graph->cpt_remap_partitions ) {
         Link::is_restart_same_parallelism = true;
     }
@@ -2286,7 +2286,7 @@ Simulation_impl::discoverRemoteLinks()
     remote_links.insert(remote_links.begin(), local_links.begin(), local_links.end());
 
     for ( size_t i = 0; i < num_ranks.rank * num_ranks.thread - 1; ++i ) {
-        discoverRemoteLinks_move_data(remote_links, remote_links);
+        discoverRemoteLinksMoveData(remote_links, remote_links);
 
         // Process the data.  When we find matches, we will compress both lists
         auto local_iter   = local_links.begin();
@@ -2368,13 +2368,13 @@ Simulation_impl::discoverRemoteLinks()
     if ( local_links.size() != 0 ) {
         sim_output.fatal(CALL_INFO_LONG, 1,
             "ERROR: Found unmatched cross-partition links when restarting from a checkpoint.  This indicates a "
-            "bad/inconsistend set of checkpoint files.");
+            "bad/inconsistent set of checkpoint files.");
     }
 }
 
 
 void
-Simulation_impl::discoverRemoteLinks_move_data(
+Simulation_impl::discoverRemoteLinksMoveData(
     std::vector<std::pair<LinkId_t, RankInfo>>& send_vec, std::vector<std::pair<LinkId_t, RankInfo>>& recv_vec)
 {
     if ( num_ranks.thread != 1 ) {

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -25,6 +25,7 @@
 #include "sst/core/linkMap.h"
 #include "sst/core/linkPair.h"
 #include "sst/core/model/configGraph.h"
+#include "sst/core/objectComms.h"
 #include "sst/core/output.h"
 #include "sst/core/profile/clockHandlerProfileTool.h"
 #include "sst/core/profile/eventHandlerProfileTool.h"
@@ -863,6 +864,19 @@ Simulation_impl::exchangeLinkInfo()
 {
     syncManager->exchangeLinkInfo();
 }
+
+void
+Simulation_impl::findRankSyncInterval()
+{
+    syncManager->findRankSyncInterval();
+}
+
+void
+Simulation_impl::findThreadSyncInterval()
+{
+    syncManager->findThreadSyncInterval();
+}
+
 
 void
 Simulation_impl::initialize()
@@ -2009,7 +2023,7 @@ Simulation_impl::checkpoint(const std::string& checkpoint_filename)
 }
 
 void
-Simulation_impl::restart()
+Simulation_impl::restart(ConfigGraph* graph)
 {
     std::ifstream fs(config.configFile());
 
@@ -2075,11 +2089,31 @@ Simulation_impl::restart()
     // for current rank
     std::vector<std::string> blob_filenames;
 
+    // Need to set Link::is_restart_same_parallelism flag. If we aren't doing a serial restart or a remap, then we must
+    // have the same parallelism or we would have errored before getting here.  The variable is static, but all threads
+    // will set it since they will all set it to the same thing.  This will avoid the need for a barrier while ensuring
+    // that all threadss will see the proper value.
+    if ( !serial_restart_ && !graph->cpt_remap_partitions ) {
+        Link::is_restart_same_parallelism = true;
+    }
+
+    // Check to see if we are doing a remapping of the partitions (i.e. restart run has same total number of partitions,
+    // but different rank/thread values)
+    uint32_t effective_rank   = my_rank.rank;
+    uint32_t effective_thread = my_rank.thread;
+    if ( graph->cpt_remap_partitions ) {
+        // Need to generate an effective rank and thread as we are remapping partitions because we have the same total
+        // number, but not the same exact ranks and threads.
+        uint32_t index   = (my_rank.rank * num_ranks.thread) + my_rank.thread;
+        effective_rank   = index / graph->cpt_ranks.thread;
+        effective_thread = index % graph->cpt_ranks.thread;
+    }
+
     // Need to do this in the same order as the registry file so we
     // don't have to keep looking from the beginning
     for ( uint32_t r = 0; r < num_ranks_cpt.rank; ++r ) {
         for ( uint32_t t = 0; t < num_ranks_cpt.thread; ++t ) {
-            if ( !serial_restart_ && (my_rank.rank != r || my_rank.thread != t) ) continue;
+            if ( !serial_restart_ && (effective_rank != r || effective_thread != t) ) continue;
             search_str = "** (";
             search_str = search_str + std::to_string(r) + ":" + std::to_string(t) + "): ";
             while ( std::getline(fs, line) ) {
@@ -2111,6 +2145,11 @@ Simulation_impl::restart()
 
         SST_SER(interThreadMinLatency);
         SST_SER(independent);
+
+        if ( graph->cpt_remap_partitions ) {
+            interThreadMinLatency = num_ranks.thread != 1 ? 0 : bit_util::type_max<SimTime_t>;
+            minPart               = num_ranks.rank != 1 ? 0 : bit_util::type_max<SimTime_t>;
+        }
 
         // Set up the syncManager
         syncManager = new SyncManager(my_rank, num_ranks, minPart, interThreadLatencies, real_time_);
@@ -2190,6 +2229,7 @@ Simulation_impl::restart()
     // the sync data structures. This will also cause the SyncManager to
     // compute its next fire time.
     if ( num_ranks.rank > 1 || num_ranks.thread > 1 ) {
+        discoverRemoteLinks();
         syncManager->setRestartTime(currentSimCycle);
         setupBarrier.wait();
         syncManager->finalizeLinkConfigurations();
@@ -2207,6 +2247,194 @@ Simulation_impl::restart()
 
     real_time_->begin();
 }
+
+void
+Simulation_impl::discoverRemoteLinks()
+{
+    // If we are multi-threaded, Need to intialize the necessary data structures
+    if ( num_ranks.thread > 1 ) {
+        // Initialize my local queue.  This will be used to receive data from the previous thread
+        local_discover_queue.initialize(2);
+
+        // Now, get a pointer to the queue on the next thread
+        uint32_t next_thread = my_rank.thread + 1;
+        if ( next_thread == num_ranks.thread ) next_thread = 0;
+        remote_discover_queue = &(instanceVec_[next_thread]->local_discover_queue);
+        initBarrier.wait();
+    }
+
+    // Initialize the vector that we will use to transfer data between threads
+    xfer_vec = new std::vector<std::pair<LinkId_t, RankInfo>>();
+
+    // Need to create a vector we can pass around to get rank info for my remote links
+    std::vector<std::pair<LinkId_t, RankInfo>> local_links;
+    local_links.reserve(link_restart_tracking.size());
+    for ( auto [id, link] : link_restart_tracking ) {
+        local_links.emplace_back(id, my_rank);
+    }
+
+    // Need to sort the info in the vector
+    std::sort(local_links.begin(), local_links.end(),
+        [](std::pair<LinkId_t, RankInfo> const& a, std::pair<LinkId_t, RankInfo> const& b) {
+            return a.first < b.first;
+        });
+
+
+    // Create a vector that will be used to get the remote_data and send data on.  We'll copy local_links into this
+    // vector because we need to keep the original data to compare against.
+    std::vector<std::pair<LinkId_t, RankInfo>> remote_links;
+    remote_links.insert(remote_links.begin(), local_links.begin(), local_links.end());
+
+    for ( size_t i = 0; i < num_ranks.rank * num_ranks.thread - 1; ++i ) {
+        discoverRemoteLinks_move_data(remote_links, remote_links);
+
+        // Process the data.  When we find matches, we will compress both lists
+        auto local_iter   = local_links.begin();
+        auto local_write  = local_links.begin();
+        auto remote_iter  = remote_links.begin();
+        auto remote_write = remote_links.begin();
+
+        // Exit loop once we hit the end of either list
+        while ( local_iter != local_links.end() && remote_iter != remote_links.end() ) {
+            LinkId_t local_id  = local_iter->first;
+            LinkId_t remote_id = remote_iter->first;
+            if ( local_id == remote_id ) {
+                // Found a matching link. Need to register the link with the SyncManager and remove it from both lists.
+                // We do the remove by compacting as we go
+                Link* link = link_restart_tracking[local_id];
+                link->type = Link::SYNC;
+                link->mode = link->pair_link->mode;
+                link->tag  = link->pair_link->tag;
+
+                link->defaultTimeBase = 1;
+                link->id              = link->pair_link->getId();
+                link->pair_link->send_queue =
+                    syncManager->registerLink(remote_iter->second, local_iter->second, link_restart_tracking[local_id]);
+
+                // Remove the link from link_restart_tracking
+                link_restart_tracking.erase(local_id);
+
+                ++local_iter;
+                ++remote_iter;
+                // Do not increment the write iterator (this is how we will compact as we go)
+            }
+            else if ( local_id < remote_id ) {
+                *local_write = *local_iter;
+                ++local_iter;
+                ++local_write;
+            }
+            else {
+                *remote_write = *remote_iter;
+                ++remote_iter;
+                ++remote_write;
+            }
+        }
+
+        // Need to either delete the remaining elements left after compacting if we finished the list, or we need to
+        // delete the spaces left by compacting and move the data up if we didn't finish the list. Do this for both the
+        // local and remote vectors
+
+        // LOCAL
+        if ( local_iter != local_links.end() ) {
+            // Need to remove all the entries from local_write to local_iter
+            local_links.erase(local_write, local_iter);
+        }
+        else {
+            // Need to remove everything from local_write to end()
+            local_links.erase(local_write, local_links.end());
+        }
+
+        // REMOTE
+        if ( remote_iter != remote_links.end() ) {
+            // Need to remove all the entries from local_write to local_iter
+            remote_links.erase(remote_write, remote_iter);
+        }
+        else {
+            // Need to remove everything from local_write to end()
+            remote_links.erase(remote_write, remote_links.end());
+        }
+    }
+
+    // If we are multi-threaded, clean up data structures
+    if ( num_ranks.thread > 1 ) {
+        remote_discover_queue = nullptr;
+
+        // Initialize the vector that we will use to transfer data between threads
+        delete xfer_vec;
+        xfer_vec = nullptr;
+    }
+
+    // When we are done, we should have no links left in local_links;
+    if ( local_links.size() != 0 ) {
+        sim_output.fatal(CALL_INFO_LONG, 1,
+            "ERROR: Found unmatched cross-partition links when restarting from a checkpoint.  This indicates a "
+            "bad/inconsistend set of checkpoint files.");
+    }
+}
+
+
+void
+Simulation_impl::discoverRemoteLinks_move_data(
+    std::vector<std::pair<LinkId_t, RankInfo>>& send_vec, std::vector<std::pair<LinkId_t, RankInfo>>& recv_vec)
+{
+    if ( num_ranks.thread != 1 ) {
+        // First send my data to next thread
+        xfer_vec->swap(send_vec);
+        while ( !remote_discover_queue->try_insert(xfer_vec) )
+            sst_pause();
+        xfer_vec = nullptr;
+
+        // Now get data from previous thread
+        xfer_vec = local_discover_queue.remove();
+
+        if ( my_rank.thread != 0 || num_ranks.rank == 1 ) {
+
+            // Swap the data into the recv_vec
+            xfer_vec->swap(recv_vec);
+            // Leave xfer_vec for the next time
+            return;
+        }
+    }
+    else {
+        xfer_vec->swap(send_vec);
+    }
+
+#ifdef SST_CONFIG_HAVE_MPI
+    // If we get here, we are a multirank job and are thread 0 and we already have the data from the last thread that we
+    // need to send on
+    uint32_t next_rank = my_rank.rank + 1;
+    if ( next_rank == num_ranks.rank ) next_rank = 0;
+    uint32_t prev_rank = my_rank.rank - 1;
+    if ( prev_rank == bit_util::type_max<uint32_t> ) prev_rank = num_ranks.rank - 1;
+
+
+    // First, send the data size to the next thread and get the data size from the previous thread
+    int send_data_size = xfer_vec->size();
+    int recv_data_size = 0;
+
+    MPI_Request req[2];
+    MPI_Status  status[2];
+    MPI_Isend(&send_data_size, 1, MPI_INT, next_rank, 0, MPI_COMM_WORLD, &req[0]);
+    MPI_Irecv(&recv_data_size, 1, MPI_INT, prev_rank, 0, MPI_COMM_WORLD, &req[1]);
+
+    MPI_Waitall(2, req, status);
+
+    // NOTE: This code does not yet support sending more than 2GB of total data
+
+    // Need to send my data
+    MPI_Isend(xfer_vec->data(), send_data_size * sizeof(std::pair<LinkId_t, RankInfo>), MPI_BYTE, next_rank, 1,
+        MPI_COMM_WORLD, &req[0]);
+
+    // Receive the data.  First need to resize vector, then copy in the data
+    recv_vec.resize(recv_data_size);
+    MPI_Irecv(recv_vec.data(), recv_data_size * sizeof(std::pair<LinkId_t, RankInfo>), MPI_BYTE, prev_rank, 1,
+        MPI_COMM_WORLD, &req[1]);
+
+    MPI_Waitall(2, req, status);
+    xfer_vec->clear();
+#endif
+}
+
 
 void
 Simulation_impl::initialize_interactive_console(const std::string& type)

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -218,6 +218,8 @@ public:
     int  prepareLinks(ConfigGraph& graph, const RankInfo& myRank, SimTime_t min_part);
     int  performWireUp(ConfigGraph& graph, const RankInfo& myRank, SimTime_t min_part);
     void exchangeLinkInfo();
+    void findRankSyncInterval();
+    void findThreadSyncInterval();
 
     /** Setup external control actions (forced stops, signal handling */
     void setupSimActions();
@@ -416,7 +418,19 @@ public:
      */
     void checkpoint_write_globals(int checkpoint_id, const std::string& checkpoint_filename,
         const std::string& registry_filename, const std::string& globals_filename);
-    void restart();
+    void restart(ConfigGraph* graph);
+
+    void discoverRemoteLinks();
+
+    /**** Functions/variables needed for discoverRemoteLinks() ****/
+    Core::ThreadSafe::BoundedQueue<std::vector<std::pair<LinkId_t, RankInfo>>*>  local_discover_queue;
+    Core::ThreadSafe::BoundedQueue<std::vector<std::pair<LinkId_t, RankInfo>>*>* remote_discover_queue;
+    std::vector<std::pair<LinkId_t, RankInfo>>*                                  xfer_vec = nullptr;
+
+    void discoverRemoteLinks_move_data(
+        std::vector<std::pair<LinkId_t, RankInfo>>& send_vec, std::vector<std::pair<LinkId_t, RankInfo>>& recv_vec);
+
+    /**************************************************************/
 
     /**
        Function used to get the rank for a link on restart.  A rank of

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -427,7 +427,7 @@ public:
     Core::ThreadSafe::BoundedQueue<std::vector<std::pair<LinkId_t, RankInfo>>*>* remote_discover_queue;
     std::vector<std::pair<LinkId_t, RankInfo>>*                                  xfer_vec = nullptr;
 
-    void discoverRemoteLinks_move_data(
+    void discoverRemoteLinksMoveData(
         std::vector<std::pair<LinkId_t, RankInfo>>& send_vec, std::vector<std::pair<LinkId_t, RankInfo>>& recv_vec);
 
     /**************************************************************/

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -310,8 +310,8 @@ RankSync::findSyncInterval(uint32_t UNUSED_WO_MPI(my_rank))
         Comms::recv(i, 0, data);
         Comms::send(i, 0, link_maps[i]);
 
-        // Process the data. Get the Link and the send latency and add any addional receive latency that was added with
-        // addRecvLatency(). Compare again current minimum and update if necessary.
+        // Process the data. Get the Link and the send latency and add any additional receive latency that was added
+        // with addRecvLatency(). Compare again current minimum and update if necessary.
 
         for ( auto& x : data ) {
             Link* local = reinterpret_cast<Link*>(x.second);
@@ -352,8 +352,8 @@ RankSync::findSyncInterval(uint32_t UNUSED_WO_MPI(my_rank))
         Comms::send(i, 0, link_maps[i]);
         Comms::recv(i, 0, data);
 
-        // Process the data. Get the Link and the send latency and add any addional receive latency that was added with
-        // addRecvLatency(). Compare again current minimum and update if necessary.
+        // Process the data. Get the Link and the send latency and add any additional receive latency that was added
+        // with addRecvLatency(). Compare again current minimum and update if necessary.
 
         for ( auto& x : data ) {
             Link* local = reinterpret_cast<Link*>(x.second);

--- a/src/sst/core/sync/syncManager.h
+++ b/src/sst/core/sync/syncManager.h
@@ -146,6 +146,21 @@ protected:
     inline void setLinkDeliveryInfo(Link* link, uintptr_t info) { link->pair_link->setDeliveryInfo(info); }
 
     inline Link* getDeliveryLink(Event* ev) { return ev->getDeliveryLink(); }
+
+    /**
+       Get the latency on the link in units of core atomic time base
+    */
+    SimTime_t getLatency(Link* link) { return link->latency; }
+
+    /**
+       Get the delivery_info for the link
+    */
+    uintptr_t getDeliveryInfo(Link* link) { return link->delivery_info; }
+
+    /**
+       Get the pair_link
+    */
+    Link* getPairLink(Link* link) { return link->pair_link; }
 };
 
 class SyncManager : public Action

--- a/src/sst/core/sync/threadSyncSimpleSkip.cc
+++ b/src/sst/core/sync/threadSyncSimpleSkip.cc
@@ -69,7 +69,7 @@ void
 ThreadSyncSimpleSkip::registerLink(Link* link)
 {
     std::scoped_lock slock(lock);
-    link_vec.push_back(link->getPairLink());
+    link_vec.push_back(getPairLink(link));
     auto iter = link_map.find(link->getId());
     if ( iter == link_map.end() ) {
         // I have initialized first, so just put the id and link in
@@ -190,7 +190,7 @@ ThreadSyncSimpleSkip::findSyncInterval()
     for ( auto* x : link_vec ) {
         // I need to see if addRecvLatency() was called on the remote side of the link.  We have a pointer to that Link
         // (as a uintptr_t) in delivery_info.
-        SimTime_t latency = x->getLatency() + reinterpret_cast<Link*>(x->getDeliveryInfo())->getLatency();
+        SimTime_t latency = getLatency(x) + getLatency(reinterpret_cast<Link*>(getDeliveryInfo(x)));
         if ( latency < min_lat ) min_lat = latency;
     }
 

--- a/tests/test_StatisticsComponent_basic.py
+++ b/tests/test_StatisticsComponent_basic.py
@@ -881,15 +881,15 @@ if testH5:
 
 
 count = 0;
-curr_comp = None
-link = None
-comp_list.append(None)
+prior_comp = None
 
 for x in comp_list:
-    if curr_comp:
-        curr_comp.addLink(link, "left")
-    if x:
-        link = sst.Link("link{}".format(count), "1ns")
-        count += 1
-        x.addLink(link, "right")
-    curr_comp = x
+    if prior_comp is None:
+        prior_comp = x
+        continue
+
+    link = sst.Link("link{0}".format(count), "1ns")
+    count += 1
+    prior_comp.addLink(link, "left")
+    x.addLink(link, "right")
+    prior_comp = x

--- a/tests/testsuite_default_Checkpoint.py
+++ b/tests/testsuite_default_Checkpoint.py
@@ -97,6 +97,12 @@ class testcase_Checkpoint(SSTTestCase):
     def test_Checkpoint_sc_2u2u_n2one(self) -> None:
         self.checkpoint_test_template("sc_2u2u", 1, 2, subcomp=True, modelparams="1", n_to_one=True)
 
+    def test_Checkpoint_Statistics_basic_par_remap(self) -> None:
+        self.checkpoint_test_template("StatisticsComponent_basic", par_remap=True)
+
+    def test_Checkpoint_sc_2u2u_par_remap(self) -> None:
+        self.checkpoint_test_template("sc_2u2u", 1, 2, subcomp=True, modelparams="1", par_remap=True)
+
     def test_Checkpoint_SharedObject_bool_array_n2one(self) -> None:
         self.checkpoint_test_template("SharedObject", 1, 2, modelparams="--param=object_type:bool_array --param=num_entities:12 --param=full_initialization:true --param=checkpoint:true", outstr = "SharedObject_bool_array", n_to_one=True)
 
@@ -115,7 +121,7 @@ class testcase_Checkpoint(SSTTestCase):
     # subcom: Set to True if this is a subcomponent test as the file/path name differs
     # modelparams: Set what is passed into --model-params when running SST
     # outstr: If set, is used in place of testtype to generate reference and output filenames
-    def checkpoint_test_template(self, testtype: str, rst_index: int = 1, cr_index: int = 0, subcomp: bool = False, modelparams: str = "", outstr: str = "", n_to_one: bool = False) -> None:
+    def checkpoint_test_template(self, testtype: str, rst_index: int = 1, cr_index: int = 0, subcomp: bool = False, modelparams: str = "", outstr: str = "", n_to_one: bool = False, par_remap : bool = False) -> None:
 
         # name conventions:
         # X_cpt - files/options associated with first checkpoint run
@@ -207,6 +213,8 @@ class testcase_Checkpoint(SSTTestCase):
 
         if n_to_one:
             self.run_sst(sdlfile_rst, outfile_rst, other_args=options_rst, num_ranks=1, num_threads=1)
+        elif par_remap:
+            self.run_sst(sdlfile_rst, outfile_rst, other_args=options_rst, num_ranks=testing_check_get_num_threads(), num_threads=testing_check_get_num_ranks())
         else:
             self.run_sst(sdlfile_rst, outfile_rst, other_args=options_rst)
 
@@ -229,6 +237,7 @@ class testcase_Checkpoint(SSTTestCase):
         outfile_cr = "{0}/test_Checkpoint_{1}_ckpt_restart.out".format(outdir, testtype)
         options_cr = "--load-checkpoint"
 
+        # If par_remap is on, we will still just rerun the checkpoint from the restart with the original parallelism
         if n_to_one:
             self.run_sst(sdlfile_cr, outfile_cr, other_args=options_cr, num_ranks=1, num_threads=1)
         else:


### PR DESCRIPTION
Restarts can now restart with different parallelism as long as the total number of threads in the run is the same between the checkpoint and restart runs.