### PR TITLE
Added registerOrderedClock() to BaseComponent API

### DIFF
--- a/src/sst/core/baseComponent.cc
+++ b/src/sst/core/baseComponent.cc
@@ -381,7 +381,7 @@ BaseComponent::configureSelfLink(const std::string& name, Event::HandlerBase* ha
 TimeConverter
 BaseComponent::registerClock(TimeConverter tc, Clock::HandlerBase* handler, bool reg_all)
 {
-    registerClock_impl(tc, handler, reg_all);
+    registerClock_impl(tc, handler, reg_all, false);
     return tc;
 }
 
@@ -491,22 +491,33 @@ BaseComponent::serialize_order(SST::Core::Serialization::serializer& ser)
     }
 }
 
+void
+BaseComponent::serialize_final(SST::Core::Serialization::serializer& UNUSED(ser))
+{
+    // Nothing to do in the default case
+}
 
 void
-BaseComponent::registerClock_impl(TimeConverter tc, Clock::HandlerBase* handler, bool reg_all)
+BaseComponent::registerClock_impl(TimeConverter tc, Clock::HandlerBase* handler, bool reg_all, bool group)
 {
 
-    sim_->registerClock(tc, handler, CLOCKPRIORITY);
-
-    // Need to see if I already know about this clock handler
-    bool found = false;
-    for ( auto* x : clock_handlers_ ) {
-        if ( handler == x ) {
-            found = true;
-            break;
-        }
+    if ( group ) {
+        Clock::Group* group = getClockGroup(tc);
+        group->registerHandler(handler);
     }
-    if ( !found ) clock_handlers_.push_back(handler);
+    else {
+        sim_->registerClock(tc, handler, CLOCKPRIORITY);
+
+        // Need to see if I already know about this clock handler
+        bool found = false;
+        for ( auto* x : clock_handlers_ ) {
+            if ( handler == x ) {
+                found = true;
+                break;
+            }
+        }
+        if ( !found ) clock_handlers_.push_back(handler);
+    }
 
     // Check to see if there is a profile tool installed
     auto tools = sim_->getProfileTool<Profile::ClockHandlerProfileTool>("clock");
@@ -862,7 +873,7 @@ BaseComponent::registerAsPrimaryComponent()
     if ( sim_->isWireUpFinished() ) {
         // Error, called after construct phase
         sim_->getSimulationOutput().fatal(
-            CALL_INFO, 1, "ERROR: registerAsPrimaryComponent() must be called during ComponentConstruction\n");
+            CALL_INFO, 1, "ERROR: registerAsPrimaryComponent() must be called during Component construction\n");
     }
     else if ( !isStatePrimary() ) {
         setStateAsPrimary();

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -60,6 +60,7 @@ namespace Core::Serialization::pvt {
 class SerializeBaseComponentHelper;
 }
 
+
 /**
  * Main component object for the simulation.
  */

--- a/src/sst/core/baseComponent.h
+++ b/src/sst/core/baseComponent.h
@@ -339,6 +339,13 @@ private:
     */
     void removeWatchPointRecursive(WatchPoint* pt);
 
+    /**
+       This function is called by ComponentInfo after all SubComponents have been serialized.  Currently only Component
+       uses this functionality to make sure SubComponents are serialized before serializing any ordered clock handlers.
+    */
+    virtual void serialize_final(SST::Core::Serialization::serializer& ser);
+
+
 protected:
     /**
        Check to see if the run mode was set to INIT
@@ -505,13 +512,16 @@ protected:
 
        @param obj Pointer to object that the handler function should be called on
 
+       @param reg_all Should this clock period be used as the default timebase for all of the links connected to this
+       component
+
        @return The Clock::Handler object that encapsulates the function and object pointer
     */
     template <typename classT, auto funcT>
     Clock::HandlerBase* registerClock(TimeConverter tc, classT* obj, bool reg_all = true)
     {
         auto* handler = new Clock::Handler<classT, funcT, void>(obj);
-        registerClock_impl(tc, handler, reg_all);
+        registerClock_impl(tc, handler, reg_all, false);
         return handler;
     }
 
@@ -530,13 +540,77 @@ protected:
 
        @param obj Pointer to object that the handler function should be called on
 
+       @param metadata Metadata to associate with the handler
+
+       @param reg_all Should this clock period be used as the default timebase for all of the links connected to this
+       component
+
        @return The Clock::Handler object that encapsulates the function and object pointer
     */
     template <typename classT, auto funcT, typename dataT>
     Clock::HandlerBase* registerClock(TimeConverter tc, classT* obj, dataT metadata, bool reg_all = true)
     {
         auto* handler = new Clock::Handler<classT, funcT, dataT>(obj, metadata);
-        registerClock_impl(tc, handler, reg_all);
+        registerClock_impl(tc, handler, reg_all, false);
+        return handler;
+    }
+
+
+    /**
+       Registers an ordered clock handler for this component. Active handlers registered with this function are
+       guaranteed to always fire in the order they were registered, for a given clock frequency.
+
+       @tparam classT Class that the callback function lives in
+
+       @tparam funcT Function that should be called by the Clock::Handler. Must be a member of classT and specified as
+       &<classT>::<name_of_function>.
+
+       @param tc TimeConverter object specifying the clock frequency.  May be specified as a TimeConverter, std::string
+       or UnitAlgebra
+
+       @param obj Pointer to object that the handler function should be called on
+
+       @param reg_all Should this clock period be used as the default timebase for all of the links connected to this
+       component
+
+       @return The Clock::Handler object that encapsulates the function and object pointer
+    */
+    template <typename classT, auto funcT>
+    Clock::HandlerBase* registerOrderedClock(TimeConverter tc, classT* obj, bool reg_all = true)
+    {
+        auto* handler = new Clock::Handler<classT, funcT, void>(obj);
+        registerClock_impl(tc, handler, reg_all, true);
+        return handler;
+    }
+
+    /**
+       Registers an ordered clock handler for this component. Active handlers registered with this function are
+       guaranteed to always fire in the order they were registered, for a given clock frequency.
+
+       @tparam classT Class that the callback function lives in
+
+       @tparam funcT Function that should be called by the Clock::Handler. Must be a member of classT and specified as
+       &<classT>::<name_of_function>.
+
+       @tparam dataT Type of metadata to be passed to the handler function
+
+       @param tc TimeConverter object specifying the clock frequency.  May be specified as a TimeConverter, std::string
+       or UnitAlgebra
+
+       @param obj Pointer to object that the handler function should be called on
+
+       @param metadata Metadata to associate with the handler
+
+       @param reg_all Should this clock period be used as the default timebase for all of the links connected to this
+       component
+
+       @return The Clock::Handler object that encapsulates the function and object pointer
+    */
+    template <typename classT, auto funcT, typename dataT>
+    Clock::HandlerBase* registerOrderedClock(TimeConverter tc, classT* obj, dataT metadata, bool reg_all = true)
+    {
+        auto* handler = new Clock::Handler<classT, funcT, dataT>(obj, metadata);
+        registerClock_impl(tc, handler, reg_all, true);
         return handler;
     }
 
@@ -605,8 +679,10 @@ private:
 
        @param reg_all Should this clock period be used as the default timebase for all of the links connected to this
        component
+
+       @param group Whether or not this clock is being registered with a group (i.e. is an ordered clock)
     */
-    void registerClock_impl(TimeConverter tc, Clock::HandlerBase* handler, bool reg_all);
+    void registerClock_impl(TimeConverter tc, Clock::HandlerBase* handler, bool reg_all, bool group = false);
 
     /**
         Handles default timebase setup
@@ -1345,6 +1421,8 @@ private:
         }
         return base_info->component;
     }
+
+    virtual Clock::Group* getClockGroup(TimeConverter tc) { return getParentComponent()->getClockGroup(tc); }
 };
 
 /**

--- a/src/sst/core/clock.cc
+++ b/src/sst/core/clock.cc
@@ -21,11 +21,170 @@
 
 namespace SST {
 
+void
+Clock::Group::registerHandler(HandlerBase* handler)
+{
+    bool currently_inactive = (inactive_start_ == 0);
+    handler->order_         = handler_count_++;
+    handler->group_         = this;
+
+    // Put handler at end of list, then swap to active region if necessary
+    int32_t end_index = (int32_t)handlers_.size();
+    handler->index_   = end_index;
+    handlers_.push_back(handler);
+
+    if ( inactive_start_ != end_index ) {
+        // Need to swap this to the active region (i.e. to inactive_start_)
+        swapActiveWithInactive(handlers_[end_index], handlers_[inactive_start_]);
+    }
+
+    // Increment inactive_start_
+    ++inactive_start_;
+
+    if ( currently_inactive ) clock_->activateGroup(this);
+}
+
+void
+Clock::Group::activateHandler(HandlerBase* handler)
+{
+    // Check to see if it's already active
+    if ( handler->index_ >= 0 ) return;
+
+    bool currently_inactive = (inactive_start_ == 0);
+
+    // Get the actual index of the inactive handler
+    int32_t index = -1 - handler->index_;
+
+    // We will just swap the handler at inactive_start_ with this handler, then we don't need to move as much stuff
+    // around
+    if ( index != inactive_start_ ) {
+        swapSameActiveState(handlers_[index], handlers_[inactive_start_]);
+    }
+
+    // Mark this as active
+    handler->toggleActiveState();
+
+    // Now we need to move down all the active handlers until we find where we belong based on order
+    index = inactive_start_;
+
+    // Increment inactive_start_ since we have another active handler
+    ++inactive_start_;
+
+    while ( index > 0 ) {
+        if ( handlers_[index - 1]->order_ < handler->order_ ) {
+            // Found where this goes
+            break;
+        }
+        handlers_[index]         = handlers_[index - 1];
+        handlers_[index]->index_ = index;
+        --index;
+    }
+
+    handlers_[index] = handler;
+    handler->index_  = index;
+
+    if ( currently_inactive ) clock_->activateGroup(this);
+}
+
+void
+Clock::Group::deactivateHandler(HandlerBase* handler)
+{
+    // Check to see if this is currently inactive
+    if ( handler->index_ < 0 ) return;
+
+    // We need to move the handler below inactive_start_ and move everything up to that point up one space
+    --inactive_start_;
+    for ( int i = handler->index_; i < inactive_start_; ++i ) {
+        handlers_[i]         = handlers_[i + 1];
+        handlers_[i]->index_ = i;
+    }
+    handler->index_ = inactive_start_;
+    handler->toggleActiveState();
+    handlers_[inactive_start_] = handler;
+
+    // No need to check to deactivate group as it will do it automatically on the next call to execute(). The only
+    // oddity would be if a handler gets reactivated before the next call to execute(), in which case it will activate
+    // the group even though it is already active.  This will end up being a no-op
+}
+
+bool
+Clock::Group::execute(Cycle_t current_cycle)
+{
+    int32_t call_index = 0;
+    for ( ; call_index < inactive_start_; ++call_index ) {
+        HandlerBase* handler = handlers_[call_index];
+        if ( (*handler)(current_cycle) ) {
+            handler->toggleActiveState();
+            // Just break here. This will break us into the compacting version of the iteration in the loop below
+            break;
+        }
+    }
+
+    // Check to see if it finished all the handlers without any of them removing themselves.  As soon as the first
+    // handler removes itself, we drop out of the original loop and enter this one that will compact the rest of the
+    // entries then, then reset inactive_start_ to the appropriate place. This gets rid of the need to constantly delete
+    // individual elements, doing multiple memcpy's of all entries below. This also allows us to update the index for
+    // each handler.
+
+    int32_t copy_index = call_index;
+
+    // Need to increment call_index for the case where we broke out of the upper loop before completing.  If it did
+    // complete, then incrementing it won't hurt anything and the next loop will just be skipped.  It will also be
+    // skipped if the break was on the last entry in the vector
+    for ( ++call_index; call_index < inactive_start_; ++call_index ) {
+        HandlerBase* handler = handlers_[call_index];
+        if ( (*handler)(current_cycle) ) {
+            // Just mark it as inactive and continue on
+            handler->toggleActiveState();
+        }
+        else {
+            // Need to swap this with the handler at copy_index and increment copy_index.  For the swap, the current
+            // handler is active and the one at copy_index is inactive, by construction
+            swapActiveWithInactive(handlers_[call_index], handlers_[copy_index]);
+            ++copy_index;
+        }
+    }
+
+    // inactive_start_ is now at copy_index
+    inactive_start_ = copy_index;
+
+    if ( inactive_start_ == 0 ) {
+        return true; // No active handlers
+    }
+    return false;
+}
+
+void
+Clock::Group::activateOnRestart()
+{
+    // Reset all the pointers to the group
+    for ( size_t x = 0; x < handlers_.size(); ++x ) {
+        handlers_[x]->group_ = this;
+    }
+    if ( inactive_start_ == 0 ) return;
+    clock_->activateGroup(this);
+}
+
+void
+Clock::Group::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    SST_SER(handlers_);
+    SST_SER(inactive_start_);
+    SST_SER(handler_count_);
+    SST_SER(index_);
+    // clock_ gets set after deserialzation when reregistered with the clock
+}
+
+Clock::Clock() :
+    sim_(Simulation::getSimulation())
+{}
+
 Clock::Clock(TimeConverter period, int priority) :
     Action(),
     current_cycle_(0),
     period_(period),
-    scheduled_(false)
+    scheduled_(false),
+    sim_(Simulation::getSimulation())
 {
     setPriority(priority);
 }
@@ -62,8 +221,9 @@ Clock::registerHandler(Clock::HandlerBase* handler)
             "WARNING: Register Clock::Handler that is already active.  Handler will not be registered again.\n");
         return;
     }
-    handler->markAsActive(static_handler_map_.size());
-    static_handler_map_.push_back(handler);
+    handler->markAsActive();
+    handler->index_ = handlers_.size();
+    handlers_.push_back(handler);
 
     if ( !scheduled_ ) {
         schedule();
@@ -73,20 +233,19 @@ Clock::registerHandler(Clock::HandlerBase* handler)
 bool
 Clock::unregisterHandler(Clock::HandlerBase* handler, bool& empty)
 {
-    if ( handler->active_ ) {
+    if ( handler->isActive() ) {
         // Need to get index before marking it as inactive, which sets index to -1
         int  index = handler->index_;
-        auto iter  = static_handler_map_.begin() + index;
-        iter       = static_handler_map_.erase(iter);
+        auto iter  = handlers_.begin() + index;
+        iter       = handlers_.erase(iter);
         handler->markAsInactive();
 
         // Need to update the index for every handler below this one
-        for ( ; iter != static_handler_map_.end(); ++iter ) {
+        for ( ; iter != handlers_.end(); ++iter ) {
             (*iter)->index_ = index++;
         }
     }
-
-    empty = static_handler_map_.empty();
+    empty = handlers_.empty();
 
     return 0;
 }
@@ -95,10 +254,10 @@ void
 Clock::registerHandler_restart(Clock::HandlerBase* handler)
 {
     handler->clock_ = this;
-    if ( !handler->active_ ) return;
+    if ( !handler->isActive() ) return;
 
-    handler->index_ = static_handler_map_.size();
-    static_handler_map_.push_back(handler);
+    handler->index_ = handlers_.size();
+    handlers_.push_back(handler);
 
     if ( !scheduled_ ) {
         schedule();
@@ -108,13 +267,40 @@ Clock::registerHandler_restart(Clock::HandlerBase* handler)
 bool
 Clock::isHandlerRegistered(Clock::HandlerBase* handler)
 {
-    for ( auto* h : static_handler_map_ ) {
+    for ( auto* h : handlers_ ) {
         if ( h == handler ) return true;
     }
 
     return false;
 }
 
+void
+Clock::registerGroup(Clock::Group* group)
+{
+    group->clock_ = this;
+    group->index_ = groups_.size();
+
+    // Groups start life inactive, so just put at the end of the vector
+    groups_.push_back(group);
+}
+
+void
+Clock::activateGroup(Clock::Group* group)
+{
+    // Check to see if it's already active
+    if ( group->index_ < groups_inactive_start_ ) return;
+
+    // Just swap it with the group at groups_inactive_start_, if necessary, and increment groups_inactive_start_
+    if ( group->index_ != groups_inactive_start_ ) {
+        // Not in the right place, do the swap
+        int32_t index = group->index_;
+        std::swap(groups_[index], groups_[groups_inactive_start_]);
+        groups_[index]->index_                  = index;
+        groups_[groups_inactive_start_]->index_ = groups_inactive_start_;
+    }
+    ++groups_inactive_start_;
+    if ( !scheduled_ ) schedule();
+}
 
 Cycle_t
 Clock::getNextCycle()
@@ -127,9 +313,7 @@ Clock::getNextCycle()
 void
 Clock::execute()
 {
-    Simulation* sim = Simulation::getSimulation();
-
-    if ( static_handler_map_.empty() ) {
+    if ( handlers_.empty() && groups_inactive_start_ == 0 ) {
         scheduled_ = false;
         return;
     }
@@ -137,8 +321,8 @@ Clock::execute()
     // Derive the current cycle from the core time
     current_cycle_++;
 
-    auto sop_iter = static_handler_map_.begin();
-    for ( ; sop_iter != static_handler_map_.end(); ++sop_iter ) {
+    auto sop_iter = handlers_.begin();
+    for ( ; sop_iter != handlers_.end(); ++sop_iter ) {
         Clock::HandlerBase* handler = *sop_iter;
 
         if ( (*handler)(current_cycle_) ) {
@@ -154,13 +338,13 @@ Clock::execute()
     // handler removes itself, we drop out of the original loop and enter this one that will compact the rest of the
     // entries then delete any empty spaces at the end. This gets rid of the need to constantly delete individual
     // elements, doing multiple memcpy's of all entries below. This also allows us to update the index for each handler.
-    if ( sop_iter != static_handler_map_.end() ) {
+    if ( sop_iter != handlers_.end() ) {
         // sop_iter becomes the location to copy to and we will start one past this calling the handler.  Then, we will
         // copy the handler to the copy_iter and update its index.
         auto   copy_iter = sop_iter; // Rename for clarity
-        size_t index     = copy_iter - static_handler_map_.begin();
+        size_t index     = copy_iter - handlers_.begin();
 
-        for ( auto call_iter = sop_iter + 1; call_iter != static_handler_map_.end(); ++call_iter ) {
+        for ( auto call_iter = sop_iter + 1; call_iter != handlers_.end(); ++call_iter ) {
             Clock::HandlerBase* handler = *call_iter;
 
             if ( (*handler)(current_cycle_) ) {
@@ -178,13 +362,36 @@ Clock::execute()
             }
         }
 
-        // Need to remove an empty locations in the vector
-        static_handler_map_.erase(copy_iter, static_handler_map_.end());
+        // Need to remove any empty locations in the vector
+        handlers_.erase(copy_iter, handlers_.end());
+    }
+
+
+    // Now we need to go through all the active groups.  This loop is a bit weird because each iteration through the
+    // loop can do one of too things to the control variables:
+
+    // 1 - increment i if the group does not ask to be removed
+
+    // 2 - decrement groups_inactive_start_ if the group asks to be removed.  This is because the removed group gets
+    // moved to groups_inactive_start_ (after decrementing it) and we need to execute the group that just got moved to
+    // that index
+    for ( int i = 0; i < groups_inactive_start_; /* incremented in loop */ ) {
+        if ( groups_[i]->execute(current_cycle_) ) {
+            // Need to deactivate this group by swapping it below groups_inactive_start_
+            --groups_inactive_start_;
+            if ( i != groups_inactive_start_ ) std::swap(groups_[i], groups_[groups_inactive_start_]);
+            groups_[i]->index_                      = i;
+            groups_[groups_inactive_start_]->index_ = groups_inactive_start_;
+            // Don't increment i because we need to execute the one we just swapped into this position
+        }
+        else {
+            ++i;
+        }
     }
 
     // Compute the next time to fire
-    next_ = sim->getCurrentSimCycle() + period_.getFactor();
-    sim->insertActivity(next_, this);
+    next_ = sim_->getCurrentSimCycle() + period_.getFactor();
+    sim_->insertActivity(next_, this);
 
     return;
 }
