### PR TITLE
header fixes MAC and SLES

### DIFF
--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -27,6 +27,7 @@
 #include "sst/core/timeConverter.h"
 #include "sst/core/warnmacros.h"
 
+#include <cstdarg>
 #include <cstdint>
 #include <functional>
 #include <map>

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -21,6 +21,7 @@
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <functional>
 #include <getopt.h>
 #include <iostream>

--- a/src/sst/core/configShared.h
+++ b/src/sst/core/configShared.h
@@ -16,6 +16,7 @@
 #include "sst/core/sst_types.h"
 #include "sst/core/warnmacros.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <iostream>
 #include <stdexcept>

--- a/src/sst/core/elemLoader.h
+++ b/src/sst/core/elemLoader.h
@@ -12,6 +12,7 @@
 #ifndef SST_CORE_ELEMLOADER_H
 #define SST_CORE_ELEMLOADER_H
 
+#include <ostream>
 #include <string>
 #include <vector>
 

--- a/src/sst/core/eli/attributeInfo.h
+++ b/src/sst/core/eli/attributeInfo.h
@@ -15,6 +15,7 @@
 #include "sst/core/eli/elibase.h"
 #include "sst/core/warnmacros.h"
 
+#include <ostream>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/src/sst/core/eli/categoryInfo.h
+++ b/src/sst/core/eli/categoryInfo.h
@@ -17,6 +17,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <ostream>
 #include <string>
 #include <vector>
 

--- a/src/sst/core/eli/checkpointableInfo.h
+++ b/src/sst/core/eli/checkpointableInfo.h
@@ -17,6 +17,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <ostream>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/src/sst/core/eli/defaultInfo.h
+++ b/src/sst/core/eli/defaultInfo.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/eli/elibase.h"
 
+#include <ostream>
 #include <string>
 #include <vector>
 

--- a/src/sst/core/eli/elementinfo.h
+++ b/src/sst/core/eli/elementinfo.h
@@ -29,6 +29,7 @@
 #include "sst/core/warnmacros.h"
 
 #include <map>
+#include <ostream>
 #include <string>
 #include <vector>
 

--- a/src/sst/core/eli/interfaceInfo.h
+++ b/src/sst/core/eli/interfaceInfo.h
@@ -13,6 +13,7 @@
 #define SST_CORE_ELI_INTERFACE_INFO_H
 
 #include <iostream>
