### PR TITLE
Centralize profiling output from multiple sources

### DIFF
--- a/config/sst_enable_perf_tracking.m4
+++ b/config/sst_enable_perf_tracking.m4
@@ -13,8 +13,6 @@ AC_DEFUN([SST_ENABLE_PERF_TRACKING], [
                [EXPERIMENTAL Tracks clock handler execution time and counters])])
    AS_IF([test "$enable_debug_perf_tracking" = "yes"], [AC_DEFINE([SST_EVENT_PROFILING], [1],
                [EXPERIMENTAL Tracks event and communication time and counters])])
-   AS_IF([test "$enable_debug_perf_tracking" = "yes"], [AC_DEFINE([SST_SYNC_PROFILING], [1],
-                [EXPERIMENTAL Tracks synchronization time and count])])
    AS_IF([test "$enable_debug_perf_tracking" = "yes"], [AC_DEFINE([SST_PERIODIC_PRINT], [0],
                [EXPERIMENTAL Periodically prints performance information to files])])
    AS_IF([test "$enable_debug_perf_tracking" = "yes"], [AC_DEFINE([SST_PERIODIC_PRINT_THRESHOLD], [10000],

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -421,10 +421,8 @@ Config::insertOptions()
         "Print SST timing information.  Can supply an optional level to control the granularity of timing information. "
         "Level = 0 turns all timing info off, level = 1 will print total runtime, as well as other performance data. "
         "Level >= 2 will print increasing granularity of performance data. If specified with no level, then the level "
-        "will be set to 2.",
+        "will be set to 2. '--profiling-output' may be used to control the destination for timing information.",
         print_timing_, true, true, false);
-    DEF_ARG(
-        "timing-info-json", 0, "FILE", "Write SST timing information in JSON format", timing_json_, true, true, false);
     DEF_ARG("stop-at", 0, "TIME", "Set time at which simulation will end execution", stop_at_, true, true, false);
     DEF_ARG("exit-after", 0, "TIME",
         "Set the maximum wall time after which simulation will end execution.  Time is specified in hours, minutes and "
@@ -515,7 +513,10 @@ Config::insertOptions()
         "Enables default profiling for the specified points.  Argument is a semicolon separated list specifying the "
         "points to enable.",
         enabled_profiling_, true, false, false);
-    DEF_ARG("profiling-output", 0, "FILE", "Set output location for profiling data [stdout (default) or a filename]",
+    DEF_ARG("profiling-output", 0, "FILE",
+        "Set output location for profiling and timing data [stdout (default) and/or a "
+        "filename including a '.txt' (text) or '.json' (JSON) extension. To specify stdout and a filename, list both "
+        "separated by a comma such as 'stdout,output.json']",
         profiling_output_, true, false, false);
 
     /* Advanced Features - Debug */

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -418,6 +418,13 @@ Config::insertOptions()
         "will be appended to the model options (or used as the model options if --model-options was not specified).",
         model_options_, false, false, true);
     DEF_ARG_OPTVAL("print-timing-info", 0, "LEVEL",
+        "DEPRECATED: Use '--timing-info' instead. Print SST timing information.  Can supply an optional level to "
+        "control the granularity of timing information. "
+        "Level = 0 turns all timing info off, level = 1 will print total runtime, as well as other performance data. "
+        "Level >= 2 will print increasing granularity of performance data. If specified with no level, then the level "
+        "will be set to 2. '--profiling-output' may be used to control the destination for timing information.",
+        print_timing_, true, true, false);
+    DEF_ARG_OPTVAL("timing-info", 0, "LEVEL",
         "Print SST timing information.  Can supply an optional level to control the granularity of timing information. "
         "Level = 0 turns all timing info off, level = 1 will print total runtime, as well as other performance data. "
         "Level >= 2 will print increasing granularity of performance data. If specified with no level, then the level "

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -188,11 +188,6 @@ private:
         std::bind(&StandardConfigParsers::from_string_default<int>, std::placeholders::_1, std::placeholders::_2, 2));
 
     /**
-        Print SST timing information to JSON file
-    */
-    SST_CONFIG_DECLARE_OPTION(std::string, timing_json, "", &StandardConfigParsers::from_string<std::string>);
-
-    /**
        Simulated cycle to stop the simulation at
     */
     SST_CONFIG_DECLARE_OPTION(std::string, stop_at, "0ns", &StandardConfigParsers::from_string<std::string>);

--- a/src/sst/core/cputimer.cc
+++ b/src/sst/core/cputimer.cc
@@ -24,6 +24,15 @@ sst_get_cpu_time()
     return ((double)the_time.tv_sec) + (((double)the_time.tv_usec) * 1.0e-6);
 }
 
+uint64_t
+sst_get_cpu_time_usec()
+{
+    struct timeval the_time;
+    gettimeofday(&the_time, nullptr);
+
+    return the_time.tv_usec + (the_time.tv_sec * 1.0e6);
+}
+
 std::string
 sst_get_current_time()
 {

--- a/src/sst/core/cputimer.h
+++ b/src/sst/core/cputimer.h
@@ -12,13 +12,19 @@
 #ifndef SST_CORE_CPU_TIMER_H
 #define SST_CORE_CPU_TIMER_H
 
+#include <cstdint>
 #include <string>
 #include <sys/time.h>
 
 /**
- * @return Current CPU time using the time of day. Timezone information is not filled.
+ * @return Current CPU time in seconds using the time of day. Timezone information is not filled.
  */
 double sst_get_cpu_time();
+
+/**
+ * @return Current CPU time in us using the time of day. Timezone information is not filled.
+ */
+uint64_t sst_get_cpu_time_usec();
 
 /**
    Returns a string with the current time in HH:MM:SS format

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -1539,7 +1539,6 @@ main(int argc, char* argv[])
 #endif
 
     if ( cfg.verbose() || cfg.print_timing() ) {
-        perfReporter.configureOutput(cfg.profiling_output());
 
         // These functions invoke MPI_Allreduce
         const uint64_t local_max_rss     = maxLocalMemSize();

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -56,6 +56,7 @@ REENABLE_WARNING
 #include "sst/core/timingOutput.h"
 #include "sst/core/unitAlgebra.h"
 #include "sst/core/util/bit_util.h"
+#include "sst/core/util/perfReporter.h"
 
 #include <cinttypes>
 #include <csignal>
@@ -79,7 +80,8 @@ using namespace SST::Partition;
 using namespace SST;
 
 
-static SST::Output g_output;
+static SST::Output             g_output;
+static SST::Util::PerfReporter perfReporter;
 
 
 // Functions to force initialization stages of simulation to execute
@@ -750,50 +752,8 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
     info.max_tv_depth     = sim->getTimeVortexMaxDepth();
     info.current_tv_depth = sim->getTimeVortexCurrentDepth();
 
-    // Print the profiling info.  For threads, we will serialize
-    // writing and for ranks we will use different files, unless we
-    // are writing to console, in which case we will serialize the
-    // output as well.
-    FILE*       fp   = nullptr;
-    std::string file = cfg.profiling_output();
-    if ( file == "stdout" ) {
-        // Output to the console, so we will force both rank and
-        // thread output to be sequential
-        force_rank_sequential_start(info.world_size.rank > 1, info.myRank, info.world_size);
-
-        for ( uint32_t i = 0; i < info.world_size.thread; ++i ) {
-            if ( i == info.myRank.thread ) {
-                sim->printProfilingInfo(stdout);
-            }
-            barrier.wait();
-        }
-
-        force_rank_sequential_stop(info.world_size.rank > 1, info.myRank, info.world_size);
-        barrier.wait();
-    }
-    else {
-        // Output to file
-        if ( info.world_size.rank > 1 ) {
-            addRankToFileName(file, info.myRank.rank);
-        }
-
-        // First thread will open a new file
-        std::string mode;
-        // Thread 0 will open a new file, all others will append
-        if ( info.myRank.thread == 0 )
-            mode = "w";
-        else
-            mode = "a";
-
-        for ( uint32_t i = 0; i < info.world_size.thread; ++i ) {
-            if ( i == info.myRank.thread ) {
-                fp = Simulation_impl::filesystem.fopen(file, mode.c_str());
-                sim->printProfilingInfo(fp);
-                fclose(fp);
-            }
-            barrier.wait();
-        }
-    }
+    // Print the profiling info if requested
+    sim->printProfilingInfo(&perfReporter);
 
     // Put in info about sync memory usage
     info.sync_data_size = sim->getSyncQueueDataSize();
@@ -992,12 +952,14 @@ main(int argc, char* argv[])
     // Create global output object
     Output::setFileName(cfg.debugFile() != "/dev/null" ? cfg.debugFile() : "sst_output");
     Output::setWorldSize(world_size.rank, world_size.thread, myrank);
-    // g_output = Output::setDefaultObject(cfg.output_core_prefix(), cfg.verbose(), 0, Output::STDOUT);
+
     g_output.setPrefix(cfg.output_core_prefix());
     g_output.setVerboseLevel(cfg.verbose());
 
     g_output.verbose(CALL_INFO, 1, 0, "main() My rank is (%u,%u), on %u/%u nodes/threads\n", myRank.rank, myRank.thread,
         world_size.rank, world_size.thread);
+
+    perfReporter.configureOutput(cfg.profiling_output());
 
     // TimeLord must be initialized prior to postCreationCleanup() call
     Simulation_impl::getTimeLord()->init(cfg.timeBase());
@@ -1545,11 +1507,6 @@ main(int argc, char* argv[])
             "Simulation is complete, simulated time: %s\n", threadInfo[0].simulated_time.toStringBestSI().c_str());
     }
 
-
-    double max_run_time   = Simulation_impl::basicPerf.getRegionDuration("run");
-    double max_build_time = Simulation_impl::basicPerf.getRegionDuration("build");
-    double max_total_time = Simulation_impl::basicPerf.getRegionDuration("total");
-
     uint64_t local_max_tv_depth      = threadInfo[0].max_tv_depth;
     uint64_t global_max_tv_depth     = 0;
     uint64_t local_current_tv_depth  = threadInfo[0].current_tv_depth;
@@ -1581,40 +1538,56 @@ main(int argc, char* argv[])
     global_active_activities  = active_activities;
 #endif
 
-    // These functions invoke MPI_Allreduce
-    const uint64_t local_max_rss     = maxLocalMemSize();
-    const uint64_t global_max_rss    = maxGlobalMemSize();
-    const uint64_t local_max_pf      = maxLocalPageFaults();
-    const uint64_t global_pf         = globalPageFaults();
-    const uint64_t global_max_io_in  = maxInputOperations();
-    const uint64_t global_max_io_out = maxOutputOperations();
+    if ( cfg.verbose() || cfg.print_timing() ) {
+        perfReporter.configureOutput(cfg.profiling_output());
 
-    if ( cfg.verbose() || cfg.print_timing() || cfg.timing_json() != "" ) {
+        // These functions invoke MPI_Allreduce
+        const uint64_t local_max_rss     = maxLocalMemSize();
+        const uint64_t global_max_rss    = maxGlobalMemSize();
+        const uint64_t local_max_pf      = maxLocalPageFaults();
+        const uint64_t global_pf         = globalPageFaults();
+        const uint64_t global_max_io_in  = maxInputOperations();
+        const uint64_t global_max_io_out = maxOutputOperations();
+
         if ( myRank.rank == 0 ) {
             int          timing_verbose = cfg.print_timing() == 0 ? (cfg.verbose() > 0 ? 2 : 0) : cfg.print_timing();
             TimingOutput timingOutput(g_output, std::max(timing_verbose, cfg.verbose() == 0 ? 0 : cfg.verbose() + 1));
-            if ( cfg.timing_json() != "" ) timingOutput.setJSON(cfg.timing_json());
+            timingOutput.generate(&perfReporter); // Triggers basicPerf to dump data to the record
 
-            timingOutput.set(TimingOutput::Key::LOCAL_MAX_RSS, local_max_rss);
-            timingOutput.set(TimingOutput::Key::GLOBAL_MAX_RSS, global_max_rss);
-            timingOutput.set(TimingOutput::Key::LOCAL_MAX_PF, local_max_pf);
-            timingOutput.set(TimingOutput::Key::GLOBAL_PF, global_pf);
-            timingOutput.set(TimingOutput::Key::GLOBAL_MAX_IO_IN, global_max_io_in);
-            timingOutput.set(TimingOutput::Key::GLOBAL_MAX_IO_OUT, global_max_io_out);
-            timingOutput.set(TimingOutput::Key::GLOBAL_MAX_SYNC_DATA_SIZE, global_max_sync_data_size);
-            timingOutput.set(TimingOutput::Key::GLOBAL_SYNC_DATA_SIZE, global_sync_data_size);
-            timingOutput.set(TimingOutput::Key::MAX_MEMPOOL_SIZE, (uint64_t)max_mempool_size);
-            timingOutput.set(TimingOutput::Key::GLOBAL_MEMPOOL_SIZE, (uint64_t)global_mempool_size);
-            timingOutput.set(TimingOutput::Key::MAX_BUILD_TIME, max_build_time);
-            timingOutput.set(TimingOutput::Key::MAX_RUN_TIME, max_run_time);
-            timingOutput.set(TimingOutput::Key::MAX_TOTAL_TIME, max_total_time);
-            timingOutput.set(TimingOutput::Key::SIMULATED_TIME_UA, threadInfo[0].simulated_time);
-            timingOutput.set(TimingOutput::Key::GLOBAL_ACTIVE_ACTIVITIES, (uint64_t)global_active_activities);
-            timingOutput.set(TimingOutput::Key::GLOBAL_CURRENT_TV_DEPTH, global_current_tv_depth);
-            timingOutput.set(TimingOutput::Key::GLOBAL_MAX_TV_DEPTH, global_max_tv_depth);
-            timingOutput.set(TimingOutput::Key::RANKS, (uint64_t)world_size.rank);
-            timingOutput.set(TimingOutput::Key::THREADS, (uint64_t)world_size.thread);
-            timingOutput.generate();
+            SST::Util::DataRecord* resources = perfReporter.createDataRecord("resources");
+            std::map<std::string, std::pair<std::string, std::string>> key_map = {
+                { "resources", { "Simulation Resource Information", "" } },
+                { "local_max_rss", { "Max Resident Set Size", "" } }, // UnitAlgebra, units unnecessary
+                { "global_max_rss", { "Approx. Global Max RSS Size", "" } },
+                { "local_max_page_faults", { "Max Local Page Faults", "faults" } },
+                { "global_max_page_faults", { "Global Page Faults", "faults" } },
+                { "global_max_io_in", { "Max Output Blocks", "blocks" } },
+                { "global_max_io_out", { "Max Input Blocks", "blocks" } },
+                { "global_max_sync_data_size", { "Max Sync data size", "B" } },
+                { "global_sync_data_size", { "Global Sync data size", "B" } },
+                { "max_mempool_size", { "Max mempool usage", "" } },
+                { "global_mempool_size", { "Global mempool usage", "" } },
+                { "global_undeleted_activities", { "Global undeleted activities", "" } },
+                { "global_current_timevortex_depth", { "Current global TimeVortex depth", "entries" } },
+                { "global_max_tv_depth", { "Max TimeVortex depth", "entries" } },
+                { "global_page_faults", { "Global Page Faults", "faults" } },
+                { "local_max_page_faults", { "Max Local Page Faults", "faults" } }
+            };
+
+            resources->setKeys(key_map);
+            resources->addData("local_max_rss", UnitAlgebra(std::to_string(local_max_rss) + "KiB"));
+            resources->addData("global_max_rss", UnitAlgebra(std::to_string(global_max_rss) + "KiB"));
+            resources->addData("local_max_page_faults", local_max_pf);
+            resources->addData("global_page_faults", global_pf);
+            resources->addData("global_max_io_in", global_max_io_in);
+            resources->addData("global_max_io_out", global_max_io_out);
+            resources->addData("global_max_sync_data_size", global_max_sync_data_size);
+            resources->addData("global_sync_data_size", global_sync_data_size);
+            resources->addData("max_mempool_size", UnitAlgebra(std::to_string(max_mempool_size) + "B"));
+            resources->addData("global_mempool_size", UnitAlgebra(std::to_string(global_mempool_size) + "B"));
+            resources->addData("global_undeleted_activities", global_active_activities);
+            resources->addData("global_current_timevortex_depth", global_current_tv_depth);
+            resources->addData("global_max_tv_depth", global_max_tv_depth);
         }
     }
 
@@ -1644,7 +1617,13 @@ main(int argc, char* argv[])
         }
         MemPoolAccessor::printUndeletedMemPoolItems("  ", out);
     }
+#endif // USE_MEMPOOL
+
+#ifdef SST_CONFIG_HAVE_MPI
+    MPI_Barrier(MPI_COMM_WORLD);
 #endif
+
+    perfReporter.output(myRank.rank, world_size.rank);
 
 #ifdef SST_CONFIG_HAVE_MPI
     MPI_Finalize();

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -1569,7 +1569,7 @@ main(int argc, char* argv[])
                 { "global_mempool_size", { "Global mempool usage", "" } },
                 { "global_undeleted_activities", { "Global undeleted activities", "" } },
                 { "global_current_timevortex_depth", { "Current global TimeVortex depth", "entries" } },
-                { "global_max_tv_depth", { "Max TimeVortex depth", "entries" } },
+                { "global_max_timevortex_depth", { "Max TimeVortex depth", "entries" } },
                 { "global_page_faults", { "Global Page Faults", "faults" } },
                 { "local_max_page_faults", { "Max Local Page Faults", "faults" } }
             };
@@ -1587,7 +1587,7 @@ main(int argc, char* argv[])
             resources->addData("global_mempool_size", UnitAlgebra(std::to_string(global_mempool_size) + "B"));
             resources->addData("global_undeleted_activities", global_active_activities);
             resources->addData("global_current_timevortex_depth", global_current_tv_depth);
-            resources->addData("global_max_tv_depth", global_max_tv_depth);
+            resources->addData("global_max_timevortex_depth", global_max_tv_depth);
         }
     }
 

--- a/src/sst/core/model/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/jsonConfigOutput.cc
@@ -435,7 +435,6 @@ JSONConfigGraphOutput::outputProgramOptions(const Config* cfg, std::ofstream& of
     record["verbose"]                = std::to_string(cfg->verbose());
     record["stop-at"]                = cfg->stop_at();
     record["print-timing-info"]      = std::to_string(cfg->print_timing());
-    record["timing-info-json"]       = cfg->timing_json();
     // Ignore stopAfter for now
     // outputJson["program_options"]["stopAfter"] = cfg->stopAfterSec();
     record["heartbeat-sim-period"]   = cfg->heartbeat_sim_period();

--- a/src/sst/core/model/cfgoutput/jsonConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/jsonConfigOutput.cc
@@ -434,7 +434,7 @@ JSONConfigGraphOutput::outputProgramOptions(const Config* cfg, std::ofstream& of
     ofs << "\"program_options\":";
     record["verbose"]                = std::to_string(cfg->verbose());
     record["stop-at"]                = cfg->stop_at();
-    record["print-timing-info"]      = std::to_string(cfg->print_timing());
+    record["timing-info"]            = std::to_string(cfg->print_timing());
     // Ignore stopAfter for now
     // outputJson["program_options"]["stopAfter"] = cfg->stopAfterSec();
     record["heartbeat-sim-period"]   = cfg->heartbeat_sim_period();

--- a/src/sst/core/model/cfgoutput/pythonConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/pythonConfigOutput.cc
@@ -383,7 +383,7 @@ PythonConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph)
     fprintf(outputFile, "# (These reflect the settings from original run and are not necessary in all files)\n");
     fprintf(outputFile, "sst.setProgramOption(\"verbose\", \"%" PRIu32 "\")\n", cfg->verbose());
     fprintf(outputFile, "sst.setProgramOption(\"stop-at\", \"%s\")\n", cfg->stop_at().c_str());
-    fprintf(outputFile, "sst.setProgramOption(\"print-timing-info\", \"%d\")\n", cfg->print_timing());
+    fprintf(outputFile, "sst.setProgramOption(\"timing-info\", \"%d\")\n", cfg->print_timing());
     // Ignore stopAfter for now
     // fprintf(outputFile, "sst.setProgramOption(\"stopAfter\", \"%" PRIu32 "\")\n", cfg->stopAfterSec);
     fprintf(

--- a/src/sst/core/model/cfgoutput/pythonConfigOutput.cc
+++ b/src/sst/core/model/cfgoutput/pythonConfigOutput.cc
@@ -384,7 +384,6 @@ PythonConfigGraphOutput::generate(const Config* cfg, ConfigGraph* graph)
     fprintf(outputFile, "sst.setProgramOption(\"verbose\", \"%" PRIu32 "\")\n", cfg->verbose());
     fprintf(outputFile, "sst.setProgramOption(\"stop-at\", \"%s\")\n", cfg->stop_at().c_str());
     fprintf(outputFile, "sst.setProgramOption(\"print-timing-info\", \"%d\")\n", cfg->print_timing());
-    fprintf(outputFile, "sst.setProgramOption(\"timing-info-json\", \"%s\")\n", cfg->timing_json().c_str());
     // Ignore stopAfter for now
     // fprintf(outputFile, "sst.setProgramOption(\"stopAfter\", \"%" PRIu32 "\")\n", cfg->stopAfterSec);
     fprintf(

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -329,7 +329,7 @@ getProgramOptions(PyObject* UNUSED(self), PyObject* UNUSED(args))
     PyDict_SetItem(dict, SST_ConvertToPythonString("num-ranks"), SST_ConvertToPythonLong(cfg->num_ranks()));
     PyDict_SetItem(dict, SST_ConvertToPythonString("num-threads"), SST_ConvertToPythonLong(cfg->num_threads()));
     PyDict_SetItem(dict, SST_ConvertToPythonString("sdl-file"), SST_ConvertToPythonString(cfg->configFile().c_str()));
-    PyDict_SetItem(dict, SST_ConvertToPythonString("print-timing-info"), SST_ConvertToPythonBool(cfg->print_timing()));
+    PyDict_SetItem(dict, SST_ConvertToPythonString("timing-info"), SST_ConvertToPythonBool(cfg->print_timing()));
     PyDict_SetItem(dict, SST_ConvertToPythonString("stop-at"), SST_ConvertToPythonString(cfg->stop_at().c_str()));
     PyDict_SetItem(dict, SST_ConvertToPythonString("exit-after"), SST_ConvertToPythonLong(cfg->exit_after()));
     PyDict_SetItem(

--- a/src/sst/core/model/python/pymodel.cc
+++ b/src/sst/core/model/python/pymodel.cc
@@ -330,8 +330,6 @@ getProgramOptions(PyObject* UNUSED(self), PyObject* UNUSED(args))
     PyDict_SetItem(dict, SST_ConvertToPythonString("num-threads"), SST_ConvertToPythonLong(cfg->num_threads()));
     PyDict_SetItem(dict, SST_ConvertToPythonString("sdl-file"), SST_ConvertToPythonString(cfg->configFile().c_str()));
     PyDict_SetItem(dict, SST_ConvertToPythonString("print-timing-info"), SST_ConvertToPythonBool(cfg->print_timing()));
-    PyDict_SetItem(
-        dict, SST_ConvertToPythonString("timing-info-json"), SST_ConvertToPythonString(cfg->timing_json().c_str()));
     PyDict_SetItem(dict, SST_ConvertToPythonString("stop-at"), SST_ConvertToPythonString(cfg->stop_at().c_str()));
     PyDict_SetItem(dict, SST_ConvertToPythonString("exit-after"), SST_ConvertToPythonLong(cfg->exit_after()));
     PyDict_SetItem(

--- a/src/sst/core/profile/clockHandlerProfileTool.cc
+++ b/src/sst/core/profile/clockHandlerProfileTool.cc
@@ -16,6 +16,7 @@
 #include "sst/core/output.h"
 #include "sst/core/params.h"
 #include "sst/core/sst_types.h"
+#include "sst/core/util/perfReporter.h"
 
 #include <chrono>
 #include <cinttypes>
@@ -85,12 +86,13 @@ ClockHandlerProfileToolCount::beforeHandler(uintptr_t key, const Cycle_t& UNUSED
 
 
 void
-ClockHandlerProfileToolCount::outputData(FILE* fp)
+ClockHandlerProfileToolCount::outputData(SST::Util::DataRecord* record, RankInfo rank)
 {
-    fprintf(fp, "%s\n", name.c_str());
-    fprintf(fp, "Name, count\n");
+    record->addChild(std::to_string(rank.rank) + "_" + std::to_string(rank.thread));
     for ( auto& x : counts_ ) {
-        fprintf(fp, "%s, %" PRIu64 "\n", x.first.c_str(), x.second);
+        record->addChild(x.first);
+        record->addData("count", x.second);
+        record->changeLevelUp();
     }
 }
 
@@ -109,13 +111,19 @@ ClockHandlerProfileToolTime<T>::registerHandler(const AttachPointMetaData& mdata
 
 template <typename T>
 void
-ClockHandlerProfileToolTime<T>::outputData(FILE* fp)
+ClockHandlerProfileToolTime<T>::outputData(SST::Util::DataRecord* record, RankInfo rank)
 {
-    fprintf(fp, "%s\n", name.c_str());
-    fprintf(fp, "Name, count, handler time (s), avg. handler time (ns)\n");
+    record->addChild(std::to_string(rank.rank) + "_" + std::to_string(rank.thread));
+
     for ( auto& x : times_ ) {
-        fprintf(fp, "%s, %" PRIu64 ", %lf, %" PRIu64 "\n", x.first.c_str(), x.second.count,
-            ((double)x.second.time) / 1000000000.0, x.second.count == 0 ? 0 : x.second.time / x.second.count);
+        record->addChild(x.first);
+        record->addData("count", x.second.count);
+        UnitAlgebra handler_time(std::to_string(((double)x.second.time) / 1000000000.0) + "s");
+        record->addData("handler_time", handler_time);
+        if ( x.second.count != 0 ) {
+            record->addData("avg_handler_time", UnitAlgebra(std::to_string(x.second.time / x.second.count) + "ns"));
+        }
+        record->changeLevelUp();
     }
 }
 

--- a/src/sst/core/profile/clockHandlerProfileTool.h
+++ b/src/sst/core/profile/clockHandlerProfileTool.h
@@ -15,6 +15,7 @@
 #include "sst/core/clock.h"
 #include "sst/core/eli/elementinfo.h"
 #include "sst/core/profile/profiletool.h"
+#include "sst/core/rankInfo.h"
 #include "sst/core/sst_types.h"
 #include "sst/core/ssthandler.h"
 #include "sst/core/warnmacros.h"
@@ -24,7 +25,13 @@
 #include <map>
 #include <string>
 
-namespace SST::Profile {
+namespace SST {
+
+namespace Util {
+class DataRecord;
+}
+
+namespace Profile {
 
 class ClockHandlerProfileTool : public ProfileTool, public Clock::HandlerBase::AttachPoint
 {
@@ -75,7 +82,7 @@ public:
 
     void beforeHandler(uintptr_t key, const Cycle_t& cycle) override;
 
-    void outputData(FILE* fp) override;
+    void outputData(SST::Util::DataRecord* record, RankInfo rank) override;
 
 private:
     std::map<std::string, uint64_t> counts_;
@@ -116,13 +123,14 @@ public:
         entry->count++;
     }
 
-    void outputData(FILE* fp) override;
+    void outputData(SST::Util::DataRecord* record, RankInfo rank) override;
 
 private:
     typename T::time_point              start_time_;
     std::map<std::string, clock_data_t> times_;
 };
 
-} // namespace SST::Profile
+} // namespace Profile
+} // namespace SST
 
 #endif // SST_CORE_PROFILE_CLOCKHANDLERPROFILETOOL_H

--- a/src/sst/core/profile/componentProfileTool.cc
+++ b/src/sst/core/profile/componentProfileTool.cc
@@ -16,6 +16,7 @@
 #include "sst/core/output.h"
 #include "sst/core/params.h"
 #include "sst/core/sst_types.h"
+#include "sst/core/util/perfReporter.h"
 
 #include <chrono>
 #include <cinttypes>
@@ -93,13 +94,12 @@ ComponentCodeSegmentProfileToolCount::codeSegmentStart(uintptr_t key)
 }
 
 void
-ComponentCodeSegmentProfileToolCount::outputData(FILE* fp)
+ComponentCodeSegmentProfileToolCount::outputData(SST::Util::DataRecord* record, RankInfo UNUSED(rank))
 {
-    fprintf(fp, "%s\n", name.c_str());
-    fprintf(fp, "Name, Count\n");
     for ( auto& x : counts_ ) {
-        fprintf(fp, "%s", x.first.c_str());
-        fprintf(fp, ", %" PRIu64 "\n", x.second);
+        record->addChild(x.first);
+        record->addData("count", x.second);
+        record->changeLevelUp();
     }
 }
 
@@ -119,14 +119,14 @@ ComponentCodeSegmentProfileToolTime<T>::registerProfilePoint(
 
 template <typename T>
 void
-ComponentCodeSegmentProfileToolTime<T>::outputData(FILE* fp)
+ComponentCodeSegmentProfileToolTime<T>::outputData(SST::Util::DataRecord* record, RankInfo UNUSED(rank))
 {
-    fprintf(fp, "%s\n", name.c_str());
-    fprintf(fp, "Name, count, time (s), avg time (ns)\n");
     for ( auto& x : times_ ) {
-        fprintf(fp, "%s", x.first.c_str());
-        fprintf(fp, ", %" PRIu64 ", %lf, %" PRIu64 "\n", x.second.count, ((double)x.second.time) / 1000000000.0,
-            x.second.count == 0 ? 0 : x.second.time / x.second.count);
+        record->addChild(x.first);
+        record->addData("count", x.second.count);
+        record->addData("time", UnitAlgebra(std::to_string(((double)x.second.time) / 1000000000) + "s"));
+        if ( x.second.count != 0 )
+            record->addData("time", UnitAlgebra(std::to_string((x.second.time) / x.second.count) + "ns"));
     }
 }
 

--- a/src/sst/core/profile/componentProfileTool.h
+++ b/src/sst/core/profile/componentProfileTool.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/eli/elementinfo.h"
 #include "sst/core/profile/profiletool.h"
+#include "sst/core/rankInfo.h"
 #include "sst/core/sst_types.h"
 #include "sst/core/warnmacros.h"
 
@@ -26,7 +27,12 @@
 
 namespace SST {
 class BaseComponent;
+
+namespace Util {
+class DataRecord;
 }
+
+} // namespace SST
 
 namespace SST::Profile {
 
@@ -145,7 +151,7 @@ public:
 
     void codeSegmentStart(uintptr_t key) override;
 
-    void outputData(FILE* fp) override;
+    void outputData(SST::Util::DataRecord* record, RankInfo rank) override;
 
 private:
     std::map<std::string, uint64_t> counts_;
@@ -187,7 +193,7 @@ public:
         entry->count++;
     }
 
-    void outputData(FILE* fp) override;
+    void outputData(SST::Util::DataRecord* record, RankInfo rank) override;
 
 private:
     typename T::time_point                start_time_;

--- a/src/sst/core/profile/eventHandlerProfileTool.cc
+++ b/src/sst/core/profile/eventHandlerProfileTool.cc
@@ -16,6 +16,7 @@
 #include "sst/core/output.h"
 #include "sst/core/params.h"
 #include "sst/core/sst_types.h"
+#include "sst/core/util/perfReporter.h"
 
 #include <chrono>
 #include <cinttypes>
@@ -104,18 +105,13 @@ EventHandlerProfileToolCount::eventSent(uintptr_t key, Event*& UNUSED(ev))
 
 
 void
-EventHandlerProfileToolCount::outputData(FILE* fp)
+EventHandlerProfileToolCount::outputData(SST::Util::DataRecord* record, RankInfo UNUSED(rank))
 {
-    fprintf(fp, "%s\n", name.c_str());
-    fprintf(fp, "Name");
-    if ( profile_receives_ ) fprintf(fp, ", recv count");
-    if ( profile_sends_ ) fprintf(fp, ", send count");
-    fprintf(fp, "\n");
     for ( auto& x : counts_ ) {
-        fprintf(fp, "%s", x.first.c_str());
-        if ( profile_receives_ ) fprintf(fp, ", %" PRIu64, x.second.recv_count);
-        if ( profile_sends_ ) fprintf(fp, ", %" PRIu64, x.second.send_count);
-        fprintf(fp, "\n");
+        record->addChild(x.first);
+        if ( profile_receives_ ) record->addData("recv_count", x.second.recv_count);
+        if ( profile_sends_ ) record->addData("send_count", x.second.send_count);
+        record->changeLevelUp();
     }
 }
 
@@ -141,21 +137,20 @@ EventHandlerProfileToolTime<T>::registerLinkAttachTool(const AttachPointMetaData
 
 template <typename T>
 void
-EventHandlerProfileToolTime<T>::outputData(FILE* fp)
+EventHandlerProfileToolTime<T>::outputData(SST::Util::DataRecord* record, RankInfo UNUSED(rank))
 {
-    fprintf(fp, "%s\n", name.c_str());
-    fprintf(fp, "Name");
-    if ( profile_receives_ ) fprintf(fp, ", recv count, recv time (s), avg. recv time (ns)");
-    if ( profile_sends_ ) fprintf(fp, ", send count");
-    fprintf(fp, "\n");
     for ( auto& x : times_ ) {
-        fprintf(fp, "%s", x.first.c_str());
-        if ( profile_receives_ )
-            fprintf(fp, ", %" PRIu64 ", %lf, %" PRIu64, x.second.recv_count,
-                ((double)x.second.recv_time) / 1000000000.0,
-                x.second.recv_count == 0 ? 0 : x.second.recv_time / x.second.recv_count);
-        if ( profile_sends_ ) fprintf(fp, ", %" PRIu64, x.second.send_count);
-        fprintf(fp, "\n");
+        record->addChild(x.first);
+        if ( profile_receives_ ) {
+            record->addData("recv_count", x.second.recv_count);
+            UnitAlgebra recv_time(std::to_string(((double)x.second.recv_time) / 1000000000.0) + "s");
+            record->addData("recv_time", recv_time);
+            if ( x.second.recv_count != 0 )
+                record->addData(
+                    "avg_recv_time", UnitAlgebra(std::to_string(x.second.recv_time / x.second.recv_count) + "ns"));
+        }
+        if ( profile_sends_ ) record->addData("send_count", x.second.send_count);
+        record->changeLevelUp();
     }
 }
 

--- a/src/sst/core/profile/eventHandlerProfileTool.h
+++ b/src/sst/core/profile/eventHandlerProfileTool.h
@@ -25,6 +25,10 @@
 #include <map>
 #include <string>
 
+namespace SST::Util {
+class DataRecord;
+}
+
 namespace SST::Profile {
 
 class EventHandlerProfileTool : public ProfileTool, public Event::HandlerBase::AttachPoint, public Link::AttachPoint
@@ -102,7 +106,7 @@ public:
     void beforeHandler(uintptr_t key, const SST::Event* event) override;
     void eventSent(uintptr_t key, Event*& ev) override;
 
-    void outputData(FILE* fp) override;
+    void outputData(SST::Util::DataRecord* record, RankInfo rank) override;
 
 private:
     std::map<std::string, event_data_t> counts_;
@@ -148,7 +152,7 @@ public:
 
     void eventSent(uintptr_t key, Event*& UNUSED(ev)) override { reinterpret_cast<event_data_t*>(key)->send_count++; }
 
-    void outputData(FILE* fp) override;
+    void outputData(SST::Util::DataRecord* record, RankInfo rank) override;
 
 private:
     typename T::time_point              start_time_;

--- a/src/sst/core/profile/profiletool.h
+++ b/src/sst/core/profile/profiletool.h
@@ -13,6 +13,7 @@
 #define SST_CORE_PROFILE_PROFILETOOL_H
 
 #include "sst/core/eli/elementinfo.h"
+#include "sst/core/rankInfo.h"
 #include "sst/core/sst_types.h"
 #include "sst/core/warnmacros.h"
 
@@ -20,7 +21,12 @@
 
 namespace SST {
 class Params;
+
+namespace Util {
+class DataRecord;
 }
+} // namespace SST
+
 
 namespace SST::Profile {
 
@@ -45,7 +51,7 @@ public:
 
     std::string getName() { return name; }
 
-    virtual void outputData(FILE* fp) = 0;
+    virtual void outputData(SST::Util::DataRecord* record, RankInfo rank) = 0;
 
 protected:
     const std::string name;

--- a/src/sst/core/profile/syncProfileTool.cc
+++ b/src/sst/core/profile/syncProfileTool.cc
@@ -63,7 +63,7 @@ SyncProfileToolCount::outputData(SST::Util::DataRecord* record, RankInfo rank)
 
         record->setKeys(keys);
     }
-    record->addChild(std::to_string(rank.rank) + "_" + std::to_string(rank.thread));
+    record->addChild("rank" + std::to_string(rank.rank));
     record->addData("ranksync_total_count", syncmanager_count);
     record->addData("threadsync_total_count", threadsync_count_);
     record->addData("ranksync_total_events", events_exchanged_);
@@ -94,7 +94,7 @@ SyncProfileToolTime<T>::outputData(SST::Util::DataRecord* record, RankInfo rank)
         record->setKeys(keys);
         record->setFormat(SST::Util::DataRecord::TextFormat::list);
     }
-    record->addChild(std::to_string(rank.rank) + "_" + std::to_string(rank.thread));
+    record->addChild("rank" + std::to_string(rank.rank));
     record->addData("ranksync_total_count", syncmanager_count);
     record->addData("ranksync_total_time", UnitAlgebra(std::to_string((float)syncmanager_time / 1000000000.0) + "s"));
     record->addData("threadsync_total_count", threadsync_count);

--- a/src/sst/core/profile/syncProfileTool.cc
+++ b/src/sst/core/profile/syncProfileTool.cc
@@ -15,6 +15,7 @@
 
 #include "sst/core/output.h"
 #include "sst/core/sst_types.h"
+#include "sst/core/util/perfReporter.h"
 
 #include <chrono>
 #include <cinttypes>
@@ -31,17 +32,42 @@ SyncProfileToolCount::SyncProfileToolCount(const std::string& name, Params& para
 {}
 
 void
-SyncProfileToolCount::syncManagerStart()
+SyncProfileToolCount::syncManagerStart(bool ranksync)
 {
-    syncmanager_count++;
+    if ( !ranksync ) {
+        threadsync_count_++;
+    }
+    else {
+        syncmanager_count++;
+    }
 }
 
+void
+SyncProfileToolCount::updateSyncSize(size_t bytes, size_t events)
+{
+    bytes_exchanged_ += bytes;
+    events_exchanged_ += events;
+}
 
 void
-SyncProfileToolCount::outputData(FILE* fp)
+SyncProfileToolCount::outputData(SST::Util::DataRecord* record, RankInfo rank)
 {
-    fprintf(fp, "%s\n", name.c_str());
-    fprintf(fp, "  SyncManager Count = %" PRIu64 "\n", syncmanager_count);
+    if ( rank.thread == 0 ) {
+        record->setFormat(SST::Util::DataRecord::TextFormat::list);
+
+        std::map<std::string, std::pair<std::string, std::string>> keys = { { "sync", { "Sync Profiling Data", "" } },
+            { "ranksync_total_count", { "RankSync Total Syncs", "" } },
+            { "threadsync_total_count", { "ThreadSync Total Syncs", "" } },
+            { "ranksync_total_events", { "RankSync Total Events Exchanged", "" } },
+            { "ranksync_total_data", { "RankSync Total Data Exchanged", "" } } };
+
+        record->setKeys(keys);
+    }
+    record->addChild(std::to_string(rank.rank) + "_" + std::to_string(rank.thread));
+    record->addData("ranksync_total_count", syncmanager_count);
+    record->addData("threadsync_total_count", threadsync_count_);
+    record->addData("ranksync_total_events", events_exchanged_);
+    record->addData("ranksync_total_data", UnitAlgebra(std::to_string(bytes_exchanged_) + "B"));
 }
 
 
@@ -52,17 +78,42 @@ SyncProfileToolTime<T>::SyncProfileToolTime(const std::string& name, Params& par
 
 template <typename T>
 void
-SyncProfileToolTime<T>::outputData(FILE* fp)
+SyncProfileToolTime<T>::outputData(SST::Util::DataRecord* record, RankInfo rank)
 {
-    fprintf(fp, "%s\n", name.c_str());
-    fprintf(fp, "  SyncManager Count = %" PRIu64 "\n", syncmanager_count);
-    fprintf(fp, "  Total SyncManager Time = %lfs\n", (float)syncmanager_time / 1000000000.0);
-    if ( syncmanager_count == 0 ) {
-        fprintf(fp, "  Average SyncManager Time = N/A\n");
+    if ( rank.thread == 0 ) {
+        std::map<std::string, std::pair<std::string, std::string>> keys = { { "sync", { "Sync Profiling Data", "" } },
+            { "ranksync_total_count", { "RankSync Total Syncs", "" } },
+            { "ranksync_total_time", { "RankSync Total Time", "" } },
+            { "ranksync_avg_time", { "RankSync Time per Sync", "" } },
+            { "threadsync_total_count", { "ThreadSync Total Syncs", "" } },
+            { "threadsync_total_time", { "ThreadSync Total Time", "" } },
+            { "threadsync_avg_time", { "ThreadSync Time per Sync", "" } },
+            { "ranksync_total_events", { "RankSync Total Events Exchanged", "" } },
+            { "ranksync_total_data", { "RankSync Total Data Exchanged", "" } } };
+
+        record->setKeys(keys);
+        record->setFormat(SST::Util::DataRecord::TextFormat::list);
+    }
+    record->addChild(std::to_string(rank.rank) + "_" + std::to_string(rank.thread));
+    record->addData("ranksync_total_count", syncmanager_count);
+    record->addData("ranksync_total_time", UnitAlgebra(std::to_string((float)syncmanager_time / 1000000000.0) + "s"));
+    record->addData("threadsync_total_count", threadsync_count);
+    record->addData("threadsync_total_time", UnitAlgebra(std::to_string((float)threadsync_time / 1000000000.0) + "s"));
+
+    if ( syncmanager_count != 0 ) {
+        record->addData("ranksync_avg_time", UnitAlgebra(std::to_string(syncmanager_time / syncmanager_count) + "ns"));
     }
     else {
-        fprintf(fp, "  Average SyncManager Time = %" PRIu64 "ns\n", syncmanager_time / syncmanager_count);
+        record->addData("ranksync_avg_time", UnitAlgebra("0ns"));
     }
+    if ( threadsync_count != 0 ) {
+        record->addData("threadsync_avg_time", UnitAlgebra(std::to_string(threadsync_time / threadsync_count) + "ns"));
+    }
+    else {
+        record->addData("threadsync_avg_time", UnitAlgebra("0ns"));
+    }
+    record->addData("ranksync_total_events", events_exchanged_);
+    record->addData("ranksync_total_data", UnitAlgebra(std::to_string(bytes_exchanged_) + "B"));
 }
 
 
@@ -107,5 +158,6 @@ public:
 
     SST_ELI_EXPORT(SyncProfileToolTimeSteady)
 };
+
 
 } // namespace SST::Profile

--- a/src/sst/core/profile/syncProfileTool.h
+++ b/src/sst/core/profile/syncProfileTool.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/eli/elementinfo.h"
 #include "sst/core/profile/profiletool.h"
+#include "sst/core/rankInfo.h"
 #include "sst/core/sst_types.h"
 #include "sst/core/ssthandler.h"
 #include "sst/core/warnmacros.h"
@@ -22,6 +23,10 @@
 #include <cstdint>
 #include <map>
 #include <string>
+
+namespace SST::Util {
+class DataRecord;
+}
 
 namespace SST::Profile {
 
@@ -39,8 +44,10 @@ public:
 
     SyncProfileTool(const std::string& name, Params& params);
 
-    virtual void syncManagerStart() {}
+    virtual void syncManagerStart(bool UNUSED(ranksync)) {}
     virtual void syncManagerEnd() {}
+
+    virtual void updateSyncSize(size_t UNUSED(bytes), size_t UNUSED(events)) {}
 };
 
 
@@ -65,12 +72,17 @@ public:
 
     virtual ~SyncProfileToolCount() {}
 
-    void syncManagerStart() override;
+    void syncManagerStart(bool ranksync) override;
 
-    void outputData(FILE* fp) override;
+    void updateSyncSize(size_t bytes, size_t events) override;
+
+    void outputData(SST::Util::DataRecord* record, RankInfo rank) override;
 
 private:
     uint64_t syncmanager_count = 0;
+    uint64_t threadsync_count_ = 0;
+    uint64_t events_exchanged_ = 0;
+    uint64_t bytes_exchanged_  = 0;
 };
 
 /**
@@ -85,22 +97,79 @@ public:
 
     virtual ~SyncProfileToolTime() {}
 
-    void syncManagerStart() override { start_time_ = T::now(); }
+    void syncManagerStart(bool ranksync) override
+    {
+        start_time_ = T::now();
+        rank_sync_  = ranksync;
+    }
 
     void syncManagerEnd() override
     {
         auto total_time = T::now() - start_time_;
-        syncmanager_time += std::chrono::duration_cast<std::chrono::nanoseconds>(total_time).count();
-        syncmanager_count++;
+
+        if ( !rank_sync_ ) {
+            threadsync_count++;
+            threadsync_time += std::chrono::duration_cast<std::chrono::nanoseconds>(total_time).count();
+        }
+        else {
+            syncmanager_time += std::chrono::duration_cast<std::chrono::nanoseconds>(total_time).count();
+            syncmanager_count++;
+        }
     }
 
-    void outputData(FILE* fp) override;
+    void updateSyncSize(size_t bytes, size_t events) override
+    {
+        bytes_exchanged_ += bytes;
+        events_exchanged_ += events;
+    }
+
+    void outputData(SST::Util::DataRecord* record, RankInfo rank) override;
 
 private:
     uint64_t syncmanager_time  = 0;
     uint64_t syncmanager_count = 0;
+    uint64_t threadsync_count  = 0;
+    uint64_t threadsync_time   = 0;
+    uint64_t events_exchanged_ = 0;
+    uint64_t bytes_exchanged_  = 0;
+    bool     rank_sync_        = false;
 
     typename T::time_point start_time_;
+};
+
+// Class used to hold the list of profile tools installed in the SyncManager
+// Here so that it can be used by multiple classes throughout the sync objects
+class SyncProfileToolList
+{
+public:
+    SyncProfileToolList() = default;
+
+    void syncManagerStart(bool ranksync)
+    {
+        for ( auto* x : tools )
+            x->syncManagerStart(ranksync);
+    }
+
+    void syncManagerEnd()
+    {
+        for ( auto* x : tools )
+            x->syncManagerEnd();
+    }
+
+    void updateSyncSize(size_t bytes, size_t events)
+    {
+        for ( auto* x : tools )
+            x->updateSyncSize(bytes, events);
+    }
+
+    /**
+       Adds a profile tool the the list and registers this handler
+       with the profile tool
+    */
+    void addProfileTool(Profile::SyncProfileTool* tool) { tools.push_back(tool); }
+
+private:
+    std::vector<Profile::SyncProfileTool*> tools;
 };
 
 } // namespace SST::Profile

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -43,6 +43,7 @@
 #include "sst/core/timeLord.h"
 #include "sst/core/timeVortex.h"
 #include "sst/core/unitAlgebra.h"