@@ -192,9 +399,8 @@ Clock::execute()
 void
 Clock::schedule()
 {
-    Simulation* sim = Simulation::getSimulation();
-    current_cycle_  = sim->getCurrentSimCycle() / period_.getFactor();
-    SimTime_t next  = (current_cycle_ * period_.getFactor()) + period_.getFactor();
+    current_cycle_ = sim_->getCurrentSimCycle() / period_.getFactor();
+    SimTime_t next = (current_cycle_ * period_.getFactor()) + period_.getFactor();
 
     // Check to see if we need to insert clock into queue at current
     // simtime.  This happens if the clock would have fired at this
@@ -202,22 +408,21 @@ Clock::schedule()
     // However, if we are at time = 0, then we always go out to the
     // next cycle. Also, if the call happens during complete() or
     // finish(), then we don't adjust either.
-    if ( sim->getCurrentPriority() < getPriority() && sim->getCurrentSimCycle() != 0 && !sim->endSim ) {
-        if ( sim->getCurrentSimCycle() % period_.getFactor() == 0 ) {
-            next = sim->getCurrentSimCycle();
+    if ( sim_->getCurrentPriority() < getPriority() && sim_->getCurrentSimCycle() != 0 && !sim_->endSim ) {
+        if ( sim_->getCurrentSimCycle() % period_.getFactor() == 0 ) {
+            next = sim_->getCurrentSimCycle();
             current_cycle_--; // First thing execute does in increment current_cycle_
         }
     }
 
-    sim->insertActivity(next, this);
+    sim_->insertActivity(next, this);
     scheduled_ = true;
 }
 
 void
 Clock::updateCurrentCycle()
 {
-    Simulation* sim = Simulation::getSimulation();
-    current_cycle_  = sim->getCurrentSimCycle() / period_.getFactor();
+    current_cycle_ = sim_->getCurrentSimCycle() / period_.getFactor();
     return;
 }
 
@@ -226,7 +431,7 @@ Clock::toString() const
 {
     std::stringstream buf;
     buf << "Clock Activity with period " << period_.getFactor() << " to be delivered at " << getDeliveryTime()
-        << " with priority " << getPriority() << " with " << static_handler_map_.size() << " items on clock list";
+        << " with priority " << getPriority() << " with " << handlers_.size() << " items on clock list";
     return buf.str();
 }
 

--- a/src/sst/core/clock.h
+++ b/src/sst/core/clock.h
@@ -18,6 +18,7 @@
 
 #include <cinttypes>
 #include <string>
+#include <utility>
 #include <vector>
 
 #define _CLE_DBG(fmt, args...) __DBG(DBG_CLOCK, Clock, fmt, ##args)
@@ -25,6 +26,7 @@
 namespace SST {
 
 class BaseComponent;
+class Component;
 class Simulation;
 class TimeConverter;
 
@@ -36,33 +38,24 @@ class TimeConverter;
 class Clock : public Action
 {
 public:
-    /** Create a new clock with a specified period */
-    Clock(TimeConverter period, int priority = CLOCKPRIORITY);
-    ~Clock() = default; // Handlers are owned by BaseComponent and are deleted there
+    class HandlerBase;
 
-
-    /**
-       Base handler for clock functions.
-     */
-
-    /**
-       Base Class for Clock::Handlers.  We need to implement HandlerBase as a class because we need a base class with
-       more functionality than SSTHandlerBase provides. BaseHandler will track the clock that is associated with,
-       whether or not it is active, and an index the Clock object can use to more efficiently remove handlers.
-    */
-    class HandlerBase : public SSTHandlerBase<bool, Cycle_t>
+private:
+    friend class BaseComponent;
+    friend class Component;
+    friend class Simulation;
+    // Clock Group for handling ordered clocks
+    class Group
     {
+        friend class Clock;
+
+        std::vector<HandlerBase*> handlers_;
+        int32_t                   inactive_start_ = 0;
+        int32_t                   handler_count_  = 0;
+        Clock*                    clock_          = nullptr;
+        int32_t                   index_;
+
     public:
-        HandlerBase() = default;
-
-        void serialize_order(SST::Core::Serialization::serializer& ser) override
-        {
-            SSTHandlerBase<bool, Cycle_t>::serialize_order(ser);
-            SST_SER(active_);
-            // No need to serialize clock_ or index_ as they will be initialized on register on restart
-        }
-
-        ImplementVirtualSerializable(HandlerBase);
 
         /**
            Get the period of the associated clock as a SimTime_t in units of the core atomic timebase
@@ -75,9 +68,109 @@ public:
         int getClockPriority() { return clock_->getPriority(); }
 
         /**
+           Get the next cycle for the clock associated with this group
+        */
+        SimTime_t getNextCycle() { return clock_->getNextCycle(); }
+
+        /**
+           Registers a handler with this group and marks it as active.  This function should only be called once when
+           the handler is registered.  To activate or deactivate, call activateHandler()/deactivateHandler().
+        */
+        void registerHandler(HandlerBase* handler);
+
+        /**
+           Activates a handler.
+        */
+        void activateHandler(HandlerBase* handler);
+
+        /**
+           Deactivates a Handler
+        */
+        void deactivateHandler(HandlerBase* handler);
+
+        /**
+           Activates the Group if there are any active handlers
+        */
+        void activateOnRestart();
+
+        /**
+           Call all active handlers
+        */
+        bool execute(Cycle_t current_cycle);
+
+        void serialize_order(SST::Core::Serialization::serializer& ser);
+
+    private:
+
+        /**
+           Swaps locations of an active handler with an inactive handler.  It will also swap the index state of the two
+           handlers. No checks will be done to ensure the active state
+        */
+        static void swapActiveWithInactive(HandlerBase*& active, HandlerBase*& inactive)
+        {
+            // First swap the indices, then do the actual pointer swap
+            int32_t tmp      = -1 - inactive->index_;
+            inactive->index_ = -1 - active->index_;
+            active->index_   = tmp;
+
+            std::swap(active, inactive);
+        }
+
+        /**
+           Swaps locations of two handlers with the same active state.  It will also swap the index state of the two
+           handlers. No checks will be done to ensure the active states are the same
+        */
+        static void swapSameActiveState(HandlerBase*& h1, HandlerBase*& h2)
+        {
+            // First swap the indices, then do the actual pointer swap
+            std::swap(h1->index_, h2->index_);
+            std::swap(h1, h2);
+        }
+    };
+
+public:
+    /** Create a new clock with a specified period */
+    Clock(TimeConverter period, int priority = CLOCKPRIORITY);
+    ~Clock() = default; // Handlers are owned by BaseComponent and are deleted there
+
+
+    /**
+       Base classes for clock handlers.  There are three classes:
+
+       HandlerBase: This is a publicly available class that is the base class that contains the API used by elements,
+       including checking active status and starting and stopping the handler.
+     */
+
+    class HandlerBase : public SSTHandlerBase<bool, Cycle_t>
+    {
+    public:
+        HandlerBase()  = default;
+        ~HandlerBase() = default;
+
+        void serialize_order(SST::Core::Serialization::serializer& ser) override
+        {
+            SSTHandlerBase<bool, Cycle_t>::serialize_order(ser);
+            SST_SER(index_);
+            SST_SER(order_);
+            // No need to serialize clock_ or group_ as they get reset on restart
+        }
+
+        ImplementVirtualSerializable(HandlerBase);
+
+        /**
+           Get the period of the associated clock as a SimTime_t in units of the core atomic timebase
+        */
+        TimeConverter getClockPeriod() { return (order_ < 0) ? clock_->getPeriod() : group_->getClockPeriod(); }
+
+        /**
+           Get the priority of the associated clock as a SimTime_t in units of the core atomic timebase
+        */
+        int getClockPriority() { return (order_ < 0) ? clock_->getPriority() : group_->getClockPriority(); }
+
+        /**
            Query whether handler is currently active
         */
-        bool isActive() { return active_; }
+        bool isActive() { return index_ >= 0; }
 
         /**
            Activate this Clock Handler
@@ -86,8 +179,14 @@ public:
         */
         Cycle_t activate()
         {
-            clock_->registerHandler(this);
-            return clock_->getNextCycle();
+            if ( order_ < 0 ) {
+                clock_->registerHandler(this);
+                return clock_->getNextCycle();
+            }
+            else {
+                group_->activateHandler(this);
+                return group_->getNextCycle();
+            }
         }
 
         /**
@@ -95,8 +194,13 @@ public:
         */
         void deactivate()
         {
-            bool empty = false;
-            clock_->unregisterHandler(this, empty);
+            if ( order_ < 0 ) {
+                bool empty = false;
+                clock_->unregisterHandler(this, empty);
+            }
+            else {
+                group_->deactivateHandler(this);
+            }
         }
 
     private:
@@ -110,38 +214,51 @@ public:
            NOTE: Registering with two different clocks will continue to "work", though it may have unintended
            results. For now, a warning will be issued, but starting at SST 17, this will become an error condition.
         */
-        Clock* clock_ = nullptr;
+        union {
+            Clock* clock_ = nullptr;
+            Group* group_;
+        };
+
 
         /**
-           Whether or not the handler is currently active on a clock list.  The state is set by Clock whenever a
-           handler is registered, reregistered, or unregistered (either by calling unregisterHandler() or by returning
-           true from the handler execution)
-         */
-        bool active_ = false;
-
-        /**
-           Variable used by Clock to record the index where this handler is stored in the handler vector.  It will be
-           set to -1 if not currently in the vector.
+           Tracks the order for this handler.  If it is less than 0, then the handler is not ordered. If it is ordered,
+           then it's contained in a Clock::Group rather than a Clock
         */
-        int index_ = -1;
+        int32_t order_ = -1;
 
         /**
-           Mark the handler as active
+           Dual purpose variable.  Because adding a bool to this class would require 8-bytes due to padding, the index_
+           variable will also be used to indicate if the handler is active or not.  If < 0, then then it is not
+           active. The other purpose of the variable is to hold the index where the handler currently resides in the
+           handler list of either the Clock or Clock::Group object.  The index for inactive handlers will be stored
+           starting at -1 (i.e. -1 means inactive at index 0, -2 means inactive at index 1, etc). If an implementation
+           of either Clock or Clock::Group does not store inactive handers in the array, then any negative number can be
+           used to indicate that the handler is inactive.
         */
-        void markAsActive(int index)
+        int32_t index_ = -1;
+
+        /**
+           Mark the handler as active.
+        */
+        void markAsActive()
         {
-            active_ = true;
-            index_  = index;
+            if ( index_ >= 0 ) return;
+            index_ = -1 - index_;
         }
 
         /**
-           Mark the handler as inactive
+           Mark the handler as inactive.
         */
         void markAsInactive()
         {
-            active_ = false;
-            index_  = -1;
+            if ( index_ < 0 ) return;
+            index_ = -1 - index_;
         }
+
+        /**
+           Toggle the active state of the handler.
+        */
+        void toggleActiveState() { index_ = -1 - index_; }
     };
 
     /**
@@ -177,6 +294,7 @@ public:
     using Handler2 [[deprecated(
         "The name Handler2 has been deprecated and will be removed in SST 17. Please rename Handler2 to Handler.")]]
     = SSTHandler<bool, Cycle_t, classT, dataT, funcT, HandlerBase>;
+
 
     /**
      * Activates this clock object, by inserting into the simulation's
@@ -214,6 +332,17 @@ public:
     */
     bool isHandlerRegistered(Clock::HandlerBase* handler);
 
+    /**
+       Register a group with this Clock object
+    */
+    void registerGroup(Group* group);
+
+    /**
+       Activates a group that is inactive.  If group is already active, nothing is done.  There is no need for a
+       deactivateGroup() call as deactivation is only done based on return value during execute()
+    */
+    void activateGroup(Group* group);
+
     std::string toString() const override;
 
     /**
@@ -222,20 +351,23 @@ public:
     TimeConverter getPeriod() { return period_; }
 
 private:
-    using StaticHandlerMap_t = std::vector<Clock::HandlerBase*>;
 
-    Clock() {}
-
+    Clock();
     Clock(const Clock&)            = delete;
     Clock& operator=(const Clock&) = delete;
 
     void execute() override;
 
-    Cycle_t            current_cycle_;
-    TimeConverter      period_;
-    StaticHandlerMap_t static_handler_map_;
-    SimTime_t          next_;
-    bool               scheduled_;
+    // Vectors to hold the handlers and groups
+    std::vector<HandlerBase*> handlers_;
+    std::vector<Group*>       groups_;
+    int32_t                   groups_inactive_start_ = 0;
+
+    Cycle_t       current_cycle_ = 0;
+    TimeConverter period_;
+    SimTime_t     next_      = 0;
+    bool          scheduled_ = false;
+    Simulation*   sim_       = nullptr;
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::Clock)

--- a/src/sst/core/component.cc
+++ b/src/sst/core/component.cc
@@ -31,11 +31,40 @@ Component::Component(ComponentId_t id) :
     // currentlyLoadingSubComponent = my_info;
 }
 
+Clock::Group*
+Component::getClockGroup(TimeConverter tc)
+{
+    auto it = clock_groups_.find(tc.getFactor());
+    if ( it != clock_groups_.end() ) return it->second;
+
+    // Need to create a clock group and register it with the Clock object
+    Clock::Group* group = new Clock::Group();
+    sim_->registerClockGroup(tc, group);
+    clock_groups_[tc.getFactor()] = group;
+    return group;
+}
+
 
 void
 Component::serialize_order(SST::Core::Serialization::serializer& ser)
 {
     BaseComponent::serialize_order(ser);
 }
+
+void
+Component::serialize_final(SST::Core::Serialization::serializer& ser)
+{
+    // Need to serialize the ordered clock handlers
+    SST_SER(clock_groups_);
+
+    if ( ser.mode() == SST::Core::Serialization::serializer::UNPACK ) {
+        // Need to reregister the groups with their clocks
+        for ( auto& [period, group] : clock_groups_ ) {
+            sim_->registerClockGroup(period, group);
+            group->activateOnRestart();
+        }
+    }
+}
+
 
 } // namespace SST

--- a/src/sst/core/component.h
+++ b/src/sst/core/component.h
@@ -54,11 +54,21 @@ public:
 
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
+
     ImplementSerializable(SST::Component)
 
 protected:
     friend class SubComponent;
     Component() = default; // For Serialization only
+
+private:
+    friend class BaseComponent;
+    std::map<SimTime_t, Clock::Group*> clock_groups_;
+
+    Clock::Group* getClockGroup(TimeConverter tc) override;
+
+    // This is for serializing anything that needs to happen after all the SubComponents are serialized
+    void serialize_final(SST::Core::Serialization::serializer& ser) override;
 };
 
 } // namespace SST

--- a/src/sst/core/componentInfo.cc
+++ b/src/sst/core/componentInfo.cc
@@ -200,6 +200,10 @@ ComponentInfo::serialize_comp(SST::Core::Serialization::serializer& ser)
     for ( auto it = subComponents.begin(); it != subComponents.end(); ++it ) {
         it->second.serialize_comp(ser);
     }
+
+    // For the component, call serialize_final() to get anything that needs to serialize after the subcomponents.  Need
+    // to check for nullptr for the independent ComponentInfo serialization test.
+    if ( component != nullptr ) component->serialize_final(ser);
 }
 
 void
@@ -277,9 +281,9 @@ ComponentInfo::serialize_order(SST::Core::Serialization::serializer& ser)
 
     // For SubComponents map, need to serialize map by hand since we
     // we will need to use the track non-pointer as pointer feature in
-    // the serializer. This is becaues the SubComponent's ComponentInfo
+    // the serializer. This is because the SubComponent's ComponentInfo
     // object is actually stored in the map and they may have their
-    // own SubCompenents that will need to point to the data location
+    // own SubComponents that will need to point to the data location
     // in the map.
 
     SST_SER(subComponents, SerOption::as_ptr_elem);

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -1490,6 +1490,33 @@ Simulation::unregisterClock(TimeConverter tc, Clock::HandlerBase* handler, int p
     }
 }
 
+void
+Simulation::registerClockGroup(TimeConverter tc, Clock::Group* group)
+{
+    // Clock groups are only available to BaseComponents, so we just use CLOCKPRIORITY
+    clockMap_t::key_type mapKey = std::make_pair(tc.getFactor(), CLOCKPRIORITY);
+    if ( clockMap.find(mapKey) == clockMap.end() ) {
+        Clock* ce        = new Clock(tc, CLOCKPRIORITY);
+        clockMap[mapKey] = ce;
+
+        ce->schedule();
+    }
+    clockMap[mapKey]->registerGroup(group);
+}
+
+void
+Simulation::registerClockGroup(SimTime_t factor, Clock::Group* group)
+{
+    // Clock groups are only available to BaseComponents, so we just use CLOCKPRIORITY
+    clockMap_t::key_type mapKey = std::make_pair(factor, CLOCKPRIORITY);
+    if ( clockMap.find(mapKey) == clockMap.end() ) {
+        Clock* ce        = new Clock(timeLord.getTimeConverter(factor), CLOCKPRIORITY);
+        clockMap[mapKey] = ce;
+
+        ce->schedule();
+    }
+    clockMap[mapKey]->registerGroup(group);
+}
 
 void
 Simulation::insertActivity(SimTime_t time, Activity* ev)
@@ -1756,7 +1783,7 @@ Simulation::writeCheckpointConfigGraph(ConfigGraph* graph)
     //  copy to original one.  We can do the check by looking at cpt_repartition and cpt_orig_configgraph.
     if ( !graph->cpt_orig_configgraph.empty() && !graph->cpt_repartition ) {
         // We are restarting (known because we have an original configgraph), but are not repartitioning, so the main
-        // ConfigGraph datastructure will be empty.  We will just copy the file
+        // ConfigGraph data structure will be empty.  We will just copy the file
         std::filesystem::copy_file(graph->cpt_orig_configgraph, checkpoint_directory_ + "/" + checkpoint_configgraph_);
         return;
     }

--- a/src/sst/core/simulation.h
+++ b/src/sst/core/simulation.h
@@ -381,6 +381,9 @@ public:
      */
     SimTime_t getClockForHandler(Clock::HandlerBase* handler);
 
+    void registerClockGroup(TimeConverter tc, Clock::Group* group);
+    void registerClockGroup(SimTime_t factor, Clock::Group* group);
+
     /** Return the Statistic Processing Engine associated with this Simulation */
     Statistics::StatisticProcessingEngine* getStatisticsProcessingEngine();
 
@@ -436,7 +439,7 @@ public:
 
     /**
        Function used to get the rank for a link on restart.  A rank of
-       -1 on the return means that the paritioning stayed the same
+       -1 on the return means that the partitioning stayed the same
        between checkpoint and restart and the original rank info
        stored in the checkpoint should be used.
      */
@@ -620,7 +623,7 @@ public:
                     // This shouldn't happen.  If it does, then something
                     // didn't get initialized correctly.
                     Output::getDefaultObject().fatal(CALL_INFO_LONG, 1,
-                        "INTERNAL ERROR: ProfileTool refered to in profiler_map not found in profile_tools map\n");
+                        "INTERNAL ERROR: ProfileTool referred to in profiler_map not found in profile_tools map\n");
                     return ret;
                 }
             }

--- a/src/sst/core/testElements/coreTest_ClockerComponent.cc
+++ b/src/sst/core/testElements/coreTest_ClockerComponent.cc
@@ -23,6 +23,38 @@
 
 namespace SST::CoreTestClockerComponent {
 
+/********** ClockSubComponentAPI functions **********/
+void
+ClockSubComponentAPI::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    SST::SubComponent::serialize_order(ser);
+    SST_SER(handler_);
+}
+
+/********** ClockSubComponent functions **********/
+ClockSubComponent::ClockSubComponent(
+    ComponentId_t id, Params& UNUSED(p), coreTestClockerComponent* comp, TimeConverter period, int clock) :
+    ClockSubComponentAPI(id),
+    comp_(comp)
+{
+    handler_ = registerOrderedClock<ClockSubComponent, &ClockSubComponent::clock_handler, int>(period, this, clock);
+}
+
+bool
+ClockSubComponent::clock_handler(Cycle_t cycle, int clock)
+{
+    return comp_->test_ordered_handler(cycle, clock);
+}
+
+void
+ClockSubComponent::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    ClockSubComponentAPI::serialize_order(ser);
+    SST_SER(comp_);
+}
+
+
+/********** coreTestClockerComponent functions **********/
 void
 coreTestClockerComponent::serialize_order(SST::Core::Serialization::serializer& ser)
 {
@@ -35,6 +67,8 @@ coreTestClockerComponent::serialize_order(SST::Core::Serialization::serializer& 
     SST_SER(inst_link_);
     SST_SER(master_);
     SST_SER(clocks_);
+    SST_SER(ordered_var_test_);
+    SST_SER(ordered_handler_remove_);
 }
 
 
@@ -57,7 +91,7 @@ coreTestClockerComponent::coreTestClockerComponent(ComponentId_t id, Params& UNU
     inst_link_ = configureSelfLink(
         "inst_link", new Event::Handler<coreTestClockerComponent, &coreTestClockerComponent::inst_handler>(this));
 
-    // Register the master clock to fire every 50ns, but immediately remove it if I'm not ID 0
+    // Register the master clock, but immediately remove it if I'm not ID 0
     master_ = registerClock<coreTestClockerComponent, &coreTestClockerComponent::master_handler>(master_period, this);
     if ( id_ != 0 ) {
         master_->deactivate();
@@ -88,6 +122,40 @@ coreTestClockerComponent::coreTestClockerComponent(ComponentId_t id, Params& UNU
     unregisterClock(test_tc, clocks_[1].handler);
     clocks_[2].handler->deactivate();
     clocks_[3].handler->deactivate();
+
+
+    // Ordered clock testing
+    handler = registerOrderedClock<coreTestClockerComponent, &coreTestClockerComponent::test_ordered_handler, int>(
+        "1ns", this, 4);
+    handler->deactivate();
+    clocks_.push_back({ handler, test_tc, total_count, true });
+
+    handler = registerOrderedClock<coreTestClockerComponent, &coreTestClockerComponent::test_ordered_handler, int>(
+        "1ns", this, 5);
+    handler->deactivate();
+    clocks_.push_back({ handler, test_tc, total_count, true });
+
+    // Register some clocks in subcomponents
+    Params empty_params;
+
+    // Anonymous subcomponent
+    ClockSubComponentAPI* sub = loadAnonymousSubComponent<ClockSubComponentAPI>(
+        "coreTestElement.ClockSubComponent", "anon_slot", 0, ComponentInfo::SHARE_NONE, empty_params, this, test_tc, 6);
+    handler = sub->getClockHandler();
+    handler->deactivate();
+    clocks_.push_back({ handler, test_tc, total_count, true });
+
+    // User subcomponent
+    sub     = loadUserSubComponent<ClockSubComponentAPI>("user_slot", ComponentInfo::SHARE_NONE, this, test_tc, 7);
+    handler = sub->getClockHandler();
+    handler->deactivate();
+    clocks_.push_back({ handler, test_tc, total_count, true });
+
+    // Back to registering clock here
+    handler = registerOrderedClock<coreTestClockerComponent, &coreTestClockerComponent::test_ordered_handler, int>(
+        "1ns", this, 8);
+    handler->deactivate();
+    clocks_.push_back({ handler, test_tc, total_count, true });
 }
 
 void
@@ -116,8 +184,11 @@ bool
 coreTestClockerComponent::master_handler(Cycle_t UNUSED(cycle))
 {
     if ( done_ ) return true;
-    OpEvent* ev = new OpEvent(instructions[inst_count_++]);
-    inst_link_->send(ev);
+    const std::vector<OpBundle>& insts = instructions[inst_count_++];
+    for ( auto& x : insts ) {
+        OpEvent* ev = new OpEvent(x);
+        inst_link_->send(ev);
+    }
     return false;
 }
 
@@ -185,5 +256,39 @@ coreTestClockerComponent::test_handler(Cycle_t cycle, int clock_index)
     }
     return false;
 }
+
+bool
+coreTestClockerComponent::test_ordered_handler(Cycle_t cycle, int clock_index)
+{
+    // int64_t& counter = clocks_[clock_index].counter;
+    switch ( clock_index ) {
+    case 4:
+        // Clock 4 turns on ordered handler remove
+        ordered_handler_remove_ = true;
+        break;
+    case 5:
+        // Clock 5 will set the variable to 36
+        ordered_var_test_ = 36;
+        break;
+    case 6:
+        // Clock 6 will divide by 2
+        ordered_var_test_ /= 2;
+        break;
+    case 7:
+        // Clock 7 will subtract 6
+        ordered_var_test_ -= 6;
+        break;
+    case 8:
+        // Clock 8 will print the result
+        getSimulationOutput().output(
+            "%d: ordered clock result = %d (cycle = %" PRIu64 ")\n", id_, ordered_var_test_, cycle);
+        break;
+    default:
+        break;
+    }
+    if ( ordered_handler_remove_ ) return true;
+    return false;
+}
+
 
 } // namespace SST::CoreTestClockerComponent

