### PR TITLE
Update checkValue to assign to temporary value

### DIFF
--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -1253,7 +1253,9 @@ public:
     bool checkValue(const std::string& value) const override
     {
         try {
-            *addr_ = SST::Core::from_string<T>(value);
+            [[maybe_unused]]
+            decltype(SST::Core::from_string<T>(value)) v;
+            v = SST::Core::from_string<T>(value);
             return true;
         }
         catch ( const std::exception& e ) {


### PR DESCRIPTION
The checkValue function was meant to catch errors and avoid a seg fault for bad variables. It was erroneously updating the trace variable instead of just checking it. This changes uses a temporary value to avoid the assignment. 