### PR TITLE
Profile metadata

### DIFF
--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -1567,9 +1567,9 @@ main(int argc, char* argv[])
         const uint64_t global_max_io_out = maxOutputOperations();
 
         if ( myRank.rank == 0 ) {
-            int          timing_verbose = cfg.print_timing() == 0 ? (cfg.verbose() > 0 ? 2 : 0) : cfg.print_timing();
-            TimingOutput timingOutput(g_output, std::max(timing_verbose, cfg.verbose() == 0 ? 0 : cfg.verbose() + 1));
-            timingOutput.generate(&perfReporter); // Triggers basicPerf to dump data to the record
+            int timing_verbose = cfg.print_timing() == 0 ? (cfg.verbose() > 0 ? 2 : 0) : cfg.print_timing();
+            timing_verbose     = std::max(timing_verbose, cfg.verbose() == 0 ? 0 : cfg.verbose() + 1);
+            Simulation_impl::basicPerf.outputRegionData(timing_verbose, &perfReporter);
 
             SST::Util::DataRecord* resources = perfReporter.createDataRecord("resources");
             std::map<std::string, std::pair<std::string, std::string>> key_map = {
@@ -1640,6 +1640,20 @@ main(int argc, char* argv[])
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
+    if ( perfReporter.recordCount() > 0 && myRank.rank == 0 ) {
+        // Add a metadata section
+        Util::DataRecord* record = perfReporter.createDataRecord("metadata");
+        record->addData("ranks", (uint64_t)world_size.rank);
+        record->addData("threads", (uint64_t)world_size.thread);
+        record->addData("simulation_time", threadInfo[0].simulated_time);
+        record->addData("input_file", cfg.configFile_.value);
+        std::map<std::string, std::pair<std::string, std::string>> key_map = { { "metadata",
+                                                                                   { "Simulation Summary", "" } },
+            { "ranks", { "Ranks", "" } }, // UnitAlgebra, units unnecessary
+            { "threads", { "Threads", "" } }, { "simulation_time", { "Simulated time", "" } },
+            { "input_file", { "Simulation Input File", "" } } };
+        record->setKeys(key_map);
+    }
     perfReporter.output(myRank.rank, world_size.rank);
 
 #ifdef SST_CONFIG_HAVE_MPI

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -1649,9 +1649,8 @@ main(int argc, char* argv[])
         record->addData("input_file", cfg.configFile_.value);
         std::map<std::string, std::pair<std::string, std::string>> key_map = { { "metadata",
                                                                                    { "Simulation Summary", "" } },
-            { "ranks", { "Ranks", "" } }, // UnitAlgebra, units unnecessary
-            { "threads", { "Threads", "" } }, { "simulation_time", { "Simulated time", "" } },
-            { "input_file", { "Simulation Input File", "" } } };
+            { "ranks", { "Ranks", "" } }, { "threads", { "Threads", "" } },
+            { "simulation_time", { "Simulated time", "" } }, { "input_file", { "Simulation Input File", "" } } };
         record->setKeys(key_map);
     }
     perfReporter.output(myRank.rank, world_size.rank);

--- a/src/sst/core/timingOutput.cc
+++ b/src/sst/core/timingOutput.cc
@@ -31,46 +31,28 @@ namespace SST::Core {
 
 TimingOutput::TimingOutput(const SST::Output& output, int print_verbosity) :
     output_(output),
-    print_verbosity_(print_verbosity),
-    jsonEnable_(false)
+    print_verbosity_(print_verbosity)
 {}
-
-void
-TimingOutput::setJSON(const std::string& path)
-{
-    SST::Util::Filesystem filesystem = Simulation_impl::filesystem;
-    outputFile                       = filesystem.fopen(path, "wt");
-    if ( outputFile == nullptr )
-        output_.fatal(CALL_INFO, -1, "Could not open %s\n", path.c_str());
-    else
-        jsonEnable_ = true;
-}
 
 void
 TimingOutput::set(Key key, const uint64_t v)
 {
-    // output_.output("%s %" PRId64 "\n", key2cstr.at(key), v);
     u64map_[key] = v;
 }
 
 void
 TimingOutput::set(Key key, UnitAlgebra v)
 {
-    // output_.output("%s %s\n", key2cstr.at(key), v.toStringBestSI().c_str());
     uamap_[key] = v;
 }
 
 void
 TimingOutput::set(Key key, double v)
 {
-    // output_.output("%s %f\n", key2cstr.at(key), v);
     dmap_[key] = v;
 }
 
-TimingOutput::~TimingOutput()
-{
-    if ( outputFile ) fclose(outputFile);
-}
+TimingOutput::~TimingOutput() {}
 
 
 void

--- a/src/sst/core/timingOutput.h
+++ b/src/sst/core/timingOutput.h
@@ -60,31 +60,8 @@ public:
         THREADS,                   // Threads
     };
 
