### PR TITLE
Add floating point tolerance for floating point statistics in tests

### DIFF
--- a/src/sst/core/testingframework/sst_unittest_support.py
+++ b/src/sst/core/testingframework/sst_unittest_support.py
@@ -1097,6 +1097,7 @@ class CheckpointRefFileFilter(IgnoreAllBeforeFilter):
 
 
 
+
 def _read_and_filter(fileloc: str, filters: Sequence[LineFilter], sort: bool, is_ref: bool) -> List[str]:
     lines = list()
 
@@ -1176,6 +1177,99 @@ def testing_compare_filtered_diff(
 
     # Files are the same if there were no lines of diff output
     return count == 0
+
+###
+
+_FLOAT_STAT_PATTERN = re.compile(r'\.(f32|f64) = ([\d.]+)')
+
+def _extract_float_key_and_values(line: str) -> Tuple[str, List[float]]:
+    values: List[float] = []
+    def replace(m: re.Match) -> str:
+        values.append(float(m.group(2)))
+        return ".{0} = <F>".format(m.group(1))
+    key = _FLOAT_STAT_PATTERN.sub(replace, line)
+    return key, values
+
+def testing_compare_filtered_diff_with_fp_tolerance(
+    test_name: str,
+    outfile: str,
+    reffile: str,
+    sort: bool = False,
+    filters: Union[LineFilter, List[LineFilter]] = list(),
+    rel_tol: float = 1e-5,
+    abs_tol: float = 1e-9,
+) -> bool:
+    """Filter, optionally sort, then compare 2 files with numeric tolerance
+       for floating-point statistic fields (.f32 and .f64).
+
+       Non-float lines and the non-float portions of float lines are compared
+       exactly. Float values are compared with: abs(out - ref) <= max(rel_tol * abs(ref), abs_tol).
+
+        Args:
+            test_name (str): Unique name to prefix the diff file.
+            outfile (str): Path to the output file
+            reffile (str): Path to the reference file
+            sort (bool): If True, lines from files will be sorted before comparison
+            filters (list): List of LineFilters to apply to both files
+            rel_tol (float): Relative tolerance for float comparison (default 1e-5 = 0.001%)
+            abs_tol (float): Absolute tolerance floor for near-zero values (default 1e-9)
+
+        Returns:
+            (bool) True if the files match within tolerance
+    """
+
+    if isinstance(filters, LineFilter):
+        filters = [filters]
+
+    if not os.path.isfile(outfile):
+        log_error("Cannot diff files: Out File {0} does not exist".format(outfile))
+        return False
+
+    if not os.path.isfile(reffile):
+        log_error("Cannot diff files: Ref File {0} does not exist".format(reffile))
+        return False
+
+    out_lines = _read_and_filter(outfile, filters, sort, False)
+    ref_lines = _read_and_filter(reffile, filters, sort, True)
+
+    diff_file = "{1}/{0}_diff_file".format(test_name, test_output_get_tmp_dir())
+    diffs: List[str] = []
+
+    if len(out_lines) != len(ref_lines):
+        diffs.append("Line count mismatch: output has {0} lines, reference has {1}\n".format(
+            len(out_lines), len(ref_lines)))
+
+    for i, (out_line, ref_line) in enumerate(zip(out_lines, ref_lines)):
+        if out_line == ref_line:
+            continue
+
+        out_key, out_vals = _extract_float_key_and_values(out_line)
+        ref_key, ref_vals = _extract_float_key_and_values(ref_line)
+
+        if out_key != ref_key or len(out_vals) != len(ref_vals):
+            diffs.append("< {0}> {1}".format(ref_line, out_line))
+            continue
+
+        if not out_vals:
+            diffs.append("< {0}> {1}".format(ref_line, out_line))
+            continue
+
+        for j, (ov, rv) in enumerate(zip(out_vals, ref_vals)):
+            threshold = max(rel_tol * abs(rv), abs_tol)
+            if abs(ov - rv) > threshold:
+                diffs.append("< {0}> {1}  [float field {2}: ref={3}, out={4}, diff={5}, threshold={6}]\n".format(
+                    ref_line, out_line, j, rv, ov, abs(ov - rv), threshold))
+                break
+
+    for line in out_lines[len(ref_lines):]:
+        diffs.append("> {0}".format(line))
+    for line in ref_lines[len(out_lines):]:
+        diffs.append("< {0}".format(line))
+
+    with open(diff_file, "w") as fp:
+        fp.writelines(diffs)
+
+    return len(diffs) == 0
 
 ###
 

--- a/src/sst/core/testingframework/sst_unittest_support.py
+++ b/src/sst/core/testingframework/sst_unittest_support.py
@@ -1184,7 +1184,7 @@ _FLOAT_STAT_PATTERN = re.compile(r'\.(f32|f64) = ([\d.]+)')
 
 def _extract_float_key_and_values(line: str) -> Tuple[str, List[float]]:
     values: List[float] = []
-    def replace(m: re.Match) -> str:
+    def replace(m: re.Match[str]) -> str:
         values.append(float(m.group(2)))
         return ".{0} = <F>".format(m.group(1))
     key = _FLOAT_STAT_PATTERN.sub(replace, line)

--- a/tests/testsuite_default_Checkpoint.py
+++ b/tests/testsuite_default_Checkpoint.py
@@ -97,28 +97,22 @@ class testcase_Checkpoint(SSTTestCase):
         self.checkpoint_test_template("Module")
 
     ### Stats tests, including repartitioned restart tests
-    @unittest.skipIf(host_os_get_distribution_type() == OS_DIST_ROCKY and host_os_get_distribution_version().split('.')[0] == "10", "This test fails on Rocky 10")
     def test_Checkpoint_Statistics_basic(self) -> None:
         self.checkpoint_test_template("StatisticsComponent_basic")
 
-    @unittest.skipIf(host_os_get_distribution_type() == OS_DIST_ROCKY and host_os_get_distribution_version().split('.')[0] == "10", "This test fails on Rocky 10")
     def test_Checkpoint_Statistics_basic_n2one(self) -> None:
         self.checkpoint_test_template("StatisticsComponent_basic", n_to_one=True, cpt_suffix="_n2one")
 
-    @unittest.skipIf(host_os_get_distribution_type() == OS_DIST_ROCKY and host_os_get_distribution_version().split('.')[0] == "10", "This test fails on Rocky 10")
     def test_Checkpoint_Statistics_basic_start_serial(self) -> None:
         self.checkpoint_test_template("StatisticsComponent_basic", start_serial=True, cpt_suffix="_start_serial")
 
-    @unittest.skipIf(host_os_get_distribution_type() == OS_DIST_ROCKY and host_os_get_distribution_version().split('.')[0] == "10", "This test fails on Rocky 10")
     def test_Checkpoint_Statistics_basic_restart_smaller(self) -> None:
         self.checkpoint_test_template("StatisticsComponent_basic", restart_smaller=True, cpt_suffix="_restart_smaller")
 
-    @unittest.skipIf(host_os_get_distribution_type() == OS_DIST_ROCKY and host_os_get_distribution_version().split('.')[0] == "10", "This test fails on Rocky 10")
     @unittest.skipIf(not have_mpi, "MPI is not included as part of this build")
     def test_Checkpoint_Statistics_basic_remap(self) -> None:
         self.checkpoint_test_template("StatisticsComponent_basic", swap_rank_thread=True, cpt_suffix="_remap")
 
-    @unittest.skipIf(host_os_get_distribution_type() == OS_DIST_ROCKY and host_os_get_distribution_version().split('.')[0] == "10", "This test fails on Rocky 10")
     @unittest.skipIf(not have_mpi, "MPI is not included as part of this build")
     def test_Checkpoint_Statistics_basic_swap_restart_smaller(self) -> None:
         self.checkpoint_test_template("StatisticsComponent_basic", swap_rank_thread=True, restart_smaller=True, cpt_suffix="_swap_restart_smaller")
@@ -306,7 +300,7 @@ class testcase_Checkpoint(SSTTestCase):
             CheckpointInfoFilter(),
             StartsWithFilter("WARNING: No components are assigned") ]
 