+#include <ostream>
 #include <string>
 
 namespace SST::ELI {

--- a/src/sst/core/eli/paramsInfo.h
+++ b/src/sst/core/eli/paramsInfo.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/eli/elibase.h"
 
+#include <ostream>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/src/sst/core/eli/portsInfo.h
+++ b/src/sst/core/eli/portsInfo.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/eli/elibase.h"
 
+#include <ostream>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/src/sst/core/eli/profilePointInfo.h
+++ b/src/sst/core/eli/profilePointInfo.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/eli/elibase.h"
 
+#include <ostream>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/src/sst/core/eli/statsInfo.h
+++ b/src/sst/core/eli/statsInfo.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/eli/elibase.h"
 
+#include <ostream>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/src/sst/core/eli/subcompSlotInfo.h
+++ b/src/sst/core/eli/subcompSlotInfo.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/eli/elibase.h"
 
+#include <ostream>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/src/sst/core/exit.h
+++ b/src/sst/core/exit.h
@@ -17,6 +17,7 @@
 #include "sst/core/threadsafe.h"
 
 #include <cinttypes>
+#include <cstdint>
 #include <string>
 #include <unordered_set>
 

--- a/src/sst/core/factory.h
+++ b/src/sst/core/factory.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <iostream>
 #include <mutex>
+#include <ostream>
 #include <set>
 #include <sstream>
 #include <stdio.h>

--- a/src/sst/core/model/cfgoutput/jsonConfigOutput.h
+++ b/src/sst/core/model/cfgoutput/jsonConfigOutput.h
@@ -19,6 +19,7 @@
 
 #include "nlohmann/json.hpp"
 
+#include <fstream>
 #include <map>
 #include <string>
 

--- a/src/sst/core/model/python/pymodel.h
+++ b/src/sst/core/model/python/pymodel.h
@@ -28,6 +28,7 @@
 DISABLE_WARN_DEPRECATED_REGISTER
 #include <Python.h>
 #include <cstddef>
+#include <cstdint>
 REENABLE_WARNING
 
 #include <map>

--- a/src/sst/core/params.h
+++ b/src/sst/core/params.h
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <map>
 #include <mutex>
+#include <ostream>
 #include <set>
 #include <sstream>
 #include <stack>

--- a/src/sst/core/profile/syncProfileTool.h
+++ b/src/sst/core/profile/syncProfileTool.h
@@ -20,6 +20,7 @@
 #include "sst/core/warnmacros.h"
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <string>

--- a/src/sst/core/serialization/impl/serialize_trivial.h
+++ b/src/sst/core/serialization/impl/serialize_trivial.h
@@ -22,6 +22,7 @@
 
 #include <array>
 #include <bitset>
+#include <cstddef>
 #include <string>
 #include <type_traits>
 #include <typeinfo>

--- a/src/sst/core/serialization/serializable_base.h
+++ b/src/sst/core/serialization/serializable_base.h
@@ -15,6 +15,7 @@
 #include "sst/core/serialization/serializer.h"
 #include "sst/core/warnmacros.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <limits>

--- a/src/sst/core/sstinfo.h
+++ b/src/sst/core/sstinfo.h
@@ -16,8 +16,11 @@
 #include "sst/core/eli/elementinfo.h"
 
 #include <cstdio>
+#include <functional>
 #include <map>
+#include <ostream>
 #include <set>
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/src/sst/core/statapi/statbase.h
+++ b/src/sst/core/statapi/statbase.h
@@ -21,6 +21,7 @@
 #include "sst/core/unitAlgebra.h"
 #include "sst/core/warnmacros.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <tuple>

--- a/src/sst/core/statapi/statoutput.h
+++ b/src/sst/core/statapi/statoutput.h
@@ -21,6 +21,7 @@
 #include "sst/core/statapi/statfieldinfo.h"
 #include "sst/core/warnmacros.h"
 
+#include <cstdint>
 #include <mutex>
 #include <string>
 #include <unordered_map>

--- a/src/sst/core/statapi/statoutputcsv.cc
+++ b/src/sst/core/statapi/statoutputcsv.cc
@@ -20,6 +20,7 @@
 #include <cstdarg>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 namespace SST::Statistics {
 

--- a/src/sst/core/statapi/statoutputcsv.h
+++ b/src/sst/core/statapi/statoutputcsv.h
@@ -19,6 +19,7 @@
 #include <zlib.h>
 #endif
 
+#include <cstdint>
 #include <cstdio>
 #include <string>
 #include <vector>

--- a/src/sst/core/statapi/statoutputjson.cc
+++ b/src/sst/core/statapi/statoutputjson.cc
@@ -19,6 +19,7 @@
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 namespace SST::Statistics {
 

--- a/src/sst/core/statapi/statoutputjson.h
+++ b/src/sst/core/statapi/statoutputjson.h
@@ -15,6 +15,7 @@
 #include "sst/core/sst_types.h"
 #include "sst/core/statapi/statoutput.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <string>
 

--- a/src/sst/core/statapi/statoutputtxt.cc
+++ b/src/sst/core/statapi/statoutputtxt.cc
@@ -19,6 +19,7 @@
 #include <cstdarg>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 namespace SST::Statistics {
 

--- a/src/sst/core/statapi/statoutputtxt.h
+++ b/src/sst/core/statapi/statoutputtxt.h
@@ -19,6 +19,7 @@
 #include <zlib.h>
 #endif
 
+#include <cstdint>
 #include <cstdio>
 #include <string>
 

--- a/src/sst/core/testElements/coreTest_ClockerComponent.h
+++ b/src/sst/core/testElements/coreTest_ClockerComponent.h
@@ -14,6 +14,7 @@
 
 #include "sst/core/component.h"
 
+#include <cstdint>
 #include <string>
 
 namespace SST::CoreTestClockerComponent {

--- a/src/sst/core/testElements/coreTest_Links.h
+++ b/src/sst/core/testElements/coreTest_Links.h
@@ -16,6 +16,8 @@
 #include "sst/core/link.h"
 #include "sst/core/rng/marsaglia.h"
 
+#include <string>
+
 namespace SST::CoreTestComponent {
 
 class coreTestLinks : public SST::Component

--- a/src/sst/core/testElements/coreTest_PortModule.h
+++ b/src/sst/core/testElements/coreTest_PortModule.h
@@ -16,6 +16,8 @@
 #include "sst/core/event.h"
 #include "sst/core/subcomponent.h"
 
+#include <cstdint>
+
 namespace SST::CoreTestPortModule {
 
 class PortSubComponent;

--- a/src/sst/core/util/perfReporter.h
+++ b/src/sst/core/util/perfReporter.h
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <map>
 #include <mutex>
+#include <sstream>
 #include <stack>
 #include <string>
 #include <utility>


### PR DESCRIPTION
./scripts/test-includes.py failed on a few TCL platforms.
Reran the script to fix missing includes.
With these changes the header checks now pass on all systems