--- a/src/sst/core/testElements/coreTest_ClockerComponent.h
+++ b/src/sst/core/testElements/coreTest_ClockerComponent.h
@@ -13,11 +13,76 @@
 #define SST_CORE_CORETEST_CLOCKERCOMPONENT_H
 
 #include "sst/core/component.h"
+#include "sst/core/subcomponent.h"
 
 #include <cstdint>
 #include <string>
 
 namespace SST::CoreTestClockerComponent {
+
+class coreTestClockerComponent;
+
+/**
+   API for SubComponents that will register a clock handler and return the handler to the parent
+*/
+class ClockSubComponentAPI : public SST::SubComponent
+{
+public:
+
+    /**
+       Constructor parameters are: parent, clock frequency, clock_index
+     */
+    SST_ELI_REGISTER_SUBCOMPONENT_API(SST::CoreTestClockerComponent::ClockSubComponentAPI, coreTestClockerComponent*, TimeConverter, int)
+
+    ClockSubComponentAPI(ComponentId_t id) :
+        SST::SubComponent(id)
+    {}
+
+    ClockSubComponentAPI()  = default;
+    ~ClockSubComponentAPI() = default;
+
+    /**
+       Return registered clock handler
+    */
+    Clock::HandlerBase* getClockHandler() { return handler_; }
+
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(ClockSubComponentAPI);
+
+protected:
+    // Handler that was registered
+    Clock::HandlerBase* handler_ = nullptr;
+};
+
+class ClockSubComponent : public ClockSubComponentAPI
+{
+public:
+    SST_ELI_REGISTER_SUBCOMPONENT(
+        ClockSubComponent,
+        "coreTestElement",
+        "ClockSubComponent",
+        SST_ELI_ELEMENT_VERSION(1,0,0),
+        "SubComponent which registers an ordered clock that can be returned to the parent",
+        SST::CoreTestClockerComponent::ClockSubComponentAPI
+    )
+
+    SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
+        {"anon_slot", "Slot for anonymous subcomponent", "SST::CoreTestClockerComponent::ClockSubComponentAPI" },
+        {"user_slot", "Slot for user subcomponent", "SST::CoreTestClockerComponent::ClockSubComponentAPI" }
+    )
+
+    ClockSubComponent(ComponentId_t id, Params& p, coreTestClockerComponent* comp, TimeConverter period, int clock);
+    ClockSubComponent()  = default;
+    ~ClockSubComponent() = default;
+
+    bool clock_handler(Cycle_t cycle, int clock);
+
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(ClockSubComponent);
+
+private:
+    coreTestClockerComponent* comp_ = nullptr;
+};
 
 class coreTestClockerComponent : public SST::Component
 {
@@ -32,6 +97,7 @@ public:
         COMPONENT_CATEGORY_UNCATEGORIZED
     )
 
