### PR TITLE
Allow insecure Node version for GitHub Actions

### DIFF
--- a/.github/workflows/PR_clang-format_test.yml
+++ b/.github/workflows/PR_clang-format_test.yml
@@ -61,6 +61,8 @@ jobs:
 #   Checkout this users SST-core repo/branch
     - name: Checkout Users SST-Core source
       uses: actions/checkout@v4
+      env:
+        ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       with:
         path: ./sst-core_source
         ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
GitHub has deprecated Node20.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

We should update sooner than later.