+#include "sst/core/util/perfReporter.h"
 
 #include <algorithm>
 #include <atomic>
@@ -1479,30 +1480,7 @@ Simulation_impl::incrementSerialCounters(uint64_t count)
     rankLatency += count;
     ++rankExchangeCounter;
 }
-
-void
-Simulation_impl::incrementExchangeCounters(uint64_t events, uint64_t bytes)
-{
-    rankExchangeEvents += events;
-    rankExchangeBytes += bytes;
-}
 #endif // SST_EVENT_PROFILING
-
-
-#if SST_SYNC_PROFILING
-void
-Simulation_impl::incrementSyncTime(bool rankSync, uint64_t count)
-{
-    if ( rankSync ) {
-        ++rankSyncCounter;
-        rankSyncTime += count;
-    }
-    else {
-        ++threadSyncCounter;
-        threadSyncTime += count;
-    }
-}
-#endif // SST_SYNC_PROFILING
 
 
 std::pair<pvt::TimeVortexSort::iterator, pvt::TimeVortexSort::iterator>
@@ -2456,32 +2434,19 @@ Simulation_impl::printSimulationState()
 }
 
 void
-Simulation_impl::printProfilingInfo(FILE* fp)
+Simulation_impl::printProfilingInfo(Util::PerfReporter* reporter)
 {
+    // Modifying shared state so serialize threads through this function
+    std::lock_guard<std::mutex> lock(simulationMutex);
+
     // If no profile tools are installed, return without doing
     // anything
     if ( profile_tools.size() == 0 ) return;
 
-    // Print out a header if printing to stdout
-    if ( fp == stdout && my_rank.rank == 0 && my_rank.thread == 0 ) {
-        fprintf(fp, "\n------------------------------------------------------------\n");
-        fprintf(fp, "Profiling Output:\n\n");
-    }
-
-    fprintf(fp, "-----------------------------\n");
-
-    // Print the rank and thread.  Profiling output is serialized
-    // through both ranks and threads.
-    fprintf(fp, "Rank = %" PRIu32 ", thread = %" PRIu32 ":\n\n", my_rank.rank, my_rank.thread);
-
     for ( auto tool : profile_tools ) {
-        tool.second->outputData(fp);
-        fprintf(fp, "\n");
-    }
-
-    // Print footer if printing on stdout
-    if ( fp == stdout && my_rank.rank == num_ranks.rank - 1 && my_rank.thread == num_ranks.thread - 1 ) {
-        fprintf(fp, "------------------------------------------------------------\n");
+        // Creates record if it does not yet exist on this rank, otherwise acquires record pointer
+        auto record = reporter->createDataRecord(tool.first);
+        tool.second->outputData(record, my_rank);
     }
 }
 
