### PR TITLE
Post delay sampling fix for parallel execution

### DIFF
--- a/src/sst/core/impl/interactive/debugConsole.cc
+++ b/src/sst/core/impl/interactive/debugConsole.cc
@@ -1708,7 +1708,7 @@ DebugConsole::cmd_print_rank_serial(std::string& cmd_str)
     result.clear();
 
     if ( current_rank == 0 ) {
-        succeed = cmd_ls_remote(tokens);
+        succeed = cmd_print_remote(tokens);
         std::cout << result.str();
     }
     else {

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -1019,7 +1019,6 @@ public:
 
     void resetTraceBuffer()
     {
-        printf("    Reset Trace Buffer\n");
         postCount_   = 0;
         cur_         = 0;
         first_       = 0;
@@ -1067,41 +1066,43 @@ public:
             // printf("    Sample: post trigger\n");
         }
 
+        if ( !(state_ == POSTTRIGGER && postCount_ >= postDelay_) ) {
 // Circular buffer
 #ifdef _OBJMAP_DEBUG_
-        std::cout << "    Sample:" << handler << ": numRecs:" << numRecs_ << " first:" << first_ << " cur:" << cur_
-                  << " state:" << state2char.at(state_) << " isOverrun:" << isOverrun_
-                  << " samplesLost:" << samplesLost_ << std::endl;
+            std::cout << "    Sample:" << handler << ": numRecs:" << numRecs_ << " first:" << first_ << " cur:" << cur_
+                      << " state:" << state2char.at(state_) << " isOverrun:" << isOverrun_
+                      << " samplesLost:" << samplesLost_ << std::endl;
 #endif
-        cycleBuffer_[cur_]   = cycle;
-        handlerBuffer_[cur_] = handler;
-        if ( trigger ) {
-            triggerCycle = cycle;
-        }
-
-        // Sample all the trace object buffers
-        ObjectBuffer* varBuffer_;
-        for ( size_t obj = 0; obj < numObjects; obj++ ) {
-            varBuffer_ = objBuffers_[obj];
-            varBuffer_->sample(cur_, trigger);
-        }
-
-        if ( numRecs_ < bufSize_ ) {
-            tagBuffer_[cur_] = state_;
-            numRecs_++;
-            cur_ = (cur_ + 1) % bufSize_;
-            if ( cur_ == 0 ) first_ = 0; // 1;
-        }
-        else { // Buffer full
-            // Check to see if we are overwriting trigger
-            if ( tagBuffer_[cur_] == TRIGGER ) {
-                // printf("    Sample Overrun\n");
-                isOverrun_ = true;
+            cycleBuffer_[cur_]   = cycle;
+            handlerBuffer_[cur_] = handler;
+            if ( trigger ) {
+                triggerCycle = cycle;
             }
-            tagBuffer_[cur_] = state_;
-            numRecs_++;
-            cur_   = (cur_ + 1) % bufSize_;
-            first_ = cur_;
+
+            // Sample all the trace object buffers
+            ObjectBuffer* varBuffer_;
+            for ( size_t obj = 0; obj < numObjects; obj++ ) {
+                varBuffer_ = objBuffers_[obj];
+                varBuffer_->sample(cur_, trigger);
+            }
+
+            if ( numRecs_ < bufSize_ ) {
+                tagBuffer_[cur_] = state_;
+                numRecs_++;
+                cur_ = (cur_ + 1) % bufSize_;
+                if ( cur_ == 0 ) first_ = 0; // 1;
+            }
+            else { // Buffer full
+                // Check to see if we are overwriting trigger
+                if ( tagBuffer_[cur_] == TRIGGER ) {
+                    // printf("    Sample Overrun\n");
+                    isOverrun_ = true;
+                }
+                tagBuffer_[cur_] = state_;
+                numRecs_++;
+                cur_   = (cur_ + 1) % bufSize_;
+                first_ = cur_;
+            }
         }
 
         if ( isOverrun_ ) {
@@ -1110,14 +1111,12 @@ public:
 
         if ( (state_ == TRIGGER) && (postDelay_ == 0) ) {
             invokeAction = true;
-            std::cout << "    Invoke Action\n";
         }
 
         if ( state_ == POSTTRIGGER ) {
             postCount_++;
             if ( postCount_ >= postDelay_ ) {
                 invokeAction = true;
-                std::cout << "    Invoke Action\n";
             }
         }
 

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -383,7 +383,6 @@ void
 WatchPoint::setBufferReset()
 {
     if ( tb_ != nullptr ) {
-        printf("    Set Buffer Reset\n");
         tb_->setBufferReset();
         reset_ = true;
     }
@@ -412,7 +411,6 @@ WatchPoint::check()
         s << "      ";
         cmpObjects_[i]->print(s);
         s << " -> " << result2 << std::endl;
-        // printf("      comparison%ld = %d\n", i, result2);
 
         if ( logicOps_[i - 1] == LogicOp::AND ) {
             result = result && result2;

--- a/tests/refFiles/test_DebugConsole_Checkpoint_serial0.out
+++ b/tests/refFiles/test_DebugConsole_Checkpoint_serial0.out
@@ -31,10 +31,7 @@ c1 talkingc1, bounce 991, t=9000000
 c0 talkingClock cycle count = 1
 c0 talkingRNG: 4074790800, 774252441, 24684
 c0 talkingDistributions: 1.500000, 5.000000, 0.721430, 0.919625, 0.000000, 1.000000
-    Invoke Action
-    Set Buffer Reset
 # Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.04483 seconds)
-    Reset Trace Buffer
 c1 talkingClock cycle count = 1
 c1 talkingRNG: 4074790800, 774252441, 24684
 c1 talkingDistributions: 1.500000, 1.000000, 0.721430, 0.919625, 0.000000, 1.000000

--- a/tests/refFiles/test_DebugConsole_Checkpoint_serial1.out
+++ b/tests/refFiles/test_DebugConsole_Checkpoint_serial1.out
@@ -31,10 +31,7 @@ c1 talkingc1, bounce 991, t=9000000
 c0 talkingClock cycle count = 1
 c0 talkingRNG: 4074790800, 774252441, 24684
 c0 talkingDistributions: 1.500000, 5.000000, 0.721430, 0.919625, 0.000000, 1.000000
-    Invoke Action
-    Set Buffer Reset
 # Simulation Checkpoint: Simulated Time 10 us (Real CPU time since last checkpoint 0.03792 seconds)
-    Reset Trace Buffer
 c1 talkingClock cycle count = 1
 c1 talkingRNG: 4074790800, 774252441, 24684
 c1 talkingDistributions: 1.500000, 1.000000, 0.721430, 0.919625, 0.000000, 1.000000

--- a/tests/refFiles/test_DebugConsole_r2_rankserial0.out
+++ b/tests/refFiles/test_DebugConsole_r2_rankserial0.out
@@ -99,21 +99,6 @@ Added watchpoint #1
 > setHandler 1 ae
 WP 1 - component2/message_count_
 > run 1ps
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/2 Thread:0/1 (Triggered)
@@ -153,8 +138,6 @@ Added watchpoint #2
 > setHandler 2 ae
 WP 2 - component5/message_count_
 > run 2000ps
-    Invoke Action
-    Set Buffer Reset
 TriggerCount=5
 LastTriggerRecord:@cycle5000: SamplesLost=0: component5/message_count_=16 
 buf[0] AE @4000 (!) component5/message_count_=12 
@@ -162,7 +145,6 @@ buf[1] AE @4000 (+) component5/message_count_=13
 buf[2] AE @4000 (+) component5/message_count_=14 
 buf[3] AE @5000 (+) component5/message_count_=15 
 buf[4] AE @5000 (+) component5/message_count_=16 
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/2 Thread:0/1 (Triggered)
@@ -419,33 +401,14 @@ Simulation is complete, simulated time: 0 s
    StopAction to be delivered at 10000000
    StopAction to be delivered at 18446744073709551615
 ---- Components: ----
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle6000: SamplesLost=0: component8/message_count_=24 
 set component8/my_id_ 50
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=29 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=31 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
 15 received 28 messages
 14 received 35 messages
 13 received 34 messages

--- a/tests/refFiles/test_DebugConsole_r2_rankserial1.out
+++ b/tests/refFiles/test_DebugConsole_r2_rankserial1.out
@@ -73,29 +73,6 @@ Added watchpoint #1
 > setHandler 1 ae
 WP 1 - component2/message_count_
 > run 1ps
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/2 Thread:0/1 (Triggered)
@@ -135,8 +112,6 @@ Added watchpoint #2
 > setHandler 2 ae
 WP 2 - component5/message_count_
 > run 2000ps
-    Invoke Action
-    Set Buffer Reset
 TriggerCount=5
 LastTriggerRecord:@cycle4000: SamplesLost=0: component5/message_count_=13 
 buf[0] AE @3000 (!) component5/message_count_=9 
@@ -144,8 +119,6 @@ buf[1] AE @3000 (+) component5/message_count_=10
 buf[2] AE @3000 (+) component5/message_count_=11 
 buf[3] AE @4000 (+) component5/message_count_=12 
 buf[4] AE @4000 (+) component5/message_count_=13 
-    Reset Trace Buffer
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/2 Thread:0/1 (Triggered)
@@ -472,37 +445,14 @@ Simulation is complete, simulated time: 0 s
    StopAction to be delivered at 10000000
    StopAction to be delivered at 18446744073709551615
 ---- Components: ----
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle5000: SamplesLost=0: component8/message_count_=21 
 set component8/my_id_ 50
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=29 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=31 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
 15 received 28 messages
 14 received 35 messages
 13 received 34 messages

--- a/tests/refFiles/test_DebugConsole_r4_rankserial0.out
+++ b/tests/refFiles/test_DebugConsole_r4_rankserial0.out
@@ -1,5 +1,3 @@
-    Invoke Action
-    Set Buffer Reset
 TriggerCount=5
 LastTriggerRecord:@cycle5000: SamplesLost=0: component5/message_count_=16 
 buf[0] AE @4000 (!) component5/message_count_=12 
@@ -7,26 +5,12 @@ buf[1] AE @4000 (+) component5/message_count_=13
 buf[2] AE @4000 (+) component5/message_count_=14 
 buf[3] AE @5000 (+) component5/message_count_=15 
 buf[4] AE @5000 (+) component5/message_count_=16 
-    Reset Trace Buffer
 7 received 25 messages
 6 received 31 messages
 5 received 28 messages
 4 received 28 messages
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle6000: SamplesLost=0: component8/message_count_=24 
 set component8/my_id_ 50
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
 11 received 34 messages
 10 received 40 messages
 9 received 39 messages
@@ -152,21 +136,6 @@ Added watchpoint #1
 > setHandler 1 ae
 WP 1 - component2/message_count_
 > run 1ps
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/4 Thread:0/1 (Triggered)
@@ -447,18 +416,12 @@ Simulation is complete, simulated time: 0 s
    StopAction to be delivered at 10000000
    StopAction to be delivered at 18446744073709551615
 ---- Components: ----
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=29 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=31 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
 15 received 28 messages
 14 received 35 messages
 13 received 34 messages

--- a/tests/refFiles/test_DebugConsole_r4_rankserial1.out
+++ b/tests/refFiles/test_DebugConsole_r4_rankserial1.out
@@ -1,28 +1,9 @@
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle5000: SamplesLost=0: component8/message_count_=21 
 set component8/my_id_ 50
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
 11 received 34 messages
 10 received 40 messages
 9 received 39 messages
 50 received 31 messages
-    Invoke Action
-    Set Buffer Reset
 TriggerCount=5
 LastTriggerRecord:@cycle4000: SamplesLost=0: component5/message_count_=13 
 buf[0] AE @3000 (!) component5/message_count_=9 
@@ -30,24 +11,16 @@ buf[1] AE @3000 (+) component5/message_count_=10
 buf[2] AE @3000 (+) component5/message_count_=11 
 buf[3] AE @4000 (+) component5/message_count_=12 
 buf[4] AE @4000 (+) component5/message_count_=13 
-    Reset Trace Buffer
-    Reset Trace Buffer
 7 received 25 messages
 6 received 31 messages
 5 received 28 messages
 4 received 28 messages
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=29 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=31 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
 15 received 28 messages
 14 received 35 messages
 13 received 34 messages
@@ -141,29 +114,6 @@ Added watchpoint #1
 > setHandler 1 ae
 WP 1 - component2/message_count_
 > run 1ps
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/4 Thread:0/1 (Triggered)

--- a/tests/refFiles/test_DebugConsole_rankparallel0.out
+++ b/tests/refFiles/test_DebugConsole_rankparallel0.out
@@ -119,21 +119,6 @@ Added watchpoint #1
 > setHandler 1 ae
 WP 1 - component2/message_count_
 > run 1ps
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/2 Thread:0/2 (Triggered)
@@ -184,8 +169,6 @@ Added watchpoint #0
 > setHandler 0 ae
 WP 0 - component5/message_count_
 > run 2000ps
-    Invoke Action
-    Set Buffer Reset
 TriggerCount=5
 LastTriggerRecord:@cycle5000: SamplesLost=0: component5/message_count_=16 
 buf[0] AE @4000 (!) component5/message_count_=12 
@@ -193,7 +176,6 @@ buf[1] AE @4000 (+) component5/message_count_=13
 buf[2] AE @4000 (+) component5/message_count_=14 
 buf[3] AE @5000 (+) component5/message_count_=15 
 buf[4] AE @5000 (+) component5/message_count_=16 
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/2 Thread:0/2 (Triggered)
@@ -431,33 +413,14 @@ Simulation is complete, simulated time: 0 s
    StopAction to be delivered at 10000000
    StopAction to be delivered at 18446744073709551615
 ---- Components: ----
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle6000: SamplesLost=0: component8/message_count_=24 
 set component8/my_id_ 50
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=29 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=31 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
 15 received 28 messages
 14 received 35 messages
 13 received 34 messages

--- a/tests/refFiles/test_DebugConsole_rankparallel1.out
+++ b/tests/refFiles/test_DebugConsole_rankparallel1.out
@@ -1,34 +1,11 @@
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle5000: SamplesLost=0: component8/message_count_=21 
 set component8/my_id_ 50
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=29 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=31 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
 15 received 28 messages
 14 received 35 messages
 13 received 34 messages
@@ -126,29 +103,6 @@ Added watchpoint #1
 > setHandler 1 ae
 WP 1 - component2/message_count_
 > run 1ps
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/2 Thread:0/2 (Triggered)
@@ -199,8 +153,6 @@ Added watchpoint #0
 > setHandler 0 ae
 WP 0 - component5/message_count_
 > run 2000ps
-    Invoke Action
-    Set Buffer Reset
 TriggerCount=5
 LastTriggerRecord:@cycle4000: SamplesLost=0: component5/message_count_=13 
 buf[0] AE @3000 (!) component5/message_count_=9 
@@ -208,8 +160,6 @@ buf[1] AE @3000 (+) component5/message_count_=10
 buf[2] AE @3000 (+) component5/message_count_=11 
 buf[3] AE @4000 (+) component5/message_count_=12 
 buf[4] AE @4000 (+) component5/message_count_=13 
-    Reset Trace Buffer
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/2 Thread:0/2 (Triggered)

--- a/tests/refFiles/test_DebugConsole_rankserial0.out
+++ b/tests/refFiles/test_DebugConsole_rankserial0.out
@@ -1,5 +1,3 @@
-    Invoke Action
-    Set Buffer Reset
 TriggerCount=5
 LastTriggerRecord:@cycle5000: SamplesLost=0: component5/message_count_=16 
 buf[0] AE @4000 (!) component5/message_count_=12 
@@ -7,26 +5,12 @@ buf[1] AE @4000 (+) component5/message_count_=13
 buf[2] AE @4000 (+) component5/message_count_=14 
 buf[3] AE @5000 (+) component5/message_count_=15 
 buf[4] AE @5000 (+) component5/message_count_=16 
-    Reset Trace Buffer
 7 received 25 messages
 6 received 31 messages
 5 received 28 messages
 4 received 28 messages
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle6000: SamplesLost=0: component8/message_count_=24 
 set component8/my_id_ 50
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
 11 received 34 messages
 10 received 40 messages
 9 received 39 messages
@@ -152,21 +136,6 @@ Added watchpoint #1
 > setHandler 1 ae
 WP 1 - component2/message_count_
 > run 1ps
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/4 Thread:0/1 (Triggered)
@@ -447,18 +416,12 @@ Simulation is complete, simulated time: 0 s
    StopAction to be delivered at 10000000
    StopAction to be delivered at 18446744073709551615
 ---- Components: ----
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=29 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=31 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
 15 received 28 messages
 14 received 35 messages
 13 received 34 messages

--- a/tests/refFiles/test_DebugConsole_rankserial1.out
+++ b/tests/refFiles/test_DebugConsole_rankserial1.out
@@ -1,28 +1,9 @@
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle5000: SamplesLost=0: component8/message_count_=21 
 set component8/my_id_ 50
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
 11 received 34 messages
 10 received 40 messages
 9 received 39 messages
 50 received 31 messages
-    Invoke Action
-    Set Buffer Reset
 TriggerCount=5
 LastTriggerRecord:@cycle4000: SamplesLost=0: component5/message_count_=13 
 buf[0] AE @3000 (!) component5/message_count_=9 
@@ -30,24 +11,16 @@ buf[1] AE @3000 (+) component5/message_count_=10
 buf[2] AE @3000 (+) component5/message_count_=11 
 buf[3] AE @4000 (+) component5/message_count_=12 
 buf[4] AE @4000 (+) component5/message_count_=13 
-    Reset Trace Buffer
-    Reset Trace Buffer
 7 received 25 messages
 6 received 31 messages
 5 received 28 messages
 4 received 28 messages
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=29 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=31 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
 15 received 28 messages
 14 received 35 messages
 13 received 34 messages
@@ -141,29 +114,6 @@ Added watchpoint #1
 > setHandler 1 ae
 WP 1 - component2/message_count_
 > run 1ps
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/4 Thread:0/1 (Triggered)

--- a/tests/refFiles/test_DebugConsole_serial0.out
+++ b/tests/refFiles/test_DebugConsole_serial0.out
@@ -301,21 +301,6 @@ WP 1 - component2/message_count_
    StopAction to be delivered at 10000000
    StopAction to be delivered at 18446744073709551615
 ---- Components: ----
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
 ---- Rank0:Thread0: Entering interactive mode at time 1001
 Ran clock for 1 sim cycles
 > wl
@@ -344,11 +329,8 @@ Added watchpoint #3
 > setHandler 3 ae
 WP 3 - component6/message_count_
 > run 1000ps
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle3000: SamplesLost=0: component6/message_count_=13 
 set component6/my_id_ 50
-    Reset Trace Buffer
 ---- Rank0:Thread0: Entering interactive mode at time 3001
 Ran clock for 1000 sim cycles
 > wl
@@ -364,8 +346,6 @@ Added watchpoint #4
 > setHandler 4 ae
 WP 4 - component10/message_count_
 > run
-    Invoke Action
-    Set Buffer Reset
 ---- Rank0:Thread0: Entering interactive mode at time 4000
   Last Trigger: WP4: AE : component10/message_count_ ...
 > wl
@@ -378,8 +358,6 @@ R0,T0: Current watch points:
 > trace message_count_ changed : 16 2 : message_count_ : shutdown
 Added watchpoint #5
 > run
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle4000: SamplesLost=0: component12/message_count_=14 
   Trigger action shutting down simulation
 wp simulation shutdown

--- a/tests/refFiles/test_DebugConsole_serial1.out
+++ b/tests/refFiles/test_DebugConsole_serial1.out
@@ -298,21 +298,6 @@ WP 1 - component2/message_count_
    StopAction to be delivered at 10000000
    StopAction to be delivered at 18446744073709551615
 ---- Components: ----
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
 ---- Rank0:Thread0: Entering interactive mode at time 1001
 Ran clock for 1 sim cycles
 > wl
@@ -341,11 +326,8 @@ Added watchpoint #3
 > setHandler 3 ae
 WP 3 - component6/message_count_
 > run 1000ps
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle3000: SamplesLost=0: component6/message_count_=13 
 set component6/my_id_ 50
-    Reset Trace Buffer
 ---- Rank0:Thread0: Entering interactive mode at time 3001
 Ran clock for 1000 sim cycles
 > wl
@@ -361,8 +343,6 @@ Added watchpoint #4
 > setHandler 4 ae
 WP 4 - component10/message_count_
 > run
-    Invoke Action
-    Set Buffer Reset
 ---- Rank0:Thread0: Entering interactive mode at time 4000
   Last Trigger: WP4: AE : component10/message_count_ ...
 > wl
@@ -375,8 +355,6 @@ R0,T0: Current watch points:
 > trace message_count_ changed : 16 2 : message_count_ : shutdown
 Added watchpoint #5
 > run
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle4000: SamplesLost=0: component12/message_count_=14 
   Trigger action shutting down simulation
 wp simulation shutdown

--- a/tests/refFiles/test_DebugConsole_thread0.out
+++ b/tests/refFiles/test_DebugConsole_thread0.out
@@ -219,29 +219,6 @@ WP 1 - component2/message_count_
    StopAction to be delivered at 10000000
    StopAction to be delivered at 18446744073709551615
 ---- Components: ----
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/1 Thread:0/4 (Triggered)
@@ -292,8 +269,6 @@ Added watchpoint #0
 > setHandler 0 ae
 WP 0 - component5/message_count_
 > run 2000ps
-    Invoke Action
-    Set Buffer Reset
 TriggerCount=6
 LastTriggerRecord:@cycle4000: SamplesLost=0: component5/message_count_=14 
 buf[0] AE @3000 (!) component5/message_count_=9 
@@ -302,7 +277,6 @@ buf[2] AE @3000 (+) component5/message_count_=11
 buf[3] AE @4000 (+) component5/message_count_=12 
 buf[4] AE @4000 (+) component5/message_count_=13 
 buf[5] AE @4000 (+) component5/message_count_=14 
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/1 Thread:0/4 (Triggered)
@@ -352,11 +326,8 @@ Added watchpoint #0
 > setHandler 0 ae
 WP 0 - component8/message_count_
 > run 1000ps
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle5000: SamplesLost=0: component8/message_count_=21 
 set component8/my_id_ 50
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/1 Thread:0/4 (Triggered)
@@ -405,20 +376,6 @@ Added watchpoint #1
 > setHandler 1 ae
 WP 1 - component10/message_count_
 > run
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
 
 INTERACTIVE CONSOLE
 -- Rank:0/1 Thread:0/4 (Not Triggered)
@@ -467,18 +424,12 @@ Interactive start at 0
 > trace message_count_ changed : 16 2 : message_count_ : shutdown
 Added watchpoint #0
 > run
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=29 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=31 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
 7 received 25 messages
 11 received 34 messages
 10 received 40 messages

--- a/tests/refFiles/test_DebugConsole_thread1.out
+++ b/tests/refFiles/test_DebugConsole_thread1.out
@@ -186,29 +186,6 @@ WP 1 - component2/message_count_
    StopAction to be delivered at 10000000
    StopAction to be delivered at 18446744073709551615
 ---- Components: ----
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/1 Thread:0/4 (Triggered)
@@ -259,8 +236,6 @@ Added watchpoint #0
 > setHandler 0 ae
 WP 0 - component5/message_count_
 > run 2000ps
-    Invoke Action
-    Set Buffer Reset
 TriggerCount=6
 LastTriggerRecord:@cycle4000: SamplesLost=0: component5/message_count_=14 
 buf[0] AE @3000 (!) component5/message_count_=9 
@@ -269,7 +244,6 @@ buf[2] AE @3000 (+) component5/message_count_=11
 buf[3] AE @4000 (+) component5/message_count_=12 
 buf[4] AE @4000 (+) component5/message_count_=13 
 buf[5] AE @4000 (+) component5/message_count_=14 
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/1 Thread:0/4 (Triggered)
@@ -319,11 +293,8 @@ Added watchpoint #0
 > setHandler 0 ae
 WP 0 - component8/message_count_
 > run 1000ps
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle5000: SamplesLost=0: component8/message_count_=21 
 set component8/my_id_ 50
-    Reset Trace Buffer
 
 INTERACTIVE CONSOLE
 -- Rank:0/1 Thread:0/4 (Triggered)
@@ -372,20 +343,6 @@ Added watchpoint #1
 > setHandler 1 ae
 WP 1 - component10/message_count_
 > run
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
-    Invoke Action
-    Set Buffer Reset
 
 INTERACTIVE CONSOLE
 -- Rank:0/1 Thread:0/4 (Not Triggered)
@@ -434,18 +391,12 @@ Interactive start at 1
 > trace message_count_ changed : 16 2 : message_count_ : shutdown
 Added watchpoint #0
 > run
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=29 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
-    Invoke Action
-    Set Buffer Reset
 LastTriggerRecord:@cycle8000: SamplesLost=0: component12/message_count_=31 
   Trigger action shutting down simulation
 wp simulation shutdown
-    Reset Trace Buffer
 7 received 25 messages
 11 received 34 messages
 15 received 28 messages


### PR DESCRIPTION
Fixes an issue where the trace buffer continues to sample until the sync rather than stopping after postDelay samples. Also cleans up unnecessary output around the triggers and updates the tests to remove the extraneous prints. 
