### PR TITLE
Fix warnings about whitespace in nlohmann_json operator definitions

### DIFF
--- a/external/nlohmann/json.hpp
+++ b/external/nlohmann/json.hpp
@@ -26001,7 +26001,7 @@ if no parse error occurred.
 @since version 1.0.0
 */
 JSON_HEDLEY_NON_NULL(1)
-inline nlohmann::json operator "" _json(const char* s, std::size_t n)
+inline nlohmann::json operator""_json(const char* s, std::size_t n)
 {
     return nlohmann::json::parse(s, s + n);
 }
@@ -26020,7 +26020,7 @@ object if no parse error occurred.
 @since version 2.0.0
 */
 JSON_HEDLEY_NON_NULL(1)
-inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size_t n)
+inline nlohmann::json::json_pointer operator""_json_pointer(const char* s, std::size_t n)
 {
     return nlohmann::json::json_pointer(std::string(s, n));
 }


### PR DESCRIPTION
This eliminates the following warnings:
```
/Users/ejberqu/development/sst/forks/sst-core/external/nlohmann/json.hpp:26004:34: warning: identifier '_json' preceded by whitespace in a literal operator declaration
      is deprecated [-Wdeprecated-literal-operator]
 26004 | inline nlohmann::json operator"" _json(const char* s, std::size_t n)
       |                       ~~~~~~~~~~~^~~~~
       |                       operator""_json
/Users/ejberqu/development/sst/forks/sst-core/external/nlohmann/json.hpp:26023:48: warning: identifier '_json_pointer' preceded by whitespace in a literal operator
      declaration is deprecated [-Wdeprecated-literal-operator]
 26023 | inline nlohmann::json::json_pointer operator"" _json_pointer(const char* s, std::size_t n)
       |                                     ~~~~~~~~~~~^~~~~~~~~~~~~
       |                                     operator""_json_pointer
```