### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/PR_clang-format_test.yml
+++ b/.github/workflows/PR_clang-format_test.yml
@@ -60,10 +60,13 @@ jobs:
 
 #   Checkout this users SST-core repo/branch
     - name: Checkout Users SST-Core source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         path: ./sst-core_source
         ref: ${{ github.event.pull_request.head.sha }}
+        # This is safe in a pull_request_target workflow because we are not
+        # executing the code in any way.
+        allow-unsafe-pr-checkout: true
 
 #   Running the github action for clang format
     - name: Run Action clang-format-lint

--- a/.github/workflows/free-macos-14.yml
+++ b/.github/workflows/free-macos-14.yml
@@ -46,7 +46,7 @@ jobs:
           echo "TERM=dumb" >> "${GITHUB_ENV}"
 
       - name: Pin Python version
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        uses: actions/setup-python@v7
         with:
           python-version: '3.9'
 

--- a/.github/workflows/free-macos-14.yml
+++ b/.github/workflows/free-macos-14.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
 
       - name: Clone core
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v7
         with:
           path: sst-core
           persist-credentials: false
 
       - name: Clone elements
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v7
         with:
           path: sst-elements
           persist-credentials: false

--- a/.github/workflows/free-macos-14.yml
+++ b/.github/workflows/free-macos-14.yml
@@ -60,7 +60,7 @@ jobs:
           install_autotools_noflags_nodeps_gcc/bin/sst-test-core
 
       - name: Save sst_test_outputs after core tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sst_test_outputs_core_free-macos-14
           path: sst_test_outputs
@@ -79,7 +79,7 @@ jobs:
           install_autotools_noflags_nodeps_gcc/bin/sst-test-elements
 
       - name: Save sst_test_outputs after elements tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sst_test_outputs_elements_free-macos-14
           path: sst_test_outputs

--- a/.github/workflows/free-macos-15.yml
+++ b/.github/workflows/free-macos-15.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
 
       - name: Clone core
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v7
         with:
           path: sst-core
           persist-credentials: false
 
       - name: Clone elements
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v7
         with:
           path: sst-elements
           persist-credentials: false

--- a/.github/workflows/free-macos-15.yml
+++ b/.github/workflows/free-macos-15.yml
@@ -46,7 +46,7 @@ jobs:
           echo "TERM=dumb" >> "${GITHUB_ENV}"
 
       - name: Pin Python version
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 

--- a/.github/workflows/free-macos-15.yml
+++ b/.github/workflows/free-macos-15.yml
@@ -60,7 +60,7 @@ jobs:
           install_autotools_noflags_nodeps_gcc/bin/sst-test-core
 
       - name: Save sst_test_outputs after core tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sst_test_outputs_core_free-macos-15
           path: sst_test_outputs
@@ -79,7 +79,7 @@ jobs:
           install_autotools_noflags_nodeps_gcc/bin/sst-test-elements
 
       - name: Save sst_test_outputs after elements tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sst_test_outputs_elements_free-macos-15
           path: sst_test_outputs

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: "3.9"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.9"
       - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ requires two things:
- Updating GitHub Actions to versions that use Node 24 instead of 20
- `action/checkout` specifically guards against `pull_request_target` workflows unless opting in to a specific unsafe flag, which I've determined is safe for us to do (https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target).

This updates most, but not all, of the actions to use the latest major version.  I think there are a few others that are using Node 20, specifically pre-commit, but the Node 20 removal date is not immediate, and updating pre-commit actually requires switching to https://github.com/j178/prek-action.  This PR is most important for the `actions/checkout` change.

I'm also unpinning a few of the actions from refs and switching to moving tags, at least until we move to full Autotester 2 usage.