-        cmp_result = testing_compare_filtered_diff(testtype, outfile_cpt, reffile, True, filters_cpt)
+        cmp_result = testing_compare_filtered_diff_with_fp_tolerance(testtype, outfile_cpt, reffile, True, filters_cpt)
         if not cmp_result:
             diffdata = testing_get_diff_data(testtype)
             log_failure(diffdata)
@@ -357,7 +351,7 @@ class testcase_Checkpoint(SSTTestCase):
             CheckpointInfoFilter(),
             StartsWithFilter("WARNING: No components are assigned") ]
 
-        cmp_result = testing_compare_filtered_diff(testtype, outfile_rst, reffile, True, filters_rst)
+        cmp_result = testing_compare_filtered_diff_with_fp_tolerance(testtype, outfile_rst, reffile, True, filters_rst)
         if not cmp_result:
             diffdata = testing_get_diff_data(testtype)
             log_failure(diffdata)
@@ -383,7 +377,7 @@ class testcase_Checkpoint(SSTTestCase):
             CheckpointRefFileFilter(cr_index + rst_index),
             CheckpointInfoFilter() ]
 
-        cmp_result = testing_compare_filtered_diff(testtype, outfile_cr, reffile, True, filters_cr)
+        cmp_result = testing_compare_filtered_diff_with_fp_tolerance(testtype, outfile_cr, reffile, True, filters_cr)
         if not cmp_result:
             diffdata = testing_get_diff_data(testtype)
             log_failure(diffdata)