+    // Optional since there is nothing to document
     SST_ELI_DOCUMENT_PARAMS(
     )
 
@@ -39,7 +105,6 @@ public:
     SST_ELI_DOCUMENT_STATISTICS(
     )
 
-    // Optional since there is nothing to document
     SST_ELI_DOCUMENT_PORTS(
         {"left", "Left port", { "" } },
         {"right", "Right port", { "" } },
@@ -50,8 +115,9 @@ public:
     )
 
     coreTestClockerComponent(SST::ComponentId_t id, SST::Params& params);
+
+    // setup() is the only untimed stage used
     void setup() override;
-    void finish() override {}
 
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(coreTestClockerComponent);
@@ -96,11 +162,18 @@ private:
     */
     void inst_handler(Event* ev);
 
-    /*
-      Handler for the "tsst" clocks
+public:
+    /**
+      Handler for the "test" clocks.  Needs to be public so that subcomponents can call it.
     */
     bool test_handler(Cycle_t cycle, int clock_index);
 
+    /**
+       Handler function for ordered clocks
+    */
+    bool test_ordered_handler(Cycle_t cycle, int clock_index);
+
+private:
     /*
       There are multiple clocks to test out the various clock APIs in the core:
 
@@ -116,7 +189,7 @@ private:
 
       Clock 1:
         Period: 1ns
-        - This clock will run until removed from the clock list by the master clock using unregsterClock().
+        - This clock will run until removed from the clock list by the master clock using unregisterClock().
           The master clock will then restart it later using reregisterClock().
 
       ** Clocks using the new API
@@ -129,7 +202,34 @@ private:
         Period: 1ns
         - This clock will run until removed from the clock list by the master clock using deactivate(),
           The master clock will then restart it later using activate().
-     */
+
+      Clock 4:
+        Period: 1ns
+        - This clock will set ordered_handler_remove_ to true, which causes the ordered clock handlers to remove
+          themselves after completing their operation
+
+          ** Clocks 5-8 will wait to be stopped by the master clock by default.  When ordered_handler_remove_ is
+             set to true, they will remove themselves after completing their operation
+
+      Clock 5:
+        Period: 1ns
+        - This clock will initialize ordered_var_test_ to 36
+
+      Clock 6:
+        Period: 1ns
+        - This clock will divide ordered_var_test_ by 2
+        - This clock will be registered by an anonymous subcomponent
+
+      Clock 7:
+        Period: 1ns
+        - This clock will add 6 to ordered_var_test_
+        - This clock will be registered by a user subcomponent
+
+      Clock 8:
+        Period: 1ns
+        - This clock will print ordered_var_test_
+
+    */
 
     // Struct to hold the data needed to manage the clocks
     struct ClockInfo
