### PR TITLE
Fix copy paste error in rankserial print

### DIFF
--- a/src/sst/core/impl/interactive/debugConsole.cc
+++ b/src/sst/core/impl/interactive/debugConsole.cc
@@ -1708,7 +1708,7 @@ DebugConsole::cmd_print_rank_serial(std::string& cmd_str)
     result.clear();
 
     if ( current_rank == 0 ) {
-        succeed = cmd_ls_remote(tokens);
+        succeed = cmd_print_remote(tokens);
         std::cout << result.str();
     }
     else {


### PR DESCRIPTION
A copy paste error caused rank 0 in rank serial execution to call the ls function instead of the print function. This is a one-line change.