@@ -2501,39 +2466,11 @@ Simulation_impl::printPerformanceInfo()
     fprintf(fp, "Serialization Information:\n");
     fprintf(fp, "Rank total serialization time: %" PRIu64 " %s\n", rankLatency, clockResolution.c_str());
     fprintf(fp, "Rank pairwise sync count: %" PRIu64 "\n", rankExchangeCounter);
-    fprintf(fp, "Rank total events sent: %" PRIu64 "\n", rankExchangeEvents);
-    fprintf(fp, "Rank total bytes sent: %" PRIu64 "\n", rankExchangeBytes);
     fprintf(fp, "Rank average sync serialization time: %.6f %s/sync\n",
         (rankExchangeCounter == 0 ? 0.0 : (double)rankLatency / rankExchangeCounter), clockResolution.c_str());
-    fprintf(fp, "Rank average sync bytes sent: %.6f bytes/sync\n",
-        (rankExchangeCounter == 0 ? 0.0 : (double)rankExchangeBytes / rankExchangeCounter));
     fprintf(fp, "Rank average sync serialization time: %.6f %s/sync\n",
         (rankExchangeCounter == 0 ? 0.0 : (double)rankLatency / rankExchangeCounter), clockResolution.c_str());
-    fprintf(fp, "Rank average event bytes sent: %.6f bytes/event\n",
-        (rankExchangeEvents == 0 ? 0.0 : (double)rankExchangeBytes / rankExchangeEvents));
 #endif // SST_EVENT_PROFILING