@@ -156,8 +256,11 @@ private:
 
 private:
 
-    // Operations that the master handler can peform
+    // Operations that the master handler can perform
     enum class Op { nop, start, stop, term };
+
+    int  ordered_var_test_       = -1;
+    bool ordered_handler_remove_ = false;
 
     struct OpBundle
     {
@@ -166,9 +269,16 @@ private:
     };
 
     // Everyone does the same program, so make it static
-    inline static const std::vector<OpBundle> instructions = { { Op::start, 1 }, { Op::start, 0 }, { Op::start, 3 },
-        { Op::stop, 1 }, { Op::start, 2 }, { Op::stop, 3 }, { Op::start, 1 }, { Op::start, 0 }, { Op::start, 3 },
-        { Op::stop, 1 }, { Op::start, 2 }, { Op::stop, 3 }, { Op::term, -1 } };
+    inline static const std::vector<std::vector<OpBundle>> instructions = {
+        { { Op::start, 1 }, { Op::start, 5 }, { Op::start, 6 }, { Op::start, 7 }, { Op::start, 8 } },
+        { { Op::start, 0 }, { Op::stop, 6 } }, { { Op::start, 3 }, { Op::stop, 7 } },
+        { { Op::stop, 1 }, { Op::start, 6 } },
+        { { Op::start, 2 }, { Op::start, 4 } }, // causes ordered clock handlers to remove themselves
+        { { Op::stop, 3 }, { Op::start, 5 }, { Op::start, 6 }, { Op::start, 8 } },
+        { { Op::start, 1 }, { Op::start, 6 }, { Op::start, 5 }, { Op::start, 8 }, { Op::start, 7 } },
+        { { Op::start, 0 } }, { { Op::start, 3 } }, { { Op::stop, 1 } }, { { Op::start, 2 } }, { { Op::stop, 3 } },
+        { { Op::term, -1 } }
+    };
 
     using OpEvent  = BasicEvent<OpBundle>;
     using IntEvent = BasicEvent<int>;

--- a/tests/refFiles/test_Clocks_basic.out
+++ b/tests/refFiles/test_Clocks_basic.out
@@ -1,68 +1,126 @@
 # Creating simulation checkpoint at simulated time period of 20ns.
 0: starting test sequence at 0
 0: Clock 1 will restart at cycle 6
+0: Clock 5 will restart at cycle 6
+0: Clock 6 will restart at cycle 6
+0: Clock 7 will restart at cycle 6
+0: Clock 8 will restart at cycle 6
 0: Clock 1 at cycle 6
+0: ordered clock result = 12 (cycle = 6)
 0: Clock 1 at cycle 7
+0: ordered clock result = 12 (cycle = 7)
 0: Clock 1 at cycle 8
+0: ordered clock result = 12 (cycle = 8)
 0: Clock 1 at cycle 9
+0: ordered clock result = 12 (cycle = 9)
 0: Clock 1 at cycle 10
+0: ordered clock result = 12 (cycle = 10)
 0: Clock 0 will restart at cycle 11
+0: Stopping Clock 6 at time 10000
 0: Clock 1 at cycle 11
 0: Clock 0 at cycle 11
+0: ordered clock result = 30 (cycle = 11)
 1: Starting test sequence at 11000
 0: Clock 1 at cycle 12
 0: Clock 0 at cycle 12
+0: ordered clock result = 30 (cycle = 12)
 0: Clock 1 at cycle 13
 0: Clock 0 at cycle 13
 0: Self stopping Clock 0 at time 13000
+0: ordered clock result = 30 (cycle = 13)
 0: Clock 1 at cycle 14
+0: ordered clock result = 30 (cycle = 14)
 0: Clock 1 at cycle 15
+0: ordered clock result = 30 (cycle = 15)
 0: Clock 3 will restart at cycle 16
+0: Stopping Clock 7 at time 15000
 1: Clock 1 will restart at cycle 16
+1: Clock 5 will restart at cycle 16
+1: Clock 6 will restart at cycle 16
+1: Clock 7 will restart at cycle 16
+1: Clock 8 will restart at cycle 16
 0: Clock 1 at cycle 16
 0: Clock 3 at cycle 16
 1: Clock 1 at cycle 16
+0: ordered clock result = 36 (cycle = 16)
+1: ordered clock result = 12 (cycle = 16)
 0: Clock 1 at cycle 17
 0: Clock 3 at cycle 17
 1: Clock 1 at cycle 17
+0: ordered clock result = 36 (cycle = 17)
+1: ordered clock result = 12 (cycle = 17)
 2: Starting test sequence at 17000
 0: Clock 1 at cycle 18
 0: Clock 3 at cycle 18
 1: Clock 1 at cycle 18
+0: ordered clock result = 36 (cycle = 18)
+1: ordered clock result = 12 (cycle = 18)
 0: Clock 1 at cycle 19
 0: Clock 3 at cycle 19
 1: Clock 1 at cycle 19
-# Simulation Checkpoint: Simulated Time 20 ns (Real CPU time since last checkpoint 0.00132 seconds)
+0: ordered clock result = 36 (cycle = 19)
+1: ordered clock result = 12 (cycle = 19)
+# Simulation Checkpoint: Simulated Time 20 ns (Real CPU time since last checkpoint 0.00106 seconds)
 0: Clock 1 at cycle 20
 0: Clock 3 at cycle 20
 1: Clock 1 at cycle 20
+0: ordered clock result = 36 (cycle = 20)
+1: ordered clock result = 12 (cycle = 20)
 0: Stopping Clock 1 at time 20000
+0: Clock 6 will restart at cycle 21
 1: Clock 0 will restart at cycle 21
