### PR TITLE
Fix issue with set variable action in trace command

### DIFF
--- a/src/sst/core/impl/interactive/debugConsole.cc
+++ b/src/sst/core/impl/interactive/debugConsole.cc
@@ -4753,7 +4753,7 @@ DebugConsole::executeRankParallel(const std::string& UNUSED_WO_MPI(msg))
 
         // Set done in local rank threads
         tokens.clear();
-        tokens[0] = "done";
+        tokens.push_back("done");
         handleCommand();
 
         // Send done to remote ranks

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -1254,8 +1254,7 @@ public:
     {
         try {
             [[maybe_unused]]
-            decltype(SST::Core::from_string<T>(value)) v;
-            v = SST::Core::from_string<T>(value);
+            T v = SST::Core::from_string<T>(value);
             return true;
         }
         catch ( const std::exception& e ) {

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -1253,7 +1253,9 @@ public:
     bool checkValue(const std::string& value) const override
     {
         try {
-            *addr_ = SST::Core::from_string<T>(value);
+            [[maybe_unused]]
+            decltype(SST::Core::from_string<T>(value)) v;
+            v = SST::Core::from_string<T>(value);
             return true;
         }
         catch ( const std::exception& e ) {


### PR DESCRIPTION
Issue: When using the 'set variable' action in a trace command, the variable was erroneously being set during trace creation instead of waiting until a trigger. 

The checkValue function (called when setting up a trace command with a 'set variable' action) was meant to catch errors and avoid a seg fault for invalid variables. It was erroneously updating the trace variable instead of just checking it. This changes the function to use a temporary value to avoid the assignment.