### PR TITLE
Fix Python 3.14 compatibility: segfaults in GC and module loader

### DIFF
--- a/config/sst_check_python.m4
+++ b/config/sst_check_python.m4
@@ -16,8 +16,8 @@ dnl check if user provided a specific python-config
 dnl search python3-config
   AS_IF([test $PYTHON_CONFIG_EXE = "no"],
     [AS_IF([test -n "$with_python"],
-        [AC_PATH_PROGS([PYTHON_CONFIG_EXE], ["python3-config" "python3.13-config" "python3.12-config" "python3.11-config" "python3.10-config" "python3.9-config"], ["no"], ["$with_python/bin"])],
-        [AC_PATH_PROGS([PYTHON_CONFIG_EXE], ["python3-config" "python3.13-config" "python3.12-config" "python3.11-config" "python3.10-config" "python3.9-config"], ["no"])])])
+        [AC_PATH_PROGS([PYTHON_CONFIG_EXE], ["python3-config" "python3.14-config" "python3.13-config" "python3.12-config" "python3.11-config" "python3.10-config" "python3.9-config"], ["no"], ["$with_python/bin"])],
+        [AC_PATH_PROGS([PYTHON_CONFIG_EXE], ["python3-config" "python3.14-config" "python3.13-config" "python3.12-config" "python3.11-config" "python3.10-config" "python3.9-config"], ["no"])])])
 
 dnl search python-config
   AS_IF([test $PYTHON_CONFIG_EXE = "no"],

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -74,6 +74,7 @@ static PyObject* setStatisticLoadLevelForComponentType(PyObject* self, PyObject*
 
 static PyObject* setCallPythonFinalize(PyObject* self, PyObject* args);
 
+static void      mlDealloc(PyObject* self);
 static PyObject* mlFindModule(PyObject* self, PyObject* args);
 static PyObject* mlCreateModule(PyObject* self, PyObject* args);
 static PyObject* mlExecModule(PyObject* self, PyObject* args);
@@ -91,7 +92,7 @@ static PyTypeObject ModuleLoaderType = {
     SST_PY_OBJ_HEAD "ModuleLoader", /* tp_name */
     sizeof(ModuleLoaderPy_t),       /* tp_basicsize */
     0,                              /* tp_itemsize */
-    nullptr,                        /* tp_dealloc */
+    mlDealloc,                      /* tp_dealloc */
     0,                              /* tp_vectorcall_offset */
     nullptr,                        /* tp_getattr */
     nullptr,                        /* tp_setattr */
@@ -145,6 +146,12 @@ static PyTypeObject ModuleLoaderType = {
 REENABLE_WARNING
 #endif
 #endif
+
+static void
+mlDealloc(PyObject* self)
+{
+    Py_TYPE(self)->tp_free(self);
+}
 
 // I hate having to do this through a global variable
 // but there's really no other way to communicate errors from the importer
@@ -204,9 +211,11 @@ static struct PyModuleDef emptyModDef {
 #endif
 
 static PyObject*
-mlExecModule(PyObject* UNUSED(self), PyObject* args)
+mlExecModule(PyObject* UNUSED(self), PyObject* UNUSED(args))
 {
-    return args;
+    // exec_module must return None per the import protocol (PEP 451).
+    // All module loading is done in create_module via PyImport_ExecCodeModule.
+    Py_RETURN_NONE;
 }
 
 static PyObject*
@@ -223,24 +232,23 @@ mlCreateModule(PyObject* UNUSED(self), PyObject* args)
     // error there.
     if ( !PyArg_ParseTuple(args, "O", &spec) ) return nullptr;
 
-    PyObject*   nameobj;
-    const char* name;
-
-    nameobj = PyObject_GetAttrString(spec, "name");
+    PyObject* nameobj = PyObject_GetAttrString(spec, "name");
     if ( nameobj == nullptr ) {
         return nullptr;
     }
-    name = SST_ConvertToCppString(nameobj);
 
-    if ( strncmp(name, "sst.", 4) ) {
-        // We know how to handle only sst.<module>
-        return nullptr; // ERROR!
+    // SST_ConvertToCppString (PyUnicode_AsUTF8) returns a pointer into
+    // nameobj's internal buffer, so copy before decref.
+    std::string nameStr(SST_ConvertToCppString(nameobj));
+    Py_DECREF(nameobj);
+
+    if ( nameStr.compare(0, 4, "sst.") != 0 ) {
+        Py_RETURN_NONE;
     }
 
-    const char* modName = name + 4; // sst.<modName>
+    std::string modName = nameStr.substr(4);
 
-    // fprintf(stderr, "Loading SST module '%s' (from %s)\n", modName, name);
-    // genPythonModuleFunction func = Factory::getFactory()->getPythonModule(modName);
+    // fprintf(stderr, "Loading SST module '%s' (from %s)\n", modName.c_str(), nameStr.c_str());
     SSTElementPythonModule* pymod = Factory::getFactory()->getPythonModule(modName);
     PyObject*               mod   = nullptr;
     if ( !pymod ) {
@@ -1187,13 +1195,18 @@ SSTPythonModelDefinition::initModel(
                        "import sst\n"
                        "import importlib\n"
                        "import importlib.machinery\n"
-                       "spec = importlib.machinery.ModuleSpec(\"sst loader\", sst.ModuleLoader())\n"
                        "class SSTModuleFinder:\n"
+                       "  _loader = sst.ModuleLoader()\n"
                        "  def find_spec(self, fullname, path, target=None):\n"
-                       "    loader = sst.ModuleLoader()\n"
-                       "    found_loader = loader.find_module(fullname)\n"
-                       "    if found_loader:  return importlib.machinery.ModuleSpec(fullname, found_loader)\n"
-                       "    else: return None\n"
+                       "    if not fullname.startswith('sst.'):\n"
+                       "      return None\n"
+                       "    try:\n"
+                       "      found = self._loader.find_module(fullname)\n"
+                       "      if found:\n"
+                       "        return importlib.machinery.ModuleSpec(fullname, found)\n"
+                       "    except Exception:\n"
+                       "      pass\n"
+                       "    return None\n"
                        "sys.meta_path.append(SSTModuleFinder())\n");
 
 // https://github.com/sstsimulator/sst-core/issues/1531
@@ -1321,7 +1334,16 @@ SSTPythonModelDefinition::~SSTPythonModelDefinition()
         Py_Finalize();
     }
     else {
+        // Python 3.14 rewrote the cycle GC to be incremental (two generations
+        // instead of three). Calling PyGC_Collect() during shutdown can trigger
+        // a segfault because type_clear may have already cleared type MROs and
+        // internal references, causing the collector to dereference freed memory
+        // when traversing objects. See CPython issues #130380, #133932, #135115.
+        // Py_Finalize() already calls PyGC_Collect() internally, so the explicit
+        // call here is only needed as a best-effort cleanup when we skip finalize.
+#if PY_MINOR_VERSION < 14
         PyGC_Collect();
+#endif
     }
 }
 


### PR DESCRIPTION
## Summary

SST core crashes with SIGSEGV on Python 3.14 due to three independent bugs in the Python/C API integration. All 10 Merlin tests now pass with Python 3.14.2.

## Root Causes & Fixes

### 1. `PyGC_Collect()` crash during shutdown (Pattern 2)

Python 3.14 rewrote the cycle GC to be incremental (two generations instead of three). Calling `PyGC_Collect()` during shutdown triggers a segfault because `type_clear` may have already cleared type MROs and internal references, causing the collector to dereference freed memory. See CPython issues [#130380](https://github.com/python/cpython/issues/130380), [#133932](https://github.com/python/cpython/issues/133932), [#135115](https://github.com/python/cpython/issues/135115).

**Fix:** Skip the explicit `PyGC_Collect()` call on Python >= 3.14. `Py_Finalize()` already calls it internally.

### 2. `mlExecModule()` returns borrowed reference as new reference (Pattern 1)

`mlExecModule()` returned `args` (a borrowed reference) instead of `Py_None`. The C API contract requires returned values to be new references. This caused a refcount underflow leading to use-after-free, manifesting as SIGSEGV in `BaseException_clear` during error display after any exception when SST element modules (e.g., merlin) were loaded.

**Fix:** Return `Py_None` per PEP 451 import protocol.

### 3. Reference leak and error handling in `mlCreateModule()`

- `PyObject_GetAttrString` result (`nameobj`) was never `Py_DECREF`'d — memory leak.
- Returned `nullptr` without setting a Python exception when module name didn't start with `"sst."` — C API violation causing `SystemError`.

**Fix:** Copy string, decref `nameobj`, return `Py_None` for non-SST modules.

### 4. Additional hardening

- Added `tp_dealloc` to `ModuleLoaderType` (was `nullptr` — undefined behavior on dealloc).
- Hardened `SSTModuleFinder`: reuse single `ModuleLoader` instance, early `startswith` check, `try/except` guard.
- Added `python3.14-config` to `AC_PATH_PROGS` search list in `sst_check_python.m4`.

## Testing

All 10 Merlin tests pass with Python 3.14.2 on macOS (Apple Silicon):

| Test | Before | After |
|------|--------|-------|
| torus_64, torus_128, dragon_72, torus_5_trafficgen | SIGSEGV | ✅ PASS |
| dragon_128, dragon_128_fl, dragon_128_deferred | SIGSEGV | ✅ PASS |
| fattree_128, fattree_256, hyperx_128 | SIGSEGV | ✅ PASS |

## Files Changed

- `src/sst/core/model/python/pymodel.cc` — All code fixes
- `config/sst_check_python.m4` — Added `python3.14-config` to search list