+1: Stopping Clock 6 at time 20000
 2: Clock 1 will restart at cycle 21
+2: Clock 5 will restart at cycle 21
+2: Clock 6 will restart at cycle 21
+2: Clock 7 will restart at cycle 21
+2: Clock 8 will restart at cycle 21
 0: Clock 3 at cycle 21
 1: Clock 1 at cycle 21
 1: Clock 0 at cycle 21
 2: Clock 1 at cycle 21
+0: ordered clock result = 18 (cycle = 21)
+1: ordered clock result = 30 (cycle = 21)
+2: ordered clock result = 12 (cycle = 21)
 0: Clock 3 at cycle 22
 1: Clock 1 at cycle 22
 1: Clock 0 at cycle 22
 2: Clock 1 at cycle 22
+0: ordered clock result = 18 (cycle = 22)
+1: ordered clock result = 30 (cycle = 22)
+2: ordered clock result = 12 (cycle = 22)
 0: Clock 3 at cycle 23
 1: Clock 1 at cycle 23
 1: Clock 0 at cycle 23
 1: Self stopping Clock 0 at time 23000
 2: Clock 1 at cycle 23
+0: ordered clock result = 18 (cycle = 23)
+1: ordered clock result = 30 (cycle = 23)
+2: ordered clock result = 12 (cycle = 23)
 3: Starting test sequence at 23000
 0: Clock 3 at cycle 24
 1: Clock 1 at cycle 24
 2: Clock 1 at cycle 24
+0: ordered clock result = 18 (cycle = 24)
+1: ordered clock result = 30 (cycle = 24)
+2: ordered clock result = 12 (cycle = 24)
 0: Clock 3 at cycle 25
 1: Clock 1 at cycle 25
 2: Clock 1 at cycle 25
+0: ordered clock result = 18 (cycle = 25)
+1: ordered clock result = 30 (cycle = 25)
+2: ordered clock result = 12 (cycle = 25)
 0: Clock 2 will restart at cycle 26
+0: Clock 4 will restart at cycle 26
 1: Clock 3 will restart at cycle 26
+1: Stopping Clock 7 at time 25000
 2: Clock 0 will restart at cycle 26
+2: Stopping Clock 6 at time 25000
 3: Clock 1 will restart at cycle 26
+3: Clock 5 will restart at cycle 26
+3: Clock 6 will restart at cycle 26
+3: Clock 7 will restart at cycle 26
+3: Clock 8 will restart at cycle 26
 0: Clock 3 at cycle 26
 1: Clock 1 at cycle 26
 2: Clock 1 at cycle 26
@@ -70,6 +128,10 @@
 1: Clock 3 at cycle 26
 2: Clock 0 at cycle 26
 3: Clock 1 at cycle 26
+0: ordered clock result = 18 (cycle = 26)
+3: ordered clock result = 12 (cycle = 26)
+1: ordered clock result = 36 (cycle = 26)
+2: ordered clock result = 30 (cycle = 26)
 0: Clock 3 at cycle 27
 1: Clock 1 at cycle 27
 2: Clock 1 at cycle 27
@@ -77,6 +139,9 @@
 1: Clock 3 at cycle 27
 2: Clock 0 at cycle 27
 3: Clock 1 at cycle 27
+3: ordered clock result = 12 (cycle = 27)
+1: ordered clock result = 36 (cycle = 27)
+2: ordered clock result = 30 (cycle = 27)
 0: Clock 3 at cycle 28
 1: Clock 1 at cycle 28
 2: Clock 1 at cycle 28
@@ -86,34 +151,62 @@
 2: Clock 0 at cycle 28
 2: Self stopping Clock 0 at time 28000
 3: Clock 1 at cycle 28
+3: ordered clock result = 12 (cycle = 28)
+1: ordered clock result = 36 (cycle = 28)
+2: ordered clock result = 30 (cycle = 28)
 0: Clock 3 at cycle 29
 1: Clock 1 at cycle 29
 2: Clock 1 at cycle 29
 1: Clock 3 at cycle 29
 3: Clock 1 at cycle 29
+3: ordered clock result = 12 (cycle = 29)
+1: ordered clock result = 36 (cycle = 29)
+2: ordered clock result = 30 (cycle = 29)
 4: Starting test sequence at 29000
 0: Clock 3 at cycle 30
 1: Clock 1 at cycle 30
 2: Clock 1 at cycle 30
 1: Clock 3 at cycle 30
 3: Clock 1 at cycle 30
+3: ordered clock result = 12 (cycle = 30)
+1: ordered clock result = 36 (cycle = 30)
+2: ordered clock result = 30 (cycle = 30)
 0: Stopping Clock 3 at time 30000
+0: Clock 5 will restart at cycle 31
+0: Clock 6 will restart at cycle 31
+0: Clock 8 will restart at cycle 31
 1: Stopping Clock 1 at time 30000
+1: Clock 6 will restart at cycle 31
 2: Clock 3 will restart at cycle 31
+2: Stopping Clock 7 at time 30000
 3: Clock 0 will restart at cycle 31
+3: Stopping Clock 6 at time 30000
 4: Clock 1 will restart at cycle 31
+4: Clock 5 will restart at cycle 31
+4: Clock 6 will restart at cycle 31
+4: Clock 7 will restart at cycle 31
+4: Clock 8 will restart at cycle 31
 2: Clock 1 at cycle 31
 1: Clock 3 at cycle 31
 3: Clock 1 at cycle 31
 2: Clock 3 at cycle 31
 3: Clock 0 at cycle 31
 4: Clock 1 at cycle 31
+3: ordered clock result = 30 (cycle = 31)
+1: ordered clock result = 18 (cycle = 31)
+2: ordered clock result = 36 (cycle = 31)
+0: ordered clock result = 18 (cycle = 31)
+4: ordered clock result = 12 (cycle = 31)
 2: Clock 1 at cycle 32
 1: Clock 3 at cycle 32
 3: Clock 1 at cycle 32
 2: Clock 3 at cycle 32
 3: Clock 0 at cycle 32
 4: Clock 1 at cycle 32
+3: ordered clock result = 30 (cycle = 32)
+1: ordered clock result = 18 (cycle = 32)
+2: ordered clock result = 36 (cycle = 32)
+4: ordered clock result = 12 (cycle = 32)
 2: Clock 1 at cycle 33
 1: Clock 3 at cycle 33
 3: Clock 1 at cycle 33
@@ -121,22 +214,42 @@
 3: Clock 0 at cycle 33
 3: Self stopping Clock 0 at time 33000
 4: Clock 1 at cycle 33
+3: ordered clock result = 30 (cycle = 33)
+1: ordered clock result = 18 (cycle = 33)
+2: ordered clock result = 36 (cycle = 33)
+4: ordered clock result = 12 (cycle = 33)
 2: Clock 1 at cycle 34
 1: Clock 3 at cycle 34
 3: Clock 1 at cycle 34
 2: Clock 3 at cycle 34
 4: Clock 1 at cycle 34
+3: ordered clock result = 30 (cycle = 34)
+1: ordered clock result = 18 (cycle = 34)
+2: ordered clock result = 36 (cycle = 34)
+4: ordered clock result = 12 (cycle = 34)
 2: Clock 1 at cycle 35
 1: Clock 3 at cycle 35
 3: Clock 1 at cycle 35
 2: Clock 3 at cycle 35
 4: Clock 1 at cycle 35
+3: ordered clock result = 30 (cycle = 35)
+1: ordered clock result = 18 (cycle = 35)
+2: ordered clock result = 36 (cycle = 35)
+4: ordered clock result = 12 (cycle = 35)
 5: Starting test sequence at 35000
 0: Clock 1 will restart at cycle 36
+0: Clock 6 will restart at cycle 36
+0: Clock 5 will restart at cycle 36
+0: Clock 8 will restart at cycle 36
+0: Clock 7 will restart at cycle 36
 1: Clock 2 will restart at cycle 36
+1: Clock 4 will restart at cycle 36
 2: Stopping Clock 1 at time 35000
+2: Clock 6 will restart at cycle 36
 3: Clock 3 will restart at cycle 36
+3: Stopping Clock 7 at time 35000
 4: Clock 0 will restart at cycle 36
+4: Stopping Clock 6 at time 35000
 1: Clock 3 at cycle 36
 3: Clock 1 at cycle 36
 2: Clock 3 at cycle 36
@@ -145,6 +258,11 @@
 1: Clock 2 at cycle 36
 3: Clock 3 at cycle 36
 4: Clock 0 at cycle 36
+3: ordered clock result = 36 (cycle = 36)
+1: ordered clock result = 18 (cycle = 36)
+0: ordered clock result = 12 (cycle = 36)
+4: ordered clock result = 30 (cycle = 36)
+2: ordered clock result = 18 (cycle = 36)
 1: Clock 3 at cycle 37
 3: Clock 1 at cycle 37
 2: Clock 3 at cycle 37
@@ -153,6 +271,9 @@
 1: Clock 2 at cycle 37
 3: Clock 3 at cycle 37
 4: Clock 0 at cycle 37
+3: ordered clock result = 36 (cycle = 37)
+4: ordered clock result = 30 (cycle = 37)
+2: ordered clock result = 18 (cycle = 37)
 1: Clock 3 at cycle 38
 3: Clock 1 at cycle 38
 2: Clock 3 at cycle 38
@@ -163,25 +284,44 @@
 3: Clock 3 at cycle 38
 4: Clock 0 at cycle 38
 4: Self stopping Clock 0 at time 38000
+3: ordered clock result = 36 (cycle = 38)
+4: ordered clock result = 30 (cycle = 38)
+2: ordered clock result = 18 (cycle = 38)
 1: Clock 3 at cycle 39
 3: Clock 1 at cycle 39
 2: Clock 3 at cycle 39
 4: Clock 1 at cycle 39
 0: Clock 1 at cycle 39
 3: Clock 3 at cycle 39
-# Simulation Checkpoint: Simulated Time 40 ns (Real CPU time since last checkpoint 0.00564 seconds)
+3: ordered clock result = 36 (cycle = 39)
+4: ordered clock result = 30 (cycle = 39)
+2: ordered clock result = 18 (cycle = 39)
+# Simulation Checkpoint: Simulated Time 40 ns (Real CPU time since last checkpoint 0.00461 seconds)
 1: Clock 3 at cycle 40
 3: Clock 1 at cycle 40
 2: Clock 3 at cycle 40
 4: Clock 1 at cycle 40
 0: Clock 1 at cycle 40
 3: Clock 3 at cycle 40
+3: ordered clock result = 36 (cycle = 40)
+4: ordered clock result = 30 (cycle = 40)
+2: ordered clock result = 18 (cycle = 40)
 0: Clock 0 will restart at cycle 41
 1: Stopping Clock 3 at time 40000
+1: Clock 5 will restart at cycle 41
+1: Clock 6 will restart at cycle 41
+1: Clock 8 will restart at cycle 41
 2: Clock 2 will restart at cycle 41
+2: Clock 4 will restart at cycle 41
 3: Stopping Clock 1 at time 40000
+3: Clock 6 will restart at cycle 41
 4: Clock 3 will restart at cycle 41
+4: Stopping Clock 7 at time 40000
 5: Clock 1 will restart at cycle 41