-    const std::map<Key, const char*> key2cstr = {
-        { LOCAL_MAX_RSS, "local_max_rss" },
-        { GLOBAL_MAX_RSS, "global_max_rss" },
-        { LOCAL_MAX_PF, "local_max_pf" },
-        { GLOBAL_PF, "global_pf" },
-        { GLOBAL_MAX_IO_IN, "global_max_io_in" },
-        { GLOBAL_MAX_IO_OUT, "global_max_io_out" },
-        { GLOBAL_MAX_SYNC_DATA_SIZE, "global_max_sync_data_size" },
-        { GLOBAL_SYNC_DATA_SIZE, "global_sync_data_size" },
-        { MAX_MEMPOOL_SIZE, "max_mempool_size" },
-        { GLOBAL_MEMPOOL_SIZE, "global_mempool_size" },
-        { MAX_BUILD_TIME, "max_build_time" },
-        { MAX_RUN_TIME, "max_run_time" },
-        { MAX_TOTAL_TIME, "max_total_time" },
-        { SIMULATED_TIME_UA, "simulated_time_ua" },
-        { GLOBAL_ACTIVE_ACTIVITIES, "global_active_activities" },
-        { GLOBAL_CURRENT_TV_DEPTH, "global_current_tv_depth" },
-        { GLOBAL_MAX_TV_DEPTH, "global_max_tv_depth" },
-        { RANKS, "ranks" },
-        { THREADS, "threads" },
-    };
-
     TimingOutput(const SST::Output& output, int print_verbosity);
     virtual ~TimingOutput();
-    void setJSON(const std::string& path);
     void generate(SST::Util::PerfReporter* reporter);
 
     void set(Key key, uint64_t v);
@@ -94,12 +71,10 @@ public:
 private:
     SST::Output output_;
     int         print_verbosity_;
-    bool        jsonEnable_;
 
-    std::map<Key, uint64_t>    u64map_    = {};
-    std::map<Key, UnitAlgebra> uamap_     = {};
-    std::map<Key, double>      dmap_      = {};
-    FILE*                      outputFile = nullptr;
+    std::map<Key, uint64_t>    u64map_ = {};
+    std::map<Key, UnitAlgebra> uamap_  = {};
+    std::map<Key, double>      dmap_   = {};
 };
 } // namespace Core
 } // namespace SST

--- a/src/sst/core/util/perfReporter.cc
+++ b/src/sst/core/util/perfReporter.cc
@@ -107,6 +107,11 @@ DataRecord::addData(std::string key, int64_t value)
 }
 
 void
+DataRecord::addData(std::string key, std::string value)
+{
+    current_record_->data_[key] = value;
+}
+void
 DataRecord::addData(std::string key, UnitAlgebra value)
 {
     current_record_->data_[key] = value;
@@ -244,7 +249,6 @@ PerfReporter::output(int rank, int num_ranks)
             int length = static_cast<int>(record.first.size());
             SST_MPI_Bcast(&length, 1, MPI_INT, 0, MPI_COMM_WORLD);
             SST_MPI_Bcast((void*)&record.first[0], length, MPI_CHAR, 0, MPI_COMM_WORLD);
-
             auto json_o = nlohmann::ordered_json::object();
 
             // Output any text formatted data, first for rank 0 and then append from other ranks
@@ -294,10 +298,10 @@ PerfReporter::output(int rank, int num_ranks)
                 }
 
                 if ( idx != records_.size() ) {
-                    filestream << "},\n";
+                    filestream << "\n},\n";
                 }
                 else {
-                    filestream << "}\n";
+                    filestream << "\n}\n";
                 }
             }
         }
@@ -641,6 +645,12 @@ PerfReporter::outputRecordToJSON(const PerfData* node, json::ordered_json* json_
         outputRecordToJSON(child, &record);
         (*json_obj)[child->name_] = record;
     }