-
-#if SST_SYNC_PROFILING
-    fprintf(fp, "Synchronization Information:\n");
-    fprintf(fp, "Thread-only sync (apart from Rank syncs):\n");
-    fprintf(fp, "Thread-sync count: %" PRIu64 "\n", threadSyncCounter);
-    fprintf(fp, "Thread-sync total execution time: %.6f s\n", (double)threadSyncTime / clockDivisor);
-    fprintf(fp, "Thread-sync average execution time: %.6f %s/sync\n",
-        (threadSyncCounter == 0.0 ? 0.0 : (double)threadSyncTime / threadSyncCounter), clockResolution.c_str());
-    fprintf(fp, "Rank Sync (including associated thread syncs):\n");
-    fprintf(fp, "Rank sync count: %" PRIu64 "\n", rankSyncCounter);
-    fprintf(fp, "Rank sync total execution time: %.6f s\n", (double)rankSyncTime / clockDivisor);
-    fprintf(fp, "Rank sync average execution time: %.6f %s/sync\n",
-        (rankSyncCounter == 0.0 ? 0.0 : (double)rankSyncTime / rankSyncCounter), clockResolution.c_str());
-    fprintf(fp, "All sync count:  %" PRIu64 "\n", threadSyncCounter + rankSyncCounter);
-    fprintf(fp, "All sync execution time: %.6f s\n", (double)(threadSyncTime + rankSyncTime) / clockDivisor);
-    fprintf(fp, "All sync average execution time: %.6f %s/sync\n",
-        ((threadSyncCounter + rankSyncCounter) == 0
-                ? 0.0
-                : (double)(threadSyncTime + rankSyncTime) / (threadSyncCounter + rankSyncCounter)),
-        clockResolution.c_str());
-    fprintf(fp, "\n");
-#endif // SST_SYNC_PROFILING
 }
 #endif
 

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -78,6 +78,10 @@ class StatisticOutput;
 class StatisticProcessingEngine;
 } // namespace Statistics
 
