### PR TITLE
perfReporter address sanitizer fix

### DIFF
--- a/src/sst/core/util/perfReporter.cc
+++ b/src/sst/core/util/perfReporter.cc
@@ -327,8 +327,9 @@ PerfReporter::output(int rank, int num_ranks)
             // Get record name
             int length = 0;
             SST_MPI_Bcast(&length, 1, MPI_INT, 0, MPI_COMM_WORLD);
-            char* name = new char[length];
-            SST_MPI_Bcast(name, length, MPI_CHAR, 0, MPI_COMM_WORLD);
+            std::string name;
+            name.resize(length);
+            SST_MPI_Bcast(&name[0], length, MPI_CHAR, 0, MPI_COMM_WORLD);
 
             // Lookup record
             auto record = records_.find(name);
@@ -382,7 +383,6 @@ PerfReporter::output(int rank, int num_ranks)
                     SST_MPI_Send(send_str.data(), length, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
                 }
             }
-            delete[] name;
         }
     }
 }


### PR DESCRIPTION

**Overview**

This PR fixes a memory error detected when generating timing information with an MPI run.

The command line options used:
```mpirun -np 2 --bind-to socket sst  --print-timing-info=4 --profiling-output=timing.json <SDL>```

Compile/run-time: 
```
CXXFLAGS+="-fsanitize=address -fno-omit-frame-pointer"
ASAN_OPTIONS=detect_leaks=0
```
I don't think the SDL matters but can provide if needed.

**The Failure**

```
==795570==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x50200007a698 at pc 0x7c3f6267d96f bp 0x7ffe075571e0 sp 0x7ffe07556988
READ of size 9 at 0x50200007a698 thread T0
```

This is detected at 
`  SST::Util::PerfReporter::output(int, int) ../../../../src/sst/core/util/perfReporter.cc:334`

```
    else { // Not rank 0
        // All other ranks generate output strings for the currently-parsing record
        for ( uint32_t count = 0; count < record_count; count++ ) {
            // Get record name
            int length = 0;
            SST_MPI_Bcast(&length, 1, MPI_INT, 0, MPI_COMM_WORLD);
            char* name = new char[length];
            SST_MPI_Bcast(name, length, MPI_CHAR, 0, MPI_COMM_WORLD);

            // Lookup record
            auto record = records_.find(name);  <-- HERE
```

To eliminate this error, I used a sized std::string on the stack rather than create a char array on the heap.