+5: Clock 5 will restart at cycle 41
+5: Clock 6 will restart at cycle 41
+5: Clock 7 will restart at cycle 41
+5: Clock 8 will restart at cycle 41
 2: Clock 3 at cycle 41
 4: Clock 1 at cycle 41
 0: Clock 1 at cycle 41
@@ -190,6 +330,11 @@
 2: Clock 2 at cycle 41
 4: Clock 3 at cycle 41
 5: Clock 1 at cycle 41
+3: ordered clock result = 18 (cycle = 41)
+4: ordered clock result = 36 (cycle = 41)
+2: ordered clock result = 18 (cycle = 41)
+5: ordered clock result = 12 (cycle = 41)
+1: ordered clock result = 18 (cycle = 41)
 6: Starting test sequence at 41000
 2: Clock 3 at cycle 42
 4: Clock 1 at cycle 42
@@ -199,6 +344,9 @@
 2: Clock 2 at cycle 42
 4: Clock 3 at cycle 42
 5: Clock 1 at cycle 42
+3: ordered clock result = 18 (cycle = 42)
+4: ordered clock result = 36 (cycle = 42)
+5: ordered clock result = 12 (cycle = 42)
 2: Clock 3 at cycle 43
 4: Clock 1 at cycle 43
 0: Clock 1 at cycle 43
@@ -209,25 +357,48 @@
 2: Self stopping Clock 2 at time 43000
 4: Clock 3 at cycle 43
 5: Clock 1 at cycle 43
+3: ordered clock result = 18 (cycle = 43)
+4: ordered clock result = 36 (cycle = 43)
+5: ordered clock result = 12 (cycle = 43)
 2: Clock 3 at cycle 44
 4: Clock 1 at cycle 44
 0: Clock 1 at cycle 44
 3: Clock 3 at cycle 44
 4: Clock 3 at cycle 44
 5: Clock 1 at cycle 44
+3: ordered clock result = 18 (cycle = 44)
+4: ordered clock result = 36 (cycle = 44)
+5: ordered clock result = 12 (cycle = 44)
 2: Clock 3 at cycle 45
 4: Clock 1 at cycle 45
 0: Clock 1 at cycle 45
 3: Clock 3 at cycle 45
 4: Clock 3 at cycle 45
 5: Clock 1 at cycle 45
+3: ordered clock result = 18 (cycle = 45)
+4: ordered clock result = 36 (cycle = 45)
+5: ordered clock result = 12 (cycle = 45)
 0: Clock 3 will restart at cycle 46
 1: Clock 1 will restart at cycle 46
+1: Clock 6 will restart at cycle 46
+1: Clock 5 will restart at cycle 46
+1: Clock 8 will restart at cycle 46
+1: Clock 7 will restart at cycle 46
 2: Stopping Clock 3 at time 45000
+2: Clock 5 will restart at cycle 46
+2: Clock 6 will restart at cycle 46
+2: Clock 8 will restart at cycle 46
 3: Clock 2 will restart at cycle 46
+3: Clock 4 will restart at cycle 46
 4: Stopping Clock 1 at time 45000
+4: Clock 6 will restart at cycle 46
 5: Clock 0 will restart at cycle 46
+5: Stopping Clock 6 at time 45000
 6: Clock 1 will restart at cycle 46
+6: Clock 5 will restart at cycle 46
+6: Clock 6 will restart at cycle 46
+6: Clock 7 will restart at cycle 46
+6: Clock 8 will restart at cycle 46
 0: Clock 1 at cycle 46
 3: Clock 3 at cycle 46
 4: Clock 3 at cycle 46
@@ -237,6 +408,12 @@
 3: Clock 2 at cycle 46
 5: Clock 0 at cycle 46
 6: Clock 1 at cycle 46
+3: ordered clock result = 18 (cycle = 46)
+6: ordered clock result = 12 (cycle = 46)
+4: ordered clock result = 18 (cycle = 46)
+5: ordered clock result = 30 (cycle = 46)
+1: ordered clock result = 12 (cycle = 46)
+2: ordered clock result = 18 (cycle = 46)
 0: Clock 1 at cycle 47
 3: Clock 3 at cycle 47
 4: Clock 3 at cycle 47
@@ -246,6 +423,9 @@
 3: Clock 2 at cycle 47
 5: Clock 0 at cycle 47
 6: Clock 1 at cycle 47
+6: ordered clock result = 12 (cycle = 47)
+4: ordered clock result = 18 (cycle = 47)
+5: ordered clock result = 30 (cycle = 47)
 7: Starting test sequence at 47000
 0: Clock 1 at cycle 48
 3: Clock 3 at cycle 48
@@ -258,6 +438,9 @@
 5: Clock 0 at cycle 48
 5: Self stopping Clock 0 at time 48000
 6: Clock 1 at cycle 48
+6: ordered clock result = 12 (cycle = 48)
+4: ordered clock result = 18 (cycle = 48)
+5: ordered clock result = 30 (cycle = 48)
 0: Clock 1 at cycle 49
 3: Clock 3 at cycle 49
 4: Clock 3 at cycle 49
@@ -265,6 +448,9 @@
 0: Clock 3 at cycle 49
 1: Clock 1 at cycle 49
 6: Clock 1 at cycle 49
+6: ordered clock result = 12 (cycle = 49)
+4: ordered clock result = 18 (cycle = 49)
+5: ordered clock result = 30 (cycle = 49)
 0: Clock 1 at cycle 50
 3: Clock 3 at cycle 50
 4: Clock 3 at cycle 50
@@ -272,14 +458,31 @@
 0: Clock 3 at cycle 50
 1: Clock 1 at cycle 50
 6: Clock 1 at cycle 50
+6: ordered clock result = 12 (cycle = 50)
+4: ordered clock result = 18 (cycle = 50)
+5: ordered clock result = 30 (cycle = 50)
 0: Stopping Clock 1 at time 50000
 1: Clock 0 will restart at cycle 51
 2: Clock 1 will restart at cycle 51
+2: Clock 6 will restart at cycle 51
+2: Clock 5 will restart at cycle 51
+2: Clock 8 will restart at cycle 51
+2: Clock 7 will restart at cycle 51
 3: Stopping Clock 3 at time 50000
+3: Clock 5 will restart at cycle 51
+3: Clock 6 will restart at cycle 51
+3: Clock 8 will restart at cycle 51
 4: Clock 2 will restart at cycle 51
+4: Clock 4 will restart at cycle 51
 5: Clock 3 will restart at cycle 51
+5: Stopping Clock 7 at time 50000
 6: Clock 0 will restart at cycle 51
+6: Stopping Clock 6 at time 50000
 7: Clock 1 will restart at cycle 51
+7: Clock 5 will restart at cycle 51
+7: Clock 6 will restart at cycle 51
+7: Clock 7 will restart at cycle 51
+7: Clock 8 will restart at cycle 51
 4: Clock 3 at cycle 51
 5: Clock 1 at cycle 51
 0: Clock 3 at cycle 51
@@ -291,6 +494,12 @@
 5: Clock 3 at cycle 51
 6: Clock 0 at cycle 51
 7: Clock 1 at cycle 51
+6: ordered clock result = 30 (cycle = 51)
+4: ordered clock result = 18 (cycle = 51)
+7: ordered clock result = 12 (cycle = 51)
+5: ordered clock result = 36 (cycle = 51)
+2: ordered clock result = 12 (cycle = 51)
+3: ordered clock result = 18 (cycle = 51)
 4: Clock 3 at cycle 52
 5: Clock 1 at cycle 52
 0: Clock 3 at cycle 52
@@ -302,6 +511,9 @@
 5: Clock 3 at cycle 52
 6: Clock 0 at cycle 52
 7: Clock 1 at cycle 52
+6: ordered clock result = 30 (cycle = 52)
+7: ordered clock result = 12 (cycle = 52)
+5: ordered clock result = 36 (cycle = 52)
 4: Clock 3 at cycle 53
 5: Clock 1 at cycle 53
 0: Clock 3 at cycle 53
@@ -316,6 +528,9 @@
 6: Clock 0 at cycle 53
 6: Self stopping Clock 0 at time 53000
 7: Clock 1 at cycle 53
+6: ordered clock result = 30 (cycle = 53)
+7: ordered clock result = 12 (cycle = 53)
+5: ordered clock result = 36 (cycle = 53)
 4: Clock 3 at cycle 54
 5: Clock 1 at cycle 54
 0: Clock 3 at cycle 54
@@ -324,6 +539,9 @@
 2: Clock 1 at cycle 54
 5: Clock 3 at cycle 54
 7: Clock 1 at cycle 54
+6: ordered clock result = 30 (cycle = 54)
+7: ordered clock result = 12 (cycle = 54)
+5: ordered clock result = 36 (cycle = 54)
 4: Clock 3 at cycle 55
 5: Clock 1 at cycle 55
 0: Clock 3 at cycle 55
@@ -332,14 +550,27 @@
 2: Clock 1 at cycle 55
 5: Clock 3 at cycle 55
 7: Clock 1 at cycle 55
+6: ordered clock result = 30 (cycle = 55)
+7: ordered clock result = 12 (cycle = 55)
+5: ordered clock result = 36 (cycle = 55)
 0: Clock 2 will restart at cycle 56
 1: Clock 3 will restart at cycle 56
 2: Clock 0 will restart at cycle 56
 3: Clock 1 will restart at cycle 56
+3: Clock 6 will restart at cycle 56
+3: Clock 5 will restart at cycle 56
+3: Clock 8 will restart at cycle 56
+3: Clock 7 will restart at cycle 56
 4: Stopping Clock 3 at time 55000
+4: Clock 5 will restart at cycle 56
+4: Clock 6 will restart at cycle 56
+4: Clock 8 will restart at cycle 56
 5: Stopping Clock 1 at time 55000
+5: Clock 6 will restart at cycle 56
 6: Clock 3 will restart at cycle 56
+6: Stopping Clock 7 at time 55000
 7: Clock 0 will restart at cycle 56
+7: Stopping Clock 6 at time 55000
 0: Clock 3 at cycle 56
 1: Clock 1 at cycle 56
 6: Clock 1 at cycle 56
@@ -352,6 +583,11 @@
 3: Clock 1 at cycle 56
 6: Clock 3 at cycle 56
 7: Clock 0 at cycle 56
+6: ordered clock result = 36 (cycle = 56)
+7: ordered clock result = 30 (cycle = 56)
+5: ordered clock result = 18 (cycle = 56)
+3: ordered clock result = 12 (cycle = 56)
+4: ordered clock result = 18 (cycle = 56)
 0: Clock 3 at cycle 57
 1: Clock 1 at cycle 57
 6: Clock 1 at cycle 57
@@ -364,6 +600,9 @@
 3: Clock 1 at cycle 57
 6: Clock 3 at cycle 57
 7: Clock 0 at cycle 57
+6: ordered clock result = 36 (cycle = 57)
+7: ordered clock result = 30 (cycle = 57)
+5: ordered clock result = 18 (cycle = 57)
 0: Clock 3 at cycle 58
 1: Clock 1 at cycle 58
 6: Clock 1 at cycle 58
@@ -379,6 +618,9 @@
 6: Clock 3 at cycle 58
 7: Clock 0 at cycle 58
 7: Self stopping Clock 0 at time 58000