+}
+
+size_t
+PerfReporter::recordCount()
+{
+    return records_.size();
 }
 
 } // namespace SST::Util

--- a/src/sst/core/util/perfReporter.h
+++ b/src/sst/core/util/perfReporter.h
@@ -83,6 +83,7 @@ public:
     void addData(std::string key, uint64_t value);
     void addData(std::string key, int64_t value);
     void addData(std::string key, UnitAlgebra value);
+    void addData(std::string key, std::string value);
     void addData(std::map<std::string, std::variant<uint64_t, int64_t, double, UnitAlgebra, std::string>> data);
 
 private:
@@ -114,9 +115,10 @@ public:
     void outputValueToText(
         const std::variant<uint64_t, int64_t, double, UnitAlgebra, std::string>& v, std::stringstream* sstr);
     std::string convertValueToString(const std::variant<uint64_t, int64_t, double, UnitAlgebra, std::string>& v);
-    void outputRecordToText(const PerfData* node, std::stringstream* sstr, int indent = 0, bool print_name = true);
-    void outputRecordToTextList(const PerfData* node, std::stringstream* sstr, bool header);
-    void outputRecordToJSON(const PerfData* node, nlohmann::ordered_json* obj);
+    void   outputRecordToText(const PerfData* node, std::stringstream* sstr, int indent = 0, bool print_name = true);
+    void   outputRecordToTextList(const PerfData* node, std::stringstream* sstr, bool header);
+    void   outputRecordToJSON(const PerfData* node, nlohmann::ordered_json* obj);
+    size_t recordCount();
 
 private:
     // Can output to console and/or a file (json or text)

--- a/tests/refFiles/test_Profiling_event_component.out
+++ b/tests/refFiles/test_Profiling_event_component.out
@@ -33,3 +33,10 @@ events:
     recv_count: 40252
   component9:
     recv_count: 40124
+
+
+Simulation Summary:
+  Simulation Input File: /sst-core/tests/test_MessageMesh.py
+  Ranks:                 1
+  Simulated time:        10 us
+  Threads:               1

--- a/tests/refFiles/test_Profiling_event_global.out
+++ b/tests/refFiles/test_Profiling_event_global.out
@@ -3,3 +3,10 @@
 events:
   global:
     recv_count: 639936
+
+
+Simulation Summary:
+  Simulation Input File: /sst-core/tests/test_MessageMesh.py
+  Ranks:                 1
+  Simulated time:        10 us
+  Threads:               1

--- a/tests/refFiles/test_Profiling_event_subcomponent.out
+++ b/tests/refFiles/test_Profiling_event_subcomponent.out
@@ -129,3 +129,10 @@ events:
     recv_count: 10103
   component9:ports[3]:port:
     recv_count: 9933
+
+
+Simulation Summary:
+  Simulation Input File: /sst-core/tests/test_MessageMesh.py
+  Ranks:                 1
+  Simulated time:        10 us
+  Threads:               1

--- a/tests/refFiles/test_Profiling_event_type.out
+++ b/tests/refFiles/test_Profiling_event_type.out
@@ -3,3 +3,10 @@
 events:
   coreTestElement.message_mesh.message_port:
     recv_count: 639936
+
+
+Simulation Summary:
+  Simulation Input File: /sst-core/tests/test_MessageMesh.py
+  Ranks:                 1
+  Simulated time:        10 us
+  Threads:               1

--- a/tests/testsuite_default_profiling.py
+++ b/tests/testsuite_default_profiling.py
@@ -70,7 +70,8 @@ class testcase_Profiling(SSTTestCase):
         self.run_sst(sdlfile, outfile, other_args=options)
 
         # Perform the test
-        cmp_result = testing_compare_sorted_diff(testtype, checkfile, reffile)
+        filters = [ StartsWithFilter("  Simulation Input File") ]
+        cmp_result = testing_compare_filtered_diff(testtype, checkfile, reffile, sort=True, filters=filters)
         if not cmp_result:
             diffdata = testing_get_diff_data(testtype)
             log_failure(diffdata)


### PR DESCRIPTION
Adds a metadata section to profile output that contains some information about the run (ranks, threads, simulated time, input file).

Also bypasses the TimingOutput object in main as that is currently only used as a pass-through to have BasicPerf output its data.