--- a/tests/testsuite_default_StatisticsComponent.py
+++ b/tests/testsuite_default_StatisticsComponent.py
@@ -37,8 +37,6 @@ class testcase_StatisticComponent(SSTTestCase):
 
     num_threads = test_engine_globals.TESTENGINE_SSTRUN_NUMTHREADS
 
-    # This test has floating point statistics in it and on certain platforms, minor rounding leads to floating point diffs
-    @unittest.skipIf(host_os_get_distribution_type() == OS_DIST_ROCKY and host_os_get_distribution_version().split('.')[0] == "10", "This test fails on Rocky 10")
     def test_StatisticsBasic(self):
         self.Statistics_test_template("basic")
 
@@ -73,7 +71,7 @@ class testcase_StatisticComponent(SSTTestCase):
         combine_per_rank_files(out_group_stat_file_csv)
 
         filters = [ StartsWithFilter("WARNING: No components are"), StartsWithFilter("#") ]
-        cmp_result = testing_compare_filtered_diff(testtype, outfile, reffile, True, filters)
+        cmp_result = testing_compare_filtered_diff_with_fp_tolerance(testtype, outfile, reffile, True, filters)
         if not cmp_result:
             diffdata = testing_get_diff_data(testtype)
             log_failure(diffdata)
@@ -86,7 +84,7 @@ class testcase_StatisticComponent(SSTTestCase):
             log_failure(diffdata)
         self.assertTrue(cmp_result, "Output/Compare file {0} does not match Reference File {1}".format(out_group_stat_file_csv, ref_group_stat_file_csv))
 
-        cmp_result = testing_compare_filtered_diff(testtype, out_group_stat_file_txt, ref_group_stat_file_txt, True)
+        cmp_result = testing_compare_filtered_diff_with_fp_tolerance(testtype, out_group_stat_file_txt, ref_group_stat_file_txt, True)
         if not cmp_result:
             diffdata = testing_get_diff_data(testtype)
             log_failure(diffdata)


### PR DESCRIPTION
Adds a comparison function for tests that have floating point values to use a tolerance. This fixes floating point rounding differences between gcc versions on recent Rocky/RHEL platforms. The statistics and checkpoint/statistics tests use the new comparison.