+6: ordered clock result = 36 (cycle = 58)
+7: ordered clock result = 30 (cycle = 58)
+5: ordered clock result = 18 (cycle = 58)
 0: Clock 3 at cycle 59
 1: Clock 1 at cycle 59
 6: Clock 1 at cycle 59
@@ -388,7 +630,10 @@
 1: Clock 3 at cycle 59
 3: Clock 1 at cycle 59
 6: Clock 3 at cycle 59
-# Simulation Checkpoint: Simulated Time 60 ns (Real CPU time since last checkpoint 0.01103 seconds)
+6: ordered clock result = 36 (cycle = 59)
+7: ordered clock result = 30 (cycle = 59)
+5: ordered clock result = 18 (cycle = 59)
+# Simulation Checkpoint: Simulated Time 60 ns (Real CPU time since last checkpoint 0.00624 seconds)
 0: Clock 3 at cycle 60
 1: Clock 1 at cycle 60
 6: Clock 1 at cycle 60
@@ -398,14 +643,24 @@
 1: Clock 3 at cycle 60
 3: Clock 1 at cycle 60
 6: Clock 3 at cycle 60
+6: ordered clock result = 36 (cycle = 60)
+7: ordered clock result = 30 (cycle = 60)
+5: ordered clock result = 18 (cycle = 60)
 0: Stopping Clock 3 at time 60000
 1: Stopping Clock 1 at time 60000
 2: Clock 3 will restart at cycle 61
 3: Clock 0 will restart at cycle 61
 4: Clock 1 will restart at cycle 61
+4: Clock 6 will restart at cycle 61
+4: Clock 5 will restart at cycle 61
+4: Clock 8 will restart at cycle 61
+4: Clock 7 will restart at cycle 61
 5: Clock 2 will restart at cycle 61
+5: Clock 4 will restart at cycle 61
 6: Stopping Clock 1 at time 60000
+6: Clock 6 will restart at cycle 61
 7: Clock 3 will restart at cycle 61
+7: Stopping Clock 7 at time 60000
 2: Clock 1 at cycle 61
 5: Clock 3 at cycle 61
 7: Clock 1 at cycle 61
@@ -417,6 +672,10 @@
 4: Clock 1 at cycle 61
 5: Clock 2 at cycle 61
 7: Clock 3 at cycle 61
+6: ordered clock result = 18 (cycle = 61)
+7: ordered clock result = 36 (cycle = 61)
+5: ordered clock result = 18 (cycle = 61)
+4: ordered clock result = 12 (cycle = 61)
 2: Clock 1 at cycle 62
 5: Clock 3 at cycle 62
 7: Clock 1 at cycle 62
@@ -428,6 +687,8 @@
 4: Clock 1 at cycle 62
 5: Clock 2 at cycle 62
 7: Clock 3 at cycle 62
+6: ordered clock result = 18 (cycle = 62)
+7: ordered clock result = 36 (cycle = 62)
 2: Clock 1 at cycle 63
 5: Clock 3 at cycle 63
 7: Clock 1 at cycle 63
@@ -441,6 +702,8 @@
 5: Clock 2 at cycle 63
 5: Self stopping Clock 2 at time 63000
 7: Clock 3 at cycle 63
+6: ordered clock result = 18 (cycle = 63)
+7: ordered clock result = 36 (cycle = 63)
 2: Clock 1 at cycle 64
 5: Clock 3 at cycle 64
 7: Clock 1 at cycle 64
@@ -450,6 +713,8 @@
 2: Clock 3 at cycle 64
 4: Clock 1 at cycle 64
 7: Clock 3 at cycle 64
+6: ordered clock result = 18 (cycle = 64)
+7: ordered clock result = 36 (cycle = 64)
 2: Clock 1 at cycle 65
 5: Clock 3 at cycle 65
 7: Clock 1 at cycle 65
@@ -459,14 +724,21 @@
 2: Clock 3 at cycle 65
 4: Clock 1 at cycle 65
 7: Clock 3 at cycle 65
+6: ordered clock result = 18 (cycle = 65)
+7: ordered clock result = 36 (cycle = 65)
 0: Terminating test sequence at 65000
 1: Clock 2 will restart at cycle 66
 2: Stopping Clock 1 at time 65000
 3: Clock 3 will restart at cycle 66
 4: Clock 0 will restart at cycle 66
 5: Stopping Clock 3 at time 65000
+5: Clock 5 will restart at cycle 66
+5: Clock 6 will restart at cycle 66
+5: Clock 8 will restart at cycle 66
 6: Clock 2 will restart at cycle 66
+6: Clock 4 will restart at cycle 66
 7: Stopping Clock 1 at time 65000
+7: Clock 6 will restart at cycle 66
 1: Clock 3 at cycle 66
 3: Clock 1 at cycle 66
 6: Clock 3 at cycle 66
@@ -477,6 +749,9 @@
 3: Clock 3 at cycle 66
 4: Clock 0 at cycle 66
 6: Clock 2 at cycle 66
+6: ordered clock result = 18 (cycle = 66)
+5: ordered clock result = 18 (cycle = 66)
+7: ordered clock result = 18 (cycle = 66)
 1: Clock 3 at cycle 67
 3: Clock 1 at cycle 67
 6: Clock 3 at cycle 67
@@ -487,6 +762,7 @@
 3: Clock 3 at cycle 67
 4: Clock 0 at cycle 67
 6: Clock 2 at cycle 67
+7: ordered clock result = 18 (cycle = 67)
 1: Clock 3 at cycle 68
 3: Clock 1 at cycle 68
 6: Clock 3 at cycle 68
@@ -500,6 +776,7 @@
 4: Self stopping Clock 0 at time 68000
 6: Clock 2 at cycle 68
 6: Self stopping Clock 2 at time 68000
+7: ordered clock result = 18 (cycle = 68)
 1: Clock 3 at cycle 69
 3: Clock 1 at cycle 69
 6: Clock 3 at cycle 69
@@ -507,6 +784,7 @@
 4: Clock 1 at cycle 69
 7: Clock 3 at cycle 69
 3: Clock 3 at cycle 69
+7: ordered clock result = 18 (cycle = 69)
 1: Clock 3 at cycle 70
 3: Clock 1 at cycle 70
 6: Clock 3 at cycle 70
@@ -514,13 +792,22 @@
 4: Clock 1 at cycle 70
 7: Clock 3 at cycle 70
 3: Clock 3 at cycle 70
+7: ordered clock result = 18 (cycle = 70)
 1: Stopping Clock 3 at time 70000
 2: Clock 2 will restart at cycle 71
 3: Stopping Clock 1 at time 70000
 4: Clock 3 will restart at cycle 71
 5: Clock 1 will restart at cycle 71
+5: Clock 6 will restart at cycle 71
+5: Clock 5 will restart at cycle 71
+5: Clock 8 will restart at cycle 71
+5: Clock 7 will restart at cycle 71
 6: Stopping Clock 3 at time 70000
+6: Clock 5 will restart at cycle 71
+6: Clock 6 will restart at cycle 71
+6: Clock 8 will restart at cycle 71
 7: Clock 2 will restart at cycle 71
+7: Clock 4 will restart at cycle 71
 2: Clock 3 at cycle 71
 4: Clock 1 at cycle 71
 7: Clock 3 at cycle 71
@@ -529,6 +816,9 @@
 4: Clock 3 at cycle 71
 5: Clock 1 at cycle 71
 7: Clock 2 at cycle 71
+7: ordered clock result = 18 (cycle = 71)
+6: ordered clock result = 18 (cycle = 71)
+5: ordered clock result = 12 (cycle = 71)
 2: Clock 3 at cycle 72
 4: Clock 1 at cycle 72
 7: Clock 3 at cycle 72
@@ -565,13 +855,22 @@
 4: Stopping Clock 1 at time 75000
 5: Clock 0 will restart at cycle 76
 6: Clock 1 will restart at cycle 76
+6: Clock 6 will restart at cycle 76
+6: Clock 5 will restart at cycle 76
+6: Clock 8 will restart at cycle 76
+6: Clock 7 will restart at cycle 76
 7: Stopping Clock 3 at time 75000
+7: Clock 5 will restart at cycle 76
+7: Clock 6 will restart at cycle 76
+7: Clock 8 will restart at cycle 76
 3: Clock 3 at cycle 76
 4: Clock 3 at cycle 76
 5: Clock 1 at cycle 76
 3: Clock 2 at cycle 76
 5: Clock 0 at cycle 76
 6: Clock 1 at cycle 76
+6: ordered clock result = 12 (cycle = 76)
+7: ordered clock result = 18 (cycle = 76)
 3: Clock 3 at cycle 77
 4: Clock 3 at cycle 77
 5: Clock 1 at cycle 77
@@ -590,7 +889,7 @@
 4: Clock 3 at cycle 79
 5: Clock 1 at cycle 79
 6: Clock 1 at cycle 79
-# Simulation Checkpoint: Simulated Time 80 ns (Real CPU time since last checkpoint 0.00493 seconds)
+# Simulation Checkpoint: Simulated Time 80 ns (Real CPU time since last checkpoint 0.01280 seconds)
 3: Clock 3 at cycle 80
 4: Clock 3 at cycle 80
 5: Clock 1 at cycle 80
@@ -601,6 +900,10 @@
 5: Clock 3 will restart at cycle 81
 6: Clock 0 will restart at cycle 81
 7: Clock 1 will restart at cycle 81
+7: Clock 6 will restart at cycle 81
+7: Clock 5 will restart at cycle 81
+7: Clock 8 will restart at cycle 81
+7: Clock 7 will restart at cycle 81
 4: Clock 3 at cycle 81
 5: Clock 1 at cycle 81
 6: Clock 1 at cycle 81
@@ -608,6 +911,7 @@
 5: Clock 3 at cycle 81
 6: Clock 0 at cycle 81
 7: Clock 1 at cycle 81
+7: ordered clock result = 12 (cycle = 81)
 4: Clock 3 at cycle 82
 5: Clock 1 at cycle 82
 6: Clock 1 at cycle 82
@@ -706,7 +1010,7 @@
 6: Self stopping Clock 2 at time 98000
 6: Clock 3 at cycle 99
 7: Clock 3 at cycle 99
-# Simulation Checkpoint: Simulated Time 100 ns (Real CPU time since last checkpoint 0.00550 seconds)
+# Simulation Checkpoint: Simulated Time 100 ns (Real CPU time since last checkpoint 0.00341 seconds)
 6: Clock 3 at cycle 100
 7: Clock 3 at cycle 100
 5: Terminating test sequence at 100000

--- a/tests/test_Clocks.py
+++ b/tests/test_Clocks.py
@@ -15,7 +15,10 @@ comp_list = []
 
 # Define the simulation components
 for x in range(total_components):
-    comp_list.append(sst.Component("clocker{0}".format(x), "coreTestElement.coreTestClockerComponent"))
+    comp = sst.Component("clocker{0}".format(x), "coreTestElement.coreTestClockerComponent")
+    comp.setSubComponent("user_slot", "coreTestElement.ClockSubComponent", 0)
+    comp_list.append(comp)
+
 
 # Links
 count = 0;


### PR DESCRIPTION
The new function will register clock handlers that are guaranteed to be called in the order they were registered (when registed at the same frequency).  This guarantee if for the entire ComponentTree. The handlers are registered with a Clock::Group that will maintain the order, even when the clocks are activated and deactivated.