+namespace Util {
+class PerfReporter;
+} // namespace Util
+
 namespace pvt {
 
 /**
@@ -251,7 +255,7 @@ public:
 
     bool isIndependentThread() { return independent; }
 
-    void printProfilingInfo(FILE* fp);
+    void printProfilingInfo(Util::PerfReporter* reporter);
 
     void printPerformanceInfo();
 
@@ -625,24 +629,12 @@ public:
     uint64_t rankLatency     = 0; // Serialization time
     uint64_t messageXferSize = 0;
 
-    uint64_t rankExchangeBytes   = 0; // Serialization size
-    uint64_t rankExchangeEvents  = 0; // Serialized events
     uint64_t rankExchangeCounter = 0; // Num rank peer exchanges
 
 
     // Profiling functions
     void incrementSerialCounters(uint64_t count);
-    void incrementExchangeCounters(uint64_t events, uint64_t bytes);
 
-#endif
-
-#if SST_SYNC_PROFILING
-    uint64_t rankSyncCounter   = 0; // Num. of rank syncs
-    uint64_t rankSyncTime      = 0; // Total time rank syncing, in ns
-    uint64_t threadSyncCounter = 0; // Num. of thread syncs
-    uint64_t threadSyncTime    = 0; // Total time thread syncing, in ns
-                                    // Does not include thread syncs as part of rank syncs
-    void     incrementSyncTime(bool rankSync, uint64_t count);
 #endif
 
 #if SST_HIGH_RESOLUTION_CLOCK

--- a/src/sst/core/sync/rankSyncParallelSkip.cc
+++ b/src/sst/core/sync/rankSyncParallelSkip.cc
@@ -17,6 +17,7 @@
 #include "sst/core/exit.h"
 #include "sst/core/link.h"
 #include "sst/core/profile.h"
+#include "sst/core/profile/syncProfileTool.h"
 #include "sst/core/serialization/serializer.h"
 #include "sst/core/simulation_impl.h"
 #include "sst/core/sst_mpi.h"
@@ -95,6 +96,7 @@ RankSyncParallelSkip::registerLink(const RankInfo& to_rank, const RankInfo& from
         comm_send_map[to_rank].to_rank = to_rank;
         queue = comm_send_map[to_rank].squeue = new RankSyncQueue(to_rank);
         comm_send_map[to_rank].remote_size    = 4096;
+        comm_send_map[to_rank].squeue->setProfileTools(profile_tools_);
     }
     else {
         queue = comm_send_map[to_rank].squeue;
@@ -501,6 +503,12 @@ RankSyncParallelSkip::deserializeMessage(comm_recv_pair* msg)
     SST_SER(msg->activity_vec);
 
     deserializeTime += SST::Core::Profile::getElapsed(deserialStart);
+}
+
+void
+RankSyncParallelSkip::setProfileToolList(Profile::SyncProfileToolList* profile_tools)
+{
+    profile_tools_ = profile_tools;
 }
 
 int RankSyncParallelSkip::sig_end_(0);

--- a/src/sst/core/sync/rankSyncParallelSkip.h
+++ b/src/sst/core/sync/rankSyncParallelSkip.h
@@ -27,6 +27,10 @@ namespace SST {
 class RankSyncQueue;
 class TimeConverter;
 
+namespace Profile {
+class SyncProfileToolList;
+};
+
 class RankSyncParallelSkip : public RankSync
 {
 public:
@@ -56,6 +60,8 @@ public:
     void setRestartTime(SimTime_t time) override;
 
     uint64_t getDataSize() const override;
+
+    void setProfileToolList(Profile::SyncProfileToolList* profile_tools) override;
 
 private:
     static SimTime_t myNextSyncTime;
@@ -131,6 +137,8 @@ private:
     Core::ThreadSafe::Barrier serializeReadyBarrier;
     Core::ThreadSafe::Barrier slaveExchangeDoneBarrier;
     Core::ThreadSafe::Barrier allDoneBarrier;
+
+    Profile::SyncProfileToolList* profile_tools_ = nullptr;
 
     Core::ThreadSafe::Spinlock lock;
     static int                 sig_end_;

--- a/src/sst/core/sync/rankSyncSerialSkip.cc
+++ b/src/sst/core/sync/rankSyncSerialSkip.cc
@@ -17,6 +17,7 @@
 #include "sst/core/exit.h"
 #include "sst/core/link.h"
 #include "sst/core/profile.h"
+#include "sst/core/profile/syncProfileTool.h"
 #include "sst/core/serialization/serializer.h"
 #include "sst/core/simulation_impl.h"
 #include "sst/core/sst_mpi.h"
@@ -74,6 +75,7 @@ RankSyncSerialSkip::registerLink(const RankInfo& to_rank, const RankInfo& UNUSED
         comm_map[to_rank.rank].rbuf           = new char[4096];
         comm_map[to_rank.rank].local_size     = 4096;
         comm_map[to_rank.rank].remote_size    = 4096;
+        comm_map[to_rank.rank].squeue->setProfileTools(profile_tools_);
     }
     else {
         queue = comm_map[to_rank.rank].squeue;
@@ -270,6 +272,7 @@ RankSyncSerialSkip::exchangeLinkUntimedData(int UNUSED_WO_MPI(thread), std::atom
     if ( thread != 0 ) {
         return;
     }
+
     // Maximum number of outstanding requests is 3 times the number of
     // ranks I communicate with (1 recv, 2 sends per rank)
     auto sreqs      = std::make_unique<MPI_Request[]>(2 * comm_map.size());
@@ -354,6 +357,13 @@ RankSyncSerialSkip::exchangeLinkUntimedData(int UNUSED_WO_MPI(thread), std::atom
     msg_count = count;
 #endif
 }
+
+void
+RankSyncSerialSkip::setProfileToolList(Profile::SyncProfileToolList* profile_tools)
+{
+    profile_tools_ = profile_tools;
+}
+
 
 int RankSyncSerialSkip::sig_end_(0);
 int RankSyncSerialSkip::sig_usr_(0);

--- a/src/sst/core/sync/rankSyncSerialSkip.h
+++ b/src/sst/core/sync/rankSyncSerialSkip.h
@@ -25,6 +25,10 @@ namespace SST {
 class RankSyncQueue;
 class TimeConverter;
 
+namespace Profile {
+class SyncProfileToolList;
+};
+
 class RankSyncSerialSkip : public RankSync
 {
 public:
@@ -55,6 +59,8 @@ public:
 
     uint64_t getDataSize() const override;
 
+    void setProfileToolList(Profile::SyncProfileToolList* profile_tools) override;
+
 private:
     static SimTime_t myNextSyncTime;
 
@@ -81,6 +87,8 @@ private:
 
     double mpiWaitTime;
     double deserializeTime;
+
+    Profile::SyncProfileToolList* profile_tools_ = nullptr;
 
     Core::ThreadSafe::Spinlock lock;
     static int                 sig_end_;

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -40,40 +40,6 @@ Core::ThreadSafe::Barrier SyncManager::RankExecBarrier_[5];
 Core::ThreadSafe::Barrier SyncManager::LinkUntimedBarrier_[3];
 SimTime_t                 SyncManager::next_rankSync_ = MAX_SIMTIME_T;
 
-#if SST_SYNC_PROFILING
-
-#if SST_HIGH_RESOLUTION_CLOCK
-#define SST_SYNC_PROFILE_START                                  \
-    auto sim                = Simulation_impl::getSimulation(); \
-    auto last_sync_type     = next_sync_type_;                  \
-    auto sync_profile_start = std::chrono::high_resolution_clock::now();
-
-#define SST_SYNC_PROFILE_STOP                                                                                 \
-    auto sync_profile_stop = std::chrono::high_resolution_clock::now();                                       \
-    auto sync_profile_count =                                                                                 \
-        std::chrono::duration_cast<std::chrono::nanoseconds>(sync_profile_stop - sync_profile_start).count(); \
-    sim_->incrementSyncTime(last_sync_type == RANK, sync_profile_count);
-
-#else
-#define SST_SYNC_PROFILE_START                                               \
-    auto           sim            = Simulation_impl::getSimulation();        \
-    auto           last_sync_type = next_sync_type_;                         \
-    struct timeval sync_profile_stop, sync_profile_start, sync_profile_diff; \
-    gettimeofday(&sync_profile_start, NULL);
-
-#define SST_SYNC_PROFILE_STOP                                                               \
-    gettimeofday(&sync_profile_stop, NULL);                                                 \
-    timersub(&sync_profile_stop, &sync_profile_start, &sync_profile_diff);                  \
-    auto sync_profile_count = (sync_profile_diff.tv_usec + sync_profile_diff.tv_sec * 1e6); \
-    sim_->incrementSyncTime(last_sync_type == RANK, sync_profile_count);
-
-#endif // SST_HIGH_RESOLUTION_CLOCK
-
-#else // SST_SYNC_PROFILING
-#define SST_SYNC_PROFILE_START
-#define SST_SYNC_PROFILE_STOP
-#endif // SST_SYNC_PROFILING
-
 class EmptyRankSync : public RankSync
 {
 public:
@@ -375,34 +341,6 @@ RankSync::findSyncInterval(uint32_t UNUSED_WO_MPI(my_rank))
     return low_latency;
 }
 
-// Class used to hold the list of profile tools installed in the SyncManager
-class SyncProfileToolList
-{
-public:
-    SyncProfileToolList() = default;
-
-    void syncManagerStart()
-    {
-        for ( auto* x : tools )
-            x->syncManagerStart();
-    }
-
-    void syncManagerEnd()
-    {
-        for ( auto* x : tools )
-            x->syncManagerEnd();
-    }
-
-    /**
-       Adds a profile tool the the list and registers this handler
-       with the profile tool
-    */
-    void addProfileTool(Profile::SyncProfileTool* tool) { tools.push_back(tool); }
-
-private:
-    std::vector<Profile::SyncProfileTool*> tools;
-};
-
 void
 SyncManager::setupSyncObjects()
 {
@@ -518,9 +456,7 @@ SyncManager::findThreadSyncInterval()
 void
 SyncManager::execute()
 {
-    SST_SYNC_PROFILE_START
-
-    if ( profile_tools_ ) profile_tools_->syncManagerStart();
+    if ( profile_tools_ ) profile_tools_->syncManagerStart(next_sync_type_ == RANK);
 
     bool signals_received;
     int  sig_end;
@@ -624,8 +560,6 @@ SyncManager::execute()
     RankExecBarrier_[4].wait();
 
     if ( profile_tools_ ) profile_tools_->syncManagerEnd();
-
-    SST_SYNC_PROFILE_STOP
 }
 
 /** Cause an exchange of Untimed Data to occur */
@@ -710,7 +644,12 @@ SyncManager::getDataSize() const
 void
 SyncManager::addProfileTool(Profile::SyncProfileTool* tool)
 {
-    if ( !profile_tools_ ) profile_tools_ = new SyncProfileToolList();
+    if ( !profile_tools_ ) {
+        profile_tools_ = new Profile::SyncProfileToolList();
+        if ( rank_.thread == 0 ) {
+            rankSync_->setProfileToolList(profile_tools_);
+        }
+    }
     profile_tools_->addProfileTool(tool);
 }
 

--- a/src/sst/core/sync/syncManager.h
+++ b/src/sst/core/sync/syncManager.h
@@ -34,10 +34,10 @@ class Simulation_impl;
 class ThreadSyncQueue;
 class TimeConverter;
 
-class SyncProfileToolList;
 namespace Profile {
 class SyncProfileTool;
-}
+class SyncProfileToolList;
+} // namespace Profile
 
 class RankSync
 {
@@ -73,6 +73,8 @@ public:
     SimTime_t getMaxPeriod() { return max_period; }
 
     virtual uint64_t getDataSize() const = 0;
+
+    virtual void setProfileToolList(Profile::SyncProfileToolList* UNUSED(profile_list)) {}
 
 protected:
     SimTime_t      nextSyncTime;
@@ -219,7 +221,7 @@ private:
     RealTimeManager*  real_time_;
     CheckpointAction* checkpoint_;
 
-    SyncProfileToolList* profile_tools_ = nullptr;
+    Profile::SyncProfileToolList* profile_tools_ = nullptr;
 
     void computeNextInsert(SimTime_t next_checkpoint_time = MAX_SIMTIME_T);
     void setupSyncObjects();

--- a/src/sst/core/sync/syncQueue.cc
+++ b/src/sst/core/sync/syncQueue.cc
@@ -14,20 +14,11 @@
 #include "sst/core/sync/syncQueue.h"
 
 #include "sst/core/event.h"
+#include "sst/core/profile/syncProfileTool.h"
 #include "sst/core/serialization/serializer.h"
 #include "sst/core/simulation_impl.h"
 
 #include <mutex>
-
-#if SST_EVENT_PROFILING
-#define SST_EVENT_PROFILE_SIZE(events, bytes)                    \
-    do {                                                         \
-        Simulation_impl* sim = Simulation_impl::getSimulation(); \
-        sim->incrementExchangeCounters(events, bytes);           \
-    } while ( 0 );
-#else
-#define SST_EVENT_PROFILE_SIZE(events, bytes)
-#endif
 
 namespace SST {
 
@@ -100,7 +91,7 @@ RankSyncQueue::getData()
 
     size_t size = ser.size();
 
-    SST_EVENT_PROFILE_SIZE(activities.size(), size)
+    if ( profile_tools_ ) profile_tools_->updateSyncSize(size, activities.size());
 
     if ( buf_size < (size + sizeof(RankSyncQueue::Header)) ) {
         if ( buffer != nullptr ) {

--- a/src/sst/core/sync/syncQueue.h
+++ b/src/sst/core/sync/syncQueue.h
@@ -22,6 +22,10 @@
 
 namespace SST {
 
+namespace Profile {
+class SyncProfileToolList;
+}
+
 /**
    \class SyncQueue
 
@@ -40,6 +44,8 @@ public:
 
     /** Accessor method to get to_rank */
     RankInfo getToRank() { return to_rank; }
+
+    virtual void setProfileTools(Profile::SyncProfileToolList* UNUSED(profile_tools)) {}
 
 private:
     RankInfo to_rank;
@@ -79,10 +85,13 @@ public:
 
     uint64_t getDataSize() { return buf_size + (activities.capacity() * sizeof(Activity*)); }
 
+    void setProfileTools(Profile::SyncProfileToolList* profile_tools) override { profile_tools_ = profile_tools; }
+
 private:
-    char*                  buffer;
-    size_t                 buf_size;
-    std::vector<Activity*> activities;
+    char*                         buffer;
+    size_t                        buf_size;
+    std::vector<Activity*>        activities;
+    Profile::SyncProfileToolList* profile_tools_ = nullptr;
 
     Core::ThreadSafe::Spinlock slock;
 };

--- a/src/sst/core/timingOutput.cc
+++ b/src/sst/core/timingOutput.cc
@@ -14,6 +14,7 @@
 
 #include "sst/core/simulation_impl.h"
 #include "sst/core/stringize.h"
+#include "sst/core/util/perfReporter.h"
 
 #include "nlohmann/json.hpp"
 
@@ -73,82 +74,9 @@ TimingOutput::~TimingOutput()
 
 
 void
-TimingOutput::generate()
+TimingOutput::generate(SST::Util::PerfReporter* reporter)
 {
-    if ( print_verbosity_ ) renderText();
-    if ( jsonEnable_ ) renderJSON();
-}
-
-void
-TimingOutput::renderText()
-{
-    std::string ua_buffer;
-    ua_buffer = format_string("%" PRIu64 "KB", u64map_.at(Key::LOCAL_MAX_RSS));
-    UnitAlgebra max_rss_ua(ua_buffer);
-
-    ua_buffer = format_string("%" PRIu64 "KB", u64map_.at(Key::GLOBAL_MAX_RSS));
-    UnitAlgebra global_rss_ua(ua_buffer);
-
-    ua_buffer = format_string("%" PRIu64 "B", u64map_.at(Key::GLOBAL_MAX_SYNC_DATA_SIZE));
-    UnitAlgebra global_max_sync_data_size_ua(ua_buffer);
-
-    ua_buffer = format_string("%" PRIu64 "B", u64map_.at(Key::GLOBAL_SYNC_DATA_SIZE));
-    UnitAlgebra global_sync_data_size_ua(ua_buffer);
-
-    ua_buffer = format_string("%" PRIu64 "B", u64map_.at(Key::MAX_MEMPOOL_SIZE));
-    UnitAlgebra max_mempool_size_ua(ua_buffer);
-
-    ua_buffer = format_string("%" PRIu64 "B", u64map_.at(GLOBAL_MEMPOOL_SIZE));
-    UnitAlgebra global_mempool_size_ua(ua_buffer);
-
-    output_.output("\n");
-    output_.output("\n");
-    output_.output("------------------------------------------------------------\n");
-    output_.output("Simulation Resource Utilization for Code Regions:\n");
-    Simulation_impl::basicPerf.outputRegionData(output_, print_verbosity_);
-    output_.output("\n");
-    output_.output("Simulated time:                    %s\n", uamap_.at(SIMULATED_TIME_UA).toStringBestSI().c_str());
-    output_.output("\n");
-    output_.output("Simulation Resource Information:\n");
-    output_.output("  Max Resident Set Size:           %s\n", max_rss_ua.toStringBestSI().c_str());
-    output_.output("  Approx. Global Max RSS Size:     %s\n", global_rss_ua.toStringBestSI().c_str());
-    output_.output("  Max Local Page Faults:           %" PRIu64 " faults\n", u64map_.at(LOCAL_MAX_PF));
-    output_.output("  Global Page Faults:              %" PRIu64 " faults\n", u64map_.at(GLOBAL_PF));
-    output_.output("  Max Output Blocks:               %" PRIu64 " blocks\n", u64map_.at(GLOBAL_MAX_IO_OUT));
-    output_.output("  Max Input Blocks:                %" PRIu64 " blocks\n", u64map_.at(GLOBAL_MAX_IO_IN));
-    output_.output("  Max mempool usage:               %s\n", max_mempool_size_ua.toStringBestSI().c_str());
-    output_.output("  Global mempool usage:            %s\n", global_mempool_size_ua.toStringBestSI().c_str());
-    output_.output("  Global active activities:        %" PRIu64 " activities\n", u64map_.at(GLOBAL_ACTIVE_ACTIVITIES));
-    output_.output("  Current global TimeVortex depth: %" PRIu64 " entries\n", u64map_.at(GLOBAL_CURRENT_TV_DEPTH));
-    output_.output("  Max TimeVortex depth:            %" PRIu64 " entries\n", u64map_.at(GLOBAL_MAX_TV_DEPTH));
-    output_.output("  Max Sync data size:              %s\n", global_max_sync_data_size_ua.toStringBestSI().c_str());
-    output_.output("  Global Sync data size:           %s\n", global_sync_data_size_ua.toStringBestSI().c_str());
-    output_.output("------------------------------------------------------------\n");
-    output_.output("\n");
-    output_.output("\n");
-}
-
-void
-TimingOutput::renderJSON()
-{
-    json::ordered_json json_o;
-    for ( auto kv : u64map_ ) {
-        // std::cout << key2cstr.at(kv.first) << " = " << std::dec << kv.second << std::endl;
-        json_o["timing-info"][key2cstr.at(kv.first)] = kv.second;
-    }
-    for ( auto kv : dmap_ ) {
-        json_o["timing-info"][key2cstr.at(kv.first)] = kv.second;
-    }
-    for ( auto kv : uamap_ ) {
-        json_o["timing-info"][key2cstr.at(kv.first)] = kv.second.toStringBestSI().c_str();
-    }
-
-    std::stringstream ss;
-    ss << std::setw(2) << json_o << std::endl;
-
-    // Avoid potential lifetime issues
-    std::string outputString = ss.str();
-    fprintf(outputFile, "%s", outputString.c_str());
+    Simulation_impl::basicPerf.outputRegionData(print_verbosity_, reporter);
 }
 
 } // namespace SST::Core

--- a/src/sst/core/timingOutput.h
+++ b/src/sst/core/timingOutput.h
@@ -21,7 +21,14 @@
 #include <map>
 #include <string>
 
-namespace SST::Core {
+
+namespace SST {
+namespace Util {
+class PerfReporter;
+}
+
+namespace Core {
+
 
 /**
  * Outputs configuration data to a specified file path.
@@ -78,9 +85,7 @@ public:
     TimingOutput(const SST::Output& output, int print_verbosity);
     virtual ~TimingOutput();
     void setJSON(const std::string& path);
-    void generate();
-    void renderText();
-    void renderJSON();
+    void generate(SST::Util::PerfReporter* reporter);
 
     void set(Key key, uint64_t v);
     void set(Key key, UnitAlgebra v);
@@ -96,7 +101,7 @@ private:
     std::map<Key, double>      dmap_      = {};
     FILE*                      outputFile = nullptr;
 };
-
-} // namespace SST::Core
+} // namespace Core
+} // namespace SST
 
 #endif // SST_CORE_TIMING_OUTPUT_H

--- a/src/sst/core/util/Makefile.inc
+++ b/src/sst/core/util/Makefile.inc
@@ -9,7 +9,9 @@ sst_core_sources += \
 	util/basicPerf.cc \
 	util/basicPerf.h \
 	util/smartTextFormatter.cc \
-	util/filesystem.cc
+	util/filesystem.cc \
+	util/perfReporter.cc \
+	util/perfReporter.h
 
 nobase_dist_sst_HEADERS += \
 	util/bit_util.h \

--- a/src/sst/core/util/basicPerf.cc
+++ b/src/sst/core/util/basicPerf.cc
@@ -17,6 +17,7 @@
 #include "sst/core/memuse.h"
 #include "sst/core/simulation_impl.h"
 #include "sst/core/sst_mpi.h"
+#include "sst/core/util/perfReporter.h"
 
 #include <clocale>
 #include <cstdio>
@@ -81,7 +82,6 @@ BasicPerfTracker::beginRegion(const std::string& tag)
     // Push the index that this region will be in the vector to the
     // stack
     current_regions_.push(regions_.size());
-
     size_t level = current_regions_.size();
 
     // Check to see if we need to print this level (need to check the verbose level because output_ may not be valid if
@@ -298,118 +298,66 @@ BasicPerfTracker::getMetricFloat(const std::string& name)
     return scalars_float[name];
 }
 
-// Need to use wstring for the unicode box drawing characters
-std::wstring horizontal   = L"─"; // ─
-std::wstring vertical     = L"│"; // │
-std::wstring topLeft      = L"┌"; // ┌
-std::wstring topRight     = L"┐"; // ┐
-std::wstring bottomLeft   = L"└"; // └
-std::wstring bottomRight  = L"┘"; // ┘
-std::wstring vertAndRight = L"├"; // ├
-std::wstring fullBox      = L"■"; // ■
-
-
 void
-BasicPerfTracker::outputRegionData(Output& out, size_t verbose)
+BasicPerfTracker::outputRegionData(size_t verbose, PerfReporter* reporter)
 {
-    // We need to change the locale to support unicode.  Just need to
-    // change the c-locale since we are using output, which uses
-    // printf
-    std::string orig_c_locale = std::setlocale(LC_ALL, nullptr);
-    std::setlocale(LC_ALL, "en_US.UTF-8");
-
-    bool print = (rank_ == 0);
 
     // Use vector as stack to keep track of hierarchy
-    std::vector<std::pair<RegionPerfInfo*, bool>> region_stack;
+    std::vector<RegionPerfInfo*> region_stack;
 
-    std::wstring prefix_stats;
-    std::wstring prefix_region;
+    std::map<std::string, std::pair<std::string, std::string>> keys = {
+        { "regions", { "Simulation Resource Utilization for Code Regions", "" } },
+        { "total_memory", { "Total Memory", "" } }, { "duration", { "Duration", "s" } },
+        { "max_local_memory", { "Max Local Memory", "" } }, { "max_local_memory_rank", { "Max Local Memory Rank", "" } }
+    };
+    DataRecord* record = reporter->createDataRecord("regions", DataRecord::TextFormat::tree);
+    record->setKeys(keys);
 
+    // Push data into DataRecord structure
     for ( auto& x : regions_ ) {
 
         if ( x.level > verbose ) continue;
 
-        // First, need to see if we need to remove the last region
-        // and/or adjust the bool that controls the printing of the
-        // vertical bars
-
-        // If the level has descreased, need to pop all regions
+        // If the level has decreased, need to pop all regions
         // that are greater than current level
-
         if ( region_stack.size() > 1 ) {
-            while ( region_stack.back().first->level > x.level ) {
+            while ( region_stack.back()->level > x.level ) {
                 region_stack.pop_back();
+                record->changeLevelUp();
             }
 
             // If last region is same level as this region, remove it
-            if ( region_stack.back().first->level == x.level ) {
+            if ( region_stack.back()->level == x.level ) {
                 region_stack.pop_back();
+                record->changeLevelUp();
             }
-        }
-
-        std::wstring region_indicator;
-        if ( x.level == 1 ) {
-            region_indicator += L"■ ";
-        }
-        else if ( !x.last_of_level ) {
-            region_indicator += L"├ ■ ";
-        }
-        else {
-            region_indicator += L"└ ■ ";
-        }
-
-        // If I'm the last child at this level, need to turn | off for my parent
-        if ( x.level != 1 && x.last_of_level ) region_stack.back().second = false;
-
-        // Create prefix string
-        std::wstring prefix;
-        for ( size_t i = 0; i < region_stack.size(); ++i ) {
-            if ( region_stack[i].second )
-                prefix += L"│ ";
-            else
-                prefix += L"  ";
         }
 
         // If this is the last level to print because of verbosity,
         // act like the region has no children
-        bool has_child = x.has_child && x.level != verbose;
-        region_stack.push_back(std::make_pair(&x, has_child));
-
-        // The prefix for the region string needs to remove the indent
-        // caused by the current level
-        std::wstring region_prefix = prefix.substr(0, prefix.length() - 2);
-
-        if ( print ) out.output("%ls%ls%s\n", region_prefix.c_str(), region_indicator.c_str(), x.tag.c_str());
+        region_stack.push_back(&x);
+        record->addChild(x.tag);
+        record->setKeys(keys); // Add to each level of the record
 
         // Print the perf values
-        std::wstring stat_prefix = prefix + (has_child ? L"│ " : L"  ") + L"├──";
-        if ( print ) out.output("%ls Duration: %.3lf seconds\n", stat_prefix.c_str(), x.end_time - x.begin_time);
+        record->addData("duration", x.end_time - x.begin_time);
 
         uint64_t    mem_size_global = getGlobalTotalRegionEndMemSize(x.tag);
         UnitAlgebra mem_size_global_us("1kB");
         mem_size_global_us *= mem_size_global;
 
-        stat_prefix = prefix + (has_child ? L"│ " : L"  ") + L"└──";
         if ( num_ranks_ > 1 ) {
             auto        mem_size_max = getGlobalMaxRegionEndMemSize(x.tag);
             UnitAlgebra mem_size_max_us("1kB");
             mem_size_max_us *= mem_size_max.first;
-
-            if ( print )
-                out.output("%ls Memory: Total - %s, Max - %s (rank %d)\n", stat_prefix.c_str(),
-                    mem_size_global_us.toStringBestSI(4).c_str(), mem_size_max_us.toStringBestSI(4).c_str(),
-                    mem_size_max.second);
+            record->addData("total_memory", mem_size_global_us);
+            record->addData("max_local_memory", mem_size_max_us);
+            record->addData("max_local_memory_rank", (int64_t)(mem_size_max.second));
         }
         else {
-            if ( print )
-                out.output(
-                    "%ls Memory: Total - %s\n", stat_prefix.c_str(), mem_size_global_us.toStringBestSI(4).c_str());
+            record->addData("total_memory", mem_size_global_us);
         }
     }
-
-    // Restore the locale
-    std::setlocale(LC_ALL, orig_c_locale.c_str());
 }
 
 void

--- a/src/sst/core/util/basicPerf.h
+++ b/src/sst/core/util/basicPerf.h
@@ -24,6 +24,7 @@ namespace SST {
 class Output;
 
 namespace Util {
+class PerfReporter;
 
 struct RegionPerfInfo
 {
@@ -193,9 +194,8 @@ public:
     int64_t  getMetricSigned(const std::string& name);
     double   getMetricFloat(const std::string& name);
 
-    void outputRegionData(Output& out, size_t);
-
     void setReportRegionInfo(Output& output, size_t verbose);
+    void outputRegionData(size_t verbose, PerfReporter* reporter);
 
 private:
 

--- a/src/sst/core/util/perfReporter.cc
+++ b/src/sst/core/util/perfReporter.cc
@@ -1,0 +1,646 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+//
+
+#include "sst_config.h"
+
+#include "sst/core/util/perfReporter.h"
+
+#include "sst/core/cputimer.h"
+#include "sst/core/memuse.h"
+#include "sst/core/simulation_impl.h"
+#include "sst/core/sst_mpi.h"
+
+#include "nlohmann/json.hpp"
+
+#include <clocale>
+#include <cstdio>
+
+namespace json = ::nlohmann;
+
+namespace SST::Util {
+
+PerfData::PerfData(std::string name, PerfData* parent) :
+    name_(name),
+    parent_(parent)
+{
+    if ( parent_ ) {
+        parent_->children_.push_back(this);
+    }
+}
+
+// PerfData
+DataRecord::DataRecord(std::string name, DataRecord::TextFormat format)
+{
+    root_           = new PerfData(name, nullptr);
+    current_record_ = root_;
+    format_         = format;
+}
+
+void
+DataRecord::setKeys(std::map<std::string, std::pair<std::string, std::string>>& key_map)
+{
+    // Insert w/ overwrite if duplicate keys
+    for ( auto const& entry : key_map ) {
+        current_record_->keys_.insert_or_assign(entry.first, entry.second);
+    }
+}
+
+void
+DataRecord::changeLevelUp()
+{
+    if ( current_record_ == root_ ) return;
+    current_record_ = current_record_->parent_;
+}
+
+bool
+DataRecord::changeLevelDown(std::string name)
+{
+    // No lookup so linear search children for matching name
+    for ( auto const& child : current_record_->children_ ) {
+        if ( child->name_ == name ) {
+            current_record_ = child;
+            return true;
+        }
+    }
+    return false; // Not found
+}
+
+void
+DataRecord::addChild(std::string name)
+{
+    PerfData* child = new PerfData(name, current_record_);
+    current_record_ = child;
+}
+
+void
+DataRecord::endChild()
+{
+    if ( current_record_ == root_ ) return;
+    current_record_ = current_record_->parent_;
+}
+
+void
+DataRecord::addData(std::string key, double value)
+{
+    current_record_->data_[key] = value;
+}
+
+void
+DataRecord::addData(std::string key, uint64_t value)
+{
+    current_record_->data_[key] = value;
+}
+
+void
+DataRecord::addData(std::string key, int64_t value)
+{
+    current_record_->data_[key] = value;
+}
+
+void
+DataRecord::addData(std::string key, UnitAlgebra value)
+{
+    current_record_->data_[key] = value;
+}
+
+void
+DataRecord::addData(std::map<std::string, std::variant<uint64_t, int64_t, double, UnitAlgebra, std::string>> data)
+{
+    for ( auto const& entry : data ) {
+        current_record_->data_.insert_or_assign(entry.first, entry.second);
+    }
+}
+
+DataRecord*
+PerfReporter::createDataRecord(std::string name, DataRecord::TextFormat format)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    DataRecord*                 record;
+    auto                        record_it = records_.find(name);
+    if ( record_it == records_.end() ) {
+        record = new DataRecord(name, format);
+        records_.insert(std::make_pair(name, record));
+    }
+    else {
+        record = record_it->second;
+    }
+    return record;
+}
+
+void
+PerfReporter::configureOutput(std::string output_str)
+{
+    auto comma_pos = output_str.find_first_of(',');
+    if ( comma_pos != std::string::npos ) {
+        if ( output_str.substr(0, comma_pos) == "stdout" ) {
+            output_console_ = true;
+            filename_       = output_str.substr(comma_pos + 1);
+        }
+        else if ( output_str.substr(comma_pos + 1) == "stdout" ) {
+            output_console_ = true;
+            filename_       = output_str.substr(0, comma_pos);
+        }
+        else {
+            // Error, bad string
+            output_.fatal(CALL_INFO, -1,
+                "Error: Bad arguments to '--profiling-output'. Should be 'stdout', 'filename', or 'stdout,filename' "
+                "where filename has an extension of '.txt' or .json'. Got '%s'\n",
+                output_str.c_str());
+        }
+    }
+    else if ( output_str == "stdout" ) {
+        output_console_ = true;
+    }
+    else {
+        filename_ = output_str;
+    }
+
+    if ( filename_ != "" ) {
+        size_t      pos = filename_.find_last_of('.');
+        std::string ext = filename_.substr(pos + 1);
+        if ( ext == "json" || ext == "txt" ) {
+            if ( !Simulation_impl::filesystem.ensureDirectoryExists(filename_, true) ) {
+                output_.fatal(CALL_INFO, -1,
+                    "Error: Unable to write a file to the directory for profiling output (filename='%s'). Check that "
+                    "this location is writeable.",
+                    filename_.c_str());
+            }
+        }
+        else {
+            output_.fatal(CALL_INFO, -1,
+                "Error: Profiling output can only be written in text or json format; specify a filename ending in "
+                "'.txt' or '.json'. Got '%s'.\n",
+                filename_.c_str());
+        }
+    }
+}
+
+/*
+ * Output is coordinated by rank 0 which will request data from
+ * each other rank
+ *
+ * For each record name
+ *  - Rank 0 broadcasts record name
+ *  - Ranks serially output the data (or send data to rank 0 one by one)
+ *
+ */
+void
+PerfReporter::output(int rank, int num_ranks)
+{
+    bool output_txt  = false;
+    bool output_json = false;
+
+    // A helper for rank exchanges
+    auto recvStringFromRank = [](int src) -> std::string {
+        int len = 0;
+        MPI_Recv(&len, 1, MPI_INT, src, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        if ( len <= 0 ) return {};
+        std::string s(static_cast<size_t>(len), '\0');
+        MPI_Recv(s.data(), len, MPI_CHAR, src, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        return s;
+    };
+
+    // Broadcast number of records from rank 0 to all others
+    uint32_t record_count = 0;
+    if ( rank == 0 ) {
+        record_count = static_cast<uint32_t>(records_.size());
+    }
+    MPI_Bcast(&record_count, 1, MPI_UINT32_T, 0, MPI_COMM_WORLD);
+
+    if ( record_count == 0 ) return; // Nothing to print
+
+    // Set up files
+    std::ofstream filestream;
+    if ( !filename_.empty() ) {
+        const auto        pos = filename_.find_last_of('.');
+        const std::string ext = (pos == std::string::npos) ? "" : filename_.substr(pos + 1);
+        output_txt            = (ext == "txt");
+        output_json           = (ext == "json");
+        filestream            = Simulation_impl::filesystem.ofstream(filename_);
+    }
+
+    std::cout << std::flush;
+
+    if ( output_json ) {
+        filestream << "{\n";
+    }
+
+    // MPI Rank 0 runs the controlling for loop
+    if ( rank == 0 ) {
+        uint32_t idx = 0;
+        for ( auto& record : records_ ) {
+            ++idx;
+
+            // Broadcast the record currently being output
+            int length = static_cast<int>(record.first.size());
+            MPI_Bcast(&length, 1, MPI_INT, 0, MPI_COMM_WORLD);
+            MPI_Bcast((void*)&record.first[0], length, MPI_CHAR, 0, MPI_COMM_WORLD);
+
+            auto json_o = nlohmann::ordered_json::object();
+
+            // Output any text formatted data, first for rank 0 and then append from other ranks
+            if ( output_console_ || output_txt ) {
+                std::stringstream str;
+                if ( record.second->format_ == DataRecord::TextFormat::plain ) {
+                    outputRecordToText(record.second->root_, &str);
+                }
+                else if ( record.second->format_ == DataRecord::TextFormat::tree ) {
+                    outputRecordToTextTree(record.second->root_, &str);
+                }
+                else { // DataRecord::TextFormat::list
+                    outputRecordToTextList(record.second->root_, &str, true);
+                }
+
+                const std::string rec_str = str.str();
+                if ( output_console_ ) std::cout << "\n" << rec_str;
+                if ( output_txt ) filestream << "\n" << rec_str;
+
+                for ( int i = 1; i < num_ranks; i++ ) {
+                    // Receive from each other rank
+                    const std::string remote_str = recvStringFromRank(i);
+                    if ( remote_str.empty() ) continue;
+                    if ( output_console_ ) std::cout << remote_str;
+                    if ( output_txt ) filestream << remote_str;
+                }
+            }
+
+            // Output any JSON formatted data, first for rank 0 and then append from other ranks
+            if ( output_json ) {
+                filestream << '"' << record.second->root_->name_ << "\": {\n";
+                outputRecordToJSON(record.second->root_, &json_o);
+                size_t item_count = 0;
+                for ( auto& [key, val] : json_o.items() ) {
+                    item_count++;
+                    filestream << "\"" << key << "\": " << val.dump(2);
+                    if ( item_count != json_o.size() ) {
+                        filestream << ",\n";
+                    }
+                }
+
+                for ( int i = 1; i < num_ranks; i++ ) {
+                    // Receive from each other rank
+                    const std::string remote_str = recvStringFromRank(i);
+                    if ( remote_str.empty() ) continue;
+                    filestream << ",\n" << remote_str;
+                }
+
+                if ( idx != records_.size() ) {
+                    filestream << "},\n";
+                }
+                else {
+                    filestream << "}\n";
+                }
+            }
+        }
+
+        // Complete output and close files
+        if ( output_json ) {
+            filestream << "}\n";
+        }
+
+        if ( filestream ) {
+            filestream.flush();
+            filestream.close();
+        }
+    }
+    else { // Not rank 0
+        // All other ranks generate output strings for the currently-parsing record
+        for ( uint32_t count = 0; count < record_count; count++ ) {
+            // Get record name
+            int length = 0;
+            MPI_Bcast(&length, 1, MPI_INT, 0, MPI_COMM_WORLD);
+            char* name = new char[length];
+            MPI_Bcast(name, length, MPI_CHAR, 0, MPI_COMM_WORLD);
+
+            // Lookup record
+            auto record = records_.find(name);
+
+            if ( output_console_ || output_txt ) {
+                if ( record == records_.end() ) { // None found
+                    int length = 0;
+                    MPI_Send(&length, 1, MPI_INT, 0, 0, MPI_COMM_WORLD);
+                }
+                else {
+                    std::stringstream str;
+                    if ( record->second->format_ == DataRecord::TextFormat::plain ) {
+                        outputRecordToText(record->second->root_, &str, 0, false);
+                    }
+                    else if ( record->second->format_ == DataRecord::TextFormat::tree ) {
+                        outputRecordToTextTree(record->second->root_, &str);
+                    }
+                    else { // DataRecord::TextFormat::list
+                        outputRecordToTextList(record->second->root_, &str, false);
+                    }
+
+                    std::string send_str = str.str();
+                    int         length   = send_str.size();
+                    MPI_Send(&length, 1, MPI_INT, 0, 0, MPI_COMM_WORLD);
+                    MPI_Send(&send_str[0], length, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+                }
+            }
+
+            if ( output_json ) {
+                if ( record == records_.end() ) {
+                    int length = 0;
+                    MPI_Send(&length, 1, MPI_INT, 0, 0, MPI_COMM_WORLD);
+                }
+                else {
+                    std::stringstream str;
+                    auto              json_o = nlohmann::ordered_json::object();
+                    outputRecordToJSON(record->second->root_, &json_o);
+                    std::string send_str;
+                    size_t      item_count = 0;
+                    for ( auto& [key, val] : json_o.items() ) {
+                        item_count++;
+                        send_str += "\"" + key + "\": " + val.dump(2);
+                        if ( item_count != json_o.size() ) {
+                            send_str += ",";
+                        }
+                        send_str += "\n";
+                    }
+
+                    int length = send_str.size();
+                    MPI_Send(&length, 1, MPI_INT, 0, 0, MPI_COMM_WORLD);
+                    MPI_Send(&send_str[0], length, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+                }
+            }
+            delete name;
+        }
+    }
+}
+
+void
+PerfReporter::outputValueToText(
+    const std::variant<uint64_t, int64_t, double, UnitAlgebra, std::string>& v, std::stringstream* sstr)
+{
+    std::visit(
+        [&sstr](auto&& arg) {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr ( std::is_same_v<T, UnitAlgebra> ) {
+                (*sstr) << arg.toStringBestSI();
+            }
+            else {
+                (*sstr) << arg;
+            }
+        },
+        v);
+}
+
+std::string
+PerfReporter::convertValueToString(const std::variant<uint64_t, int64_t, double, UnitAlgebra, std::string>& val)
+{
+    return std::visit(
+        [](auto&& arg) -> std::string {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr ( std::is_same_v<T, UnitAlgebra> ) {
+                return arg.toStringBestSI();
+            }
+            else if constexpr ( std::is_same_v<T, std::string> ) {
+                return arg;
+            }
+            else {
+                return std::to_string(arg);
+            }
+        },
+        val);
+}
+
+void
+PerfReporter::outputRecordToText(const PerfData* node, std::stringstream* sstr, int indent, bool print_name)
+{
+    if ( !node ) return;
+
+    std::string indent_str(indent * 2, ' ');
+
+    if ( print_name && node->parent_ == nullptr ) (*sstr) << "\n";
+
+    // Print name, replacing if needed
+    if ( print_name && node->keys_.find(node->name_) != node->keys_.end() ) {
+        (*sstr) << indent_str << node->keys_.find(node->name_)->second.first << ":\n";
+    }
+    else if ( print_name ) {
+        (*sstr) << indent_str << node->name_ << ":\n";
+    }
+
+    size_t max_key_width = 0;
+
+    // Temp map so we can detect vertical alignment location
+    std::vector<
+        std::tuple<std::string, const std::variant<uint64_t, int64_t, double, UnitAlgebra, std::string>*, std::string>>
+        entries;
+
+    for ( const auto& [key, value] : node->data_ ) {
+        std::string print_key = key;
+        std::string units     = "";
+        auto        it        = node->keys_.find(key);
+
+        if ( it != node->keys_.end() ) {
+            print_key = it->second.first;
+            units     = it->second.second;
+        }
+        print_key += ":";
+
+        if ( print_key.size() > max_key_width ) max_key_width = print_key.size();
+        entries.emplace_back(print_key, &value, units);
+    }
+
+    for ( const auto& [print_key, value_ptr, units_str] : entries ) {
+        (*sstr) << indent_str << "  " << std::left << std::setw(static_cast<int>(max_key_width)) << print_key << " ";
+        outputValueToText(*value_ptr, sstr);
+        if ( units_str != "" ) {
+            (*sstr) << " " << units_str;
+        }
+        (*sstr) << "\n";
+    }
+
+    for ( const auto* child : node->children_ ) {
+        outputRecordToText(child, sstr, indent + 1);
+    }
+}
+
+void
+PerfReporter::printTreeIndent(std::stringstream* sstr, const std::vector<int>& child_counts, size_t indent_level)
+{
+    for ( size_t i = 0; i < indent_level; ++i ) {
+        if ( child_counts[i] > 0 ) {
+            (*sstr) << "│ ";
+        }
+        else {
+            (*sstr) << "  ";
+        }
+    }
+}
+
+void
+PerfReporter::outputRecordToTextTree(const PerfData* node, std::stringstream* sstr)
+{
+    // Print metadata node
+    if ( node->keys_.find(node->name_) != node->keys_.end() ) {
+        (*sstr) << "\n" << node->keys_.find(node->name_)->second.first << ":\n";
+    }
+    else {
+        (*sstr) << "\n" << node->name_ << ":\n";
+    }
+
+    // Print tree nodes
+    if ( node->children_.empty() ) return;
+    outputNodeToTextTree(node->children_[0], sstr, true);
+}
+
+void
+PerfReporter::outputNodeToTextTree(
+    const PerfData* node, std::stringstream* sstr, bool last_child, std::vector<int> level_info)
+{
+    if ( !node ) return;
+
+    size_t level = level_info.size();
+
+    // Print node name with appropriate markers
+    if ( level == 0 ) {
+        (*sstr) << "■ ";
+    }
+    else {
+        // For non-root node, add the indent as needed
+        printTreeIndent(sstr, level_info, level - 1);
+        (*sstr) << (last_child ? "└ ■ " : "├ ■ ");
+    }
+
+    auto it_name = node->keys_.find(node->name_);
+    if ( it_name != node->keys_.end() && !it_name->second.first.empty() ) {
+        (*sstr) << it_name->second.first << "\n";
+    }
+    else {
+        (*sstr) << node->name_ << "\n";
+    }
+
+    // Print key/vals for this node
+    std::vector<std::string> keys_found;
+    for ( const auto& [key, val] : node->data_ ) {
+        keys_found.push_back(key);
+    }
+
+    level_info.push_back(node->children_.size());
+
+    // Print each key with tree branch lines
+    for ( size_t k = 0; k < node->data_.size(); ++k ) {
+        const std::string& key         = keys_found[k];
+        bool               is_last_key = (k == keys_found.size() - 1);
+
+        // Print indent for keys: one more level than node
+        printTreeIndent(sstr, level_info, level_info.size());
+
+        // Print branch: "├──" or "└──"
+        (*sstr) << (is_last_key ? "└── " : "├── ");
+
+        // Print key name with colon
+        std::string pretty_key = key;
+        auto        it_pretty  = node->keys_.find(key);
+        if ( it_pretty != node->keys_.end() && !it_pretty->second.first.empty() ) {
+            pretty_key = it_pretty->second.first;
+        }
+        (*sstr) << pretty_key << ": ";
+
+        // Print value with special formatting
+        outputValueToText(node->data_.at(key), sstr);
+
+        // Print units if available
+        if ( it_pretty != node->keys_.end() && !it_pretty->second.second.empty() ) {
+            (*sstr) << " " << it_pretty->second.second;
+        }
+
+        (*sstr) << "\n";
+    }
+
+    auto child_count = node->children_.size();
+    for ( size_t i = 0; i < child_count; i++ ) {
+        // Recurse into children and update level_info
+        bool last         = (i == child_count - 1);
+        level_info.back() = level_info.back() - 1;
+        outputNodeToTextTree(node->children_[i], sstr, last, level_info);
+    }
+}
+
+void
+PerfReporter::outputRecordToTextList(const PerfData* node, std::stringstream* sstr, bool header)
+{
+    if ( !node ) return;
+
+    std::vector<std::pair<std::string, std::string>> key_list; // Keep it ordered correctly and use the same units
+
+    if ( header ) {
+        // Print section header
+        if ( node->keys_.find(node->name_) != node->keys_.end() ) {
+            (*sstr) << node->keys_.find(node->name_)->second.first << std::endl;
+        }
+        else {
+            (*sstr) << node->name_ << std::endl;
+        }
+
+        (*sstr) << "Record";
+
+        for ( auto& key : node->keys_ ) {
+            if ( key.first != node->name_ ) {
+                if ( key.second.first.empty() )
+                    (*sstr) << ", " << key.first;
+                else
+                    (*sstr) << ", " << key.second.first;
+                key_list.push_back(std::make_pair(key.first, key.second.second));
+            }
+        }
+        (*sstr) << std::endl;
+    }
+    else if ( node->parent_ == nullptr ) {
+        // Just generate key list
+        for ( auto& key : node->keys_ ) {
+            if ( key.first != node->name_ ) {
+                key_list.push_back(std::make_pair(key.first, key.second.second));
+            }
+        }
+    }
+
+    // Assumes a flat structure - this node has a set of children, each of which provides a list item
+    for ( auto& record : node->children_ ) {
+        (*sstr) << record->name_;
+        for ( auto& key : key_list ) {
+            (*sstr) << ", ";
+            auto it = record->data_.find(key.first);
+            if ( it != record->data_.end() ) {
+                outputValueToText(it->second, sstr);
+                if ( key.second != "" ) (*sstr) << " " << key.second;
+            }
+        }
+        (*sstr) << std::endl;
+    }
+}
+
+
+void
+PerfReporter::outputRecordToJSON(const PerfData* node, json::ordered_json* json_obj)
+{
+    for ( auto kv : node->data_ ) {
+        std::string valstr = convertValueToString(kv.second);
+        auto        it     = node->keys_.find(kv.first);
+
+        if ( it != node->keys_.end() && it->second.second != "" ) {
+            valstr += " " + it->second.second;
+        }
+        (*json_obj)[kv.first] = valstr;
+    }
+
+    for ( auto child : node->children_ ) {
+        auto record = nlohmann::ordered_json::object();
+        outputRecordToJSON(child, &record);
+        (*json_obj)[child->name_] = record;
+    }
+}
+
+} // namespace SST::Util

--- a/src/sst/core/util/perfReporter.h
+++ b/src/sst/core/util/perfReporter.h
@@ -1,0 +1,133 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_PERF_REPORTER_H
+#define SST_CORE_PERF_REPORTER_H
+
+#include "sst/core/output.h"
+#include "sst/core/unitAlgebra.h"
+#include "sst/core/util/filesystem.h"
+
+#include "nlohmann/json.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <stack>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace SST::Util {
+
+class DataRecord;
+class PerfReporter;
+
+class PerfData
+{
+    friend DataRecord;
+
+public:
+    // Create (begin) a new record level
+    PerfData(std::string name, PerfData* parent);
+
+    template <typename T>
+    T getData(const std::string& key)
+    {
+        const auto& val = data_.at(key);
+        return std::get<T>(val);
+    }
+
+    std::string                                                                              name_ = "";
+    std::map<std::string, std::variant<uint64_t, int64_t, double, UnitAlgebra, std::string>> data_;
+    std::map<std::string, std::pair<std::string, std::string>>
+                           keys_; // Keys optionally map to a <extended_key, unit> pair for pretty print
+    PerfData*              parent_ = nullptr;
+    std::vector<PerfData*> children_;
+};
+
+// Stores a hierarchy of named key/val pairs that should be output
+class DataRecord
+{
+public:
+    friend PerfReporter;
+    enum class TextFormat { plain, tree, list };
+    DataRecord(std::string name, TextFormat format);
+
+    // API for inserting data into records
+    // Map of key str to pair of (pretty print string, units). Units may be "" if not applicable.
+    // Keys are *not* required to be entered in this structure if no pretty print string/units are required
+    // Extended string for the name of the record can also be entered
+    void setKeys(std::map<std::string, std::pair<std::string, std::string>>& key_map);
+
+    void setFormat(TextFormat format) { format_ = format; }
+
+    // API for traversing
+    void changeLevelUp();
+    bool changeLevelDown(std::string name); // Return whether level was changed
+    void addChild(std::string name);
+    void endChild();
+    void addData(std::string key, double value);
+    void addData(std::string key, uint64_t value);
+    void addData(std::string key, int64_t value);
+    void addData(std::string key, UnitAlgebra value);
+    void addData(std::map<std::string, std::variant<uint64_t, int64_t, double, UnitAlgebra, std::string>> data);
+
+private:
+    PerfData*  root_;
+    PerfData*  current_record_;
+    TextFormat format_;
+};
+
+class PerfReporter
+{
+public:
+    PerfReporter() { output_.init("", 0, 0, Output::STDOUT); }
+
+    /*
+     * Thread-safe function to return the data record with the given name
+     * If record does not already exist, it will be created
+     */
+    DataRecord* createDataRecord(std::string name, DataRecord::TextFormat format = DataRecord::TextFormat::plain);
+
+    void output(int rank, int num_ranks); // Output all registered records
+
+    void configureOutput(std::string output_str);
+    void outputRecordToTextTree(const PerfData* node, std::stringstream* sstr);
+
+    void outputNodeToTextTree(
+        const PerfData* node, std::stringstream* sstr, bool last_child, std::vector<int> levels_has_more_siblings = {});
+    void printTreeIndent(
+        std::stringstream* sstr, const std::vector<int>& levels_has_more_siblings, size_t indent_level);
+    void outputValueToText(
+        const std::variant<uint64_t, int64_t, double, UnitAlgebra, std::string>& v, std::stringstream* sstr);
+    std::string convertValueToString(const std::variant<uint64_t, int64_t, double, UnitAlgebra, std::string>& v);
+    void outputRecordToText(const PerfData* node, std::stringstream* sstr, int indent = 0, bool print_name = true);
+    void outputRecordToTextList(const PerfData* node, std::stringstream* sstr, bool header);
+    void outputRecordToJSON(const PerfData* node, nlohmann::ordered_json* obj);
+
+private:
+    // Can output to console and/or a file (json or text)
+    Output      output_;
+    bool        output_console_ = false; // output to console or not
+    std::string filename_;               // File to output to (or "" if console only; extension determines format)
+    std::map<std::string, DataRecord*>
+                       records_; // Data stored at the base level - no indent (txt) or highest-level object (JSON)
+    mutable std::mutex mtx;      // mutex for record creation
+};
+
+} // namespace SST::Util
+
+#endif // SST_CORE_PERF_REPORTER_H

--- a/tests/refFiles/test_Profiling_event_component.out
+++ b/tests/refFiles/test_Profiling_event_component.out
@@ -1,22 +1,35 @@
------------------------------
-Rank = 0, thread = 0:
 
-events
-Name, recv count
-component0, 39695
-component1, 39527
-component10, 40375
-component11, 40275
-component12, 40211
-component13, 40224
-component14, 40208
-component15, 39952
-component2, 39642
-component3, 39517
-component4, 40220
-component5, 39797
-component6, 39886
-component7, 40031
-component8, 40252
-component9, 40124
 
+events:
+  component0:
+    recv_count: 39695
+  component1:
+    recv_count: 39527
+  component10:
+    recv_count: 40375
+  component11:
+    recv_count: 40275
+  component12:
+    recv_count: 40211
+  component13:
+    recv_count: 40224
+  component14:
+    recv_count: 40208
+  component15:
+    recv_count: 39952
+  component2:
+    recv_count: 39642
+  component3:
+    recv_count: 39517
+  component4:
+    recv_count: 40220
+  component5:
+    recv_count: 39797
+  component6:
+    recv_count: 39886
+  component7:
+    recv_count: 40031
+  component8:
+    recv_count: 40252
+  component9:
+    recv_count: 40124

--- a/tests/refFiles/test_Profiling_event_global.out
+++ b/tests/refFiles/test_Profiling_event_global.out
@@ -1,7 +1,5 @@
------------------------------
-Rank = 0, thread = 0:
 
-events
-Name, recv count
-global, 639936
 
+events:
+  global:
+    recv_count: 639936

--- a/tests/refFiles/test_Profiling_event_subcomponent.out
+++ b/tests/refFiles/test_Profiling_event_subcomponent.out
@@ -1,70 +1,131 @@
------------------------------
-Rank = 0, thread = 0:
 
-events
-Name, recv count
-component0:ports[0], 9727
-component0:ports[1], 9912
-component0:ports[2]:port, 9997
-component0:ports[3]:port, 10059
-component10:ports[0], 10120
-component10:ports[1], 10238
-component10:ports[2]:port, 10046
-component10:ports[3]:port, 9971
-component11:ports[0], 10217
-component11:ports[1], 10069
-component11:ports[2]:port, 9966
-component11:ports[3]:port, 10023
-component12:ports[0], 10185
-component12:ports[1], 10073
-component12:ports[2]:port, 10041
-component12:ports[3]:port, 9912
-component13:ports[0], 10023
-component13:ports[1], 10153
-component13:ports[2]:port, 10136
-component13:ports[3]:port, 9912
-component14:ports[0], 9916
-component14:ports[1], 10036
-component14:ports[2]:port, 10135
-component14:ports[3]:port, 10121
-component15:ports[0], 9912
-component15:ports[1], 10093
-component15:ports[2]:port, 9839
-component15:ports[3]:port, 10108
-component1:ports[0], 9783
-component1:ports[1], 10079
-component1:ports[2]:port, 9764
-component1:ports[3]:port, 9901
-component2:ports[0], 9845
-component2:ports[1], 9731
-component2:ports[2]:port, 10021
-component2:ports[3]:port, 10045
-component3:ports[0], 9793
-component3:ports[1], 9789
-component3:ports[2]:port, 9938
-component3:ports[3]:port, 9997
-component4:ports[0], 10174
-component4:ports[1], 10161
-component4:ports[2]:port, 10107
-component4:ports[3]:port, 9778
-component5:ports[0], 9881
-component5:ports[1], 10039
-component5:ports[2]:port, 9943
-component5:ports[3]:port, 9934
-component6:ports[0], 9910
-component6:ports[1], 9926
-component6:ports[2]:port, 10115
-component6:ports[3]:port, 9935
-component7:ports[0], 9999
-component7:ports[1], 10012
-component7:ports[2]:port, 10097
-component7:ports[3]:port, 9923
-component8:ports[0], 10031
-component8:ports[1], 9950
-component8:ports[2]:port, 10084
-component8:ports[3]:port, 10187
-component9:ports[0], 10072
-component9:ports[1], 10016
-component9:ports[2]:port, 10103
-component9:ports[3]:port, 9933
 
+events:
+  component0:ports[0]:
+    recv_count: 9727
+  component0:ports[1]:
+    recv_count: 9912
+  component0:ports[2]:port:
+    recv_count: 9997
+  component0:ports[3]:port:
+    recv_count: 10059
+  component10:ports[0]:
+    recv_count: 10120
+  component10:ports[1]:
+    recv_count: 10238
+  component10:ports[2]:port:
+    recv_count: 10046
+  component10:ports[3]:port:
+    recv_count: 9971
+  component11:ports[0]:
+    recv_count: 10217
+  component11:ports[1]:
+    recv_count: 10069
+  component11:ports[2]:port:
+    recv_count: 9966
+  component11:ports[3]:port:
+    recv_count: 10023
+  component12:ports[0]:
+    recv_count: 10185
+  component12:ports[1]:
+    recv_count: 10073
+  component12:ports[2]:port:
+    recv_count: 10041
+  component12:ports[3]:port:
+    recv_count: 9912
+  component13:ports[0]:
+    recv_count: 10023
+  component13:ports[1]:
+    recv_count: 10153
+  component13:ports[2]:port:
+    recv_count: 10136
+  component13:ports[3]:port:
+    recv_count: 9912
+  component14:ports[0]:
+    recv_count: 9916
+  component14:ports[1]:
+    recv_count: 10036
+  component14:ports[2]:port:
+    recv_count: 10135
+  component14:ports[3]:port:
+    recv_count: 10121
+  component15:ports[0]:
+    recv_count: 9912
+  component15:ports[1]:
+    recv_count: 10093
+  component15:ports[2]:port:
+    recv_count: 9839
+  component15:ports[3]:port:
+    recv_count: 10108
+  component1:ports[0]:
+    recv_count: 9783
+  component1:ports[1]:
+    recv_count: 10079
+  component1:ports[2]:port:
+    recv_count: 9764
+  component1:ports[3]:port:
+    recv_count: 9901
+  component2:ports[0]:
+    recv_count: 9845
+  component2:ports[1]:
+    recv_count: 9731
+  component2:ports[2]:port:
+    recv_count: 10021
+  component2:ports[3]:port:
+    recv_count: 10045
+  component3:ports[0]:
+    recv_count: 9793
+  component3:ports[1]:
+    recv_count: 9789
+  component3:ports[2]:port:
+    recv_count: 9938
+  component3:ports[3]:port:
+    recv_count: 9997
+  component4:ports[0]:
+    recv_count: 10174
+  component4:ports[1]:
+    recv_count: 10161
+  component4:ports[2]:port:
+    recv_count: 10107
+  component4:ports[3]:port:
+    recv_count: 9778
+  component5:ports[0]:
+    recv_count: 9881
+  component5:ports[1]:
+    recv_count: 10039
+  component5:ports[2]:port:
+    recv_count: 9943
+  component5:ports[3]:port:
+    recv_count: 9934
+  component6:ports[0]:
+    recv_count: 9910
+  component6:ports[1]:
+    recv_count: 9926
+  component6:ports[2]:port:
+    recv_count: 10115
+  component6:ports[3]:port:
+    recv_count: 9935
+  component7:ports[0]:
+    recv_count: 9999
+  component7:ports[1]:
+    recv_count: 10012
+  component7:ports[2]:port:
+    recv_count: 10097
+  component7:ports[3]:port:
+    recv_count: 9923
+  component8:ports[0]:
+    recv_count: 10031
+  component8:ports[1]:
+    recv_count: 9950
+  component8:ports[2]:port:
+    recv_count: 10084
+  component8:ports[3]:port:
+    recv_count: 10187
+  component9:ports[0]:
+    recv_count: 10072
+  component9:ports[1]:
+    recv_count: 10016
+  component9:ports[2]:port:
+    recv_count: 10103
+  component9:ports[3]:port:
+    recv_count: 9933

--- a/tests/refFiles/test_Profiling_event_type.out
+++ b/tests/refFiles/test_Profiling_event_type.out
@@ -1,7 +1,5 @@
------------------------------
-Rank = 0, thread = 0:
 
-events
-Name, recv count
-coreTestElement.message_mesh.message_port, 639936
 
+events:
+  coreTestElement.message_mesh.message_port:
+    recv_count: 639936

--- a/tests/testsuite_default_TimingInfo.py
+++ b/tests/testsuite_default_TimingInfo.py
@@ -43,7 +43,7 @@ class testcase_TimingInfo(SSTTestCase):
         outfile = "{0}/test_TimingInfo.out".format(outdir)
         jsonfile = "{0}/test_TimingInfo.json".format(outdir)
 
-        self.run_sst(sdlfile, outfile, other_args=f"--timing-info-json={jsonfile}")
+        self.run_sst(sdlfile, outfile, other_args=f"--timing-info --profiling-output={jsonfile}")
 
         # Perform the test of the standard simulation output
         cmp_result = testing_compare_sorted_diff(testtype, outfile, reffile)
@@ -57,28 +57,22 @@ class testcase_TimingInfo(SSTTestCase):
         except FileNotFoundError:
             self.assertFalse(True, f"Could not load json timing info file {jsonfile}")
 
-        timingInfo = jsonDict['timing-info']
+        timingInfo = jsonDict['resources']
 
         timing_keys = [
             "local_max_rss",
             "global_max_rss",
-            "local_max_pf",
-            "global_pf",
+            "local_max_page_faults",
+            "global_page_faults",
             "global_max_io_in",
             "global_max_io_out",
             "global_max_sync_data_size",
             "global_sync_data_size",
             "max_mempool_size",
             "global_mempool_size",
-            "global_active_activities",
-            "global_current_tv_depth",
-            "global_max_tv_depth",
-            "max_build_time",
-            "max_run_time",
-            "max_total_time",
-            "simulated_time_ua",
-            "ranks",
-            "threads",
+            "global_undeleted_activities",
+            "global_current_timevortex_depth",
+            "global_max_timevortex_depth",
         ]
 
         # Check keys exists

--- a/tests/testsuite_default_profiling.py
+++ b/tests/testsuite_default_profiling.py
@@ -59,13 +59,13 @@ class testcase_Profiling(SSTTestCase):
         testsuitedir = self.get_testsuite_dir()
         outdir = test_output_get_run_dir()
 
-        options = "--output-directory=testsuite_profiling --profiling-output=prof_{0}.out --model-options=\"4 4\" --enable-profiling=\"{1}\"".format(testtype,profile_options);
+        options = "--output-directory=testsuite_profiling --profiling-output=prof_{0}.txt --model-options=\"4 4\" --enable-profiling=\"{1}\"".format(testtype,profile_options);
 
         # Set the various file paths
         sdlfile = "{0}/test_MessageMesh.py".format(testsuitedir)
         reffile = "{0}/refFiles/test_Profiling_{1}.out".format(testsuitedir, testtype)
         outfile = "{0}/test_Profiling_{1}.out".format(outdir, testtype)
-        checkfile = "{0}/testsuite_profiling/prof_{1}.out".format(outdir, testtype)
+        checkfile = "{0}/testsuite_profiling/prof_{1}.txt".format(outdir, testtype)
 
         self.run_sst(sdlfile, outfile, other_args=options)
 


### PR DESCRIPTION
* Enable JSON format output for all profiling data
* Adds a centralized "PerfReporter" class that combines profile output from verbose, timing-info, and profile points.
* Migrates some sync profiling information that was previously only available with a configure option to be available always at runtime using the sync profile point. This only applies to low-overhead profiling data, timing serialization within syncs still requires the configure option.
* Adds three "pretty-print" options for performance data: plain, as a tree, or as a comma-separated array

This PR changes run-time options:
`--print-timing-info` : Changed to just `--timing-info`, enables timing output
`--enable-profiling`: Unchanged, enables the requested profile points
`--timing-info-json`: Removed, use `--profiling-output` instead
`--profiling-output`: Controls the output for all sources of profiling data. Can accept 'stdout' or a filename or a list of 'stdout,filename'. Enable JSON by using a filename with a '.json' extension or pretty-print by using a filename with a '.txt' extension.

